### PR TITLE
[P0][Security] Authenticate control-plane terminal and transcript APIs

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GO_VERSION=1.26.5
+HELM_VERSION=v4.2.3
+
+mkdir -p "$HOME/.local/bin" "$HOME/.local/lib"
+
+if ! command -v go >/dev/null 2>&1 || [[ "$(go version)" != *"go${GO_VERSION}"* ]]; then
+	curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o /tmp/go.tar.gz
+	rm -rf "$HOME/.local/lib/go"
+	tar -C "$HOME/.local/lib" -xzf /tmp/go.tar.gz
+	ln -sf "$HOME/.local/lib/go/bin/go" "$HOME/.local/bin/go"
+	ln -sf "$HOME/.local/lib/go/bin/gofmt" "$HOME/.local/bin/gofmt"
+	rm -f /tmp/go.tar.gz
+fi
+
+if ! command -v helm >/dev/null 2>&1 || [[ "$(helm version --short)" != *"${HELM_VERSION}"* ]]; then
+	curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" -o /tmp/helm.tar.gz
+	tar -C /tmp -xzf /tmp/helm.tar.gz
+	install /tmp/linux-amd64/helm "$HOME/.local/bin/helm"
+	rm -rf /tmp/helm.tar.gz /tmp/linux-amd64
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,9 @@ agent credential injection, and agent adapters.
 Two Go modules — root (operator, CLI, API types) and `sandboxd/`. Everything below
 runs both via `make` targets:
 
+- **Orb setup:** `.agents/setup` installs the pinned Go and Helm versions into
+  `$HOME/.local` when they are unavailable.
+
 - **Build all binaries:** `make build` (outputs operator, control plane, CLI, and sandboxd to `bin/`, gitignored)
 - **Unit tests:** `make test` · **Vet:** `make vet`
 - **Regenerate deepcopy:** `make generate` · **CRDs + RBAC:** `make manifests`

--- a/README.md
+++ b/README.md
@@ -106,11 +106,14 @@ immediately replenishes the pool. Claiming for a Project recreates the generic w
 against its existing workspace volume so repository setup completes before the run is
 reported ready.
 
-The control plane exposes a browser terminal at
-`GET /api/v1/environments/{name}/terminal?namespace={namespace}`. The WebSocket client
+The authenticated control plane exposes a browser terminal at
+`GET /api/v1/namespaces/{namespace}/environments/{name}/terminal`. The WebSocket client
 first sends `{"type":"open","cols":80,"rows":24}`, then uses binary frames for terminal
 input and output. Send `{"type":"resize","cols":120,"rows":40}` to resize the shared
-terminal. The namespace defaults to `default`.
+terminal. Kubernetes TokenReview authenticates bearer credentials and SubjectAccessReview
+authorizes the exact namespaced environment; the namespace is never accepted from a query
+parameter. See the [Helm chart documentation](charts/swe-platform/README.md#control-plane-authentication-and-authorization)
+for credentials, browser sessions, RBAC, and self-hosted bootstrap setup.
 
 ## Contributing
 

--- a/charts/swe-platform/README.md
+++ b/charts/swe-platform/README.md
@@ -2,8 +2,8 @@
 
 This chart installs the swe-platform CRDs, operator, and the first control-plane API.
 The control plane accepts adapter-owned transcript events and streams them over SSE.
-Its current transcript store is in-memory and single-replica; durable storage, auth,
-and the gateway are not implemented yet.
+Its current transcript store is in-memory and single-replica; durable storage and portal
+proxying are not implemented yet.
 
 ## Install
 
@@ -32,6 +32,88 @@ supported by eligible nodes.
 For local development, use `values-kind.yaml`; it references locally loaded `:dev`
 images and disables leader election.
 
+## Control-plane authentication and authorization
+
+Terminal and transcript endpoints require a credential. The control plane authenticates
+Kubernetes bearer tokens with `TokenReview` for the `swe-platform` audience (configurable
+with `controlPlane.auth.tokenAudience`), then asks `SubjectAccessReview` about the
+exact namespace, resource name, and subresource on every request:
+
+| Operation | Kubernetes authorization attributes |
+|---|---|
+| Read a transcript | `get` on `runs/transcript` with the requested Run `resourceName` |
+| Append a transcript event | `update` on `runs/transcript` with the requested Run `resourceName` |
+| Open a terminal | `get` on `environments/terminal` with the requested Environment `resourceName` |
+
+This permits producer credentials to be restricted to one Run using an RBAC Role with
+`resourceNames`. The namespace is part of the URL only as a resource selector; it becomes
+authoritative only after RBAC authorizes that exact namespaced identity. Unknown Runs are
+rejected before transcript state is allocated. Transcript event `data` remains opaque,
+adapter-owned JSON.
+
+Service clients send `Authorization: Bearer <token>`. Browser transcript readers and
+terminal clients may instead use an `HttpOnly`, `Secure`, `SameSite=Strict` cookie named
+`swe-platform-session`; a trusted authentication proxy is responsible for creating that
+session. Session cookies are deliberately rejected for transcript appends, which require
+an explicit bearer service credential. WebSocket requests with an `Origin` must be
+same-origin, including scheme, host, and port. Forwarded headers are ignored by default.
+Behind a trusted reverse proxy, set `controlPlane.auth.trustProxyHeaders=true`; the control
+plane then requires single-valued `X-Forwarded-Host` and `X-Forwarded-Proto` headers, so
+the proxy must overwrite (not append or pass through) both. Non-browser WebSocket clients
+without `Origin` are allowed only with an explicit bearer credential. Tokens are never
+accepted in query parameters.
+
+For initial self-hosted setup, an optional static bootstrap token provides all control-plane
+API permissions. Create it out of band and reference it during installation:
+
+```sh
+kubectl -n swe-platform-system create secret generic swe-platform-bootstrap \
+  --from-literal=token="$(openssl rand -hex 32)"
+helm upgrade --install swe-platform ./charts/swe-platform \
+  --namespace swe-platform-system --create-namespace \
+  --set controlPlane.auth.bootstrapTokenSecret.name=swe-platform-bootstrap
+```
+
+The bootstrap token bypasses Kubernetes RBAC and is therefore equivalent to a control-plane
+administrator credential. It must contain at least 32 characters, is accepted only as an
+explicit bearer credential (never as a browser session), and changes require a control-plane
+rollout. Use it only over TLS, store it outside values files, configure normal Kubernetes
+Roles/RoleBindings, then remove the Helm value and Secret. Without this option, only
+Kubernetes tokens with the configured audience and authorization from RBAC can use the APIs.
+
+For example, this namespaced Role allows one adapter ServiceAccount to append only to
+`run-123`:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: run-123-transcript-producer
+  namespace: project-a
+rules:
+  - apiGroups: ["swe.dev"]
+    resources: ["runs/transcript"]
+    resourceNames: ["run-123"]
+    verbs: ["update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: run-123-transcript-producer
+  namespace: project-a
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: run-123-transcript-producer
+subjects:
+  - kind: ServiceAccount
+    name: run-123-adapter
+    namespace: project-a
+```
+
+Create the ServiceAccount, then mint a short-lived credential with
+`kubectl create token run-123-adapter -n project-a --audience=swe-platform`.
+
 ## Transcript API
 
 After forwarding the control-plane Service, adapters can append JSON transcript events
@@ -39,10 +121,12 @@ and clients can consume replay plus live events as an SSE stream:
 
 ```sh
 kubectl port-forward service/swe-platform-swe-platform-control-plane 8080:80
-curl -N http://127.0.0.1:8080/api/v1/runs/run-123/transcript
-curl -H 'Content-Type: application/json' \
+TOKEN="$(kubectl create token my-reader -n project-a --audience=swe-platform)"
+curl -N -H "Authorization: Bearer ${TOKEN}" \
+  http://127.0.0.1:8080/api/v1/namespaces/project-a/runs/run-123/transcript
+curl -H "Authorization: Bearer ${TOKEN}" -H 'Content-Type: application/json' \
   -d '{"type":"output","data":{"text":"hello"}}' \
-  http://127.0.0.1:8080/api/v1/runs/run-123/transcript
+  http://127.0.0.1:8080/api/v1/namespaces/project-a/runs/run-123/transcript
 ```
 
 SSE reconnects honor `Last-Event-ID`. Callers may also request events after a known ID

--- a/charts/swe-platform/templates/control-plane-deployment.yaml
+++ b/charts/swe-platform/templates/control-plane-deployment.yaml
@@ -33,6 +33,18 @@ spec:
           image: "{{ .Values.controlPlane.image.repository }}:{{ .Values.controlPlane.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.controlPlane.image.pullPolicy }}
           args: ["--listen-address=:8080"]
+          env:
+            - name: SWE_TOKEN_AUDIENCE
+              value: {{ .Values.controlPlane.auth.tokenAudience | quote }}
+            - name: SWE_TRUST_PROXY_HEADERS
+              value: {{ .Values.controlPlane.auth.trustProxyHeaders | quote }}
+            {{- with .Values.controlPlane.auth.bootstrapTokenSecret.name }}
+            - name: SWE_BOOTSTRAP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ . | quote }}
+                  key: {{ $.Values.controlPlane.auth.bootstrapTokenSecret.key | quote }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/charts/swe-platform/templates/rbac.yaml
+++ b/charts/swe-platform/templates/rbac.yaml
@@ -57,6 +57,12 @@ metadata:
     {{- include "swe-platform.labels" . | nindent 4 }}
     app.kubernetes.io/component: control-plane
 rules:
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
+    verbs: ["create"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["subjectaccessreviews"]
+    verbs: ["create"]
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get"]
@@ -68,6 +74,9 @@ rules:
     verbs: ["get", "update"]
   - apiGroups: ["swe.dev"]
     resources: ["environmenttemplates"]
+    verbs: ["get"]
+  - apiGroups: ["swe.dev"]
+    resources: ["runs"]
     verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/swe-platform/values.yaml
+++ b/charts/swe-platform/values.yaml
@@ -12,6 +12,16 @@ controlPlane:
     repository: ghcr.io/chris-cullins/swe-platform/control-plane
     tag: latest
     pullPolicy: IfNotPresent
+  auth:
+    tokenAudience: swe-platform
+    # Honor X-Forwarded-Host/Proto for WebSocket origin checks only when a trusted
+    # reverse proxy overwrites both headers.
+    trustProxyHeaders: false
+    # Optional all-access bootstrap credential for initial self-hosted setup.
+    # Create this Secret out of band and disable/remove it after configuring RBAC.
+    bootstrapTokenSecret:
+      name: ""
+      key: token
   resources: {}
 
 imagePullSecrets: []

--- a/cmd/control-plane/main.go
+++ b/cmd/control-plane/main.go
@@ -5,10 +5,12 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
@@ -30,14 +32,35 @@ func main() {
 		log.Error("register API types", "error", err)
 		os.Exit(1)
 	}
-	kubeClient, err := client.New(config.GetConfigOrDie(), client.Options{Scheme: scheme})
+	restConfig := config.GetConfigOrDie()
+	kubeClient, err := client.New(restConfig, client.Options{Scheme: scheme})
 	if err != nil {
 		log.Error("create Kubernetes client", "error", err)
 		os.Exit(1)
 	}
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		log.Error("create Kubernetes authentication client", "error", err)
+		os.Exit(1)
+	}
+	bootstrapToken := os.Getenv("SWE_BOOTSTRAP_TOKEN")
+	if bootstrapToken != "" && len(bootstrapToken) < 32 {
+		log.Error("SWE_BOOTSTRAP_TOKEN must contain at least 32 characters")
+		os.Exit(1)
+	}
+	access := controlplane.KubernetesAccessController{
+		Client:         clientset,
+		BootstrapToken: bootstrapToken,
+		Audience:       os.Getenv("SWE_TOKEN_AUDIENCE"),
+	}
 	server := &http.Server{
-		Addr:              *address,
-		Handler:           controlplane.NewServer(log, controlplane.KubernetesTerminalDialer{Client: kubeClient}).Handler(),
+		Addr: *address,
+		Handler: controlplane.NewServer(log, controlplane.ServerOptions{
+			Access:         access,
+			Runs:           controlplane.KubernetesRunResolver{Client: kubeClient},
+			TerminalDialer: controlplane.KubernetesTerminalDialer{Client: kubeClient},
+			TrustProxy:     strings.EqualFold(os.Getenv("SWE_TRUST_PROXY_HEADERS"), "true"),
+		}).Handler(),
 		ReadHeaderTimeout: 5 * time.Second,
 		IdleTimeout:       2 * time.Minute,
 	}

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -149,7 +149,8 @@ EOF
 echo "==> creating project environment + run via swe"
 bin/swe run "end-to-end smoke test" --project e2e --timeout 3m
 
-ENV_NAME=$(kubectl get runs -o jsonpath='{.items[0].spec.environmentRef}')
+RUN_NAME=$(kubectl get runs -o jsonpath='{.items[0].metadata.name}')
+ENV_NAME=$(kubectl get run "$RUN_NAME" -o jsonpath='{.spec.environmentRef}')
 if [[ "$ENV_NAME" != "$WARM_ENV_NAME" ]]; then
 	echo "FAIL: swe run created $ENV_NAME instead of claiming warm environment $WARM_ENV_NAME"
 	exit 1
@@ -170,8 +171,6 @@ fi
 echo "==> verifying state"
 kubectl get environments
 kubectl get pods -l app.kubernetes.io/managed-by=swe-platform
-RUN_NAME=$(kubectl get runs -o jsonpath='{.items[0].metadata.name}')
-ENV_NAME=$(kubectl get run "$RUN_NAME" -o jsonpath='{.spec.environmentRef}')
 
 echo "==> configuring a run-scoped transcript producer"
 cat <<EOF | kubectl apply -f -

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -54,8 +54,12 @@ echo "==> loading images into kind"
 kind load docker-image "$ENV_IMAGE" "$OPERATOR_IMAGE" "$CONTROL_PLANE_IMAGE" --name "$CLUSTER"
 
 echo "==> installing operator, CRDs, and kind template through Helm"
+E2E_BOOTSTRAP_TOKEN="$(openssl rand -hex 32)"
+kubectl create secret generic swe-platform-bootstrap --from-literal=token="$E2E_BOOTSTRAP_TOKEN"
 helm upgrade --install swe-platform charts/swe-platform \
-	--namespace default --values charts/swe-platform/values-kind.yaml --wait --timeout 2m
+	--namespace default --values charts/swe-platform/values-kind.yaml \
+	--set controlPlane.auth.bootstrapTokenSecret.name=swe-platform-bootstrap \
+	--wait --timeout 2m
 
 echo "==> waiting for warm environment"
 kubectl wait --for=jsonpath='{.status.warmPoolReady}'=1 environmenttemplate/small --timeout=2m
@@ -166,6 +170,49 @@ fi
 echo "==> verifying state"
 kubectl get environments
 kubectl get pods -l app.kubernetes.io/managed-by=swe-platform
+RUN_NAME=$(kubectl get runs -o jsonpath='{.items[0].metadata.name}')
+ENV_NAME=$(kubectl get run "$RUN_NAME" -o jsonpath='{.spec.environmentRef}')
+
+echo "==> configuring a run-scoped transcript producer"
+cat <<EOF | kubectl apply -f -
+apiVersion: swe.dev/v1alpha1
+kind: Run
+metadata:
+  name: auth-scope-run-b
+spec:
+  environmentRef: ${ENV_NAME}
+  agent: e2e
+  prompt: authorization scope test
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: e2e-transcript-producer
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: e2e-transcript-producer
+rules:
+  - apiGroups: ["swe.dev"]
+    resources: ["runs/transcript"]
+    resourceNames: ["${RUN_NAME}"]
+    verbs: ["update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: e2e-transcript-producer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: e2e-transcript-producer
+subjects:
+  - kind: ServiceAccount
+    name: e2e-transcript-producer
+    namespace: default
+EOF
+PRODUCER_TOKEN=$(kubectl create token e2e-transcript-producer --audience=swe-platform)
 
 echo "==> verifying live transcript stream through the control plane"
 kubectl port-forward service/swe-platform-swe-platform-control-plane 18080:80 >/tmp/swe-platform-port-forward.log 2>&1 &
@@ -176,14 +223,42 @@ for _ in $(seq 1 30); do
 	fi
 	sleep 1
 done
+ANONYMOUS_STATUS=$(curl --silent --output /dev/null --write-out '%{http_code}' \
+	"http://127.0.0.1:18080/api/v1/namespaces/default/runs/${RUN_NAME}/transcript")
+if [[ "$ANONYMOUS_STATUS" != "401" ]]; then
+	echo "FAIL: anonymous transcript status was ${ANONYMOUS_STATUS}, expected 401"
+	exit 1
+fi
 curl --fail --silent --no-buffer --max-time 10 \
-	http://127.0.0.1:18080/api/v1/runs/e2e-run/transcript > /tmp/swe-platform-transcript.out &
+	-H "Authorization: Bearer ${E2E_BOOTSTRAP_TOKEN}" \
+	"http://127.0.0.1:18080/api/v1/namespaces/default/runs/${RUN_NAME}/transcript" > /tmp/swe-platform-transcript.out &
 STREAM_PID=$!
 sleep 1
-curl --fail --silent \
+APPEND_STATUS=$(curl --silent --output /dev/null --write-out '%{http_code}' \
+	-H "Authorization: Bearer ${PRODUCER_TOKEN}" \
 	-H 'Content-Type: application/json' \
 	-d '{"type":"output","data":{"text":"e2e transcript event"}}' \
-	http://127.0.0.1:18080/api/v1/runs/e2e-run/transcript >/dev/null
+	"http://127.0.0.1:18080/api/v1/namespaces/default/runs/${RUN_NAME}/transcript")
+if [[ "$APPEND_STATUS" != "202" ]]; then
+	echo "FAIL: run-scoped producer append status was ${APPEND_STATUS}, expected 202"
+	exit 1
+fi
+DENIED_STATUS=$(curl --silent --output /dev/null --write-out '%{http_code}' \
+	-H "Authorization: Bearer ${PRODUCER_TOKEN}" \
+	-H 'Content-Type: application/json' \
+	-d '{"type":"output","data":{"text":"forged"}}' \
+	http://127.0.0.1:18080/api/v1/namespaces/default/runs/auth-scope-run-b/transcript)
+if [[ "$DENIED_STATUS" != "403" ]]; then
+	echo "FAIL: cross-run producer append status was ${DENIED_STATUS}, expected 403"
+	exit 1
+fi
+UNKNOWN_STATUS=$(curl --silent --output /dev/null --write-out '%{http_code}' \
+	-H "Authorization: Bearer ${E2E_BOOTSTRAP_TOKEN}" \
+	http://127.0.0.1:18080/api/v1/namespaces/default/runs/unknown-run/transcript)
+if [[ "$UNKNOWN_STATUS" != "404" ]]; then
+	echo "FAIL: unknown Run transcript status was ${UNKNOWN_STATUS}, expected 404"
+	exit 1
+fi
 for _ in $(seq 1 30); do
 	if grep -q 'e2e transcript event' /tmp/swe-platform-transcript.out; then
 		break
@@ -278,6 +353,7 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -286,7 +362,8 @@ import (
 )
 
 func main() {
-	connection, _, err := websocket.DefaultDialer.Dial(os.Args[1], nil)
+	header := http.Header{"Authorization": []string{"Bearer " + os.Args[2]}}
+	connection, _, err := websocket.DefaultDialer.Dial(os.Args[1], header)
 	if err != nil { panic(err) }
 	defer connection.Close()
 	_ = connection.SetReadDeadline(time.Now().Add(15 * time.Second))
@@ -301,7 +378,9 @@ func main() {
 	fmt.Print(output.String())
 }
 EOF
-go run "$WEB_TERMINAL_CLIENT" "ws://127.0.0.1:18080/api/v1/environments/${ENV_NAME}/terminal" > /tmp/swe-platform-web-terminal.out
+go run "$WEB_TERMINAL_CLIENT" \
+	"ws://127.0.0.1:18080/api/v1/namespaces/default/environments/${ENV_NAME}/terminal" \
+	"$E2E_BOOTSTRAP_TOKEN" > /tmp/swe-platform-web-terminal.out
 if ! grep -q 'web-terminal-e2e-ok' /tmp/swe-platform-web-terminal.out; then
 	echo "FAIL: terminal output was not received through the control-plane websocket"
 	cat /tmp/swe-platform-web-terminal.out

--- a/internal/controlplane/auth.go
+++ b/internal/controlplane/auth.go
@@ -1,0 +1,178 @@
+package controlplane
+
+import (
+	"context"
+	"crypto/subtle"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const sessionCookieName = "swe-platform-session"
+const defaultTokenAudience = "swe-platform"
+
+var (
+	errUnauthenticated = errors.New("authentication required")
+	errForbidden       = errors.New("access denied")
+)
+
+// ResourceAccess identifies one namespaced API authorization decision.
+type ResourceAccess struct {
+	Namespace   string
+	Verb        string
+	Resource    string
+	Subresource string
+	Name        string
+}
+
+type principal struct {
+	name      string
+	uid       string
+	groups    []string
+	extra     map[string]authorizationv1.ExtraValue
+	bootstrap bool
+}
+
+// AccessController authenticates credentials and authorizes resource access.
+type AccessController interface {
+	Authorize(*http.Request, ResourceAccess, bool) error
+}
+
+// KubernetesAccessController uses TokenReview and SubjectAccessReview. BootstrapToken,
+// when non-empty, is an all-access credential intended only for initial self-hosted setup.
+type KubernetesAccessController struct {
+	Client         kubernetes.Interface
+	BootstrapToken string
+	Audience       string
+}
+
+// Authorize authenticates a bearer token (or, for browser reads, a session cookie) and
+// authorizes the exact namespaced resource through Kubernetes RBAC.
+func (a KubernetesAccessController) Authorize(r *http.Request, access ResourceAccess, allowSession bool) error {
+	token, bearer, err := requestToken(r, allowSession)
+	if err != nil {
+		return err
+	}
+	user, err := a.authenticate(r.Context(), token, bearer)
+	if err != nil {
+		return err
+	}
+	if user.bootstrap {
+		return nil
+	}
+	if a.Client == nil {
+		return fmt.Errorf("authorize request: Kubernetes client is unavailable")
+	}
+	review, err := a.Client.AuthorizationV1().SubjectAccessReviews().Create(r.Context(), &authorizationv1.SubjectAccessReview{
+		Spec: authorizationv1.SubjectAccessReviewSpec{
+			User:   user.name,
+			UID:    user.uid,
+			Groups: user.groups,
+			Extra:  user.extra,
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Namespace:   access.Namespace,
+				Verb:        access.Verb,
+				Group:       "swe.dev",
+				Version:     "v1alpha1",
+				Resource:    access.Resource,
+				Subresource: access.Subresource,
+				Name:        access.Name,
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("authorize request: %w", err)
+	}
+	if review.Status.EvaluationError != "" {
+		return fmt.Errorf("authorize request: %s", review.Status.EvaluationError)
+	}
+	if !review.Status.Allowed {
+		return errForbidden
+	}
+	return nil
+}
+
+func (a KubernetesAccessController) authenticate(ctx context.Context, token string, bearer bool) (principal, error) {
+	if a.BootstrapToken != "" && subtle.ConstantTimeCompare([]byte(token), []byte(a.BootstrapToken)) == 1 {
+		if !bearer {
+			return principal{}, errUnauthenticated
+		}
+		return principal{name: "swe-platform:bootstrap", bootstrap: true}, nil
+	}
+	if a.Client == nil {
+		return principal{}, fmt.Errorf("authenticate request: Kubernetes client is unavailable")
+	}
+	audience := a.Audience
+	if audience == "" {
+		audience = defaultTokenAudience
+	}
+	review, err := a.Client.AuthenticationV1().TokenReviews().Create(ctx, &authenticationv1.TokenReview{
+		Spec: authenticationv1.TokenReviewSpec{Token: token, Audiences: []string{audience}},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		return principal{}, fmt.Errorf("authenticate request: %w", err)
+	}
+	if review.Status.Error != "" {
+		return principal{}, fmt.Errorf("authenticate request: %s", review.Status.Error)
+	}
+	if !review.Status.Authenticated {
+		return principal{}, errUnauthenticated
+	}
+	audienceMatched := false
+	for _, reviewedAudience := range review.Status.Audiences {
+		if reviewedAudience == audience {
+			audienceMatched = true
+			break
+		}
+	}
+	if !audienceMatched {
+		return principal{}, errUnauthenticated
+	}
+	extra := make(map[string]authorizationv1.ExtraValue, len(review.Status.User.Extra))
+	for key, values := range review.Status.User.Extra {
+		extra[key] = append(authorizationv1.ExtraValue(nil), values...)
+	}
+	return principal{
+		name:   review.Status.User.Username,
+		uid:    review.Status.User.UID,
+		groups: append([]string(nil), review.Status.User.Groups...),
+		extra:  extra,
+	}, nil
+}
+
+func requestToken(r *http.Request, allowSession bool) (string, bool, error) {
+	authorization := r.Header.Get("Authorization")
+	if authorization != "" {
+		scheme, token, ok := strings.Cut(authorization, " ")
+		if !ok || !strings.EqualFold(scheme, "Bearer") || strings.TrimSpace(token) == "" {
+			return "", false, errUnauthenticated
+		}
+		return strings.TrimSpace(token), true, nil
+	}
+	if allowSession {
+		cookie, err := r.Cookie(sessionCookieName)
+		if err == nil && cookie.Value != "" {
+			return cookie.Value, false, nil
+		}
+	}
+	return "", false, errUnauthenticated
+}
+
+func writeAccessError(w http.ResponseWriter, err error) {
+	if errors.Is(err, errUnauthenticated) {
+		w.Header().Set("WWW-Authenticate", "Bearer")
+		http.Error(w, "authentication required", http.StatusUnauthorized)
+		return
+	}
+	if errors.Is(err, errForbidden) {
+		http.Error(w, "access denied", http.StatusForbidden)
+		return
+	}
+	http.Error(w, "authorization service unavailable", http.StatusServiceUnavailable)
+}

--- a/internal/controlplane/auth_test.go
+++ b/internal/controlplane/auth_test.go
@@ -1,0 +1,148 @@
+package controlplane
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
+)
+
+func TestKubernetesAccessControllerReviewsExactResourceIdentity(t *testing.T) {
+	client := fake.NewClientset()
+	client.PrependReactor("create", "tokenreviews", func(action ktesting.Action) (bool, runtime.Object, error) {
+		review := action.(ktesting.CreateAction).GetObject().(*authenticationv1.TokenReview)
+		if review.Spec.Token != "reader-token" {
+			t.Fatalf("reviewed token = %q, want reader-token", review.Spec.Token)
+		}
+		if len(review.Spec.Audiences) != 1 || review.Spec.Audiences[0] != defaultTokenAudience {
+			t.Fatalf("reviewed audiences = %v, want [%s]", review.Spec.Audiences, defaultTokenAudience)
+		}
+		return true, &authenticationv1.TokenReview{Status: authenticationv1.TokenReviewStatus{
+			Authenticated: true,
+			Audiences:     []string{defaultTokenAudience},
+			User: authenticationv1.UserInfo{
+				Username: "reader",
+				UID:      "reader-uid",
+				Groups:   []string{"readers"},
+				Extra:    map[string]authenticationv1.ExtraValue{"credential-id": {"session-1"}},
+			},
+		}}, nil
+	})
+	client.PrependReactor("create", "subjectaccessreviews", func(action ktesting.Action) (bool, runtime.Object, error) {
+		review := action.(ktesting.CreateAction).GetObject().(*authorizationv1.SubjectAccessReview)
+		attributes := review.Spec.ResourceAttributes
+		if review.Spec.User != "reader" || review.Spec.UID != "reader-uid" || len(review.Spec.Groups) != 1 || review.Spec.Groups[0] != "readers" {
+			t.Fatalf("subject = %+v, want authenticated reader identity", review.Spec)
+		}
+		if values := review.Spec.Extra["credential-id"]; len(values) != 1 || values[0] != "session-1" {
+			t.Fatalf("subject extra = %v, want credential-id session-1", review.Spec.Extra)
+		}
+		want := ResourceAccess{Namespace: "project-a", Verb: "get", Resource: "runs", Subresource: "transcript", Name: "shared"}
+		if attributes.Namespace != want.Namespace || attributes.Verb != want.Verb || attributes.Group != "swe.dev" || attributes.Version != "v1alpha1" || attributes.Resource != want.Resource || attributes.Subresource != want.Subresource || attributes.Name != want.Name {
+			t.Fatalf("resource attributes = %+v, want %+v", attributes, want)
+		}
+		return true, &authorizationv1.SubjectAccessReview{Status: authorizationv1.SubjectAccessReviewStatus{Allowed: true}}, nil
+	})
+
+	request := httptest.NewRequest(http.MethodGet, transcriptURL, nil)
+	request.Header.Set("Authorization", "Bearer reader-token")
+	err := (KubernetesAccessController{Client: client}).Authorize(request, ResourceAccess{
+		Namespace: "project-a", Verb: "get", Resource: "runs", Subresource: "transcript", Name: "shared",
+	}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestKubernetesAccessControllerRejectsAnonymousAndDeniedUsers(t *testing.T) {
+	controller := KubernetesAccessController{}
+	request := httptest.NewRequest(http.MethodGet, transcriptURL, nil)
+	if err := controller.Authorize(request, ResourceAccess{}, true); !errors.Is(err, errUnauthenticated) {
+		t.Fatalf("anonymous error = %v, want unauthenticated", err)
+	}
+
+	client := fake.NewClientset()
+	client.PrependReactor("create", "tokenreviews", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, &authenticationv1.TokenReview{Status: authenticationv1.TokenReviewStatus{
+			Authenticated: true,
+			Audiences:     []string{defaultTokenAudience},
+			User:          authenticationv1.UserInfo{Username: "producer-a"},
+		}}, nil
+	})
+	client.PrependReactor("create", "subjectaccessreviews", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, &authorizationv1.SubjectAccessReview{Status: authorizationv1.SubjectAccessReviewStatus{Allowed: false}}, nil
+	})
+	request.Header.Set("Authorization", "Bearer producer-token")
+	if err := (KubernetesAccessController{Client: client}).Authorize(request, ResourceAccess{}, false); !errors.Is(err, errForbidden) {
+		t.Fatalf("denied error = %v, want forbidden", err)
+	}
+}
+
+func TestBootstrapAndBrowserSessionCredentials(t *testing.T) {
+	bootstrapToken := "bootstrap-secret-at-least-32-bytes"
+	controller := KubernetesAccessController{BootstrapToken: bootstrapToken}
+
+	bootstrap := httptest.NewRequest(http.MethodPost, transcriptURL, nil)
+	bootstrap.Header.Set("Authorization", "Bearer "+bootstrapToken)
+	if err := controller.Authorize(bootstrap, ResourceAccess{}, false); err != nil {
+		t.Fatalf("bootstrap token rejected: %v", err)
+	}
+
+	session := httptest.NewRequest(http.MethodGet, transcriptURL, nil)
+	session.AddCookie(&http.Cookie{Name: sessionCookieName, Value: bootstrapToken})
+	if err := controller.Authorize(session, ResourceAccess{}, true); !errors.Is(err, errUnauthenticated) {
+		t.Fatalf("bootstrap session error = %v, want unauthenticated", err)
+	}
+	if err := controller.Authorize(session, ResourceAccess{}, false); !errors.Is(err, errUnauthenticated) {
+		t.Fatalf("producer session error = %v, want unauthenticated", err)
+	}
+}
+
+func TestKubernetesAccessControllerRejectsWrongAudience(t *testing.T) {
+	client := fake.NewClientset()
+	client.PrependReactor("create", "tokenreviews", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, &authenticationv1.TokenReview{Status: authenticationv1.TokenReviewStatus{
+			Authenticated: true,
+			Audiences:     []string{"other-service"},
+			User:          authenticationv1.UserInfo{Username: "reader"},
+		}}, nil
+	})
+	request := httptest.NewRequest(http.MethodGet, transcriptURL, nil)
+	request.Header.Set("Authorization", "Bearer wrong-audience")
+	if err := (KubernetesAccessController{Client: client}).Authorize(request, ResourceAccess{}, true); !errors.Is(err, errUnauthenticated) {
+		t.Fatalf("wrong-audience error = %v, want unauthenticated", err)
+	}
+}
+
+func TestBrowserSessionAuthenticatesReadsButNotProducerWrites(t *testing.T) {
+	client := fake.NewClientset()
+	client.PrependReactor("create", "tokenreviews", func(action ktesting.Action) (bool, runtime.Object, error) {
+		review := action.(ktesting.CreateAction).GetObject().(*authenticationv1.TokenReview)
+		if review.Spec.Token != "browser-session-token" {
+			t.Fatalf("reviewed token = %q, want browser-session-token", review.Spec.Token)
+		}
+		return true, &authenticationv1.TokenReview{Status: authenticationv1.TokenReviewStatus{
+			Authenticated: true,
+			Audiences:     []string{defaultTokenAudience},
+			User:          authenticationv1.UserInfo{Username: "browser-user"},
+		}}, nil
+	})
+	client.PrependReactor("create", "subjectaccessreviews", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, &authorizationv1.SubjectAccessReview{Status: authorizationv1.SubjectAccessReviewStatus{Allowed: true}}, nil
+	})
+	controller := KubernetesAccessController{Client: client}
+	request := httptest.NewRequest(http.MethodGet, transcriptURL, nil)
+	request.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "browser-session-token"})
+	if err := controller.Authorize(request, ResourceAccess{}, true); err != nil {
+		t.Fatalf("browser reader session rejected: %v", err)
+	}
+	if err := controller.Authorize(request, ResourceAccess{}, false); !errors.Is(err, errUnauthenticated) {
+		t.Fatalf("browser producer session error = %v, want unauthenticated", err)
+	}
+}

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -2,6 +2,7 @@
 package controlplane
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,10 +13,15 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
 )
 
-const transcriptPathPrefix = "/api/v1/runs/"
-const terminalPathPrefix = "/api/v1/environments/"
+const namespacedPathPrefix = "/api/v1/namespaces/"
 
 // TranscriptEvent is one adapter-owned transcript event.
 type TranscriptEvent struct {
@@ -34,19 +40,52 @@ type appendTranscriptRequest struct {
 type Server struct {
 	log            *slog.Logger
 	store          *transcriptStore
+	access         AccessController
+	runs           RunResolver
 	terminalDialer TerminalDialer
+	trustProxy     bool
+}
+
+// RunResolver verifies that a namespaced Run exists before transcript state is used.
+type RunResolver interface {
+	ResolveRun(context.Context, string, string) (types.UID, error)
+}
+
+// KubernetesRunResolver resolves Runs through the Kubernetes API.
+type KubernetesRunResolver struct {
+	Client client.Client
+}
+
+// ResolveRun verifies that the requested Run exists in the authorized namespace.
+func (r KubernetesRunResolver) ResolveRun(ctx context.Context, namespace, name string) (types.UID, error) {
+	var run platformv1alpha1.Run
+	if err := r.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &run); err != nil {
+		return "", err
+	}
+	return run.UID, nil
+}
+
+// ServerOptions supplies the control plane's resource and authorization dependencies.
+type ServerOptions struct {
+	Access         AccessController
+	Runs           RunResolver
+	TerminalDialer TerminalDialer
+	TrustProxy     bool
 }
 
 // NewServer constructs a control-plane API handler.
-func NewServer(log *slog.Logger, terminalDialer ...TerminalDialer) *Server {
+func NewServer(log *slog.Logger, options ServerOptions) *Server {
 	if log == nil {
 		log = slog.Default()
 	}
-	server := &Server{log: log, store: newTranscriptStore()}
-	if len(terminalDialer) > 0 {
-		server.terminalDialer = terminalDialer[0]
+	return &Server{
+		log:            log,
+		store:          newTranscriptStore(),
+		access:         options.Access,
+		runs:           options.Runs,
+		terminalDialer: options.TerminalDialer,
+		trustProxy:     options.TrustProxy,
 	}
-	return server
 }
 
 // Handler returns the HTTP handler for the API.
@@ -55,36 +94,86 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	})
-	mux.HandleFunc("GET "+terminalPathPrefix, s.handleTerminal)
-	mux.HandleFunc(transcriptPathPrefix, s.handleTranscript)
+	mux.HandleFunc(namespacedPathPrefix, s.handleNamespacedAPI)
 	return mux
 }
 
-func (s *Server) handleTranscript(w http.ResponseWriter, r *http.Request) {
-	run, ok := transcriptRun(r.URL.Path)
+func (s *Server) handleNamespacedAPI(w http.ResponseWriter, r *http.Request) {
+	namespace, resource, name, subresource, ok := namespacedResource(r.URL.Path)
 	if !ok {
 		http.NotFound(w, r)
 		return
 	}
+	if resource == "runs" && subresource == "transcript" {
+		s.handleTranscript(w, r, namespace, name)
+		return
+	}
+	if resource == "environments" && subresource == "terminal" && r.Method == http.MethodGet {
+		s.handleTerminal(w, r, namespace, name)
+		return
+	}
+	http.NotFound(w, r)
+}
+
+func namespacedResource(path string) (namespace, resource, name, subresource string, ok bool) {
+	remainder := strings.TrimPrefix(path, namespacedPathPrefix)
+	if remainder == path {
+		return "", "", "", "", false
+	}
+	parts := strings.Split(remainder, "/")
+	if len(parts) != 4 {
+		return "", "", "", "", false
+	}
+	for _, part := range parts {
+		if part == "" {
+			return "", "", "", "", false
+		}
+	}
+	return parts[0], parts[1], parts[2], parts[3], true
+}
+
+func (s *Server) handleTranscript(w http.ResponseWriter, r *http.Request, namespace, run string) {
+	verb := "get"
+	allowSession := true
+	if r.Method == http.MethodPost {
+		verb = "update"
+		allowSession = false
+	}
+	if r.Method != http.MethodGet && r.Method != http.MethodPost {
+		w.Header().Set("Allow", "GET, POST")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.access == nil {
+		writeAccessError(w, errUnauthenticated)
+		return
+	}
+	if err := s.access.Authorize(r, ResourceAccess{Namespace: namespace, Verb: verb, Resource: "runs", Subresource: "transcript", Name: run}, allowSession); err != nil {
+		writeAccessError(w, err)
+		return
+	}
+	if s.runs == nil {
+		http.Error(w, "run resolver is unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	uid, err := s.runs.ResolveRun(r.Context(), namespace, run)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			http.Error(w, "run not found", http.StatusNotFound)
+		} else {
+			s.log.Warn("resolve transcript run", "namespace", namespace, "run", run, "error", err)
+			http.Error(w, "run resolver is unavailable", http.StatusServiceUnavailable)
+		}
+		return
+	}
+	key := namespace + "/" + string(uid)
 
 	switch r.Method {
 	case http.MethodGet:
-		s.streamTranscript(w, r, run)
+		s.streamTranscript(w, r, key)
 	case http.MethodPost:
-		s.appendTranscript(w, r, run)
-	default:
-		w.Header().Set("Allow", "GET, POST")
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		s.appendTranscript(w, r, key)
 	}
-}
-
-func transcriptRun(path string) (string, bool) {
-	remainder := strings.TrimPrefix(path, transcriptPathPrefix)
-	if remainder == path || !strings.HasSuffix(remainder, "/transcript") {
-		return "", false
-	}
-	run := strings.TrimSuffix(remainder, "/transcript")
-	return run, run != "" && !strings.Contains(run, "/")
 }
 
 func (s *Server) appendTranscript(w http.ResponseWriter, r *http.Request, run string) {

--- a/internal/controlplane/server_test.go
+++ b/internal/controlplane/server_test.go
@@ -10,19 +10,26 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 )
 
+const transcriptURL = "/api/v1/namespaces/project-1/runs/run-1/transcript"
+
 func TestTranscriptReplayAndLiveStream(t *testing.T) {
-	server := httptest.NewServer(NewServer(nil).Handler())
+	server := httptest.NewServer(newTestServer(&fakeAccess{}).Handler())
 	defer server.Close()
 
 	postEvent(t, server.URL, `{"type":"output","data":{"text":"first"}}`)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/api/v1/runs/run-1/transcript", nil)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+transcriptURL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,8 +61,9 @@ func TestTranscriptReplayAndLiveStream(t *testing.T) {
 }
 
 func TestTranscriptValidation(t *testing.T) {
-	handler := NewServer(nil).Handler()
-	request := httptest.NewRequest(http.MethodPost, "/api/v1/runs/run-1/transcript", bytes.NewBufferString(`{"type":"output"}`))
+	handler := newTestServer(&fakeAccess{}).Handler()
+	request := httptest.NewRequest(http.MethodPost, transcriptURL, bytes.NewBufferString(`{"type":"output"}`))
+	request.Header.Set("Authorization", "Bearer producer")
 	response := httptest.NewRecorder()
 
 	handler.ServeHTTP(response, request)
@@ -65,15 +73,15 @@ func TestTranscriptValidation(t *testing.T) {
 }
 
 func TestTranscriptReconnectUsesLastEventID(t *testing.T) {
-	api := NewServer(nil)
-	first := api.store.append("run-1", "output", json.RawMessage(`{"text":"first"}`))
-	api.store.append("run-1", "output", json.RawMessage(`{"text":"second"}`))
+	api := newTestServer(&fakeAccess{})
+	first := api.store.append("project-1/run-1-uid", "output", json.RawMessage(`{"text":"first"}`))
+	api.store.append("project-1/run-1-uid", "output", json.RawMessage(`{"text":"second"}`))
 
 	server := httptest.NewServer(api.Handler())
 	defer server.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/api/v1/runs/run-1/transcript", nil)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+transcriptURL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,6 +102,88 @@ func TestTranscriptReconnectUsesLastEventID(t *testing.T) {
 	t.Fatal("stream ended before replaying the second event")
 }
 
+func TestTranscriptRejectsAnonymousBeforeRunResolutionOrStoreAccess(t *testing.T) {
+	resolver := &fakeRunResolver{}
+	api := NewServer(nil, ServerOptions{Access: &fakeAccess{err: errUnauthenticated}, Runs: resolver})
+
+	for _, method := range []string{http.MethodGet, http.MethodPost} {
+		request := httptest.NewRequest(method, transcriptURL, strings.NewReader(`{"type":"output","data":{}}`))
+		response := httptest.NewRecorder()
+		api.Handler().ServeHTTP(response, request)
+		if response.Code != http.StatusUnauthorized {
+			t.Fatalf("%s status = %d, want %d", method, response.Code, http.StatusUnauthorized)
+		}
+	}
+	if resolver.calls != 0 || len(api.store.events) != 0 || len(api.store.subscribers) != 0 {
+		t.Fatalf("unauthorized request reached backend: resolves=%d events=%d subscribers=%d", resolver.calls, len(api.store.events), len(api.store.subscribers))
+	}
+}
+
+func TestTranscriptAuthorizationScopesNamespaceAndRun(t *testing.T) {
+	access := &fakeAccess{allow: func(resource ResourceAccess) bool {
+		return resource.Namespace == "project-a" && resource.Name == "run-1"
+	}}
+	api := NewServer(nil, ServerOptions{Access: access, Runs: &fakeRunResolver{}})
+
+	allowed := httptest.NewRequest(http.MethodPost, "/api/v1/namespaces/project-a/runs/run-1/transcript", strings.NewReader(`{"type":"output","data":{"source":"a"}}`))
+	allowed.Header.Set("Authorization", "Bearer producer-a")
+	allowedResponse := httptest.NewRecorder()
+	api.Handler().ServeHTTP(allowedResponse, allowed)
+	if allowedResponse.Code != http.StatusAccepted {
+		t.Fatalf("allowed append status = %d, want %d", allowedResponse.Code, http.StatusAccepted)
+	}
+
+	for _, path := range []string{
+		"/api/v1/namespaces/project-b/runs/run-1/transcript",
+		"/api/v1/namespaces/project-a/runs/run-2/transcript",
+	} {
+		request := httptest.NewRequest(http.MethodPost, path, strings.NewReader(`{"type":"output","data":{"forged":true}}`))
+		request.Header.Set("Authorization", "Bearer producer-a")
+		response := httptest.NewRecorder()
+		api.Handler().ServeHTTP(response, request)
+		if response.Code != http.StatusForbidden {
+			t.Fatalf("%s status = %d, want %d", path, response.Code, http.StatusForbidden)
+		}
+	}
+	if len(api.store.events) != 1 || len(api.store.events["project-a/run-1-uid"]) != 1 {
+		t.Fatalf("forbidden append changed transcript store: %+v", api.store.events)
+	}
+}
+
+func TestUnknownRunRejectedBeforeTranscriptState(t *testing.T) {
+	api := NewServer(nil, ServerOptions{Access: &fakeAccess{}, Runs: &fakeRunResolver{err: apierrors.NewNotFound(schema.GroupResource{Group: "swe.dev", Resource: "runs"}, "run-1")}})
+	request := httptest.NewRequest(http.MethodPost, transcriptURL, strings.NewReader(`{"type":"output","data":{}}`))
+	request.Header.Set("Authorization", "Bearer producer")
+	response := httptest.NewRecorder()
+	api.Handler().ServeHTTP(response, request)
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusNotFound)
+	}
+	if len(api.store.events) != 0 || len(api.store.subscribers) != 0 {
+		t.Fatal("unknown run allocated transcript state")
+	}
+}
+
+func TestRecreatedRunUsesNewTranscriptIdentity(t *testing.T) {
+	resolver := &fakeRunResolver{uid: "run-uid-1"}
+	api := NewServer(nil, ServerOptions{Access: &fakeAccess{}, Runs: resolver})
+	appendEvent := func() {
+		request := httptest.NewRequest(http.MethodPost, transcriptURL, strings.NewReader(`{"type":"output","data":{}}`))
+		request.Header.Set("Authorization", "Bearer producer")
+		response := httptest.NewRecorder()
+		api.Handler().ServeHTTP(response, request)
+		if response.Code != http.StatusAccepted {
+			t.Fatalf("append status = %d, want %d", response.Code, http.StatusAccepted)
+		}
+	}
+	appendEvent()
+	resolver.uid = "run-uid-2"
+	appendEvent()
+	if len(api.store.events["project-1/run-uid-1"]) != 1 || len(api.store.events["project-1/run-uid-2"]) != 1 {
+		t.Fatalf("recreated Run transcripts were not isolated by UID: %+v", api.store.events)
+	}
+}
+
 func TestTranscriptStoreRemovesEmptySubscriberMap(t *testing.T) {
 	store := newTranscriptStore()
 	_, _, _, unsubscribe := store.subscribe("run-1", 0)
@@ -105,7 +195,13 @@ func TestTranscriptStoreRemovesEmptySubscriberMap(t *testing.T) {
 
 func postEvent(t *testing.T, baseURL, body string) {
 	t.Helper()
-	response, err := http.Post(baseURL+"/api/v1/runs/run-1/transcript", "application/json", strings.NewReader(body))
+	request, err := http.NewRequest(http.MethodPost, baseURL+transcriptURL, strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Authorization", "Bearer producer")
+	response, err := http.DefaultClient.Do(request)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,6 +210,44 @@ func postEvent(t *testing.T, baseURL, body string) {
 		message, _ := io.ReadAll(response.Body)
 		t.Fatalf("post status = %d, want %d: %s", response.StatusCode, http.StatusAccepted, message)
 	}
+}
+
+func newTestServer(access AccessController) *Server {
+	return NewServer(nil, ServerOptions{Access: access, Runs: &fakeRunResolver{}})
+}
+
+type fakeAccess struct {
+	mu    sync.Mutex
+	err   error
+	allow func(ResourceAccess) bool
+	calls []ResourceAccess
+}
+
+func (a *fakeAccess) Authorize(_ *http.Request, access ResourceAccess, _ bool) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.calls = append(a.calls, access)
+	if a.err != nil {
+		return a.err
+	}
+	if a.allow != nil && !a.allow(access) {
+		return errForbidden
+	}
+	return nil
+}
+
+type fakeRunResolver struct {
+	calls int
+	err   error
+	uid   types.UID
+}
+
+func (r *fakeRunResolver) ResolveRun(_ context.Context, _, name string) (types.UID, error) {
+	r.calls++
+	if r.uid != "" {
+		return r.uid, r.err
+	}
+	return types.UID(name + "-uid"), r.err
 }
 
 func nextLine(t *testing.T, lines <-chan string) string {

--- a/internal/controlplane/terminal.go
+++ b/internal/controlplane/terminal.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -24,7 +25,6 @@ import (
 )
 
 const (
-	defaultNamespace = "default"
 	sandboxdPort     = "50051"
 	wakeTimeout      = 2 * time.Minute
 	wakePollInterval = 250 * time.Millisecond
@@ -181,21 +181,29 @@ type terminalControl struct {
 var terminalUpgrader = websocket.Upgrader{
 	ReadBufferSize:  32 * 1024,
 	WriteBufferSize: 32 * 1024,
+	CheckOrigin:     func(*http.Request) bool { return true }, // checked before backend dial
 }
 
-func (s *Server) handleTerminal(w http.ResponseWriter, r *http.Request) {
-	environment, ok := terminalEnvironment(r.URL.Path)
-	if !ok {
-		http.NotFound(w, r)
+func (s *Server) handleTerminal(w http.ResponseWriter, r *http.Request, namespace, environment string) {
+	if s.access == nil {
+		writeAccessError(w, errUnauthenticated)
+		return
+	}
+	if err := s.access.Authorize(r, ResourceAccess{Namespace: namespace, Verb: "get", Resource: "environments", Subresource: "terminal", Name: environment}, true); err != nil {
+		writeAccessError(w, err)
+		return
+	}
+	if !websocket.IsWebSocketUpgrade(r) {
+		http.Error(w, "websocket upgrade is required", http.StatusBadRequest)
+		return
+	}
+	if !s.checkWebSocketOrigin(r) {
+		http.Error(w, "websocket origin is not allowed", http.StatusForbidden)
 		return
 	}
 	if s.terminalDialer == nil {
 		http.Error(w, "terminal gateway is unavailable", http.StatusServiceUnavailable)
 		return
-	}
-	namespace := r.URL.Query().Get("namespace")
-	if namespace == "" {
-		namespace = defaultNamespace
 	}
 
 	terminal, closer, err := s.terminalDialer.DialTerminal(r.Context(), namespace, environment)
@@ -217,13 +225,36 @@ func (s *Server) handleTerminal(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func terminalEnvironment(path string) (string, bool) {
-	remainder := strings.TrimPrefix(path, terminalPathPrefix)
-	if remainder == path || !strings.HasSuffix(remainder, "/terminal") {
-		return "", false
+func (s *Server) checkWebSocketOrigin(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		_, _, err := requestToken(r, false)
+		return err == nil
 	}
-	environment := strings.TrimSuffix(remainder, "/terminal")
-	return environment, environment != "" && !strings.Contains(environment, "/")
+	parsed, err := url.Parse(origin)
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return false
+	}
+	host := r.Host
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	if s.trustProxy {
+		forwardedHost := r.Header.Get("X-Forwarded-Host")
+		forwardedProto := r.Header.Get("X-Forwarded-Proto")
+		if forwardedHost != "" || forwardedProto != "" {
+			if forwardedHost == "" || forwardedProto == "" || strings.Contains(forwardedHost, ",") || strings.Contains(forwardedProto, ",") {
+				return false
+			}
+			host = strings.TrimSpace(forwardedHost)
+			scheme = strings.ToLower(strings.TrimSpace(forwardedProto))
+			if scheme != "http" && scheme != "https" {
+				return false
+			}
+		}
+	}
+	return parsed.Scheme == scheme && strings.EqualFold(parsed.Host, host)
 }
 
 func bridgeWebTerminal(ctx context.Context, connection *websocket.Conn, client sandboxdv1.TerminalServiceClient) error {

--- a/internal/controlplane/terminal_test.go
+++ b/internal/controlplane/terminal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
@@ -39,11 +40,12 @@ func TestWebTerminalBridgesSandboxd(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = connection.Close() })
 	dialer := &terminalTestDialer{client: sandboxdv1.NewTerminalServiceClient(connection)}
-	server := httptest.NewServer(NewServer(nil, dialer).Handler())
+	server := httptest.NewServer(NewServer(nil, ServerOptions{Access: &fakeAccess{}, TerminalDialer: dialer}).Handler())
 	t.Cleanup(server.Close)
 
-	websocketURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/v1/environments/env-1/terminal?namespace=project-1"
-	websocketConnection, _, err := websocket.DefaultDialer.Dial(websocketURL, nil)
+	websocketURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/v1/namespaces/project-1/environments/env-1/terminal"
+	header := http.Header{"Authorization": []string{"Bearer reader"}}
+	websocketConnection, _, err := websocket.DefaultDialer.Dial(websocketURL, header)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,9 +84,10 @@ func TestWebTerminalBridgesSandboxd(t *testing.T) {
 }
 
 func TestWebTerminalRequiresDialer(t *testing.T) {
-	request := httptest.NewRequest("GET", "/api/v1/environments/env-1/terminal", nil)
+	request := httptest.NewRequest("GET", "/api/v1/namespaces/project-1/environments/env-1/terminal", nil)
+	setWebSocketUpgrade(request)
 	response := httptest.NewRecorder()
-	NewServer(nil).Handler().ServeHTTP(response, request)
+	NewServer(nil, ServerOptions{Access: &fakeAccess{}}).Handler().ServeHTTP(response, request)
 	if response.Code != 503 {
 		t.Fatalf("status = %d, want 503", response.Code)
 	}
@@ -115,15 +118,105 @@ func TestKubernetesTerminalDialerMarksEnvironmentActive(t *testing.T) {
 	}
 }
 
+func TestWebTerminalAuthorizesBeforeDial(t *testing.T) {
+	dialer := &terminalTestDialer{}
+	handler := NewServer(nil, ServerOptions{Access: &fakeAccess{err: errUnauthenticated}, TerminalDialer: dialer}).Handler()
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/project-a/environments/shared/terminal?namespace=project-b", nil)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusUnauthorized)
+	}
+	if dialer.calls != 0 {
+		t.Fatalf("terminal dialed %d times before authorization", dialer.calls)
+	}
+}
+
+func TestWebTerminalSameNamedEnvironmentCannotCrossNamespace(t *testing.T) {
+	dialer := &terminalTestDialer{}
+	access := &fakeAccess{allow: func(resource ResourceAccess) bool { return resource.Namespace == "project-a" }}
+	handler := NewServer(nil, ServerOptions{Access: access, TerminalDialer: dialer}).Handler()
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/project-b/environments/shared/terminal", nil)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusForbidden)
+	}
+	if dialer.calls != 0 {
+		t.Fatal("cross-namespace terminal request reached dialer")
+	}
+}
+
+func TestWebSocketOriginPolicy(t *testing.T) {
+	tests := []struct {
+		name           string
+		host           string
+		origin         string
+		forwardedHost  string
+		forwardedProto string
+		trustProxy     bool
+		want           bool
+	}{
+		{name: "non-browser bearer client", host: "control.internal", want: true},
+		{name: "same origin", host: "console.example.com", origin: "http://console.example.com", want: true},
+		{name: "scheme mismatch", host: "console.example.com", origin: "https://console.example.com", want: false},
+		{name: "cross origin", host: "console.example.com", origin: "http://evil.example.com", want: false},
+		{name: "same origin behind trusted proxy", host: "control.internal", origin: "https://console.example.com", forwardedHost: "console.example.com", forwardedProto: "https", trustProxy: true, want: true},
+		{name: "forwarded headers ignored by default", host: "control.internal", origin: "https://console.example.com", forwardedHost: "console.example.com", forwardedProto: "https", want: false},
+		{name: "cross origin behind proxy", host: "control.internal", origin: "https://evil.example.com", forwardedHost: "console.example.com", forwardedProto: "https", trustProxy: true, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, "http://"+tt.host+"/terminal", nil)
+			request.Header.Set("Authorization", "Bearer reader")
+			request.Header.Set("Origin", tt.origin)
+			request.Header.Set("X-Forwarded-Host", tt.forwardedHost)
+			request.Header.Set("X-Forwarded-Proto", tt.forwardedProto)
+			server := &Server{trustProxy: tt.trustProxy}
+			if got := server.checkWebSocketOrigin(request); got != tt.want {
+				t.Fatalf("checkWebSocketOrigin() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWebTerminalRejectsCookieWithoutOriginAndCrossOriginBeforeDial(t *testing.T) {
+	for _, origin := range []string{"", "https://evil.example.com"} {
+		dialer := &terminalTestDialer{}
+		handler := NewServer(nil, ServerOptions{Access: &fakeAccess{}, TerminalDialer: dialer}).Handler()
+		request := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/project-a/environments/env-1/terminal", nil)
+		setWebSocketUpgrade(request)
+		request.Header.Del("Authorization")
+		request.Header.Set("Origin", origin)
+		request.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "reader-session"})
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, request)
+		if response.Code != http.StatusForbidden {
+			t.Fatalf("origin %q status = %d, want %d", origin, response.Code, http.StatusForbidden)
+		}
+		if dialer.calls != 0 {
+			t.Fatalf("origin %q reached terminal dialer", origin)
+		}
+	}
+}
+
+func setWebSocketUpgrade(request *http.Request) {
+	request.Header.Set("Authorization", "Bearer reader")
+	request.Header.Set("Connection", "upgrade")
+	request.Header.Set("Upgrade", "websocket")
+}
+
 type terminalTestDialer struct {
 	mu          sync.Mutex
 	client      sandboxdv1.TerminalServiceClient
 	namespace   string
 	environment string
+	calls       int
 }
 
 func (d *terminalTestDialer) DialTerminal(_ context.Context, namespace, environment string) (sandboxdv1.TerminalServiceClient, io.Closer, error) {
 	d.mu.Lock()
+	d.calls++
 	d.namespace = namespace
 	d.environment = environment
 	d.mu.Unlock()


### PR DESCRIPTION
Closes #1.

## Security model

The control plane now has one authorization boundary for terminal and transcript access:

- callers authenticate with an audience-bound (`swe-platform` by default) Kubernetes bearer token via `TokenReview`;
- browser readers may use a `swe-platform-session` cookie issued by a trusted authentication proxy, while transcript producers must use an explicit bearer credential;
- every request receives an exact `SubjectAccessReview` for API group/version, namespace, resource, subresource, resource name, and verb before backend work starts;
- transcript reads use `get runs/transcript`, transcript producers use `update runs/transcript`, and terminal users use `get environments/terminal`, allowing namespace- and `resourceNames`-scoped RBAC;
- namespaced URLs replace the caller-authoritative `?namespace=` parameter, Runs must exist, and in-memory transcript state is keyed by namespace plus Run UID;
- WebSockets require a valid upgrade and same-origin scheme/host/port before sandboxd dialing. Forwarded origin headers are ignored unless trusted-proxy mode is explicitly enabled, and no-Origin clients require a bearer credential.

The full authenticated user identity (username, UID, groups, and extra fields) is propagated from TokenReview into SubjectAccessReview. Authentication/authorization service failures fail closed.

## Bootstrap authentication

Self-hosted installs may reference an existing Secret with `controlPlane.auth.bootstrapTokenSecret.name`. Its token must contain at least 32 characters, is accepted only through `Authorization: Bearer`, and intentionally has administrator-equivalent access without Kubernetes RBAC. It is disabled by default and documented as a temporary bootstrap mechanism to remove after Roles/RoleBindings are configured. The chart also exposes token audience and explicit trusted-proxy configuration.

## Acceptance criteria addressed

- [x] Anonymous terminal and transcript GET/POST requests return 401.
- [x] Exact namespaced SARs prevent a principal for namespace/project A from reaching same-named resources in B.
- [x] Run-scoped producer RBAC permits append to Run A and returns 403 for Run B.
- [x] Unknown Runs return 404 before transcript state is allocated.
- [x] Namespace is part of the authorized resource identity; the old query parameter is no longer authoritative.
- [x] Browser session, same-origin, cross-origin, scheme, no-Origin bearer, and opt-in trusted-proxy behavior are documented and tested.
- [x] Tests prove authorization and WebSocket checks occur before terminal dialing, transcript subscription, or event append.
- [x] Kubernetes-native and optional bootstrap authentication modes are documented for self-hosted installs.
- [x] Adapter transcript data remains opaque JSON.

## Validation

Passed locally in the Amp orb:

- `make test` — root and sandboxd module tests passed.
- `make vet` — root and sandboxd vet passed.
- `make build` — operator, control-plane, CLI, and sandboxd built successfully.
- `go test -race ./internal/controlplane` — passed.
- `helm lint charts/swe-platform` — 1 chart linted, 0 failed (informational icon recommendation only).
- Helm lint and template for `values-kind.yaml`, `values-k3s.yaml`, `values-gke.yaml`, and `values-eks.yaml` — all passed.
- Helm template with `controlPlane.auth.bootstrapTokenSecret.name=bootstrap` — passed and rendered the Secret reference.
- `make check-chart-crds` — passed.
- `bash -n .agents/setup hack/e2e.sh` — passed.
- `git diff --check` — passed.

`./hack/e2e.sh` was not executed in the orb because Docker, kind, and kubectl are unavailable. The acceptance script now provisions a real audience-scoped ServiceAccount token, Role, and RoleBinding and asserts anonymous 401, Run A append 202, Run B append 403, and unknown Run 404; the repository e2e workflow will execute it.

## Main files changed

- `internal/controlplane/auth.go`, `server.go`, `terminal.go` and tests
- `cmd/control-plane/main.go`
- `charts/swe-platform/{values.yaml,templates/*,README.md}`
- `hack/e2e.sh`
- root `README.md`
- `.agents/setup` and `AGENTS.md` for the previously missing orb Go/Helm toolchain

## Remaining risks

- RBAC `resourceNames` is name-based, so deleting and recreating a Run under the same name requires rotating/removing the old producer binding; transcript history itself is UID-isolated.
- Token/RBAC revocation is checked when an SSE/WebSocket connection opens and does not terminate an already-open connection.
- Existing sandboxd network transport hardening is outside this issue; this change prevents the control plane from acting as an unauthenticated deputy.
