### PR TITLE
Redesign sandboxd workspace filesystem API

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,9 +16,9 @@ jobs:
         with:
           go-version: "1.26"
           cache-dependency-path: sandboxd/go.sum
-      - name: Test Windows process containment
+      - name: Test Windows process containment and portable filesystem
         working-directory: sandboxd
-        run: go test ./internal/server -run "^(TestProcessDomainAssignsLeaderToJob|TestProcessServiceForceContainsDescendant|TestExecExplicitAndCloseSendEOFStillPublishOutputAndExit)$" -count=1
+        run: go test ./internal/server -run "^(TestProcessDomainAssignsLeaderToJob|TestProcessServiceForceContainsDescendant|TestExecExplicitAndCloseSendEOFStillPublishOutputAndExit|TestFilesystem.*)$" -count=1
 
   build-test:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,8 +63,8 @@ runs both via `make` targets:
 
 - **Build all binaries:** `make build` (outputs operator, control plane, CLI, and sandboxd to `bin/`, gitignored)
 - **Unit tests:** `make test` · **Vet:** `make vet`
-- **Windows containment:** CI runs focused sandboxd process and Exec tests on
-  `windows-latest`; keep OS-specific tests behind build tags.
+- **Windows portability:** CI runs focused sandboxd process, Exec, and filesystem tests
+  on `windows-latest`; keep OS-specific tests behind build tags.
 - **Regenerate deepcopy:** `make generate` · **CRDs + RBAC:** `make manifests`
   (`manifests` synchronizes chart CRDs; CI fails on a diff). Use `make check-chart-crds`
   to verify the checked-in Helm CRDs independently.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ connection-bound `Exec` supports explicit stdin EOF but is not retry-safe; keyed
 epoch-scoped `ProcessService` provides duplicate-safe launch, portable tree controls,
 timeouts, opaque execution identity, and bounded cursor output with observable loss.
 It supports both foreground agent processes and reconnectable long-lived services.
+The workspace-only filesystem contract in
+[`FILESYSTEM.md`](sandboxd/proto/sandboxd/v1/FILESYSTEM.md) uses portable logical paths,
+race-safe workspace-confined traversal, ranged reads, atomic streamed writes with SHA-256
+preconditions, portable metadata, and paginated listings.
 
 Run states are observable milestones: `Allocating`, `EnvironmentReady`,
 `AdapterAccepted`, `Running`, `NeedsInput`, `Paused`, and terminal `Succeeded`, `Failed`,

--- a/sandboxd/cmd/sandboxd/main.go
+++ b/sandboxd/cmd/sandboxd/main.go
@@ -69,7 +69,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("open workspace filesystem: %v", err)
 	}
-	defer filesystemServer.Close()
 	grpcServer := grpc.NewServer(
 		grpc.Creds(credentials.NewTLS(&tls.Config{
 			Certificates: []tls.Certificate{certificate},
@@ -88,22 +87,43 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
+	shutdownDone := make(chan struct{})
 	go func() {
 		<-ctx.Done()
+		defer close(shutdownDone)
 		log.Println("shutting down")
+		filesystemServer.BeginShutdown()
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
 		if err := processServer.CloseContext(shutdownCtx); err != nil {
 			log.Printf("sandboxd shutdown fencing failed: %v", err)
-			grpcServer.Stop()
-			return
 		}
-		grpcServer.GracefulStop()
+		cancel()
+		gracefulDone := make(chan struct{})
+		go func() {
+			grpcServer.GracefulStop()
+			close(gracefulDone)
+		}()
+		select {
+		case <-gracefulDone:
+		case <-time.After(10 * time.Second):
+			log.Println("gRPC graceful shutdown timed out; canceling active RPCs")
+			grpcServer.Stop()
+		}
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		if err := filesystemServer.CloseContext(cleanupCtx); err != nil {
+			log.Printf("filesystem shutdown cleanup failed: %v", err)
+		}
+		cleanupCancel()
 	}()
 
 	log.Printf("sandboxd %s listening on %s (workspace %s)", Version, *addr, *workspace)
 	if err := grpcServer.Serve(lis); err != nil {
 		log.Fatalf("serve: %v", err)
+	}
+	if ctx.Err() != nil {
+		<-shutdownDone
+	} else if err := filesystemServer.Close(); err != nil {
+		log.Printf("close filesystem: %v", err)
 	}
 }
 

--- a/sandboxd/cmd/sandboxd/main.go
+++ b/sandboxd/cmd/sandboxd/main.go
@@ -65,6 +65,11 @@ func main() {
 
 	supervisor := server.NewSupervisor()
 	processServer := server.NewProcessServer(*workspace, supervisor)
+	filesystemServer, err := server.NewFilesystemServer(*workspace)
+	if err != nil {
+		log.Fatalf("open workspace filesystem: %v", err)
+	}
+	defer filesystemServer.Close()
 	grpcServer := grpc.NewServer(
 		grpc.Creds(credentials.NewTLS(&tls.Config{
 			Certificates: []tls.Certificate{certificate},
@@ -76,7 +81,7 @@ func main() {
 	sandboxdv1.RegisterHealthServiceServer(grpcServer, &server.HealthServer{Version: Version})
 	sandboxdv1.RegisterExecServiceServer(grpcServer, server.NewExecServer(*workspace, supervisor))
 	sandboxdv1.RegisterProcessServiceServer(grpcServer, processServer)
-	sandboxdv1.RegisterFilesystemServiceServer(grpcServer, &server.FilesystemServer{Workspace: *workspace})
+	sandboxdv1.RegisterFilesystemServiceServer(grpcServer, filesystemServer)
 	sandboxdv1.RegisterTerminalServiceServer(grpcServer, &server.TerminalServer{Workspace: *workspace})
 	sandboxdv1.RegisterPortServiceServer(grpcServer, server.NewPortServer())
 

--- a/sandboxd/gen/proto/sandboxd/v1/sandboxd.pb.go
+++ b/sandboxd/gen/proto/sandboxd/v1/sandboxd.pb.go
@@ -351,6 +351,113 @@ func (ProcessState) EnumDescriptor() ([]byte, []int) {
 	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{5}
 }
 
+type WritePrecondition int32
+
+const (
+	WritePrecondition_WRITE_PRECONDITION_UNSPECIFIED    WritePrecondition = 0
+	WritePrecondition_WRITE_PRECONDITION_ANY            WritePrecondition = 1
+	WritePrecondition_WRITE_PRECONDITION_MUST_NOT_EXIST WritePrecondition = 2
+	WritePrecondition_WRITE_PRECONDITION_MATCH_VERSION  WritePrecondition = 3
+)
+
+// Enum value maps for WritePrecondition.
+var (
+	WritePrecondition_name = map[int32]string{
+		0: "WRITE_PRECONDITION_UNSPECIFIED",
+		1: "WRITE_PRECONDITION_ANY",
+		2: "WRITE_PRECONDITION_MUST_NOT_EXIST",
+		3: "WRITE_PRECONDITION_MATCH_VERSION",
+	}
+	WritePrecondition_value = map[string]int32{
+		"WRITE_PRECONDITION_UNSPECIFIED":    0,
+		"WRITE_PRECONDITION_ANY":            1,
+		"WRITE_PRECONDITION_MUST_NOT_EXIST": 2,
+		"WRITE_PRECONDITION_MATCH_VERSION":  3,
+	}
+)
+
+func (x WritePrecondition) Enum() *WritePrecondition {
+	p := new(WritePrecondition)
+	*p = x
+	return p
+}
+
+func (x WritePrecondition) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (WritePrecondition) Descriptor() protoreflect.EnumDescriptor {
+	return file_proto_sandboxd_v1_sandboxd_proto_enumTypes[6].Descriptor()
+}
+
+func (WritePrecondition) Type() protoreflect.EnumType {
+	return &file_proto_sandboxd_v1_sandboxd_proto_enumTypes[6]
+}
+
+func (x WritePrecondition) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use WritePrecondition.Descriptor instead.
+func (WritePrecondition) EnumDescriptor() ([]byte, []int) {
+	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{6}
+}
+
+type EntryType int32
+
+const (
+	EntryType_ENTRY_TYPE_UNSPECIFIED EntryType = 0
+	EntryType_ENTRY_TYPE_FILE        EntryType = 1
+	EntryType_ENTRY_TYPE_DIRECTORY   EntryType = 2
+	EntryType_ENTRY_TYPE_SYMLINK     EntryType = 3
+	EntryType_ENTRY_TYPE_OTHER       EntryType = 4
+)
+
+// Enum value maps for EntryType.
+var (
+	EntryType_name = map[int32]string{
+		0: "ENTRY_TYPE_UNSPECIFIED",
+		1: "ENTRY_TYPE_FILE",
+		2: "ENTRY_TYPE_DIRECTORY",
+		3: "ENTRY_TYPE_SYMLINK",
+		4: "ENTRY_TYPE_OTHER",
+	}
+	EntryType_value = map[string]int32{
+		"ENTRY_TYPE_UNSPECIFIED": 0,
+		"ENTRY_TYPE_FILE":        1,
+		"ENTRY_TYPE_DIRECTORY":   2,
+		"ENTRY_TYPE_SYMLINK":     3,
+		"ENTRY_TYPE_OTHER":       4,
+	}
+)
+
+func (x EntryType) Enum() *EntryType {
+	p := new(EntryType)
+	*p = x
+	return p
+}
+
+func (x EntryType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (EntryType) Descriptor() protoreflect.EnumDescriptor {
+	return file_proto_sandboxd_v1_sandboxd_proto_enumTypes[7].Descriptor()
+}
+
+func (EntryType) Type() protoreflect.EnumType {
+	return &file_proto_sandboxd_v1_sandboxd_proto_enumTypes[7]
+}
+
+func (x EntryType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use EntryType.Descriptor instead.
+func (EntryType) EnumDescriptor() ([]byte, []int) {
+	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{7}
+}
+
 type ExecRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Kind:
@@ -1403,10 +1510,15 @@ func (x *ReadOutputResponse) GetProducedEnd() uint64 {
 }
 
 type ReadRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Path          string                 `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	Path     string                 `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
+	Offset   uint64                 `protobuf:"varint,2,opt,name=offset,proto3" json:"offset,omitempty"`
+	MaxBytes uint32                 `protobuf:"varint,3,opt,name=max_bytes,json=maxBytes,proto3" json:"max_bytes,omitempty"`
+	// include_version requests a complete-file SHA-256 scan. Clients normally
+	// request it once, then page content without repeatedly hashing the file.
+	IncludeVersion bool `protobuf:"varint,4,opt,name=include_version,json=includeVersion,proto3" json:"include_version,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *ReadRequest) Reset() {
@@ -1446,9 +1558,37 @@ func (x *ReadRequest) GetPath() string {
 	return ""
 }
 
+func (x *ReadRequest) GetOffset() uint64 {
+	if x != nil {
+		return x.Offset
+	}
+	return 0
+}
+
+func (x *ReadRequest) GetMaxBytes() uint32 {
+	if x != nil {
+		return x.MaxBytes
+	}
+	return 0
+}
+
+func (x *ReadRequest) GetIncludeVersion() bool {
+	if x != nil {
+		return x.IncludeVersion
+	}
+	return false
+}
+
 type ReadResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Content       []byte                 `protobuf:"bytes,1,opt,name=content,proto3" json:"content,omitempty"`
+	state      protoimpl.MessageState `protogen:"open.v1"`
+	Data       []byte                 `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
+	Offset     uint64                 `protobuf:"varint,2,opt,name=offset,proto3" json:"offset,omitempty"`
+	NextOffset uint64                 `protobuf:"varint,3,opt,name=next_offset,json=nextOffset,proto3" json:"next_offset,omitempty"`
+	Size       uint64                 `protobuf:"varint,4,opt,name=size,proto3" json:"size,omitempty"`
+	Eof        bool                   `protobuf:"varint,5,opt,name=eof,proto3" json:"eof,omitempty"`
+	// version is the lowercase SHA-256 digest of the complete file when
+	// include_version was requested; otherwise it is empty.
+	Version       string `protobuf:"bytes,6,opt,name=version,proto3" json:"version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1483,19 +1623,55 @@ func (*ReadResponse) Descriptor() ([]byte, []int) {
 	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{16}
 }
 
-func (x *ReadResponse) GetContent() []byte {
+func (x *ReadResponse) GetData() []byte {
 	if x != nil {
-		return x.Content
+		return x.Data
 	}
 	return nil
 }
 
+func (x *ReadResponse) GetOffset() uint64 {
+	if x != nil {
+		return x.Offset
+	}
+	return 0
+}
+
+func (x *ReadResponse) GetNextOffset() uint64 {
+	if x != nil {
+		return x.NextOffset
+	}
+	return 0
+}
+
+func (x *ReadResponse) GetSize() uint64 {
+	if x != nil {
+		return x.Size
+	}
+	return 0
+}
+
+func (x *ReadResponse) GetEof() bool {
+	if x != nil {
+		return x.Eof
+	}
+	return false
+}
+
+func (x *ReadResponse) GetVersion() string {
+	if x != nil {
+		return x.Version
+	}
+	return ""
+}
+
 type WriteRequest struct {
-	state   protoimpl.MessageState `protogen:"open.v1"`
-	Path    string                 `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
-	Content []byte                 `protobuf:"bytes,2,opt,name=content,proto3" json:"content,omitempty"`
-	// mode is the file permission bits (e.g. 0o644); 0 means default.
-	Mode          uint32 `protobuf:"varint,3,opt,name=mode,proto3" json:"mode,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Kind:
+	//
+	//	*WriteRequest_Header
+	//	*WriteRequest_Data
+	Kind          isWriteRequest_Kind `protobuf_oneof:"kind"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1530,36 +1706,120 @@ func (*WriteRequest) Descriptor() ([]byte, []int) {
 	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{17}
 }
 
-func (x *WriteRequest) GetPath() string {
+func (x *WriteRequest) GetKind() isWriteRequest_Kind {
+	if x != nil {
+		return x.Kind
+	}
+	return nil
+}
+
+func (x *WriteRequest) GetHeader() *WriteHeader {
+	if x != nil {
+		if x, ok := x.Kind.(*WriteRequest_Header); ok {
+			return x.Header
+		}
+	}
+	return nil
+}
+
+func (x *WriteRequest) GetData() []byte {
+	if x != nil {
+		if x, ok := x.Kind.(*WriteRequest_Data); ok {
+			return x.Data
+		}
+	}
+	return nil
+}
+
+type isWriteRequest_Kind interface {
+	isWriteRequest_Kind()
+}
+
+type WriteRequest_Header struct {
+	Header *WriteHeader `protobuf:"bytes,1,opt,name=header,proto3,oneof"`
+}
+
+type WriteRequest_Data struct {
+	Data []byte `protobuf:"bytes,2,opt,name=data,proto3,oneof"`
+}
+
+func (*WriteRequest_Header) isWriteRequest_Kind() {}
+
+func (*WriteRequest_Data) isWriteRequest_Kind() {}
+
+type WriteHeader struct {
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	Path         string                 `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
+	Precondition WritePrecondition      `protobuf:"varint,2,opt,name=precondition,proto3,enum=sandboxd.v1.WritePrecondition" json:"precondition,omitempty"`
+	// expected_version is required for MATCH_VERSION and is a lowercase
+	// SHA-256 digest returned by Read or a prior Write.
+	ExpectedVersion string `protobuf:"bytes,3,opt,name=expected_version,json=expectedVersion,proto3" json:"expected_version,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *WriteHeader) Reset() {
+	*x = WriteHeader{}
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WriteHeader) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WriteHeader) ProtoMessage() {}
+
+func (x *WriteHeader) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WriteHeader.ProtoReflect.Descriptor instead.
+func (*WriteHeader) Descriptor() ([]byte, []int) {
+	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *WriteHeader) GetPath() string {
 	if x != nil {
 		return x.Path
 	}
 	return ""
 }
 
-func (x *WriteRequest) GetContent() []byte {
+func (x *WriteHeader) GetPrecondition() WritePrecondition {
 	if x != nil {
-		return x.Content
+		return x.Precondition
 	}
-	return nil
+	return WritePrecondition_WRITE_PRECONDITION_UNSPECIFIED
 }
 
-func (x *WriteRequest) GetMode() uint32 {
+func (x *WriteHeader) GetExpectedVersion() string {
 	if x != nil {
-		return x.Mode
+		return x.ExpectedVersion
 	}
-	return 0
+	return ""
 }
 
 type WriteResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
+	Size          uint64                 `protobuf:"varint,1,opt,name=size,proto3" json:"size,omitempty"`
+	Version       string                 `protobuf:"bytes,2,opt,name=version,proto3" json:"version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *WriteResponse) Reset() {
 	*x = WriteResponse{}
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[18]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1571,7 +1831,7 @@ func (x *WriteResponse) String() string {
 func (*WriteResponse) ProtoMessage() {}
 
 func (x *WriteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[18]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1584,19 +1844,35 @@ func (x *WriteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteResponse.ProtoReflect.Descriptor instead.
 func (*WriteResponse) Descriptor() ([]byte, []int) {
-	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{18}
+	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *WriteResponse) GetSize() uint64 {
+	if x != nil {
+		return x.Size
+	}
+	return 0
+}
+
+func (x *WriteResponse) GetVersion() string {
+	if x != nil {
+		return x.Version
+	}
+	return ""
 }
 
 type ListRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Path          string                 `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
+	PageSize      uint32                 `protobuf:"varint,2,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	PageToken     string                 `protobuf:"bytes,3,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ListRequest) Reset() {
 	*x = ListRequest{}
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[19]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1608,7 +1884,7 @@ func (x *ListRequest) String() string {
 func (*ListRequest) ProtoMessage() {}
 
 func (x *ListRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[19]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1621,7 +1897,7 @@ func (x *ListRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListRequest.ProtoReflect.Descriptor instead.
 func (*ListRequest) Descriptor() ([]byte, []int) {
-	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{19}
+	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ListRequest) GetPath() string {
@@ -1631,16 +1907,31 @@ func (x *ListRequest) GetPath() string {
 	return ""
 }
 
+func (x *ListRequest) GetPageSize() uint32 {
+	if x != nil {
+		return x.PageSize
+	}
+	return 0
+}
+
+func (x *ListRequest) GetPageToken() string {
+	if x != nil {
+		return x.PageToken
+	}
+	return ""
+}
+
 type ListResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Entries       []*Entry               `protobuf:"bytes,1,rep,name=entries,proto3" json:"entries,omitempty"`
+	NextPageToken string                 `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ListResponse) Reset() {
 	*x = ListResponse{}
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[20]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1652,7 +1943,7 @@ func (x *ListResponse) String() string {
 func (*ListResponse) ProtoMessage() {}
 
 func (x *ListResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[20]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1665,7 +1956,7 @@ func (x *ListResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListResponse.ProtoReflect.Descriptor instead.
 func (*ListResponse) Descriptor() ([]byte, []int) {
-	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{20}
+	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ListResponse) GetEntries() []*Entry {
@@ -1675,18 +1966,27 @@ func (x *ListResponse) GetEntries() []*Entry {
 	return nil
 }
 
+func (x *ListResponse) GetNextPageToken() string {
+	if x != nil {
+		return x.NextPageToken
+	}
+	return ""
+}
+
 type Entry struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	IsDir         bool                   `protobuf:"varint,2,opt,name=is_dir,json=isDir,proto3" json:"is_dir,omitempty"`
-	Size          int64                  `protobuf:"varint,3,opt,name=size,proto3" json:"size,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Name  string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Type  EntryType              `protobuf:"varint,2,opt,name=type,proto3,enum=sandboxd.v1.EntryType" json:"type,omitempty"`
+	// size is the regular-file byte size and zero for other entry types.
+	Size           uint64 `protobuf:"varint,3,opt,name=size,proto3" json:"size,omitempty"`
+	ModifiedUnixMs int64  `protobuf:"varint,4,opt,name=modified_unix_ms,json=modifiedUnixMs,proto3" json:"modified_unix_ms,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *Entry) Reset() {
 	*x = Entry{}
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[21]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1698,7 +1998,7 @@ func (x *Entry) String() string {
 func (*Entry) ProtoMessage() {}
 
 func (x *Entry) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[21]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1711,7 +2011,7 @@ func (x *Entry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Entry.ProtoReflect.Descriptor instead.
 func (*Entry) Descriptor() ([]byte, []int) {
-	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{21}
+	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *Entry) GetName() string {
@@ -1721,16 +2021,23 @@ func (x *Entry) GetName() string {
 	return ""
 }
 
-func (x *Entry) GetIsDir() bool {
+func (x *Entry) GetType() EntryType {
 	if x != nil {
-		return x.IsDir
+		return x.Type
 	}
-	return false
+	return EntryType_ENTRY_TYPE_UNSPECIFIED
 }
 
-func (x *Entry) GetSize() int64 {
+func (x *Entry) GetSize() uint64 {
 	if x != nil {
 		return x.Size
+	}
+	return 0
+}
+
+func (x *Entry) GetModifiedUnixMs() int64 {
+	if x != nil {
+		return x.ModifiedUnixMs
 	}
 	return 0
 }
@@ -1749,7 +2056,7 @@ type TerminalMessage struct {
 
 func (x *TerminalMessage) Reset() {
 	*x = TerminalMessage{}
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[22]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1761,7 +2068,7 @@ func (x *TerminalMessage) String() string {
 func (*TerminalMessage) ProtoMessage() {}
 
 func (x *TerminalMessage) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[22]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1774,7 +2081,7 @@ func (x *TerminalMessage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TerminalMessage.ProtoReflect.Descriptor instead.
 func (*TerminalMessage) Descriptor() ([]byte, []int) {
-	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{22}
+	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *TerminalMessage) GetKind() isTerminalMessage_Kind {
@@ -1843,7 +2150,7 @@ type TerminalOpen struct {
 
 func (x *TerminalOpen) Reset() {
 	*x = TerminalOpen{}
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[23]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1855,7 +2162,7 @@ func (x *TerminalOpen) String() string {
 func (*TerminalOpen) ProtoMessage() {}
 
 func (x *TerminalOpen) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[23]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1868,7 +2175,7 @@ func (x *TerminalOpen) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TerminalOpen.ProtoReflect.Descriptor instead.
 func (*TerminalOpen) Descriptor() ([]byte, []int) {
-	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{23}
+	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *TerminalOpen) GetCols() uint32 {
@@ -1895,7 +2202,7 @@ type TerminalResize struct {
 
 func (x *TerminalResize) Reset() {
 	*x = TerminalResize{}
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[24]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1907,7 +2214,7 @@ func (x *TerminalResize) String() string {
 func (*TerminalResize) ProtoMessage() {}
 
 func (x *TerminalResize) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[24]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1920,7 +2227,7 @@ func (x *TerminalResize) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TerminalResize.ProtoReflect.Descriptor instead.
 func (*TerminalResize) Descriptor() ([]byte, []int) {
-	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{24}
+	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *TerminalResize) GetCols() uint32 {
@@ -1948,7 +2255,7 @@ type RegisterPortRequest struct {
 
 func (x *RegisterPortRequest) Reset() {
 	*x = RegisterPortRequest{}
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[25]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1960,7 +2267,7 @@ func (x *RegisterPortRequest) String() string {
 func (*RegisterPortRequest) ProtoMessage() {}
 
 func (x *RegisterPortRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[25]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1973,7 +2280,7 @@ func (x *RegisterPortRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RegisterPortRequest.ProtoReflect.Descriptor instead.
 func (*RegisterPortRequest) Descriptor() ([]byte, []int) {
-	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{25}
+	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *RegisterPortRequest) GetPort() uint32 {
@@ -2002,7 +2309,7 @@ type Port struct {
 
 func (x *Port) Reset() {
 	*x = Port{}
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[26]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2014,7 +2321,7 @@ func (x *Port) String() string {
 func (*Port) ProtoMessage() {}
 
 func (x *Port) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[26]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2027,7 +2334,7 @@ func (x *Port) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Port.ProtoReflect.Descriptor instead.
 func (*Port) Descriptor() ([]byte, []int) {
-	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{26}
+	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *Port) GetPort() uint32 {
@@ -2059,7 +2366,7 @@ type ListPortsRequest struct {
 
 func (x *ListPortsRequest) Reset() {
 	*x = ListPortsRequest{}
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[27]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2071,7 +2378,7 @@ func (x *ListPortsRequest) String() string {
 func (*ListPortsRequest) ProtoMessage() {}
 
 func (x *ListPortsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[27]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2084,7 +2391,7 @@ func (x *ListPortsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListPortsRequest.ProtoReflect.Descriptor instead.
 func (*ListPortsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{27}
+	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{28}
 }
 
 type ListPortsResponse struct {
@@ -2096,7 +2403,7 @@ type ListPortsResponse struct {
 
 func (x *ListPortsResponse) Reset() {
 	*x = ListPortsResponse{}
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[28]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2108,7 +2415,7 @@ func (x *ListPortsResponse) String() string {
 func (*ListPortsResponse) ProtoMessage() {}
 
 func (x *ListPortsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[28]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2121,7 +2428,7 @@ func (x *ListPortsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListPortsResponse.ProtoReflect.Descriptor instead.
 func (*ListPortsResponse) Descriptor() ([]byte, []int) {
-	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{28}
+	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *ListPortsResponse) GetPorts() []*Port {
@@ -2139,7 +2446,7 @@ type HealthCheckRequest struct {
 
 func (x *HealthCheckRequest) Reset() {
 	*x = HealthCheckRequest{}
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[29]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2151,7 +2458,7 @@ func (x *HealthCheckRequest) String() string {
 func (*HealthCheckRequest) ProtoMessage() {}
 
 func (x *HealthCheckRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[29]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2164,7 +2471,7 @@ func (x *HealthCheckRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthCheckRequest.ProtoReflect.Descriptor instead.
 func (*HealthCheckRequest) Descriptor() ([]byte, []int) {
-	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{29}
+	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{30}
 }
 
 type HealthCheckResponse struct {
@@ -2177,7 +2484,7 @@ type HealthCheckResponse struct {
 
 func (x *HealthCheckResponse) Reset() {
 	*x = HealthCheckResponse{}
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[30]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2189,7 +2496,7 @@ func (x *HealthCheckResponse) String() string {
 func (*HealthCheckResponse) ProtoMessage() {}
 
 func (x *HealthCheckResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[30]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2202,7 +2509,7 @@ func (x *HealthCheckResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthCheckResponse.ProtoReflect.Descriptor instead.
 func (*HealthCheckResponse) Descriptor() ([]byte, []int) {
-	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{30}
+	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *HealthCheckResponse) GetOk() bool {
@@ -2304,24 +2611,44 @@ const file_proto_sandboxd_v1_sandboxd_proto_rawDesc = "" +
 	"\tgap_bytes\x18\x04 \x01(\x04R\bgapBytes\x12\x10\n" +
 	"\x03eof\x18\x05 \x01(\bR\x03eof\x12%\n" +
 	"\x0eretained_start\x18\x06 \x01(\x04R\rretainedStart\x12!\n" +
-	"\fproduced_end\x18\a \x01(\x04R\vproducedEnd\"!\n" +
+	"\fproduced_end\x18\a \x01(\x04R\vproducedEnd\"\x7f\n" +
 	"\vReadRequest\x12\x12\n" +
-	"\x04path\x18\x01 \x01(\tR\x04path\"(\n" +
-	"\fReadResponse\x12\x18\n" +
-	"\acontent\x18\x01 \x01(\fR\acontent\"P\n" +
-	"\fWriteRequest\x12\x12\n" +
-	"\x04path\x18\x01 \x01(\tR\x04path\x12\x18\n" +
-	"\acontent\x18\x02 \x01(\fR\acontent\x12\x12\n" +
-	"\x04mode\x18\x03 \x01(\rR\x04mode\"\x0f\n" +
-	"\rWriteResponse\"!\n" +
+	"\x04path\x18\x01 \x01(\tR\x04path\x12\x16\n" +
+	"\x06offset\x18\x02 \x01(\x04R\x06offset\x12\x1b\n" +
+	"\tmax_bytes\x18\x03 \x01(\rR\bmaxBytes\x12'\n" +
+	"\x0finclude_version\x18\x04 \x01(\bR\x0eincludeVersion\"\x9b\x01\n" +
+	"\fReadResponse\x12\x12\n" +
+	"\x04data\x18\x01 \x01(\fR\x04data\x12\x16\n" +
+	"\x06offset\x18\x02 \x01(\x04R\x06offset\x12\x1f\n" +
+	"\vnext_offset\x18\x03 \x01(\x04R\n" +
+	"nextOffset\x12\x12\n" +
+	"\x04size\x18\x04 \x01(\x04R\x04size\x12\x10\n" +
+	"\x03eof\x18\x05 \x01(\bR\x03eof\x12\x18\n" +
+	"\aversion\x18\x06 \x01(\tR\aversion\"`\n" +
+	"\fWriteRequest\x122\n" +
+	"\x06header\x18\x01 \x01(\v2\x18.sandboxd.v1.WriteHeaderH\x00R\x06header\x12\x14\n" +
+	"\x04data\x18\x02 \x01(\fH\x00R\x04dataB\x06\n" +
+	"\x04kind\"\x90\x01\n" +
+	"\vWriteHeader\x12\x12\n" +
+	"\x04path\x18\x01 \x01(\tR\x04path\x12B\n" +
+	"\fprecondition\x18\x02 \x01(\x0e2\x1e.sandboxd.v1.WritePreconditionR\fprecondition\x12)\n" +
+	"\x10expected_version\x18\x03 \x01(\tR\x0fexpectedVersion\"=\n" +
+	"\rWriteResponse\x12\x12\n" +
+	"\x04size\x18\x01 \x01(\x04R\x04size\x12\x18\n" +
+	"\aversion\x18\x02 \x01(\tR\aversion\"]\n" +
 	"\vListRequest\x12\x12\n" +
-	"\x04path\x18\x01 \x01(\tR\x04path\"<\n" +
+	"\x04path\x18\x01 \x01(\tR\x04path\x12\x1b\n" +
+	"\tpage_size\x18\x02 \x01(\rR\bpageSize\x12\x1d\n" +
+	"\n" +
+	"page_token\x18\x03 \x01(\tR\tpageToken\"d\n" +
 	"\fListResponse\x12,\n" +
-	"\aentries\x18\x01 \x03(\v2\x12.sandboxd.v1.EntryR\aentries\"F\n" +
+	"\aentries\x18\x01 \x03(\v2\x12.sandboxd.v1.EntryR\aentries\x12&\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"\x85\x01\n" +
 	"\x05Entry\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name\x12\x15\n" +
-	"\x06is_dir\x18\x02 \x01(\bR\x05isDir\x12\x12\n" +
-	"\x04size\x18\x03 \x01(\x03R\x04size\"\x97\x01\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12*\n" +
+	"\x04type\x18\x02 \x01(\x0e2\x16.sandboxd.v1.EntryTypeR\x04type\x12\x12\n" +
+	"\x04size\x18\x03 \x01(\x04R\x04size\x12(\n" +
+	"\x10modified_unix_ms\x18\x04 \x01(\x03R\x0emodifiedUnixMs\"\x97\x01\n" +
 	"\x0fTerminalMessage\x12/\n" +
 	"\x04open\x18\x01 \x01(\v2\x19.sandboxd.v1.TerminalOpenH\x00R\x04open\x12\x14\n" +
 	"\x04data\x18\x02 \x01(\fH\x00R\x04data\x125\n" +
@@ -2382,7 +2709,18 @@ const file_proto_sandboxd_v1_sandboxd_proto_rawDesc = "" +
 	"\x15PROCESS_STATE_RUNNING\x10\x01\x12\x1a\n" +
 	"\x16PROCESS_STATE_STOPPING\x10\x02\x12\x18\n" +
 	"\x14PROCESS_STATE_EXITED\x10\x03\x12\x18\n" +
-	"\x14PROCESS_STATE_FAILED\x10\x042N\n" +
+	"\x14PROCESS_STATE_FAILED\x10\x04*\xa0\x01\n" +
+	"\x11WritePrecondition\x12\"\n" +
+	"\x1eWRITE_PRECONDITION_UNSPECIFIED\x10\x00\x12\x1a\n" +
+	"\x16WRITE_PRECONDITION_ANY\x10\x01\x12%\n" +
+	"!WRITE_PRECONDITION_MUST_NOT_EXIST\x10\x02\x12$\n" +
+	" WRITE_PRECONDITION_MATCH_VERSION\x10\x03*\x84\x01\n" +
+	"\tEntryType\x12\x1a\n" +
+	"\x16ENTRY_TYPE_UNSPECIFIED\x10\x00\x12\x13\n" +
+	"\x0fENTRY_TYPE_FILE\x10\x01\x12\x18\n" +
+	"\x14ENTRY_TYPE_DIRECTORY\x10\x02\x12\x16\n" +
+	"\x12ENTRY_TYPE_SYMLINK\x10\x03\x12\x14\n" +
+	"\x10ENTRY_TYPE_OTHER\x10\x042N\n" +
 	"\vExecService\x12?\n" +
 	"\x04Exec\x12\x18.sandboxd.v1.ExecRequest\x1a\x19.sandboxd.v1.ExecResponse(\x010\x012\x9c\x02\n" +
 	"\x0eProcessService\x12?\n" +
@@ -2390,10 +2728,10 @@ const file_proto_sandboxd_v1_sandboxd_proto_rawDesc = "" +
 	"\x03Get\x12\x1e.sandboxd.v1.GetProcessRequest\x1a\x14.sandboxd.v1.Process\x12=\n" +
 	"\x04Stop\x12\x1f.sandboxd.v1.StopProcessRequest\x1a\x14.sandboxd.v1.Process\x12M\n" +
 	"\n" +
-	"ReadOutput\x12\x1e.sandboxd.v1.ReadOutputRequest\x1a\x1f.sandboxd.v1.ReadOutputResponse2\xcd\x01\n" +
+	"ReadOutput\x12\x1e.sandboxd.v1.ReadOutputRequest\x1a\x1f.sandboxd.v1.ReadOutputResponse2\xcf\x01\n" +
 	"\x11FilesystemService\x12;\n" +
-	"\x04Read\x12\x18.sandboxd.v1.ReadRequest\x1a\x19.sandboxd.v1.ReadResponse\x12>\n" +
-	"\x05Write\x12\x19.sandboxd.v1.WriteRequest\x1a\x1a.sandboxd.v1.WriteResponse\x12;\n" +
+	"\x04Read\x12\x18.sandboxd.v1.ReadRequest\x1a\x19.sandboxd.v1.ReadResponse\x12@\n" +
+	"\x05Write\x12\x19.sandboxd.v1.WriteRequest\x1a\x1a.sandboxd.v1.WriteResponse(\x01\x12;\n" +
 	"\x04List\x12\x18.sandboxd.v1.ListRequest\x1a\x19.sandboxd.v1.ListResponse2]\n" +
 	"\x0fTerminalService\x12J\n" +
 	"\bTerminal\x12\x1c.sandboxd.v1.TerminalMessage\x1a\x1c.sandboxd.v1.TerminalMessage(\x010\x012\x95\x01\n" +
@@ -2415,8 +2753,8 @@ func file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP() []byte {
 	return file_proto_sandboxd_v1_sandboxd_proto_rawDescData
 }
 
-var file_proto_sandboxd_v1_sandboxd_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
-var file_proto_sandboxd_v1_sandboxd_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
+var file_proto_sandboxd_v1_sandboxd_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
+var file_proto_sandboxd_v1_sandboxd_proto_msgTypes = make([]protoimpl.MessageInfo, 34)
 var file_proto_sandboxd_v1_sandboxd_proto_goTypes = []any{
 	(ProcessControl)(0),         // 0: sandboxd.v1.ProcessControl
 	(EnvironmentMode)(0),        // 1: sandboxd.v1.EnvironmentMode
@@ -2424,98 +2762,104 @@ var file_proto_sandboxd_v1_sandboxd_proto_goTypes = []any{
 	(OutputStream)(0),           // 3: sandboxd.v1.OutputStream
 	(StopMode)(0),               // 4: sandboxd.v1.StopMode
 	(ProcessState)(0),           // 5: sandboxd.v1.ProcessState
-	(*ExecRequest)(nil),         // 6: sandboxd.v1.ExecRequest
-	(*ExecStdinEOF)(nil),        // 7: sandboxd.v1.ExecStdinEOF
-	(*ExecControl)(nil),         // 8: sandboxd.v1.ExecControl
-	(*OutputChunk)(nil),         // 9: sandboxd.v1.OutputChunk
-	(*ExecStart)(nil),           // 10: sandboxd.v1.ExecStart
-	(*ExecResponse)(nil),        // 11: sandboxd.v1.ExecResponse
-	(*ExecExit)(nil),            // 12: sandboxd.v1.ExecExit
-	(*ProcessKey)(nil),          // 13: sandboxd.v1.ProcessKey
-	(*ProcessSpec)(nil),         // 14: sandboxd.v1.ProcessSpec
-	(*StartProcessRequest)(nil), // 15: sandboxd.v1.StartProcessRequest
-	(*GetProcessRequest)(nil),   // 16: sandboxd.v1.GetProcessRequest
-	(*StopProcessRequest)(nil),  // 17: sandboxd.v1.StopProcessRequest
-	(*Process)(nil),             // 18: sandboxd.v1.Process
-	(*ReadOutputRequest)(nil),   // 19: sandboxd.v1.ReadOutputRequest
-	(*ReadOutputResponse)(nil),  // 20: sandboxd.v1.ReadOutputResponse
-	(*ReadRequest)(nil),         // 21: sandboxd.v1.ReadRequest
-	(*ReadResponse)(nil),        // 22: sandboxd.v1.ReadResponse
-	(*WriteRequest)(nil),        // 23: sandboxd.v1.WriteRequest
-	(*WriteResponse)(nil),       // 24: sandboxd.v1.WriteResponse
-	(*ListRequest)(nil),         // 25: sandboxd.v1.ListRequest
-	(*ListResponse)(nil),        // 26: sandboxd.v1.ListResponse
-	(*Entry)(nil),               // 27: sandboxd.v1.Entry
-	(*TerminalMessage)(nil),     // 28: sandboxd.v1.TerminalMessage
-	(*TerminalOpen)(nil),        // 29: sandboxd.v1.TerminalOpen
-	(*TerminalResize)(nil),      // 30: sandboxd.v1.TerminalResize
-	(*RegisterPortRequest)(nil), // 31: sandboxd.v1.RegisterPortRequest
-	(*Port)(nil),                // 32: sandboxd.v1.Port
-	(*ListPortsRequest)(nil),    // 33: sandboxd.v1.ListPortsRequest
-	(*ListPortsResponse)(nil),   // 34: sandboxd.v1.ListPortsResponse
-	(*HealthCheckRequest)(nil),  // 35: sandboxd.v1.HealthCheckRequest
-	(*HealthCheckResponse)(nil), // 36: sandboxd.v1.HealthCheckResponse
-	nil,                         // 37: sandboxd.v1.ExecStart.EnvEntry
-	nil,                         // 38: sandboxd.v1.ProcessSpec.EnvEntry
+	(WritePrecondition)(0),      // 6: sandboxd.v1.WritePrecondition
+	(EntryType)(0),              // 7: sandboxd.v1.EntryType
+	(*ExecRequest)(nil),         // 8: sandboxd.v1.ExecRequest
+	(*ExecStdinEOF)(nil),        // 9: sandboxd.v1.ExecStdinEOF
+	(*ExecControl)(nil),         // 10: sandboxd.v1.ExecControl
+	(*OutputChunk)(nil),         // 11: sandboxd.v1.OutputChunk
+	(*ExecStart)(nil),           // 12: sandboxd.v1.ExecStart
+	(*ExecResponse)(nil),        // 13: sandboxd.v1.ExecResponse
+	(*ExecExit)(nil),            // 14: sandboxd.v1.ExecExit
+	(*ProcessKey)(nil),          // 15: sandboxd.v1.ProcessKey
+	(*ProcessSpec)(nil),         // 16: sandboxd.v1.ProcessSpec
+	(*StartProcessRequest)(nil), // 17: sandboxd.v1.StartProcessRequest
+	(*GetProcessRequest)(nil),   // 18: sandboxd.v1.GetProcessRequest
+	(*StopProcessRequest)(nil),  // 19: sandboxd.v1.StopProcessRequest
+	(*Process)(nil),             // 20: sandboxd.v1.Process
+	(*ReadOutputRequest)(nil),   // 21: sandboxd.v1.ReadOutputRequest
+	(*ReadOutputResponse)(nil),  // 22: sandboxd.v1.ReadOutputResponse
+	(*ReadRequest)(nil),         // 23: sandboxd.v1.ReadRequest
+	(*ReadResponse)(nil),        // 24: sandboxd.v1.ReadResponse
+	(*WriteRequest)(nil),        // 25: sandboxd.v1.WriteRequest
+	(*WriteHeader)(nil),         // 26: sandboxd.v1.WriteHeader
+	(*WriteResponse)(nil),       // 27: sandboxd.v1.WriteResponse
+	(*ListRequest)(nil),         // 28: sandboxd.v1.ListRequest
+	(*ListResponse)(nil),        // 29: sandboxd.v1.ListResponse
+	(*Entry)(nil),               // 30: sandboxd.v1.Entry
+	(*TerminalMessage)(nil),     // 31: sandboxd.v1.TerminalMessage
+	(*TerminalOpen)(nil),        // 32: sandboxd.v1.TerminalOpen
+	(*TerminalResize)(nil),      // 33: sandboxd.v1.TerminalResize
+	(*RegisterPortRequest)(nil), // 34: sandboxd.v1.RegisterPortRequest
+	(*Port)(nil),                // 35: sandboxd.v1.Port
+	(*ListPortsRequest)(nil),    // 36: sandboxd.v1.ListPortsRequest
+	(*ListPortsResponse)(nil),   // 37: sandboxd.v1.ListPortsResponse
+	(*HealthCheckRequest)(nil),  // 38: sandboxd.v1.HealthCheckRequest
+	(*HealthCheckResponse)(nil), // 39: sandboxd.v1.HealthCheckResponse
+	nil,                         // 40: sandboxd.v1.ExecStart.EnvEntry
+	nil,                         // 41: sandboxd.v1.ProcessSpec.EnvEntry
 }
 var file_proto_sandboxd_v1_sandboxd_proto_depIdxs = []int32{
-	10, // 0: sandboxd.v1.ExecRequest.start:type_name -> sandboxd.v1.ExecStart
-	7,  // 1: sandboxd.v1.ExecRequest.stdin_eof:type_name -> sandboxd.v1.ExecStdinEOF
-	8,  // 2: sandboxd.v1.ExecRequest.control:type_name -> sandboxd.v1.ExecControl
+	12, // 0: sandboxd.v1.ExecRequest.start:type_name -> sandboxd.v1.ExecStart
+	9,  // 1: sandboxd.v1.ExecRequest.stdin_eof:type_name -> sandboxd.v1.ExecStdinEOF
+	10, // 2: sandboxd.v1.ExecRequest.control:type_name -> sandboxd.v1.ExecControl
 	0,  // 3: sandboxd.v1.ExecControl.control:type_name -> sandboxd.v1.ProcessControl
 	3,  // 4: sandboxd.v1.OutputChunk.stream:type_name -> sandboxd.v1.OutputStream
-	37, // 5: sandboxd.v1.ExecStart.env:type_name -> sandboxd.v1.ExecStart.EnvEntry
+	40, // 5: sandboxd.v1.ExecStart.env:type_name -> sandboxd.v1.ExecStart.EnvEntry
 	1,  // 6: sandboxd.v1.ExecStart.env_mode:type_name -> sandboxd.v1.EnvironmentMode
-	9,  // 7: sandboxd.v1.ExecResponse.stdout:type_name -> sandboxd.v1.OutputChunk
-	9,  // 8: sandboxd.v1.ExecResponse.stderr:type_name -> sandboxd.v1.OutputChunk
-	12, // 9: sandboxd.v1.ExecResponse.exit:type_name -> sandboxd.v1.ExecExit
+	11, // 7: sandboxd.v1.ExecResponse.stdout:type_name -> sandboxd.v1.OutputChunk
+	11, // 8: sandboxd.v1.ExecResponse.stderr:type_name -> sandboxd.v1.OutputChunk
+	14, // 9: sandboxd.v1.ExecResponse.exit:type_name -> sandboxd.v1.ExecExit
 	2,  // 10: sandboxd.v1.ExecExit.reason:type_name -> sandboxd.v1.TerminationReason
-	38, // 11: sandboxd.v1.ProcessSpec.env:type_name -> sandboxd.v1.ProcessSpec.EnvEntry
+	41, // 11: sandboxd.v1.ProcessSpec.env:type_name -> sandboxd.v1.ProcessSpec.EnvEntry
 	1,  // 12: sandboxd.v1.ProcessSpec.env_mode:type_name -> sandboxd.v1.EnvironmentMode
-	13, // 13: sandboxd.v1.StartProcessRequest.key:type_name -> sandboxd.v1.ProcessKey
-	14, // 14: sandboxd.v1.StartProcessRequest.spec:type_name -> sandboxd.v1.ProcessSpec
-	13, // 15: sandboxd.v1.GetProcessRequest.key:type_name -> sandboxd.v1.ProcessKey
-	13, // 16: sandboxd.v1.StopProcessRequest.key:type_name -> sandboxd.v1.ProcessKey
+	15, // 13: sandboxd.v1.StartProcessRequest.key:type_name -> sandboxd.v1.ProcessKey
+	16, // 14: sandboxd.v1.StartProcessRequest.spec:type_name -> sandboxd.v1.ProcessSpec
+	15, // 15: sandboxd.v1.GetProcessRequest.key:type_name -> sandboxd.v1.ProcessKey
+	15, // 16: sandboxd.v1.StopProcessRequest.key:type_name -> sandboxd.v1.ProcessKey
 	4,  // 17: sandboxd.v1.StopProcessRequest.mode:type_name -> sandboxd.v1.StopMode
-	13, // 18: sandboxd.v1.Process.key:type_name -> sandboxd.v1.ProcessKey
-	14, // 19: sandboxd.v1.Process.spec:type_name -> sandboxd.v1.ProcessSpec
+	15, // 18: sandboxd.v1.Process.key:type_name -> sandboxd.v1.ProcessKey
+	16, // 19: sandboxd.v1.Process.spec:type_name -> sandboxd.v1.ProcessSpec
 	5,  // 20: sandboxd.v1.Process.state:type_name -> sandboxd.v1.ProcessState
 	2,  // 21: sandboxd.v1.Process.reason:type_name -> sandboxd.v1.TerminationReason
-	13, // 22: sandboxd.v1.ReadOutputRequest.key:type_name -> sandboxd.v1.ProcessKey
+	15, // 22: sandboxd.v1.ReadOutputRequest.key:type_name -> sandboxd.v1.ProcessKey
 	3,  // 23: sandboxd.v1.ReadOutputRequest.stream:type_name -> sandboxd.v1.OutputStream
-	27, // 24: sandboxd.v1.ListResponse.entries:type_name -> sandboxd.v1.Entry
-	29, // 25: sandboxd.v1.TerminalMessage.open:type_name -> sandboxd.v1.TerminalOpen
-	30, // 26: sandboxd.v1.TerminalMessage.resize:type_name -> sandboxd.v1.TerminalResize
-	32, // 27: sandboxd.v1.ListPortsResponse.ports:type_name -> sandboxd.v1.Port
-	6,  // 28: sandboxd.v1.ExecService.Exec:input_type -> sandboxd.v1.ExecRequest
-	15, // 29: sandboxd.v1.ProcessService.Start:input_type -> sandboxd.v1.StartProcessRequest
-	16, // 30: sandboxd.v1.ProcessService.Get:input_type -> sandboxd.v1.GetProcessRequest
-	17, // 31: sandboxd.v1.ProcessService.Stop:input_type -> sandboxd.v1.StopProcessRequest
-	19, // 32: sandboxd.v1.ProcessService.ReadOutput:input_type -> sandboxd.v1.ReadOutputRequest
-	21, // 33: sandboxd.v1.FilesystemService.Read:input_type -> sandboxd.v1.ReadRequest
-	23, // 34: sandboxd.v1.FilesystemService.Write:input_type -> sandboxd.v1.WriteRequest
-	25, // 35: sandboxd.v1.FilesystemService.List:input_type -> sandboxd.v1.ListRequest
-	28, // 36: sandboxd.v1.TerminalService.Terminal:input_type -> sandboxd.v1.TerminalMessage
-	31, // 37: sandboxd.v1.PortService.Register:input_type -> sandboxd.v1.RegisterPortRequest
-	33, // 38: sandboxd.v1.PortService.List:input_type -> sandboxd.v1.ListPortsRequest
-	35, // 39: sandboxd.v1.HealthService.Check:input_type -> sandboxd.v1.HealthCheckRequest
-	11, // 40: sandboxd.v1.ExecService.Exec:output_type -> sandboxd.v1.ExecResponse
-	18, // 41: sandboxd.v1.ProcessService.Start:output_type -> sandboxd.v1.Process
-	18, // 42: sandboxd.v1.ProcessService.Get:output_type -> sandboxd.v1.Process
-	18, // 43: sandboxd.v1.ProcessService.Stop:output_type -> sandboxd.v1.Process
-	20, // 44: sandboxd.v1.ProcessService.ReadOutput:output_type -> sandboxd.v1.ReadOutputResponse
-	22, // 45: sandboxd.v1.FilesystemService.Read:output_type -> sandboxd.v1.ReadResponse
-	24, // 46: sandboxd.v1.FilesystemService.Write:output_type -> sandboxd.v1.WriteResponse
-	26, // 47: sandboxd.v1.FilesystemService.List:output_type -> sandboxd.v1.ListResponse
-	28, // 48: sandboxd.v1.TerminalService.Terminal:output_type -> sandboxd.v1.TerminalMessage
-	32, // 49: sandboxd.v1.PortService.Register:output_type -> sandboxd.v1.Port
-	34, // 50: sandboxd.v1.PortService.List:output_type -> sandboxd.v1.ListPortsResponse
-	36, // 51: sandboxd.v1.HealthService.Check:output_type -> sandboxd.v1.HealthCheckResponse
-	40, // [40:52] is the sub-list for method output_type
-	28, // [28:40] is the sub-list for method input_type
-	28, // [28:28] is the sub-list for extension type_name
-	28, // [28:28] is the sub-list for extension extendee
-	0,  // [0:28] is the sub-list for field type_name
+	26, // 24: sandboxd.v1.WriteRequest.header:type_name -> sandboxd.v1.WriteHeader
+	6,  // 25: sandboxd.v1.WriteHeader.precondition:type_name -> sandboxd.v1.WritePrecondition
+	30, // 26: sandboxd.v1.ListResponse.entries:type_name -> sandboxd.v1.Entry
+	7,  // 27: sandboxd.v1.Entry.type:type_name -> sandboxd.v1.EntryType
+	32, // 28: sandboxd.v1.TerminalMessage.open:type_name -> sandboxd.v1.TerminalOpen
+	33, // 29: sandboxd.v1.TerminalMessage.resize:type_name -> sandboxd.v1.TerminalResize
+	35, // 30: sandboxd.v1.ListPortsResponse.ports:type_name -> sandboxd.v1.Port
+	8,  // 31: sandboxd.v1.ExecService.Exec:input_type -> sandboxd.v1.ExecRequest
+	17, // 32: sandboxd.v1.ProcessService.Start:input_type -> sandboxd.v1.StartProcessRequest
+	18, // 33: sandboxd.v1.ProcessService.Get:input_type -> sandboxd.v1.GetProcessRequest
+	19, // 34: sandboxd.v1.ProcessService.Stop:input_type -> sandboxd.v1.StopProcessRequest
+	21, // 35: sandboxd.v1.ProcessService.ReadOutput:input_type -> sandboxd.v1.ReadOutputRequest
+	23, // 36: sandboxd.v1.FilesystemService.Read:input_type -> sandboxd.v1.ReadRequest
+	25, // 37: sandboxd.v1.FilesystemService.Write:input_type -> sandboxd.v1.WriteRequest
+	28, // 38: sandboxd.v1.FilesystemService.List:input_type -> sandboxd.v1.ListRequest
+	31, // 39: sandboxd.v1.TerminalService.Terminal:input_type -> sandboxd.v1.TerminalMessage
+	34, // 40: sandboxd.v1.PortService.Register:input_type -> sandboxd.v1.RegisterPortRequest
+	36, // 41: sandboxd.v1.PortService.List:input_type -> sandboxd.v1.ListPortsRequest
+	38, // 42: sandboxd.v1.HealthService.Check:input_type -> sandboxd.v1.HealthCheckRequest
+	13, // 43: sandboxd.v1.ExecService.Exec:output_type -> sandboxd.v1.ExecResponse
+	20, // 44: sandboxd.v1.ProcessService.Start:output_type -> sandboxd.v1.Process
+	20, // 45: sandboxd.v1.ProcessService.Get:output_type -> sandboxd.v1.Process
+	20, // 46: sandboxd.v1.ProcessService.Stop:output_type -> sandboxd.v1.Process
+	22, // 47: sandboxd.v1.ProcessService.ReadOutput:output_type -> sandboxd.v1.ReadOutputResponse
+	24, // 48: sandboxd.v1.FilesystemService.Read:output_type -> sandboxd.v1.ReadResponse
+	27, // 49: sandboxd.v1.FilesystemService.Write:output_type -> sandboxd.v1.WriteResponse
+	29, // 50: sandboxd.v1.FilesystemService.List:output_type -> sandboxd.v1.ListResponse
+	31, // 51: sandboxd.v1.TerminalService.Terminal:output_type -> sandboxd.v1.TerminalMessage
+	35, // 52: sandboxd.v1.PortService.Register:output_type -> sandboxd.v1.Port
+	37, // 53: sandboxd.v1.PortService.List:output_type -> sandboxd.v1.ListPortsResponse
+	39, // 54: sandboxd.v1.HealthService.Check:output_type -> sandboxd.v1.HealthCheckResponse
+	43, // [43:55] is the sub-list for method output_type
+	31, // [31:43] is the sub-list for method input_type
+	31, // [31:31] is the sub-list for extension type_name
+	31, // [31:31] is the sub-list for extension extendee
+	0,  // [0:31] is the sub-list for field type_name
 }
 
 func init() { file_proto_sandboxd_v1_sandboxd_proto_init() }
@@ -2535,7 +2879,11 @@ func file_proto_sandboxd_v1_sandboxd_proto_init() {
 		(*ExecResponse_Exit)(nil),
 	}
 	file_proto_sandboxd_v1_sandboxd_proto_msgTypes[12].OneofWrappers = []any{}
-	file_proto_sandboxd_v1_sandboxd_proto_msgTypes[22].OneofWrappers = []any{
+	file_proto_sandboxd_v1_sandboxd_proto_msgTypes[17].OneofWrappers = []any{
+		(*WriteRequest_Header)(nil),
+		(*WriteRequest_Data)(nil),
+	}
+	file_proto_sandboxd_v1_sandboxd_proto_msgTypes[23].OneofWrappers = []any{
 		(*TerminalMessage_Open)(nil),
 		(*TerminalMessage_Data)(nil),
 		(*TerminalMessage_Resize)(nil),
@@ -2545,8 +2893,8 @@ func file_proto_sandboxd_v1_sandboxd_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_sandboxd_v1_sandboxd_proto_rawDesc), len(file_proto_sandboxd_v1_sandboxd_proto_rawDesc)),
-			NumEnums:      6,
-			NumMessages:   33,
+			NumEnums:      8,
+			NumMessages:   34,
 			NumExtensions: 0,
 			NumServices:   6,
 		},

--- a/sandboxd/gen/proto/sandboxd/v1/sandboxd_grpc.pb.go
+++ b/sandboxd/gen/proto/sandboxd/v1/sandboxd_grpc.pb.go
@@ -364,10 +364,12 @@ const (
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 //
-// FilesystemService provides file access inside the environment.
+// FilesystemService provides bounded access to the environment workspace.
+// Paths are slash-separated logical paths, never host filesystem paths. See
+// FILESYSTEM.md for normalization, confinement, limits, and commit semantics.
 type FilesystemServiceClient interface {
 	Read(ctx context.Context, in *ReadRequest, opts ...grpc.CallOption) (*ReadResponse, error)
-	Write(ctx context.Context, in *WriteRequest, opts ...grpc.CallOption) (*WriteResponse, error)
+	Write(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStreamingClient[WriteRequest, WriteResponse], error)
 	List(ctx context.Context, in *ListRequest, opts ...grpc.CallOption) (*ListResponse, error)
 }
 
@@ -389,15 +391,18 @@ func (c *filesystemServiceClient) Read(ctx context.Context, in *ReadRequest, opt
 	return out, nil
 }
 
-func (c *filesystemServiceClient) Write(ctx context.Context, in *WriteRequest, opts ...grpc.CallOption) (*WriteResponse, error) {
+func (c *filesystemServiceClient) Write(ctx context.Context, opts ...grpc.CallOption) (grpc.ClientStreamingClient[WriteRequest, WriteResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(WriteResponse)
-	err := c.cc.Invoke(ctx, FilesystemService_Write_FullMethodName, in, out, cOpts...)
+	stream, err := c.cc.NewStream(ctx, &FilesystemService_ServiceDesc.Streams[0], FilesystemService_Write_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
-	return out, nil
+	x := &grpc.GenericClientStream[WriteRequest, WriteResponse]{ClientStream: stream}
+	return x, nil
 }
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type FilesystemService_WriteClient = grpc.ClientStreamingClient[WriteRequest, WriteResponse]
 
 func (c *filesystemServiceClient) List(ctx context.Context, in *ListRequest, opts ...grpc.CallOption) (*ListResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
@@ -413,10 +418,12 @@ func (c *filesystemServiceClient) List(ctx context.Context, in *ListRequest, opt
 // All implementations must embed UnimplementedFilesystemServiceServer
 // for forward compatibility.
 //
-// FilesystemService provides file access inside the environment.
+// FilesystemService provides bounded access to the environment workspace.
+// Paths are slash-separated logical paths, never host filesystem paths. See
+// FILESYSTEM.md for normalization, confinement, limits, and commit semantics.
 type FilesystemServiceServer interface {
 	Read(context.Context, *ReadRequest) (*ReadResponse, error)
-	Write(context.Context, *WriteRequest) (*WriteResponse, error)
+	Write(grpc.ClientStreamingServer[WriteRequest, WriteResponse]) error
 	List(context.Context, *ListRequest) (*ListResponse, error)
 	mustEmbedUnimplementedFilesystemServiceServer()
 }
@@ -431,8 +438,8 @@ type UnimplementedFilesystemServiceServer struct{}
 func (UnimplementedFilesystemServiceServer) Read(context.Context, *ReadRequest) (*ReadResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Read not implemented")
 }
-func (UnimplementedFilesystemServiceServer) Write(context.Context, *WriteRequest) (*WriteResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "method Write not implemented")
+func (UnimplementedFilesystemServiceServer) Write(grpc.ClientStreamingServer[WriteRequest, WriteResponse]) error {
+	return status.Error(codes.Unimplemented, "method Write not implemented")
 }
 func (UnimplementedFilesystemServiceServer) List(context.Context, *ListRequest) (*ListResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method List not implemented")
@@ -476,23 +483,12 @@ func _FilesystemService_Read_Handler(srv interface{}, ctx context.Context, dec f
 	return interceptor(ctx, in, info, handler)
 }
 
-func _FilesystemService_Write_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(WriteRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(FilesystemServiceServer).Write(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: FilesystemService_Write_FullMethodName,
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(FilesystemServiceServer).Write(ctx, req.(*WriteRequest))
-	}
-	return interceptor(ctx, in, info, handler)
+func _FilesystemService_Write_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(FilesystemServiceServer).Write(&grpc.GenericServerStream[WriteRequest, WriteResponse]{ServerStream: stream})
 }
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type FilesystemService_WriteServer = grpc.ClientStreamingServer[WriteRequest, WriteResponse]
 
 func _FilesystemService_List_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(ListRequest)
@@ -524,15 +520,17 @@ var FilesystemService_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _FilesystemService_Read_Handler,
 		},
 		{
-			MethodName: "Write",
-			Handler:    _FilesystemService_Write_Handler,
-		},
-		{
 			MethodName: "List",
 			Handler:    _FilesystemService_List_Handler,
 		},
 	},
-	Streams:  []grpc.StreamDesc{},
+	Streams: []grpc.StreamDesc{
+		{
+			StreamName:    "Write",
+			Handler:       _FilesystemService_Write_Handler,
+			ClientStreams: true,
+		},
+	},
 	Metadata: "proto/sandboxd/v1/sandboxd.proto",
 }
 

--- a/sandboxd/internal/server/filesystem.go
+++ b/sandboxd/internal/server/filesystem.go
@@ -49,6 +49,11 @@ type FilesystemServer struct {
 	initErr    error
 	writeSlots chan struct{}
 	commitMu   sync.RWMutex
+	handlerMu  sync.Mutex
+	closing    bool
+	active     sync.WaitGroup
+	closeOnce  sync.Once
+	closeErr   error
 }
 
 func NewFilesystemServer(workspace string) (*FilesystemServer, error) {
@@ -60,10 +65,46 @@ func NewFilesystemServer(workspace string) (*FilesystemServer, error) {
 }
 
 func (s *FilesystemServer) Close() error {
-	if s.rootHandle == nil {
-		return nil
+	return s.CloseContext(context.Background())
+}
+
+// BeginShutdown fences new writes while the gRPC server drains active RPCs.
+func (s *FilesystemServer) BeginShutdown() {
+	s.handlerMu.Lock()
+	s.closing = true
+	s.handlerMu.Unlock()
+}
+
+// CloseContext waits for active writes to finish cleanup before closing the
+// pinned workspace root.
+func (s *FilesystemServer) CloseContext(ctx context.Context) error {
+	s.BeginShutdown()
+	done := make(chan struct{})
+	go func() {
+		s.active.Wait()
+		close(done)
+	}()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-done:
 	}
-	return s.rootHandle.Close()
+	s.closeOnce.Do(func() {
+		if s.rootHandle != nil {
+			s.closeErr = s.rootHandle.Close()
+		}
+	})
+	return s.closeErr
+}
+
+func (s *FilesystemServer) beginWrite() error {
+	s.handlerMu.Lock()
+	defer s.handlerMu.Unlock()
+	if s.closing {
+		return status.Error(codes.Unavailable, "filesystem is shutting down")
+	}
+	s.active.Add(1)
+	return nil
 }
 
 func (s *FilesystemServer) initialize() error {
@@ -112,7 +153,7 @@ func normalizeWorkspacePath(value string, allowRoot bool) (string, error) {
 		if component == ".." {
 			return "", status.Error(codes.InvalidArgument, "path must not contain upward traversal")
 		}
-		if strings.HasPrefix(component, ".sandboxd-write-") {
+		if isReservedStagingComponent(component) {
 			return "", status.Error(codes.InvalidArgument, "path uses a reserved staging name")
 		}
 		if invalidWindowsComponent(component) {
@@ -127,6 +168,10 @@ func normalizeWorkspacePath(value string, allowRoot bool) (string, error) {
 		return "", status.Error(codes.InvalidArgument, "path must name a workspace entry")
 	}
 	return clean, nil
+}
+
+func isReservedStagingComponent(component string) bool {
+	return strings.HasPrefix(strings.ToLower(component), ".sandboxd-write-")
 }
 
 func invalidWindowsComponent(component string) bool {
@@ -170,25 +215,29 @@ func (s *FilesystemServer) resolveExisting(logical string) (string, os.FileInfo,
 	return current, info, err
 }
 
-// prepareWritePath creates parents through os.Root, which confines any link
-// traversal to the already-open workspace root.
-func (s *FilesystemServer) prepareWritePath(logical string) (string, error) {
+// prepareWriteDirectory creates parents through os.Root, then pins the actual
+// destination directory so renames cannot retarget staging, commit, or cleanup.
+func (s *FilesystemServer) prepareWriteDirectory(logical string) (*os.Root, string, error) {
 	destination := filepath.FromSlash(logical)
-	if err := s.rootHandle.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
-		return "", filesystemError("create workspace directory", err)
+	directory := filepath.Dir(destination)
+	if err := s.rootHandle.MkdirAll(directory, 0o755); err != nil {
+		return nil, "", filesystemError("create workspace directory", err)
 	}
-	return destination, nil
+	directoryRoot, err := s.rootHandle.OpenRoot(directory)
+	if err != nil {
+		return nil, "", filesystemError("open workspace directory", err)
+	}
+	return directoryRoot, filepath.Base(destination), nil
 }
 
-func (s *FilesystemServer) createStagingFile(destination string) (*os.File, string, error) {
-	directory := filepath.Dir(destination)
+func createStagingFile(directory *os.Root) (*os.File, string, error) {
 	for range 100 {
 		var random [16]byte
 		if _, err := rand.Read(random[:]); err != nil {
-			return nil, "", status.Errorf(codes.Internal, "generate staging name: %v", err)
+			return nil, "", status.Error(codes.Internal, "generate staging name: host failure")
 		}
-		name := filepath.Join(directory, ".sandboxd-write-"+hex.EncodeToString(random[:]))
-		file, err := s.rootHandle.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
+		name := ".sandboxd-write-" + hex.EncodeToString(random[:])
+		file, err := directory.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
 		if errors.Is(err, os.ErrExist) {
 			continue
 		}
@@ -208,18 +257,18 @@ func filesystemError(operation string, err error) error {
 		return err
 	}
 	if errors.Is(err, os.ErrNotExist) {
-		return status.Errorf(codes.NotFound, "%s: %v", operation, err)
+		return status.Errorf(codes.NotFound, "%s: not found", operation)
 	}
 	if errors.Is(err, os.ErrExist) {
 		return status.Errorf(codes.FailedPrecondition, "%s: path component has an incompatible type", operation)
 	}
 	if errors.Is(err, os.ErrPermission) {
-		return status.Errorf(codes.PermissionDenied, "%s: %v", operation, err)
+		return status.Errorf(codes.PermissionDenied, "%s: permission denied", operation)
 	}
 	if errors.Is(err, os.ErrInvalid) || pathEscapesRoot(err) {
 		return status.Errorf(codes.FailedPrecondition, "%s: path is not confined to the workspace", operation)
 	}
-	return status.Errorf(codes.Internal, "%s: %v", operation, err)
+	return status.Errorf(codes.Internal, "%s: host I/O failure", operation)
 }
 
 func pathEscapesRoot(err error) bool {
@@ -265,7 +314,7 @@ func hashFile(ctx context.Context, file *os.File) (string, error) {
 
 func (s *FilesystemServer) Read(ctx context.Context, req *sandboxdv1.ReadRequest) (*sandboxdv1.ReadResponse, error) {
 	if err := s.initialize(); err != nil {
-		return nil, status.Errorf(codes.Internal, "initialize filesystem: %v", err)
+		return nil, status.Error(codes.Internal, "initialize filesystem")
 	}
 	logical, err := normalizeWorkspacePath(req.GetPath(), false)
 	if err != nil {
@@ -333,8 +382,12 @@ func (s *FilesystemServer) Read(ctx context.Context, req *sandboxdv1.ReadRequest
 
 func (s *FilesystemServer) Write(stream sandboxdv1.FilesystemService_WriteServer) error {
 	if err := s.initialize(); err != nil {
-		return status.Errorf(codes.Internal, "initialize filesystem: %v", err)
+		return status.Error(codes.Internal, "initialize filesystem")
 	}
+	if err := s.beginWrite(); err != nil {
+		return err
+	}
+	defer s.active.Done()
 	select {
 	case s.writeSlots <- struct{}{}:
 		defer func() { <-s.writeSlots }()
@@ -365,9 +418,9 @@ func (s *FilesystemServer) Write(stream sandboxdv1.FilesystemService_WriteServer
 	}
 
 	s.commitMu.Lock()
-	destination, err := s.prepareWritePath(logical)
+	directory, destination, err := s.prepareWriteDirectory(logical)
 	if err == nil {
-		if info, statErr := s.rootHandle.Lstat(destination); statErr == nil {
+		if info, statErr := directory.Lstat(destination); statErr == nil {
 			if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
 				err = status.Error(codes.FailedPrecondition, "write destination is not a regular file")
 			}
@@ -378,13 +431,17 @@ func (s *FilesystemServer) Write(stream sandboxdv1.FilesystemService_WriteServer
 	var staged *os.File
 	var stagedName string
 	if err == nil {
-		staged, stagedName, err = s.createStagingFile(destination)
+		staged, stagedName, err = createStagingFile(directory)
 	}
 	s.commitMu.Unlock()
 	if err != nil {
+		if directory != nil {
+			_ = directory.Close()
+		}
 		return err
 	}
-	defer s.rootHandle.Remove(stagedName)
+	defer directory.Close()
+	defer directory.Remove(stagedName)
 	defer staged.Close()
 
 	hash := sha256.New()
@@ -446,21 +503,17 @@ func (s *FilesystemServer) Write(stream sandboxdv1.FilesystemService_WriteServer
 	if err := contextError(ctx); err != nil {
 		return err
 	}
-	destination, err = s.prepareWritePath(logical)
-	if err != nil {
-		return err
-	}
-	if err := s.checkWritePrecondition(ctx, destination, header); err != nil {
+	if err := checkWritePrecondition(ctx, directory, destination, header); err != nil {
 		return err
 	}
 	if header.GetPrecondition() == sandboxdv1.WritePrecondition_WRITE_PRECONDITION_MUST_NOT_EXIST {
-		if err := s.rootHandle.Link(stagedName, destination); err != nil {
+		if err := directory.Link(stagedName, destination); err != nil {
 			if errors.Is(err, os.ErrExist) {
 				return status.Error(codes.FailedPrecondition, "write destination already exists")
 			}
 			return filesystemError("commit new workspace file", err)
 		}
-	} else if err := s.rootHandle.Rename(stagedName, destination); err != nil {
+	} else if err := directory.Rename(stagedName, destination); err != nil {
 		return filesystemError("commit workspace file", err)
 	}
 	return stream.SendAndClose(&sandboxdv1.WriteResponse{Size: size, Version: version})
@@ -484,8 +537,8 @@ func validateWriteHeader(header *sandboxdv1.WriteHeader) error {
 	return nil
 }
 
-func (s *FilesystemServer) checkWritePrecondition(ctx context.Context, destination string, header *sandboxdv1.WriteHeader) error {
-	info, err := s.rootHandle.Lstat(destination)
+func checkWritePrecondition(ctx context.Context, directory *os.Root, destination string, header *sandboxdv1.WriteHeader) error {
+	info, err := directory.Lstat(destination)
 	exists := err == nil
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return filesystemError("inspect write destination", err)
@@ -505,7 +558,7 @@ func (s *FilesystemServer) checkWritePrecondition(ctx context.Context, destinati
 		if !exists {
 			return status.Error(codes.FailedPrecondition, "write destination does not exist")
 		}
-		file, err := s.rootHandle.Open(destination)
+		file, err := directory.Open(destination)
 		if err != nil {
 			return filesystemError("open write destination", err)
 		}
@@ -528,7 +581,7 @@ func (s *FilesystemServer) checkWritePrecondition(ctx context.Context, destinati
 
 func (s *FilesystemServer) List(ctx context.Context, req *sandboxdv1.ListRequest) (*sandboxdv1.ListResponse, error) {
 	if err := s.initialize(); err != nil {
-		return nil, status.Errorf(codes.Internal, "initialize filesystem: %v", err)
+		return nil, status.Error(codes.Internal, "initialize filesystem")
 	}
 	logical, err := normalizeWorkspacePath(req.GetPath(), true)
 	if err != nil {
@@ -593,7 +646,7 @@ func (s *FilesystemServer) List(ctx context.Context, req *sandboxdv1.ListRequest
 		if err := contextError(ctx); err != nil {
 			return nil, err
 		}
-		if strings.HasPrefix(child.Name(), ".sandboxd-write-") {
+		if isReservedStagingComponent(child.Name()) {
 			continue
 		}
 		entryType := sandboxdv1.EntryType_ENTRY_TYPE_OTHER

--- a/sandboxd/internal/server/filesystem.go
+++ b/sandboxd/internal/server/filesystem.go
@@ -1,0 +1,651 @@
+package server
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	pathpkg "path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
+)
+
+const (
+	defaultReadBytes        = 64 * 1024
+	defaultMaxReadBytes     = 256 * 1024
+	defaultPageSize         = 256
+	defaultMaxPageSize      = 1000
+	defaultMaxWriteChunk    = 256 * 1024
+	defaultMaxWriteBytes    = 1 << 30
+	defaultConcurrentWrites = 16
+	filesystemHashChunk     = 64 * 1024
+)
+
+// FilesystemServer implements the bounded workspace FilesystemService.
+type FilesystemServer struct {
+	sandboxdv1.UnimplementedFilesystemServiceServer
+	Workspace           string
+	MaxReadBytes        uint32
+	MaxPageSize         uint32
+	MaxWriteChunkBytes  uint32
+	MaxWriteBytes       uint64
+	MaxConcurrentWrites int
+
+	initOnce   sync.Once
+	root       string
+	rootHandle *os.Root
+	initErr    error
+	writeSlots chan struct{}
+	commitMu   sync.RWMutex
+}
+
+func NewFilesystemServer(workspace string) (*FilesystemServer, error) {
+	server := &FilesystemServer{Workspace: workspace}
+	if err := server.initialize(); err != nil {
+		return nil, err
+	}
+	return server, nil
+}
+
+func (s *FilesystemServer) Close() error {
+	if s.rootHandle == nil {
+		return nil
+	}
+	return s.rootHandle.Close()
+}
+
+func (s *FilesystemServer) initialize() error {
+	s.initOnce.Do(func() {
+		root, err := filepath.Abs(s.Workspace)
+		if err != nil {
+			s.initErr = fmt.Errorf("workspace path: %w", err)
+			return
+		}
+		s.rootHandle, err = os.OpenRoot(root)
+		if err != nil {
+			s.initErr = fmt.Errorf("open workspace root: %w", err)
+			return
+		}
+		info, err := s.rootHandle.Stat(".")
+		if err != nil || !info.IsDir() {
+			if err == nil {
+				err = errors.New("not a directory")
+			}
+			s.initErr = fmt.Errorf("workspace root: %w", err)
+			_ = s.rootHandle.Close()
+			s.rootHandle = nil
+			return
+		}
+		s.root = filepath.Clean(root)
+		if s.MaxReadBytes > defaultMaxReadBytes || s.MaxPageSize > defaultMaxPageSize || s.MaxWriteChunkBytes > defaultMaxWriteChunk || s.MaxWriteBytes > defaultMaxWriteBytes || s.MaxConcurrentWrites > defaultConcurrentWrites {
+			s.initErr = errors.New("filesystem limit exceeds hard maximum")
+			_ = s.rootHandle.Close()
+			s.rootHandle = nil
+			return
+		}
+		limit := s.MaxConcurrentWrites
+		if limit <= 0 {
+			limit = defaultConcurrentWrites
+		}
+		s.writeSlots = make(chan struct{}, limit)
+	})
+	return s.initErr
+}
+
+func normalizeWorkspacePath(value string, allowRoot bool) (string, error) {
+	if strings.ContainsRune(value, 0) || strings.Contains(value, "\\") || strings.Contains(value, ":") || strings.HasPrefix(value, "/") {
+		return "", status.Error(codes.InvalidArgument, "path must be a workspace-relative logical path")
+	}
+	for _, component := range strings.Split(value, "/") {
+		if component == ".." {
+			return "", status.Error(codes.InvalidArgument, "path must not contain upward traversal")
+		}
+		if strings.HasPrefix(component, ".sandboxd-write-") {
+			return "", status.Error(codes.InvalidArgument, "path uses a reserved staging name")
+		}
+		if invalidWindowsComponent(component) {
+			return "", status.Error(codes.InvalidArgument, "path contains a non-portable component")
+		}
+	}
+	clean := pathpkg.Clean(value)
+	if clean == "." {
+		clean = ""
+	}
+	if clean == "" && !allowRoot {
+		return "", status.Error(codes.InvalidArgument, "path must name a workspace entry")
+	}
+	return clean, nil
+}
+
+func invalidWindowsComponent(component string) bool {
+	if component == "" || component == "." {
+		return false
+	}
+	for _, character := range component {
+		if character < 32 || strings.ContainsRune(`<>"|?*`, character) {
+			return true
+		}
+	}
+	if strings.HasSuffix(component, " ") || strings.HasSuffix(component, ".") {
+		return true
+	}
+	base := strings.ToUpper(strings.SplitN(component, ".", 2)[0])
+	if base == "CON" || base == "PRN" || base == "AUX" || base == "NUL" || base == "CONIN$" || base == "CONOUT$" {
+		return true
+	}
+	if len(base) == 4 && (strings.HasPrefix(base, "COM") || strings.HasPrefix(base, "LPT")) && base[3] >= '1' && base[3] <= '9' {
+		return true
+	}
+	if strings.HasPrefix(base, "COM") || strings.HasPrefix(base, "LPT") {
+		suffix := strings.TrimPrefix(strings.TrimPrefix(base, "COM"), "LPT")
+		if suffix == "¹" || suffix == "²" || suffix == "³" {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveExisting relies on os.Root for race-safe confinement. It may follow a
+// link that remains inside the root, but can never follow one outside it.
+func (s *FilesystemServer) resolveExisting(logical string) (string, os.FileInfo, error) {
+	current := filepath.FromSlash(logical)
+	if logical == "" {
+		current = "."
+		info, err := s.rootHandle.Stat(current)
+		return current, info, err
+	}
+	info, err := s.rootHandle.Stat(current)
+	return current, info, err
+}
+
+// prepareWritePath creates parents through os.Root, which confines any link
+// traversal to the already-open workspace root.
+func (s *FilesystemServer) prepareWritePath(logical string) (string, error) {
+	destination := filepath.FromSlash(logical)
+	if err := s.rootHandle.MkdirAll(filepath.Dir(destination), 0o755); err != nil {
+		return "", filesystemError("create workspace directory", err)
+	}
+	return destination, nil
+}
+
+func (s *FilesystemServer) createStagingFile(destination string) (*os.File, string, error) {
+	directory := filepath.Dir(destination)
+	for range 100 {
+		var random [16]byte
+		if _, err := rand.Read(random[:]); err != nil {
+			return nil, "", status.Errorf(codes.Internal, "generate staging name: %v", err)
+		}
+		name := filepath.Join(directory, ".sandboxd-write-"+hex.EncodeToString(random[:]))
+		file, err := s.rootHandle.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
+		if errors.Is(err, os.ErrExist) {
+			continue
+		}
+		if err != nil {
+			return nil, "", filesystemError("create staging file", err)
+		}
+		return file, name, nil
+	}
+	return nil, "", status.Error(codes.ResourceExhausted, "could not allocate a staging name")
+}
+
+func filesystemError(operation string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if _, ok := status.FromError(err); ok {
+		return err
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return status.Errorf(codes.NotFound, "%s: %v", operation, err)
+	}
+	if errors.Is(err, os.ErrExist) {
+		return status.Errorf(codes.FailedPrecondition, "%s: path component has an incompatible type", operation)
+	}
+	if errors.Is(err, os.ErrPermission) {
+		return status.Errorf(codes.PermissionDenied, "%s: %v", operation, err)
+	}
+	if errors.Is(err, os.ErrInvalid) || pathEscapesRoot(err) {
+		return status.Errorf(codes.FailedPrecondition, "%s: path is not confined to the workspace", operation)
+	}
+	return status.Errorf(codes.Internal, "%s: %v", operation, err)
+}
+
+func pathEscapesRoot(err error) bool {
+	for err != nil {
+		// os.Root's confinement sentinel is intentionally unexported.
+		if err.Error() == "path escapes from parent" {
+			return true
+		}
+		err = errors.Unwrap(err)
+	}
+	return false
+}
+
+func contextError(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return status.FromContextError(err).Err()
+	}
+	return nil
+}
+
+func hashFile(ctx context.Context, file *os.File) (string, error) {
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return "", err
+	}
+	hash := sha256.New()
+	buf := make([]byte, filesystemHashChunk)
+	for {
+		if err := contextError(ctx); err != nil {
+			return "", err
+		}
+		n, err := file.Read(buf)
+		if n > 0 {
+			_, _ = hash.Write(buf[:n])
+		}
+		if errors.Is(err, io.EOF) {
+			return hex.EncodeToString(hash.Sum(nil)), nil
+		}
+		if err != nil {
+			return "", err
+		}
+	}
+}
+
+func (s *FilesystemServer) Read(ctx context.Context, req *sandboxdv1.ReadRequest) (*sandboxdv1.ReadResponse, error) {
+	if err := s.initialize(); err != nil {
+		return nil, status.Errorf(codes.Internal, "initialize filesystem: %v", err)
+	}
+	logical, err := normalizeWorkspacePath(req.GetPath(), false)
+	if err != nil {
+		return nil, err
+	}
+	limit := s.MaxReadBytes
+	if limit == 0 {
+		limit = defaultMaxReadBytes
+	}
+	maxBytes := req.GetMaxBytes()
+	if maxBytes == 0 {
+		maxBytes = min(uint32(defaultReadBytes), limit)
+	}
+	if maxBytes > limit {
+		return nil, status.Errorf(codes.InvalidArgument, "max_bytes exceeds %d", limit)
+	}
+
+	s.commitMu.RLock()
+	defer s.commitMu.RUnlock()
+	if err := contextError(ctx); err != nil {
+		return nil, err
+	}
+	file, err := s.rootHandle.Open(filepath.FromSlash(logical))
+	if err != nil {
+		return nil, filesystemError("open workspace file", err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, filesystemError("inspect workspace file", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, status.Error(codes.FailedPrecondition, "read path is not a regular file")
+	}
+	size := uint64(info.Size())
+	if req.GetOffset() > size {
+		return nil, status.Errorf(codes.OutOfRange, "offset %d exceeds file size %d", req.GetOffset(), size)
+	}
+	version := ""
+	if req.GetIncludeVersion() {
+		version, err = hashFile(ctx, file)
+		if err != nil {
+			if status.Code(err) != codes.Unknown {
+				return nil, err
+			}
+			return nil, filesystemError("hash workspace file", err)
+		}
+	}
+	if _, err := file.Seek(int64(req.GetOffset()), io.SeekStart); err != nil {
+		return nil, filesystemError("seek workspace file", err)
+	}
+	want := min(uint64(maxBytes), size-req.GetOffset())
+	data := make([]byte, int(want))
+	n, err := io.ReadFull(file, data)
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return nil, status.Error(codes.Aborted, "workspace file changed during read")
+	}
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, filesystemError("read workspace file", err)
+	}
+	data = data[:n]
+	next := req.GetOffset() + uint64(len(data))
+	return &sandboxdv1.ReadResponse{Data: data, Offset: req.GetOffset(), NextOffset: next, Size: size, Eof: next == size, Version: version}, nil
+}
+
+func (s *FilesystemServer) Write(stream sandboxdv1.FilesystemService_WriteServer) error {
+	if err := s.initialize(); err != nil {
+		return status.Errorf(codes.Internal, "initialize filesystem: %v", err)
+	}
+	select {
+	case s.writeSlots <- struct{}{}:
+		defer func() { <-s.writeSlots }()
+	default:
+		return status.Error(codes.ResourceExhausted, "too many concurrent writes")
+	}
+	ctx := stream.Context()
+	first, err := stream.Recv()
+	if err != nil {
+		if ctxErr := contextError(ctx); ctxErr != nil {
+			return ctxErr
+		}
+		if status.Code(err) != codes.Unknown {
+			return err
+		}
+		return status.Errorf(codes.InvalidArgument, "write header: %v", err)
+	}
+	header := first.GetHeader()
+	if header == nil {
+		return status.Error(codes.InvalidArgument, "first write message must be a header")
+	}
+	logical, err := normalizeWorkspacePath(header.GetPath(), false)
+	if err != nil {
+		return err
+	}
+	if err := validateWriteHeader(header); err != nil {
+		return err
+	}
+
+	s.commitMu.Lock()
+	destination, err := s.prepareWritePath(logical)
+	if err == nil {
+		if info, statErr := s.rootHandle.Lstat(destination); statErr == nil {
+			if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+				err = status.Error(codes.FailedPrecondition, "write destination is not a regular file")
+			}
+		} else if !errors.Is(statErr, os.ErrNotExist) {
+			err = filesystemError("inspect write destination", statErr)
+		}
+	}
+	var staged *os.File
+	var stagedName string
+	if err == nil {
+		staged, stagedName, err = s.createStagingFile(destination)
+	}
+	s.commitMu.Unlock()
+	if err != nil {
+		return err
+	}
+	defer s.rootHandle.Remove(stagedName)
+	defer staged.Close()
+
+	hash := sha256.New()
+	var size uint64
+	chunkLimit := s.MaxWriteChunkBytes
+	if chunkLimit == 0 {
+		chunkLimit = defaultMaxWriteChunk
+	}
+	fileLimit := s.MaxWriteBytes
+	if fileLimit == 0 {
+		fileLimit = defaultMaxWriteBytes
+	}
+	for {
+		message, recvErr := stream.Recv()
+		if errors.Is(recvErr, io.EOF) {
+			break
+		}
+		if recvErr != nil {
+			if ctxErr := contextError(ctx); ctxErr != nil {
+				return ctxErr
+			}
+			if status.Code(recvErr) != codes.Unknown {
+				return recvErr
+			}
+			return status.Errorf(codes.Unavailable, "write stream interrupted: %v", recvErr)
+		}
+		if err := contextError(ctx); err != nil {
+			return err
+		}
+		if message.GetHeader() != nil || message.GetData() == nil {
+			return status.Error(codes.InvalidArgument, "write data messages must follow the single header")
+		}
+		data := message.GetData()
+		if uint64(len(data)) > uint64(chunkLimit) {
+			return status.Errorf(codes.ResourceExhausted, "write chunk exceeds %d bytes", chunkLimit)
+		}
+		if uint64(len(data)) > fileLimit-size {
+			return status.Errorf(codes.ResourceExhausted, "write exceeds %d bytes", fileLimit)
+		}
+		if _, err := staged.Write(data); err != nil {
+			return filesystemError("stage workspace file", err)
+		}
+		_, _ = hash.Write(data)
+		size += uint64(len(data))
+	}
+	if err := contextError(ctx); err != nil {
+		return err
+	}
+	if err := staged.Sync(); err != nil {
+		return filesystemError("flush staging file", err)
+	}
+	if err := staged.Close(); err != nil {
+		return filesystemError("close staging file", err)
+	}
+	version := hex.EncodeToString(hash.Sum(nil))
+
+	s.commitMu.Lock()
+	defer s.commitMu.Unlock()
+	if err := contextError(ctx); err != nil {
+		return err
+	}
+	destination, err = s.prepareWritePath(logical)
+	if err != nil {
+		return err
+	}
+	if err := s.checkWritePrecondition(ctx, destination, header); err != nil {
+		return err
+	}
+	if header.GetPrecondition() == sandboxdv1.WritePrecondition_WRITE_PRECONDITION_MUST_NOT_EXIST {
+		if err := s.rootHandle.Link(stagedName, destination); err != nil {
+			if errors.Is(err, os.ErrExist) {
+				return status.Error(codes.FailedPrecondition, "write destination already exists")
+			}
+			return filesystemError("commit new workspace file", err)
+		}
+	} else if err := s.rootHandle.Rename(stagedName, destination); err != nil {
+		return filesystemError("commit workspace file", err)
+	}
+	return stream.SendAndClose(&sandboxdv1.WriteResponse{Size: size, Version: version})
+}
+
+func validateWriteHeader(header *sandboxdv1.WriteHeader) error {
+	switch header.GetPrecondition() {
+	case sandboxdv1.WritePrecondition_WRITE_PRECONDITION_ANY, sandboxdv1.WritePrecondition_WRITE_PRECONDITION_MUST_NOT_EXIST:
+		if header.GetExpectedVersion() != "" {
+			return status.Error(codes.InvalidArgument, "expected_version is only valid with MATCH_VERSION")
+		}
+	case sandboxdv1.WritePrecondition_WRITE_PRECONDITION_MATCH_VERSION:
+		value := header.GetExpectedVersion()
+		decoded, err := hex.DecodeString(value)
+		if err != nil || len(decoded) != sha256.Size || value != strings.ToLower(value) {
+			return status.Error(codes.InvalidArgument, "expected_version must be a lowercase SHA-256 digest")
+		}
+	default:
+		return status.Error(codes.InvalidArgument, "write precondition must be specified")
+	}
+	return nil
+}
+
+func (s *FilesystemServer) checkWritePrecondition(ctx context.Context, destination string, header *sandboxdv1.WriteHeader) error {
+	info, err := s.rootHandle.Lstat(destination)
+	exists := err == nil
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return filesystemError("inspect write destination", err)
+	}
+	if exists && (info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular()) {
+		return status.Error(codes.FailedPrecondition, "write destination is not a regular file")
+	}
+	switch header.GetPrecondition() {
+	case sandboxdv1.WritePrecondition_WRITE_PRECONDITION_ANY:
+		return nil
+	case sandboxdv1.WritePrecondition_WRITE_PRECONDITION_MUST_NOT_EXIST:
+		if exists {
+			return status.Error(codes.FailedPrecondition, "write destination already exists")
+		}
+		return nil
+	case sandboxdv1.WritePrecondition_WRITE_PRECONDITION_MATCH_VERSION:
+		if !exists {
+			return status.Error(codes.FailedPrecondition, "write destination does not exist")
+		}
+		file, err := s.rootHandle.Open(destination)
+		if err != nil {
+			return filesystemError("open write destination", err)
+		}
+		defer file.Close()
+		version, err := hashFile(ctx, file)
+		if err != nil {
+			if status.Code(err) != codes.Unknown {
+				return err
+			}
+			return filesystemError("hash write destination", err)
+		}
+		if version != header.GetExpectedVersion() {
+			return status.Error(codes.FailedPrecondition, "write destination version changed")
+		}
+		return nil
+	default:
+		panic("validated write precondition changed")
+	}
+}
+
+func (s *FilesystemServer) List(ctx context.Context, req *sandboxdv1.ListRequest) (*sandboxdv1.ListResponse, error) {
+	if err := s.initialize(); err != nil {
+		return nil, status.Errorf(codes.Internal, "initialize filesystem: %v", err)
+	}
+	logical, err := normalizeWorkspacePath(req.GetPath(), true)
+	if err != nil {
+		return nil, err
+	}
+	limit := s.MaxPageSize
+	if limit == 0 {
+		limit = defaultMaxPageSize
+	}
+	pageSize := req.GetPageSize()
+	if pageSize == 0 {
+		pageSize = min(uint32(defaultPageSize), limit)
+	}
+	if pageSize > limit {
+		return nil, status.Errorf(codes.InvalidArgument, "page_size exceeds %d", limit)
+	}
+	offset, err := decodePageToken(logical, req.GetPageToken())
+	if err != nil {
+		return nil, err
+	}
+
+	s.commitMu.RLock()
+	defer s.commitMu.RUnlock()
+	hostPath, info, err := s.resolveExisting(logical)
+	if err != nil {
+		return nil, filesystemError("list workspace directory", err)
+	}
+	if !info.IsDir() {
+		return nil, status.Error(codes.FailedPrecondition, "list path is not a directory")
+	}
+	directory, err := s.rootHandle.Open(hostPath)
+	if err != nil {
+		return nil, filesystemError("open workspace directory", err)
+	}
+	defer directory.Close()
+	remaining := offset
+	for remaining > 0 {
+		if err := contextError(ctx); err != nil {
+			return nil, err
+		}
+		step := min(remaining, uint64(defaultPageSize))
+		names, readErr := directory.Readdirnames(int(step))
+		remaining -= uint64(len(names))
+		if errors.Is(readErr, io.EOF) && remaining > 0 {
+			return nil, status.Error(codes.InvalidArgument, "page token is past the end of the directory")
+		}
+		if readErr != nil && !errors.Is(readErr, io.EOF) {
+			return nil, filesystemError("scan workspace directory", readErr)
+		}
+	}
+	infos, readErr := directory.Readdir(int(pageSize) + 1)
+	if readErr != nil && !errors.Is(readErr, io.EOF) {
+		return nil, filesystemError("scan workspace directory", readErr)
+	}
+	more := len(infos) > int(pageSize)
+	if more {
+		infos = infos[:pageSize]
+	}
+	consumed := uint64(len(infos))
+	entries := make([]*sandboxdv1.Entry, 0, len(infos))
+	for _, child := range infos {
+		if err := contextError(ctx); err != nil {
+			return nil, err
+		}
+		if strings.HasPrefix(child.Name(), ".sandboxd-write-") {
+			continue
+		}
+		entryType := sandboxdv1.EntryType_ENTRY_TYPE_OTHER
+		switch {
+		case child.Mode()&os.ModeSymlink != 0:
+			entryType = sandboxdv1.EntryType_ENTRY_TYPE_SYMLINK
+		case child.Mode().IsRegular():
+			entryType = sandboxdv1.EntryType_ENTRY_TYPE_FILE
+		case child.IsDir():
+			entryType = sandboxdv1.EntryType_ENTRY_TYPE_DIRECTORY
+		}
+		size := uint64(0)
+		if entryType == sandboxdv1.EntryType_ENTRY_TYPE_FILE && child.Size() > 0 {
+			size = uint64(child.Size())
+		}
+		entries = append(entries, &sandboxdv1.Entry{Name: child.Name(), Type: entryType, Size: size, ModifiedUnixMs: child.ModTime().UnixMilli()})
+	}
+	response := &sandboxdv1.ListResponse{Entries: entries}
+	if more {
+		response.NextPageToken = encodePageToken(logical, offset+consumed)
+	}
+	return response, nil
+}
+
+func pageTokenPrefix(logical string) string {
+	sum := sha256.Sum256([]byte(logical))
+	return hex.EncodeToString(sum[:8])
+}
+
+func encodePageToken(logical string, offset uint64) string {
+	plain := pageTokenPrefix(logical) + ":" + strconv.FormatUint(offset, 10)
+	return base64.RawURLEncoding.EncodeToString([]byte(plain))
+}
+
+func decodePageToken(logical, token string) (uint64, error) {
+	if token == "" {
+		return 0, nil
+	}
+	if len(token) > 128 {
+		return 0, status.Error(codes.InvalidArgument, "invalid page token")
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return 0, status.Error(codes.InvalidArgument, "invalid page token")
+	}
+	prefix, value, found := strings.Cut(string(decoded), ":")
+	if !found || prefix != pageTokenPrefix(logical) {
+		return 0, status.Error(codes.InvalidArgument, "page token does not match path")
+	}
+	offset, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return 0, status.Error(codes.InvalidArgument, "invalid page token")
+	}
+	return offset, nil
+}

--- a/sandboxd/internal/server/filesystem_test.go
+++ b/sandboxd/internal/server/filesystem_test.go
@@ -304,7 +304,20 @@ func TestFilesystemCanceledWriteCleansPinnedRenamedDirectory(t *testing.T) {
 	})
 	moved := filepath.Join(workspace, "moved")
 	if err := os.Rename(parent, moved); err != nil {
-		t.Fatal(err)
+		if runtime.GOOS != "windows" || !errors.Is(err, os.ErrPermission) {
+			t.Fatal(err)
+		}
+		// Windows denies the rename while the pinned directory handle is
+		// open, preventing the swap rather than tracking it across a rename.
+		cancel()
+		if _, err := stream.CloseAndRecv(); status.Code(err) != codes.Canceled {
+			t.Fatalf("cancelled write: %v", err)
+		}
+		waitFor(t, func() bool {
+			matches, _ := filepath.Glob(filepath.Join(parent, ".sandboxd-write-*"))
+			return len(matches) == 0
+		})
+		return
 	}
 	cancel()
 	if _, err := stream.CloseAndRecv(); status.Code(err) != codes.Canceled {

--- a/sandboxd/internal/server/filesystem_test.go
+++ b/sandboxd/internal/server/filesystem_test.go
@@ -1,0 +1,465 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
+)
+
+func newFilesystemConn(t *testing.T, fs *FilesystemServer) *grpc.ClientConn {
+	t.Helper()
+	if err := fs.initialize(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = fs.Close() })
+	listener := bufconn.Listen(1024 * 1024)
+	grpcServer := grpc.NewServer()
+	sandboxdv1.RegisterFilesystemServiceServer(grpcServer, fs)
+	go func() { _ = grpcServer.Serve(listener) }()
+	t.Cleanup(grpcServer.Stop)
+	conn, err := grpc.NewClient("passthrough://filesystem",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return listener.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+func newTestFilesystemServer(t *testing.T, workspace string) *FilesystemServer {
+	t.Helper()
+	server, err := NewFilesystemServer(workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = server.Close() })
+	return server
+}
+
+func writeWorkspaceFile(ctx context.Context, client sandboxdv1.FilesystemServiceClient, header *sandboxdv1.WriteHeader, content []byte) (*sandboxdv1.WriteResponse, error) {
+	stream, err := client.Write(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := stream.Send(&sandboxdv1.WriteRequest{Kind: &sandboxdv1.WriteRequest_Header{Header: header}}); err != nil {
+		return nil, err
+	}
+	for len(content) > 0 {
+		n := min(len(content), 64*1024)
+		if err := stream.Send(&sandboxdv1.WriteRequest{Kind: &sandboxdv1.WriteRequest_Data{Data: content[:n]}}); err != nil {
+			return nil, err
+		}
+		content = content[n:]
+	}
+	return stream.CloseAndRecv()
+}
+
+func TestFilesystemLargeFileRoundTripIsChunked(t *testing.T) {
+	workspace := t.TempDir()
+	client := sandboxdv1.NewFilesystemServiceClient(newFilesystemConn(t, newTestFilesystemServer(t, workspace)))
+	content := bytes.Repeat([]byte("large-workspace-file\n"), 300000) // exceeds default gRPC message limits
+	written, err := writeWorkspaceFile(context.Background(), client, &sandboxdv1.WriteHeader{
+		Path: "notes/large.txt", Precondition: sandboxdv1.WritePrecondition_WRITE_PRECONDITION_MUST_NOT_EXIST,
+	}, content)
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	wantHash := sha256.Sum256(content)
+	if written.Size != uint64(len(content)) || written.Version != hex.EncodeToString(wantHash[:]) {
+		t.Fatalf("write metadata = %+v", written)
+	}
+
+	var got []byte
+	var offset uint64
+	for {
+		page, err := client.Read(context.Background(), &sandboxdv1.ReadRequest{Path: "notes/large.txt", Offset: offset, MaxBytes: 128 * 1024, IncludeVersion: offset == 0})
+		if err != nil {
+			t.Fatalf("read at %d: %v", offset, err)
+		}
+		if len(page.Data) > 128*1024 || page.Offset != offset || page.Size != uint64(len(content)) || offset == 0 && page.Version != written.Version || offset > 0 && page.Version != "" {
+			t.Fatalf("invalid page at %d: %+v", offset, page)
+		}
+		got = append(got, page.Data...)
+		offset = page.NextOffset
+		if page.Eof {
+			break
+		}
+	}
+	if !bytes.Equal(got, content) {
+		t.Fatal("chunked content mismatch")
+	}
+	if _, err := os.Stat(filepath.Join(workspace, "notes", "large.txt")); err != nil {
+		t.Fatalf("file not in workspace: %v", err)
+	}
+}
+
+func TestFilesystemRejectsNonPortableAndEscapingPaths(t *testing.T) {
+	server := newTestFilesystemServer(t, t.TempDir())
+	for _, value := range []string{"/etc/passwd", "../outside", "a/../../outside", `C:\\Windows`, "C:/Windows", `\\\\server\\share`, "a\\b", "a:b", "x\x00y", "a?b", "a<b", "control\x01", "NUL", "com1.txt", "COM¹", "lpt².log", "CONIN$", "conout$.txt", "trailing.", "trailing "} {
+		t.Run(strings.ReplaceAll(value, "/", "_"), func(t *testing.T) {
+			_, err := server.Read(context.Background(), &sandboxdv1.ReadRequest{Path: value})
+			if status.Code(err) != codes.InvalidArgument {
+				t.Fatalf("path %q returned %v", value, err)
+			}
+		})
+	}
+	for input, want := range map[string]string{"a//b": "a/b", "./a/./b": "a/b", "": ""} {
+		got, err := normalizeWorkspacePath(input, true)
+		if err != nil || got != want {
+			t.Fatalf("normalize %q = %q, %v; want %q", input, got, err, want)
+		}
+	}
+}
+
+func TestFilesystemRejectsNestedAndDanglingSymlinksAndListsTheirType(t *testing.T) {
+	workspace := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Mkdir(filepath.Join(workspace, "inside"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace, "inside", "ok"), []byte("inside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "secret"), []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(workspace, "nested")); err != nil {
+		if runtime.GOOS == "windows" {
+			t.Skipf("symlink privilege unavailable: %v", err)
+		}
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(outside, "missing"), filepath.Join(workspace, "dangling")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("inside", filepath.Join(workspace, "internal")); err != nil {
+		t.Fatal(err)
+	}
+	client := sandboxdv1.NewFilesystemServiceClient(newFilesystemConn(t, newTestFilesystemServer(t, workspace)))
+	for _, path := range []string{"nested/secret", "dangling"} {
+		if _, err := client.Read(context.Background(), &sandboxdv1.ReadRequest{Path: path}); status.Code(err) != codes.FailedPrecondition {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		_, err := writeWorkspaceFile(context.Background(), client, &sandboxdv1.WriteHeader{Path: path, Precondition: sandboxdv1.WritePrecondition_WRITE_PRECONDITION_ANY}, []byte("overwrite"))
+		if status.Code(err) != codes.FailedPrecondition {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	read, err := client.Read(context.Background(), &sandboxdv1.ReadRequest{Path: "internal/ok"})
+	if err != nil || string(read.Data) != "inside" {
+		t.Fatalf("confined internal link: %q, %v", read.GetData(), err)
+	}
+	list, err := client.List(context.Background(), &sandboxdv1.ListRequest{PageSize: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range list.Entries {
+		if entry.Name == "nested" || entry.Name == "dangling" {
+			if entry.Type != sandboxdv1.EntryType_ENTRY_TYPE_SYMLINK {
+				t.Fatalf("symlink entry = %+v", entry)
+			}
+		}
+	}
+}
+
+func TestFilesystemListPaginationAndPortableTypes(t *testing.T) {
+	workspace := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspace, "file"), []byte("abc"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(workspace, "directory"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	client := sandboxdv1.NewFilesystemServiceClient(newFilesystemConn(t, newTestFilesystemServer(t, workspace)))
+	var entries []*sandboxdv1.Entry
+	var token string
+	for {
+		page, err := client.List(context.Background(), &sandboxdv1.ListRequest{PageSize: 1, PageToken: token})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(page.Entries) > 1 {
+			t.Fatalf("unbounded page: %d", len(page.Entries))
+		}
+		entries = append(entries, page.Entries...)
+		token = page.NextPageToken
+		if token == "" {
+			break
+		}
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
+	if len(entries) != 2 || entries[0].Name != "directory" || entries[0].Type != sandboxdv1.EntryType_ENTRY_TYPE_DIRECTORY || entries[1].Name != "file" || entries[1].Type != sandboxdv1.EntryType_ENTRY_TYPE_FILE || entries[1].Size != 3 {
+		t.Fatalf("entries = %+v", entries)
+	}
+	_, err := client.List(context.Background(), &sandboxdv1.ListRequest{Path: "directory", PageToken: encodePageToken("", 1)})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("cross-directory token: %v", err)
+	}
+}
+
+func TestFilesystemInterruptedAndLimitedWritesPreserveDestination(t *testing.T) {
+	workspace := t.TempDir()
+	destination := filepath.Join(workspace, "target")
+	if err := os.WriteFile(destination, []byte("original"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	server := &FilesystemServer{Workspace: workspace, MaxWriteChunkBytes: 4, MaxWriteBytes: 6}
+	client := sandboxdv1.NewFilesystemServiceClient(newFilesystemConn(t, server))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stream, err := client.Write(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := stream.Send(&sandboxdv1.WriteRequest{Kind: &sandboxdv1.WriteRequest_Header{Header: &sandboxdv1.WriteHeader{Path: "target", Precondition: sandboxdv1.WritePrecondition_WRITE_PRECONDITION_ANY}}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := stream.Send(&sandboxdv1.WriteRequest{Kind: &sandboxdv1.WriteRequest_Data{Data: []byte("part")}}); err != nil {
+		t.Fatal(err)
+	}
+	cancel()
+	_, err = stream.CloseAndRecv()
+	if status.Code(err) != codes.Canceled {
+		t.Fatalf("cancelled write: %v", err)
+	}
+	waitFor(t, func() bool {
+		matches, _ := filepath.Glob(filepath.Join(workspace, ".sandboxd-write-*"))
+		return len(matches) == 0
+	})
+	assertFileContent(t, destination, "original")
+
+	for name, content := range map[string][]byte{"chunk": []byte("12345"), "file": []byte("1234") /* followed below */} {
+		stream, err := client.Write(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := stream.Send(&sandboxdv1.WriteRequest{Kind: &sandboxdv1.WriteRequest_Header{Header: &sandboxdv1.WriteHeader{Path: "target", Precondition: sandboxdv1.WritePrecondition_WRITE_PRECONDITION_ANY}}}); err != nil {
+			t.Fatal(err)
+		}
+		if err := stream.Send(&sandboxdv1.WriteRequest{Kind: &sandboxdv1.WriteRequest_Data{Data: content}}); err != nil {
+			t.Fatal(err)
+		}
+		if name == "file" {
+			if err := stream.Send(&sandboxdv1.WriteRequest{Kind: &sandboxdv1.WriteRequest_Data{Data: []byte("789")}}); err != nil {
+				t.Fatal(err)
+			}
+		}
+		_, err = stream.CloseAndRecv()
+		if status.Code(err) != codes.ResourceExhausted {
+			t.Fatalf("%s limit: %v", name, err)
+		}
+		assertFileContent(t, destination, "original")
+	}
+}
+
+func TestFilesystemOptimisticConcurrentWritesCommitOnce(t *testing.T) {
+	workspace := t.TempDir()
+	client := sandboxdv1.NewFilesystemServiceClient(newFilesystemConn(t, newTestFilesystemServer(t, workspace)))
+	base, err := writeWorkspaceFile(context.Background(), client, &sandboxdv1.WriteHeader{Path: "race", Precondition: sandboxdv1.WritePrecondition_WRITE_PRECONDITION_MUST_NOT_EXIST}, []byte("base"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	for _, value := range []string{"first", "second"} {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := writeWorkspaceFile(context.Background(), client, &sandboxdv1.WriteHeader{Path: "race", Precondition: sandboxdv1.WritePrecondition_WRITE_PRECONDITION_MATCH_VERSION, ExpectedVersion: base.Version}, []byte(value))
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	var succeeded, conflicted int
+	for err := range errs {
+		switch status.Code(err) {
+		case codes.OK:
+			succeeded++
+		case codes.FailedPrecondition:
+			conflicted++
+		default:
+			t.Fatalf("write error: %v", err)
+		}
+	}
+	if succeeded != 1 || conflicted != 1 {
+		t.Fatalf("succeeded=%d conflicted=%d", succeeded, conflicted)
+	}
+	content, err := os.ReadFile(filepath.Join(workspace, "race"))
+	if err != nil || string(content) != "first" && string(content) != "second" {
+		t.Fatalf("committed content = %q, %v", content, err)
+	}
+}
+
+func TestFilesystemSymlinkSwapCannotEscapeRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory/symlink swap semantics are covered by os.Root on Windows")
+	}
+	workspace := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Mkdir(filepath.Join(workspace, "swap"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace, "swap", "value"), []byte("inside"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "value"), []byte("outside-secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	client := sandboxdv1.NewFilesystemServiceClient(newFilesystemConn(t, newTestFilesystemServer(t, workspace)))
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		parked := filepath.Join(workspace, "parked")
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if os.Rename(filepath.Join(workspace, "swap"), parked) != nil {
+				continue
+			}
+			_ = os.Symlink(outside, filepath.Join(workspace, "swap"))
+			runtime.Gosched()
+			_ = os.Remove(filepath.Join(workspace, "swap"))
+			_ = os.Rename(parked, filepath.Join(workspace, "swap"))
+		}
+	}()
+	for range 500 {
+		read, err := client.Read(context.Background(), &sandboxdv1.ReadRequest{Path: "swap/value", MaxBytes: 64})
+		if err == nil && string(read.Data) != "inside" {
+			close(stop)
+			<-done
+			t.Fatalf("workspace escape returned %q", read.Data)
+		}
+	}
+	close(stop)
+	<-done
+}
+
+func TestFilesystemConcurrentTruncateNeverReturnsFabricatedBytes(t *testing.T) {
+	workspace := t.TempDir()
+	path := filepath.Join(workspace, "changing")
+	content := bytes.Repeat([]byte("x"), 256*1024)
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	client := sandboxdv1.NewFilesystemServiceClient(newFilesystemConn(t, newTestFilesystemServer(t, workspace)))
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			_ = os.Truncate(path, 1)
+			_ = os.WriteFile(path, content, 0o600)
+		}
+	}()
+	for range 200 {
+		read, err := client.Read(context.Background(), &sandboxdv1.ReadRequest{Path: "changing", MaxBytes: 128 * 1024})
+		if err != nil && status.Code(err) != codes.Aborted {
+			close(stop)
+			<-done
+			t.Fatalf("read during truncate: %v", err)
+		}
+		if err == nil && bytes.IndexByte(read.Data, 0) >= 0 {
+			close(stop)
+			<-done
+			t.Fatal("read fabricated zero-filled bytes")
+		}
+	}
+	close(stop)
+	<-done
+}
+
+func TestFilesystemCancellationAndReadListLimits(t *testing.T) {
+	workspace := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspace, "file"), bytes.Repeat([]byte("x"), 1024), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	server := &FilesystemServer{Workspace: workspace, MaxReadBytes: 8, MaxPageSize: 1}
+	client := sandboxdv1.NewFilesystemServiceClient(newFilesystemConn(t, server))
+	if _, err := client.Read(context.Background(), &sandboxdv1.ReadRequest{Path: "file", MaxBytes: 9}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("read limit: %v", err)
+	}
+	if _, err := client.Read(context.Background(), &sandboxdv1.ReadRequest{Path: "file", Offset: 1025}); status.Code(err) != codes.OutOfRange {
+		t.Fatalf("read offset: %v", err)
+	}
+	if _, err := client.List(context.Background(), &sandboxdv1.ListRequest{PageSize: 2}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("list limit: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := server.Read(ctx, &sandboxdv1.ReadRequest{Path: "file", MaxBytes: 1}); status.Code(err) != codes.Canceled {
+		t.Fatalf("cancelled read: %v", err)
+	}
+}
+
+func TestFilesystemConcurrentWriteLimit(t *testing.T) {
+	server := &FilesystemServer{Workspace: t.TempDir(), MaxConcurrentWrites: 1}
+	if err := server.initialize(); err != nil {
+		t.Fatal(err)
+	}
+	client := sandboxdv1.NewFilesystemServiceClient(newFilesystemConn(t, server))
+	first, err := client.Write(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := first.Send(&sandboxdv1.WriteRequest{Kind: &sandboxdv1.WriteRequest_Header{Header: &sandboxdv1.WriteHeader{Path: "first", Precondition: sandboxdv1.WritePrecondition_WRITE_PRECONDITION_ANY}}}); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, func() bool { return len(server.writeSlots) == 1 })
+	second, err := client.Write(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := second.Send(&sandboxdv1.WriteRequest{Kind: &sandboxdv1.WriteRequest_Header{Header: &sandboxdv1.WriteHeader{Path: "second", Precondition: sandboxdv1.WritePrecondition_WRITE_PRECONDITION_ANY}}}); err != nil {
+		t.Fatal(err)
+	}
+	_, err = second.CloseAndRecv()
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("concurrent limit: %v", err)
+	}
+	if err := first.CloseSend(); err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatal(err)
+	}
+}
+
+func assertFileContent(t *testing.T, path, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil || string(got) != want {
+		t.Fatalf("%s = %q, %v; want %q", path, got, err, want)
+	}
+}

--- a/sandboxd/internal/server/filesystem_test.go
+++ b/sandboxd/internal/server/filesystem_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -117,7 +118,7 @@ func TestFilesystemLargeFileRoundTripIsChunked(t *testing.T) {
 
 func TestFilesystemRejectsNonPortableAndEscapingPaths(t *testing.T) {
 	server := newTestFilesystemServer(t, t.TempDir())
-	for _, value := range []string{"/etc/passwd", "../outside", "a/../../outside", `C:\\Windows`, "C:/Windows", `\\\\server\\share`, "a\\b", "a:b", "x\x00y", "a?b", "a<b", "control\x01", "NUL", "com1.txt", "COM¹", "lpt².log", "CONIN$", "conout$.txt", "trailing.", "trailing "} {
+	for _, value := range []string{"/etc/passwd", "../outside", "a/../../outside", `C:\\Windows`, "C:/Windows", `\\\\server\\share`, "a\\b", "a:b", "x\x00y", "a?b", "a<b", "control\x01", "NUL", "com1.txt", "COM¹", "lpt².log", "CONIN$", "conout$.txt", "trailing.", "trailing ", ".SANDBOXD-WRITE-secret"} {
 		t.Run(strings.ReplaceAll(value, "/", "_"), func(t *testing.T) {
 			_, err := server.Read(context.Background(), &sandboxdv1.ReadRequest{Path: value})
 			if status.Code(err) != codes.InvalidArgument {
@@ -171,6 +172,10 @@ func TestFilesystemRejectsNestedAndDanglingSymlinksAndListsTheirType(t *testing.
 	if err != nil || string(read.Data) != "inside" {
 		t.Fatalf("confined internal link: %q, %v", read.GetData(), err)
 	}
+	if _, err := writeWorkspaceFile(context.Background(), client, &sandboxdv1.WriteHeader{Path: "internal/new", Precondition: sandboxdv1.WritePrecondition_WRITE_PRECONDITION_ANY}, []byte("written")); err != nil {
+		t.Fatalf("write through confined internal link: %v", err)
+	}
+	assertFileContent(t, filepath.Join(workspace, "inside", "new"), "written")
 	list, err := client.List(context.Background(), &sandboxdv1.ListRequest{PageSize: 10})
 	if err != nil {
 		t.Fatal(err)
@@ -190,6 +195,9 @@ func TestFilesystemListPaginationAndPortableTypes(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := os.Mkdir(filepath.Join(workspace, "directory"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace, ".SANDBOXD-WRITE-hidden"), []byte("staging"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	client := sandboxdv1.NewFilesystemServiceClient(newFilesystemConn(t, newTestFilesystemServer(t, workspace)))
@@ -271,6 +279,62 @@ func TestFilesystemInterruptedAndLimitedWritesPreserveDestination(t *testing.T) 
 			t.Fatalf("%s limit: %v", name, err)
 		}
 		assertFileContent(t, destination, "original")
+	}
+}
+
+func TestFilesystemCanceledWriteCleansPinnedRenamedDirectory(t *testing.T) {
+	workspace := t.TempDir()
+	parent := filepath.Join(workspace, "parent")
+	if err := os.Mkdir(parent, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	server := newTestFilesystemServer(t, workspace)
+	client := sandboxdv1.NewFilesystemServiceClient(newFilesystemConn(t, server))
+	ctx, cancel := context.WithCancel(context.Background())
+	stream, err := client.Write(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := stream.Send(&sandboxdv1.WriteRequest{Kind: &sandboxdv1.WriteRequest_Header{Header: &sandboxdv1.WriteHeader{Path: "parent/file", Precondition: sandboxdv1.WritePrecondition_WRITE_PRECONDITION_ANY}}}); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, func() bool {
+		matches, _ := filepath.Glob(filepath.Join(parent, ".sandboxd-write-*"))
+		return len(matches) == 1
+	})
+	moved := filepath.Join(workspace, "moved")
+	if err := os.Rename(parent, moved); err != nil {
+		t.Fatal(err)
+	}
+	cancel()
+	if _, err := stream.CloseAndRecv(); status.Code(err) != codes.Canceled {
+		t.Fatalf("cancelled write: %v", err)
+	}
+	waitFor(t, func() bool {
+		matches, _ := filepath.Glob(filepath.Join(moved, ".sandboxd-write-*"))
+		return len(matches) == 0
+	})
+	if _, err := os.Stat(filepath.Join(moved, "file")); !os.IsNotExist(err) {
+		t.Fatalf("canceled destination exists: %v", err)
+	}
+}
+
+func TestFilesystemErrorsDoNotExposeHostPaths(t *testing.T) {
+	workspace := t.TempDir()
+	client := sandboxdv1.NewFilesystemServiceClient(newFilesystemConn(t, newTestFilesystemServer(t, workspace)))
+	_, err := client.Read(context.Background(), &sandboxdv1.ReadRequest{Path: "missing/file"})
+	if status.Code(err) != codes.NotFound || strings.Contains(err.Error(), workspace) || strings.Contains(err.Error(), `\`) || strings.Contains(err.Error(), "missing/file") {
+		t.Fatalf("host path leaked in error: %v", err)
+	}
+	hostErr := &os.PathError{Op: "open", Path: `C:\\private\\workspace\\file`, Err: os.ErrPermission}
+	sanitized := filesystemError("open workspace file", hostErr)
+	if status.Code(sanitized) != codes.PermissionDenied || strings.Contains(sanitized.Error(), "private") || strings.Contains(sanitized.Error(), `\`) {
+		t.Fatalf("synthetic host path leaked in error: %v", sanitized)
+	}
+	uninitialized := &FilesystemServer{Workspace: filepath.Join(workspace, "absent")}
+	_, err = uninitialized.Read(context.Background(), &sandboxdv1.ReadRequest{Path: "file"})
+	if status.Code(err) != codes.Internal || strings.Contains(err.Error(), workspace) {
+		t.Fatalf("initialization host path leaked in error: %v", err)
 	}
 }
 
@@ -453,6 +517,41 @@ func TestFilesystemConcurrentWriteLimit(t *testing.T) {
 	}
 	if err := first.CloseSend(); err != nil && !errors.Is(err, context.Canceled) {
 		t.Fatal(err)
+	}
+}
+
+func TestFilesystemShutdownFencesAndWaitsForWriteCleanup(t *testing.T) {
+	workspace := t.TempDir()
+	server := &FilesystemServer{Workspace: workspace}
+	client := sandboxdv1.NewFilesystemServiceClient(newFilesystemConn(t, server))
+	ctx, cancel := context.WithCancel(context.Background())
+	stream, err := client.Write(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := stream.Send(&sandboxdv1.WriteRequest{Kind: &sandboxdv1.WriteRequest_Header{Header: &sandboxdv1.WriteHeader{Path: "active", Precondition: sandboxdv1.WritePrecondition_WRITE_PRECONDITION_ANY}}}); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, func() bool { return len(server.writeSlots) == 1 })
+	server.BeginShutdown()
+	if _, err := writeWorkspaceFile(context.Background(), client, &sandboxdv1.WriteHeader{Path: "rejected", Precondition: sandboxdv1.WritePrecondition_WRITE_PRECONDITION_ANY}, nil); status.Code(err) != codes.Unavailable {
+		t.Fatalf("write admitted during shutdown: %v", err)
+	}
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer waitCancel()
+	if err := server.CloseContext(waitCtx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("CloseContext with active write = %v", err)
+	}
+	cancel()
+	if _, err := stream.CloseAndRecv(); status.Code(err) != codes.Canceled {
+		t.Fatalf("cancelled write: %v", err)
+	}
+	if err := server.CloseContext(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	matches, err := filepath.Glob(filepath.Join(workspace, ".sandboxd-write-*"))
+	if err != nil || len(matches) != 0 {
+		t.Fatalf("staging files after shutdown = %v, %v", matches, err)
 	}
 }
 

--- a/sandboxd/internal/server/process_windows.go
+++ b/sandboxd/internal/server/process_windows.go
@@ -42,16 +42,6 @@ func (d *processDomain) start() error {
 	// This follows the MIT-licensed microsoft/hcsshim job-list launch pattern:
 	// put the Job and the exact inherited handles in the startup attribute list.
 	const procThreadAttributeJobList = 0x0002000D
-	attrs, err := windows.NewProcThreadAttributeList(2)
-	if err != nil {
-		windows.CloseHandle(job)
-		return err
-	}
-	defer attrs.Delete()
-	if err = attrs.Update(procThreadAttributeJobList, unsafe.Pointer(&job), unsafe.Sizeof(job)); err != nil {
-		windows.CloseHandle(job)
-		return err
-	}
 	files := []*os.File{d.cmd.Stdin.(*os.File), d.cmd.Stdout.(*os.File), d.cmd.Stderr.(*os.File)}
 	handles := make([]windows.Handle, len(files))
 	for i, f := range files {
@@ -61,10 +51,6 @@ func (d *processDomain) start() error {
 			return err
 		}
 		defer windows.SetHandleInformation(handles[i], windows.HANDLE_FLAG_INHERIT, 0)
-	}
-	if err = attrs.Update(windows.PROC_THREAD_ATTRIBUTE_HANDLE_LIST, unsafe.Pointer(&handles[0]), uintptr(len(handles))*unsafe.Sizeof(handles[0])); err != nil {
-		windows.CloseHandle(job)
-		return err
 	}
 	path, err := exec.LookPath(d.cmd.Path)
 	if err != nil {
@@ -77,11 +63,6 @@ func (d *processDomain) start() error {
 		return err
 	}
 	app, err := windows.UTF16PtrFromString(path)
-	if err != nil {
-		windows.CloseHandle(job)
-		return err
-	}
-	line, err := windows.UTF16PtrFromString(windows.ComposeCommandLine(d.cmd.Args))
 	if err != nil {
 		windows.CloseHandle(job)
 		return err
@@ -107,12 +88,59 @@ func (d *processDomain) start() error {
 		env = append(env, 0)
 	}
 	env = append(env, 0)
-	si := windows.StartupInfoEx{ProcThreadAttributeList: attrs.List()}
-	si.StartupInfo.Cb = uint32(unsafe.Sizeof(si))
-	si.StartupInfo.Flags = windows.STARTF_USESTDHANDLES
-	si.StartupInfo.StdInput, si.StartupInfo.StdOutput, si.StartupInfo.StdErr = handles[0], handles[1], handles[2]
-	var pi windows.ProcessInformation
-	err = windows.CreateProcess(app, line, nil, nil, true, windows.EXTENDED_STARTUPINFO_PRESENT|windows.CREATE_UNICODE_ENVIRONMENT, &env[0], cwd, &si.StartupInfo, &pi)
+	create := func(includeJob bool, flags uint32) (windows.ProcessInformation, error) {
+		line, err := windows.UTF16PtrFromString(windows.ComposeCommandLine(d.cmd.Args))
+		if err != nil {
+			return windows.ProcessInformation{}, err
+		}
+		attributeCount := uint32(1)
+		if includeJob {
+			attributeCount++
+		}
+		attrs, err := windows.NewProcThreadAttributeList(attributeCount)
+		if err != nil {
+			return windows.ProcessInformation{}, err
+		}
+		defer attrs.Delete()
+		if includeJob {
+			if err := attrs.Update(procThreadAttributeJobList, unsafe.Pointer(&job), unsafe.Sizeof(job)); err != nil {
+				return windows.ProcessInformation{}, err
+			}
+		}
+		if err := attrs.Update(windows.PROC_THREAD_ATTRIBUTE_HANDLE_LIST, unsafe.Pointer(&handles[0]), uintptr(len(handles))*unsafe.Sizeof(handles[0])); err != nil {
+			return windows.ProcessInformation{}, err
+		}
+		si := windows.StartupInfoEx{ProcThreadAttributeList: attrs.List()}
+		si.StartupInfo.Cb = uint32(unsafe.Sizeof(si))
+		si.StartupInfo.Flags = windows.STARTF_USESTDHANDLES
+		si.StartupInfo.StdInput, si.StartupInfo.StdOutput, si.StartupInfo.StdErr = handles[0], handles[1], handles[2]
+		var pi windows.ProcessInformation
+		err = windows.CreateProcess(app, line, nil, nil, true, windows.EXTENDED_STARTUPINFO_PRESENT|windows.CREATE_UNICODE_ENVIRONMENT|flags, &env[0], cwd, &si.StartupInfo, &pi)
+		return pi, err
+	}
+
+	pi, err := create(true, 0)
+	if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+		// Some supervised hosts reject an additional job in the startup list.
+		// Launch suspended, assign before any child instruction can run, then
+		// resume. Failure remains fail-closed.
+		pi, err = create(false, windows.CREATE_SUSPENDED)
+		if err == nil {
+			if err = windows.AssignProcessToJobObject(job, pi.Process); err == nil {
+				var previous uint32
+				previous, err = windows.ResumeThread(pi.Thread)
+				if err == nil && previous != 1 {
+					err = fmt.Errorf("resume suspended process returned count %d", previous)
+				}
+			}
+			if err != nil {
+				_ = windows.TerminateProcess(pi.Process, 1)
+				_, _ = windows.WaitForSingleObject(pi.Process, windows.INFINITE)
+				windows.CloseHandle(pi.Thread)
+				windows.CloseHandle(pi.Process)
+			}
+		}
+	}
 	if err != nil {
 		windows.CloseHandle(job)
 		return err

--- a/sandboxd/internal/server/process_windows.go
+++ b/sandboxd/internal/server/process_windows.go
@@ -43,6 +43,16 @@ func (d *processDomain) start() error {
 	// This follows the MIT-licensed microsoft/hcsshim job-list launch pattern:
 	// put the Job and the exact inherited handles in the startup attribute list.
 	const procThreadAttributeJobList = 0x0002000D
+	attrs, err := windows.NewProcThreadAttributeList(2)
+	if err != nil {
+		windows.CloseHandle(job)
+		return err
+	}
+	defer attrs.Delete()
+	if err = attrs.Update(procThreadAttributeJobList, unsafe.Pointer(&job), unsafe.Sizeof(job)); err != nil {
+		windows.CloseHandle(job)
+		return err
+	}
 	files := []*os.File{d.cmd.Stdin.(*os.File), d.cmd.Stdout.(*os.File), d.cmd.Stderr.(*os.File)}
 	handles := make([]windows.Handle, 0, len(files))
 	for _, f := range files {
@@ -56,6 +66,10 @@ func (d *processDomain) start() error {
 			handles = append(handles, handle)
 		}
 	}
+	if err = attrs.Update(windows.PROC_THREAD_ATTRIBUTE_HANDLE_LIST, unsafe.Pointer(&handles[0]), uintptr(len(handles))*unsafe.Sizeof(handles[0])); err != nil {
+		windows.CloseHandle(job)
+		return err
+	}
 	path, err := exec.LookPath(d.cmd.Path)
 	if err != nil {
 		windows.CloseHandle(job)
@@ -67,6 +81,11 @@ func (d *processDomain) start() error {
 		return err
 	}
 	app, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		windows.CloseHandle(job)
+		return err
+	}
+	line, err := windows.UTF16PtrFromString(windows.ComposeCommandLine(d.cmd.Args))
 	if err != nil {
 		windows.CloseHandle(job)
 		return err

--- a/sandboxd/internal/server/server.go
+++ b/sandboxd/internal/server/server.go
@@ -15,7 +15,6 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -363,64 +362,6 @@ func (s *ExecServer) Exec(stream sandboxdv1.ExecService_ExecServer) error {
 			Exit: &sandboxdv1.ExecExit{Code: code, Error: errStr, Reason: terminalReason},
 		},
 	})
-}
-
-// FilesystemServer implements FilesystemService.
-type FilesystemServer struct {
-	sandboxdv1.UnimplementedFilesystemServiceServer
-	Workspace string
-}
-
-// resolve maps a request path onto the filesystem. Relative paths resolve
-// against the workspace.
-// TODO(P1): jail paths to the workspace root.
-func (s *FilesystemServer) resolve(path string) string {
-	if path == "" {
-		return s.Workspace
-	}
-	if filepath.IsAbs(path) {
-		return filepath.Clean(path)
-	}
-	return filepath.Join(s.Workspace, path)
-}
-
-func (s *FilesystemServer) Read(_ context.Context, req *sandboxdv1.ReadRequest) (*sandboxdv1.ReadResponse, error) {
-	content, err := os.ReadFile(s.resolve(req.Path))
-	if err != nil {
-		return nil, status.Errorf(codes.NotFound, "read %s: %v", req.Path, err)
-	}
-	return &sandboxdv1.ReadResponse{Content: content}, nil
-}
-
-func (s *FilesystemServer) Write(_ context.Context, req *sandboxdv1.WriteRequest) (*sandboxdv1.WriteResponse, error) {
-	path := s.resolve(req.Path)
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return nil, status.Errorf(codes.Internal, "mkdir for %s: %v", req.Path, err)
-	}
-	mode := os.FileMode(req.Mode)
-	if req.Mode == 0 {
-		mode = 0o644
-	}
-	if err := os.WriteFile(path, req.Content, mode); err != nil {
-		return nil, status.Errorf(codes.Internal, "write %s: %v", req.Path, err)
-	}
-	return &sandboxdv1.WriteResponse{}, nil
-}
-
-func (s *FilesystemServer) List(_ context.Context, req *sandboxdv1.ListRequest) (*sandboxdv1.ListResponse, error) {
-	entries, err := os.ReadDir(s.resolve(req.Path))
-	if err != nil {
-		return nil, status.Errorf(codes.NotFound, "list %s: %v", req.Path, err)
-	}
-	resp := &sandboxdv1.ListResponse{Entries: make([]*sandboxdv1.Entry, 0, len(entries))}
-	for _, e := range entries {
-		entry := &sandboxdv1.Entry{Name: e.Name(), IsDir: e.IsDir()}
-		if info, err := e.Info(); err == nil {
-			entry.Size = info.Size()
-		}
-		resp.Entries = append(resp.Entries, entry)
-	}
-	return resp, nil
 }
 
 // PortServer implements PortService.

--- a/sandboxd/internal/server/server_test.go
+++ b/sandboxd/internal/server/server_test.go
@@ -38,7 +38,7 @@ func newConn(t *testing.T, workspace string) *grpc.ClientConn {
 	sandboxdv1.RegisterHealthServiceServer(grpcServer, &HealthServer{Version: "test"})
 	sandboxdv1.RegisterExecServiceServer(grpcServer, NewExecServer(workspace, supervisor))
 	sandboxdv1.RegisterProcessServiceServer(grpcServer, processServer)
-	sandboxdv1.RegisterFilesystemServiceServer(grpcServer, &FilesystemServer{Workspace: workspace})
+	sandboxdv1.RegisterFilesystemServiceServer(grpcServer, newTestFilesystemServer(t, workspace))
 	sandboxdv1.RegisterTerminalServiceServer(grpcServer, &TerminalServer{
 		Workspace:  workspace,
 		SocketName: socketName,
@@ -203,38 +203,6 @@ func TestNormalizeEnvReplaceAndStable(t *testing.T) {
 	}
 	if strings.Join(env, ",") != "A=1,B=2" {
 		t.Fatalf("replace env = %v", env)
-	}
-}
-
-func TestFilesystemRoundTrip(t *testing.T) {
-	workspace := t.TempDir()
-	conn := newConn(t, workspace)
-	fs := sandboxdv1.NewFilesystemServiceClient(conn)
-	ctx := context.Background()
-
-	if _, err := fs.Write(ctx, &sandboxdv1.WriteRequest{Path: "notes/hello.txt", Content: []byte("hi there")}); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-
-	read, err := fs.Read(ctx, &sandboxdv1.ReadRequest{Path: "notes/hello.txt"})
-	if err != nil {
-		t.Fatalf("read: %v", err)
-	}
-	if string(read.Content) != "hi there" {
-		t.Fatalf("unexpected content: %q", read.Content)
-	}
-
-	list, err := fs.List(ctx, &sandboxdv1.ListRequest{Path: "notes"})
-	if err != nil {
-		t.Fatalf("list: %v", err)
-	}
-	if len(list.Entries) != 1 || list.Entries[0].Name != "hello.txt" {
-		t.Fatalf("unexpected entries: %+v", list.Entries)
-	}
-
-	// The file must have landed inside the workspace.
-	if _, err := os.Stat(filepath.Join(workspace, "notes", "hello.txt")); err != nil {
-		t.Fatalf("file not in workspace: %v", err)
 	}
 }
 

--- a/sandboxd/proto/sandboxd/v1/FILESYSTEM.md
+++ b/sandboxd/proto/sandboxd/v1/FILESYSTEM.md
@@ -19,8 +19,10 @@ also invalid.
 The workspace root is opened and fixed before the gRPC server starts. Resolution uses
 that root's race-safe host handles: a relative symlink may be followed only when its
 target remains inside the fixed workspace. Dangling, absolute, and outside-workspace
-links fail; writes reject an encountered symlink and always refuse to replace a symlink
-at the final destination. `List`
+links fail. Writes may follow a confined relative link in a parent component. A final
+symlink observed while evaluating a write precondition is rejected; publication replaces
+the final directory entry without following its target, so an external process racing
+publication may have its symlink entry replaced but cannot redirect the write. `List`
 reports a direct child link as `ENTRY_TYPE_SYMLINK` without following it. These rules
 prevent escapes even if another workspace process swaps a checked component; callers
 with `Exec` remain able to access whatever that separate capability permits.
@@ -49,9 +51,11 @@ server admits at most 16 concurrent streams by default. Cancellation observed be
 publication and malformed, over-limit, or interrupted streams remove their staging file
 and leave the destination unchanged.
 
-Data is staged in the destination directory, flushed, closed, and published with the
-host's same-filesystem atomic replacement operation only after the complete stream is
-received. Staging names cannot be addressed or listed through this capability. `ANY`
+Data is staged in the destination directory, flushed, closed, and published with one
+host replacement operation only after the complete stream is received. The portable
+guarantee is that the destination never contains partially streamed data; namespace
+replacement is atomic where the host and workspace filesystem guarantee atomic rename.
+Staging names cannot be addressed or listed through this capability. `ANY`
 replaces any regular file; `MUST_NOT_EXIST` uses atomic no-replace publication and
 creates only when absent. `MATCH_VERSION` replaces only when the current complete-file
 SHA-256 equals `expected_version`. Hash checking and replacement are serialized with

--- a/sandboxd/proto/sandboxd/v1/FILESYSTEM.md
+++ b/sandboxd/proto/sandboxd/v1/FILESYSTEM.md
@@ -1,0 +1,82 @@
+# sandboxd workspace filesystem contract (v1alpha1)
+
+This document is versioned with `sandboxd.proto` and is normative. `FilesystemService`
+is a bounded workspace capability, not arbitrary container filesystem access. A future
+whole-container capability, if needed, must be a separately authorized service.
+
+## Logical paths and confinement
+
+Paths are workspace-relative UTF-8 logical paths with `/` separators on every host.
+The empty path denotes the workspace root. Empty components and `.` are normalized
+away. A leading `/`, `..` component, `\`, NUL, Windows drive prefix (such as `C:`), or
+UNC/device form is invalid regardless of the server operating system. Responses use
+logical names and never expose host paths or separators. Components beginning with
+`.sandboxd-write-` are reserved for hidden staging files and are rejected. For the same
+syntax on every host, control characters, Windows-invalid `<>:"|?*`, trailing dots or
+spaces, and reserved device names such as `NUL`, `CONIN$`, `COM1`, and their aliases are
+also invalid.
+
+The workspace root is opened and fixed before the gRPC server starts. Resolution uses
+that root's race-safe host handles: a relative symlink may be followed only when its
+target remains inside the fixed workspace. Dangling, absolute, and outside-workspace
+links fail; writes reject an encountered symlink and always refuse to replace a symlink
+at the final destination. `List`
+reports a direct child link as `ENTRY_TYPE_SYMLINK` without following it. These rules
+prevent escapes even if another workspace process swaps a checked component; callers
+with `Exec` remain able to access whatever that separate capability permits.
+
+## Reads and metadata
+
+`Read` returns at most the server maximum (256 KiB by default); zero `max_bytes` uses
+64 KiB. Clients continue from `next_offset` until `eof`. `offset` beyond the current
+size is `OutOfRange`. `size` describes the complete regular file. When
+`include_version` is true, `version` is its lowercase SHA-256 digest; clients normally
+request this once and omit it while paging the remaining content. Hashing and transfer
+use fixed-size buffers, so files larger than gRPC's default message limit do not require
+whole-file memory.
+
+Metadata is portable: entry type, regular-file byte size (zero for other types), and
+Unix-millisecond modification time.
+No POSIX owner, group, or mode is required or fabricated on Windows. Filesystem objects
+other than regular files and directories can be listed as `ENTRY_TYPE_OTHER` but cannot
+be read or written through this capability.
+
+## Writes, optimistic replacement, and cancellation
+
+`Write` is a client stream. Exactly one header comes first, followed by bounded data
+messages (256 KiB each by default). A stream is limited to 1 GiB by default, and the
+server admits at most 16 concurrent streams by default. Cancellation observed before
+publication and malformed, over-limit, or interrupted streams remove their staging file
+and leave the destination unchanged.
+
+Data is staged in the destination directory, flushed, closed, and published with the
+host's same-filesystem atomic replacement operation only after the complete stream is
+received. Staging names cannot be addressed or listed through this capability. `ANY`
+replaces any regular file; `MUST_NOT_EXIST` uses atomic no-replace publication and
+creates only when absent. `MATCH_VERSION` replaces only when the current complete-file
+SHA-256 equals `expected_version`. Hash checking and replacement are serialized with
+other writes in this server, so concurrent RPC writers cannot both commit.
+Non-cooperating processes with `Exec` can modify workspace files outside this
+serialization, so `MATCH_VERSION` is not a global filesystem compare-and-swap.
+Cancellation observed before publication leaves the destination unchanged; as with any
+committing RPC, cancellation racing with publication can produce an unknown successful
+result. A successful response returns the committed size/version.
+The API intentionally has no Unix mode field; newly created files use server defaults.
+
+## Listings, limits, errors, and mutation
+
+`List` returns at most 1,000 direct entries (256 by default). Its opaque page token is
+scoped to that logical directory and server implementation. Responses hold only one
+page in memory. If the directory changes between pages, the listing is weakly
+consistent and clients may restart from an empty token to obtain a fresh traversal.
+
+Malformed paths, tokens, headers, and limits are `InvalidArgument`; stale offsets are
+`OutOfRange`; missing objects are `NotFound`; symlinks, wrong object types, and failed
+write preconditions are `FailedPrecondition`; stream/file/concurrency bounds are
+`ResourceExhausted`; cancellation is `Canceled` or `DeadlineExceeded`; and unexpected
+host I/O failures are `Internal`. RPC contexts are checked during hashing, transfer,
+directory scans, staging, and commit.
+
+Separate ranged reads are weakly consistent when another process changes the file
+between calls. Clients that need a stable edit base request a version and use
+`MATCH_VERSION` when publishing their replacement.

--- a/sandboxd/proto/sandboxd/v1/sandboxd.proto
+++ b/sandboxd/proto/sandboxd/v1/sandboxd.proto
@@ -182,42 +182,87 @@ message ReadOutputResponse {
   uint64 produced_end = 7;
 }
 
-// FilesystemService provides file access inside the environment.
+// FilesystemService provides bounded access to the environment workspace.
+// Paths are slash-separated logical paths, never host filesystem paths. See
+// FILESYSTEM.md for normalization, confinement, limits, and commit semantics.
 service FilesystemService {
   rpc Read(ReadRequest) returns (ReadResponse);
-  rpc Write(WriteRequest) returns (WriteResponse);
+  rpc Write(stream WriteRequest) returns (WriteResponse);
   rpc List(ListRequest) returns (ListResponse);
 }
 
 message ReadRequest {
   string path = 1;
+  uint64 offset = 2;
+  uint32 max_bytes = 3;
+  // include_version requests a complete-file SHA-256 scan. Clients normally
+  // request it once, then page content without repeatedly hashing the file.
+  bool include_version = 4;
 }
 
 message ReadResponse {
-  bytes content = 1;
+  bytes data = 1;
+  uint64 offset = 2;
+  uint64 next_offset = 3;
+  uint64 size = 4;
+  bool eof = 5;
+  // version is the lowercase SHA-256 digest of the complete file when
+  // include_version was requested; otherwise it is empty.
+  string version = 6;
 }
 
 message WriteRequest {
-  string path = 1;
-  bytes content = 2;
-  // mode is the file permission bits (e.g. 0o644); 0 means default.
-  uint32 mode = 3;
+  oneof kind {
+    WriteHeader header = 1;
+    bytes data = 2;
+  }
 }
 
-message WriteResponse {}
+enum WritePrecondition {
+  WRITE_PRECONDITION_UNSPECIFIED = 0;
+  WRITE_PRECONDITION_ANY = 1;
+  WRITE_PRECONDITION_MUST_NOT_EXIST = 2;
+  WRITE_PRECONDITION_MATCH_VERSION = 3;
+}
+
+message WriteHeader {
+  string path = 1;
+  WritePrecondition precondition = 2;
+  // expected_version is required for MATCH_VERSION and is a lowercase
+  // SHA-256 digest returned by Read or a prior Write.
+  string expected_version = 3;
+}
+
+message WriteResponse {
+  uint64 size = 1;
+  string version = 2;
+}
 
 message ListRequest {
   string path = 1;
+  uint32 page_size = 2;
+  string page_token = 3;
 }
 
 message ListResponse {
   repeated Entry entries = 1;
+  string next_page_token = 2;
+}
+
+enum EntryType {
+  ENTRY_TYPE_UNSPECIFIED = 0;
+  ENTRY_TYPE_FILE = 1;
+  ENTRY_TYPE_DIRECTORY = 2;
+  ENTRY_TYPE_SYMLINK = 3;
+  ENTRY_TYPE_OTHER = 4;
 }
 
 message Entry {
   string name = 1;
-  bool is_dir = 2;
-  int64 size = 3;
+  EntryType type = 2;
+  // size is the regular-file byte size and zero for other entry types.
+  uint64 size = 3;
+  int64 modified_unix_ms = 4;
 }
 
 // TerminalService multiplexes the environment's shared terminal session.


### PR DESCRIPTION
## Summary

- replace unary whole-file filesystem RPCs with bounded ranged reads, streamed atomic writes, optimistic versions, and paginated listings
- define portable workspace-only path, metadata, limits, cancellation, and error semantics
- anchor confinement with `os.Root` and cover symlink races, interrupted writes, concurrent optimistic writes, pagination, and platform-specific paths
- regenerate protobufs and add focused Windows CI coverage

## Verification

- `go test ./internal/server -run '^TestFilesystem' -count=1`
- `go test -race ./internal/server -run '^TestFilesystem' -count=1`
- `make generate manifests`
- `make proto`
- `make check-chart-crds`
- `make test`
- `make vet`
- `make build`
- `git diff --check`
- Helm lint/render: default, kind, k3s, GKE, EKS
- Windows amd64 server test cross-compilation and `go build ./...`
- full unmodified `./hack/e2e.sh` (`E2E OK`)

Fixes #15