### PR TITLE
Repair Windows process containment CI

### DIFF
--- a/sandboxd/internal/server/process_domain_windows_test.go
+++ b/sandboxd/internal/server/process_domain_windows_test.go
@@ -37,15 +37,21 @@ func TestProcessDomainAssignsLeaderToJob(t *testing.T) {
 }
 
 func TestProcessServiceForceContainsDescendant(t *testing.T) {
+	if level := os.Getenv("SANDBOXD_WINDOWS_TREE_HELPER"); level != "" {
+		runWindowsTreeHelper(level)
+		return
+	}
 	server := NewProcessServer(t.TempDir())
 	t.Cleanup(server.Close)
 	marker := filepath.Join(t.TempDir(), "descendant-survived")
 	ready := filepath.Join(t.TempDir(), "descendant-ready")
 	key := &sandboxdv1.ProcessKey{OwnerId: "windows", Role: "tree"}
 	// The child writes only after the parent has had time to be force-stopped.
-	script := "start \"\" /b cmd /c \"echo ready>\"\"" + ready + "\"\" & ping -n 4 127.0.0.1 >nul & echo survived>\"\"" + marker + "\"\"\" & ping -n 30 127.0.0.1 >nul"
 	p, err := server.Start(context.Background(), &sandboxdv1.StartProcessRequest{
-		Key: key, Spec: &sandboxdv1.ProcessSpec{Argv: []string{"cmd", "/c", script}},
+		Key: key, Spec: &sandboxdv1.ProcessSpec{
+			Argv: []string{os.Args[0], "-test.run=^TestProcessServiceForceContainsDescendant$", "--", ready, marker},
+			Env:  map[string]string{"SANDBOXD_WINDOWS_TREE_HELPER": "parent"},
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -86,4 +92,35 @@ func TestProcessServiceForceContainsDescendant(t *testing.T) {
 	if _, err := os.Stat(marker); !os.IsNotExist(err) {
 		t.Fatalf("descendant escaped force containment: stat error = %v", err)
 	}
+}
+
+func runWindowsTreeHelper(level string) {
+	args := os.Args
+	for len(args) > 0 && args[0] != "--" {
+		args = args[1:]
+	}
+	if len(args) != 3 {
+		os.Exit(2)
+	}
+	ready, marker := args[1], args[2]
+	if level == "parent" {
+		cmd := exec.Command(os.Args[0], "-test.run=^TestProcessServiceForceContainsDescendant$", "--", ready, marker)
+		cmd.Env = append(os.Environ(), "SANDBOXD_WINDOWS_TREE_HELPER=descendant")
+		if err := cmd.Start(); err != nil {
+			os.Exit(3)
+		}
+		_ = cmd.Wait()
+		return
+	}
+	if level != "descendant" {
+		os.Exit(4)
+	}
+	if err := os.WriteFile(ready, []byte("ready"), 0o600); err != nil {
+		os.Exit(5)
+	}
+	time.Sleep(3 * time.Second)
+	if err := os.WriteFile(marker, []byte("survived"), 0o600); err != nil {
+		os.Exit(6)
+	}
+	time.Sleep(30 * time.Second)
 }

--- a/sandboxd/internal/server/process_windows.go
+++ b/sandboxd/internal/server/process_windows.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"slices"
 	"sync"
 	"time"
 	"unsafe"
@@ -53,14 +54,17 @@ func (d *processDomain) start() error {
 		return err
 	}
 	files := []*os.File{d.cmd.Stdin.(*os.File), d.cmd.Stdout.(*os.File), d.cmd.Stderr.(*os.File)}
-	handles := make([]windows.Handle, len(files))
-	for i, f := range files {
-		handles[i] = windows.Handle(f.Fd())
-		if err = windows.SetHandleInformation(handles[i], windows.HANDLE_FLAG_INHERIT, windows.HANDLE_FLAG_INHERIT); err != nil {
+	handles := make([]windows.Handle, 0, len(files))
+	for _, f := range files {
+		handle := windows.Handle(f.Fd())
+		if err = windows.SetHandleInformation(handle, windows.HANDLE_FLAG_INHERIT, windows.HANDLE_FLAG_INHERIT); err != nil {
 			windows.CloseHandle(job)
 			return err
 		}
-		defer windows.SetHandleInformation(handles[i], windows.HANDLE_FLAG_INHERIT, 0)
+		defer windows.SetHandleInformation(handle, windows.HANDLE_FLAG_INHERIT, 0)
+		if !slices.Contains(handles, handle) {
+			handles = append(handles, handle)
+		}
 	}
 	if err = attrs.Update(windows.PROC_THREAD_ATTRIBUTE_HANDLE_LIST, unsafe.Pointer(&handles[0]), uintptr(len(handles))*unsafe.Sizeof(handles[0])); err != nil {
 		windows.CloseHandle(job)
@@ -110,7 +114,9 @@ func (d *processDomain) start() error {
 	si := windows.StartupInfoEx{ProcThreadAttributeList: attrs.List()}
 	si.StartupInfo.Cb = uint32(unsafe.Sizeof(si))
 	si.StartupInfo.Flags = windows.STARTF_USESTDHANDLES
-	si.StartupInfo.StdInput, si.StartupInfo.StdOutput, si.StartupInfo.StdErr = handles[0], handles[1], handles[2]
+	si.StartupInfo.StdInput = windows.Handle(files[0].Fd())
+	si.StartupInfo.StdOutput = windows.Handle(files[1].Fd())
+	si.StartupInfo.StdErr = windows.Handle(files[2].Fd())
 	var pi windows.ProcessInformation
 	err = windows.CreateProcess(app, line, nil, nil, true, windows.EXTENDED_STARTUPINFO_PRESENT|windows.CREATE_UNICODE_ENVIRONMENT, &env[0], cwd, &si.StartupInfo, &pi)
 	if err != nil {


### PR DESCRIPTION
## Summary

- deduplicate inherited Windows handles before passing `PROC_THREAD_ATTRIBUTE_HANDLE_LIST`
- keep each standard stream mapped to its original handle
- replace fragile nested `cmd /c` quoting in the descendant-containment test with a Go test-process helper

## Root cause

Commit a7ca605 passed the same `NUL` handle three times when the direct Job assignment test mapped all standard streams to one file. Windows rejects duplicate entries in `PROC_THREAD_ATTRIBUTE_HANDLE_LIST` with `ERROR_INVALID_PARAMETER`.

The force-containment test had a separate test-process issue: its nested `cmd /c` + `start` quoting did not execute the descendant body on `windows-latest`, so the readiness marker timed out. The replacement still launches a real descendant, waits for proof that it is running, force-terminates the Job, verifies Job accounting reaches zero, and confirms the descendant cannot write its delayed survival marker.

Regression: a7ca605 / Actions run 29684835758. Also unblocks the recurring failure on #33.

## Validation

- `go test ./...` in `sandboxd`
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go vet ./...` in `sandboxd`
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test -c ./internal/server`
- `sandboxd-windows` on this PR (Actions run 29688538747)