### PR TITLE
Recover failed and completed Environment pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,10 +171,12 @@ after checkout. Set `Environment.spec.paused` to `true` to delete the pod while 
 its workspace PVC, then set it to `false` to create a fresh pod; `.agents/resume` runs
 after the volume is reattached. Both hooks can use values from the Project Secret, which
 also remains available to the running environment. Setup and resume hooks are limited to
-30 minutes each. Environment readiness is reported by the current-generation `Ready`
-condition only after initialization completes and the sandboxd startup/readiness probes
-pass; `status.phase` is a display summary rather than the scheduling contract. GitHub App
-token minting is not implemented yet.
+30 minutes each. Failed or completed environment pods are replaced with bounded exponential
+backoff while retaining the workspace PVC; recovery progress and exhaustion are reported by
+the `Ready` condition and pod-recovery status fields. Environment readiness is reported by
+the current-generation `Ready` condition only after initialization completes and the sandboxd
+startup/readiness probes pass; `status.phase` is a display summary rather than the scheduling
+contract. GitHub App token minting is not implemented yet.
 
 Active environments are automatically paused after their template's `idleTimeout`
 (15 minutes by default). Opening the control-plane web terminal records activity and

--- a/api/v1alpha1/environment_types.go
+++ b/api/v1alpha1/environment_types.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const EnvironmentConditionReady = "Ready"
@@ -96,6 +97,26 @@ type EnvironmentStatus struct {
 	// The idle reaper uses it to decide when to pause.
 	// +optional
 	LastActiveAt *metav1.Time `json:"lastActiveAt,omitempty"`
+
+	// PodRecoveryAttempts is the number of terminal Pod replacements attempted
+	// for PodRecoveryObservedGeneration.
+	// +optional
+	PodRecoveryAttempts int32 `json:"podRecoveryAttempts,omitempty"`
+
+	// PodRecoveryObservedGeneration is the Environment generation for which the
+	// Pod recovery budget is being tracked.
+	// +optional
+	PodRecoveryObservedGeneration int64 `json:"podRecoveryObservedGeneration,omitempty"`
+
+	// PodRecoveryUID identifies the exact terminal Pod covered by the pending or
+	// in-progress recovery attempt.
+	// +optional
+	PodRecoveryUID types.UID `json:"podRecoveryUID,omitempty"`
+
+	// PodRecoveryNextAttemptAt is when the controller may next replace a
+	// terminal Pod.
+	// +optional
+	PodRecoveryNextAttemptAt *metav1.Time `json:"podRecoveryNextAttemptAt,omitempty"`
 
 	// +optional
 	// +listType=map

--- a/api/v1alpha1/environment_types.go
+++ b/api/v1alpha1/environment_types.go
@@ -99,14 +99,14 @@ type EnvironmentStatus struct {
 	LastActiveAt *metav1.Time `json:"lastActiveAt,omitempty"`
 
 	// PodRecoveryAttempts is the number of terminal Pod replacements attempted
-	// for PodRecoveryObservedGeneration.
+	// since the current Pod recovery sequence last became ready.
 	// +optional
 	PodRecoveryAttempts int32 `json:"podRecoveryAttempts,omitempty"`
 
-	// PodRecoveryObservedGeneration is the Environment generation for which the
-	// Pod recovery budget is being tracked.
+	// PodRecoveryExhausted reports that automatic terminal Pod replacement has
+	// consumed its retry budget. It remains set until sandboxd becomes ready.
 	// +optional
-	PodRecoveryObservedGeneration int64 `json:"podRecoveryObservedGeneration,omitempty"`
+	PodRecoveryExhausted bool `json:"podRecoveryExhausted,omitempty"`
 
 	// PodRecoveryUID identifies the exact terminal Pod covered by the pending or
 	// in-progress recovery attempt.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -112,6 +112,10 @@ func (in *EnvironmentStatus) DeepCopyInto(out *EnvironmentStatus) {
 		in, out := &in.LastActiveAt, &out.LastActiveAt
 		*out = (*in).DeepCopy()
 	}
+	if in.PodRecoveryNextAttemptAt != nil {
+		in, out := &in.PodRecoveryNextAttemptAt, &out.PodRecoveryNextAttemptAt
+		*out = (*in).DeepCopy()
+	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]v1.Condition, len(*in))

--- a/charts/swe-platform/crds/swe.dev_environments.yaml
+++ b/charts/swe-platform/crds/swe.dev_environments.yaml
@@ -198,21 +198,20 @@ spec:
               podRecoveryAttempts:
                 description: |-
                   PodRecoveryAttempts is the number of terminal Pod replacements attempted
-                  for PodRecoveryObservedGeneration.
+                  since the current Pod recovery sequence last became ready.
                 format: int32
                 type: integer
+              podRecoveryExhausted:
+                description: |-
+                  PodRecoveryExhausted reports that automatic terminal Pod replacement has
+                  consumed its retry budget. It remains set until sandboxd becomes ready.
+                type: boolean
               podRecoveryNextAttemptAt:
                 description: |-
                   PodRecoveryNextAttemptAt is when the controller may next replace a
                   terminal Pod.
                 format: date-time
                 type: string
-              podRecoveryObservedGeneration:
-                description: |-
-                  PodRecoveryObservedGeneration is the Environment generation for which the
-                  Pod recovery budget is being tracked.
-                format: int64
-                type: integer
               podRecoveryUID:
                 description: |-
                   PodRecoveryUID identifies the exact terminal Pod covered by the pending or

--- a/charts/swe-platform/crds/swe.dev_environments.yaml
+++ b/charts/swe-platform/crds/swe.dev_environments.yaml
@@ -195,6 +195,29 @@ spec:
               podName:
                 description: PodName is the name of the backing pod, when one exists.
                 type: string
+              podRecoveryAttempts:
+                description: |-
+                  PodRecoveryAttempts is the number of terminal Pod replacements attempted
+                  for PodRecoveryObservedGeneration.
+                format: int32
+                type: integer
+              podRecoveryNextAttemptAt:
+                description: |-
+                  PodRecoveryNextAttemptAt is when the controller may next replace a
+                  terminal Pod.
+                format: date-time
+                type: string
+              podRecoveryObservedGeneration:
+                description: |-
+                  PodRecoveryObservedGeneration is the Environment generation for which the
+                  Pod recovery budget is being tracked.
+                format: int64
+                type: integer
+              podRecoveryUID:
+                description: |-
+                  PodRecoveryUID identifies the exact terminal Pod covered by the pending or
+                  in-progress recovery attempt.
+                type: string
             type: object
         type: object
     served: true

--- a/config/crd/bases/swe.dev_environments.yaml
+++ b/config/crd/bases/swe.dev_environments.yaml
@@ -198,21 +198,20 @@ spec:
               podRecoveryAttempts:
                 description: |-
                   PodRecoveryAttempts is the number of terminal Pod replacements attempted
-                  for PodRecoveryObservedGeneration.
+                  since the current Pod recovery sequence last became ready.
                 format: int32
                 type: integer
+              podRecoveryExhausted:
+                description: |-
+                  PodRecoveryExhausted reports that automatic terminal Pod replacement has
+                  consumed its retry budget. It remains set until sandboxd becomes ready.
+                type: boolean
               podRecoveryNextAttemptAt:
                 description: |-
                   PodRecoveryNextAttemptAt is when the controller may next replace a
                   terminal Pod.
                 format: date-time
                 type: string
-              podRecoveryObservedGeneration:
-                description: |-
-                  PodRecoveryObservedGeneration is the Environment generation for which the
-                  Pod recovery budget is being tracked.
-                format: int64
-                type: integer
               podRecoveryUID:
                 description: |-
                   PodRecoveryUID identifies the exact terminal Pod covered by the pending or

--- a/config/crd/bases/swe.dev_environments.yaml
+++ b/config/crd/bases/swe.dev_environments.yaml
@@ -195,6 +195,29 @@ spec:
               podName:
                 description: PodName is the name of the backing pod, when one exists.
                 type: string
+              podRecoveryAttempts:
+                description: |-
+                  PodRecoveryAttempts is the number of terminal Pod replacements attempted
+                  for PodRecoveryObservedGeneration.
+                format: int32
+                type: integer
+              podRecoveryNextAttemptAt:
+                description: |-
+                  PodRecoveryNextAttemptAt is when the controller may next replace a
+                  terminal Pod.
+                format: date-time
+                type: string
+              podRecoveryObservedGeneration:
+                description: |-
+                  PodRecoveryObservedGeneration is the Environment generation for which the
+                  Pod recovery budget is being tracked.
+                format: int64
+                type: integer
+              podRecoveryUID:
+                description: |-
+                  PodRecoveryUID identifies the exact terminal Pod covered by the pending or
+                  in-progress recovery attempt.
+                type: string
             type: object
         type: object
     served: true

--- a/internal/controllers/environment_controller.go
+++ b/internal/controllers/environment_controller.go
@@ -61,7 +61,10 @@ const (
 	projectAnnotation  = "swe.dev/project"
 )
 
-var errPodReplacing = stderrors.New("environment pod is being replaced")
+var (
+	errPodReplacing       = stderrors.New("environment pod is being replaced")
+	errPodRecoveryChanged = stderrors.New("environment pod recovery state changed")
+)
 
 type childOwnershipCollisionError struct {
 	kind string
@@ -216,11 +219,14 @@ func (r *EnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 // create a replacement. This keeps backoff and exhaustion effective even when
 // a terminal Pod disappears without the controller deleting it.
 func (r *EnvironmentReconciler) reconcilePendingPodRecovery(ctx context.Context, env *platformv1alpha1.Environment) (ctrl.Result, bool, error) {
-	if env.Status.PodRecoveryObservedGeneration != env.Generation {
-		return ctrl.Result{}, false, nil
-	}
 	ready := apimeta.FindStatusCondition(env.Status.Conditions, platformv1alpha1.EnvironmentConditionReady)
-	if ready != nil && ready.ObservedGeneration == env.Generation && ready.Status == metav1.ConditionFalse && ready.Reason == "PodRecoveryExhausted" {
+	if env.Status.PodRecoveryExhausted {
+		message := fmt.Sprintf("automatic recovery is exhausted after %d terminal pod replacements", env.Status.PodRecoveryAttempts)
+		if ready == nil || ready.ObservedGeneration != env.Generation || ready.Status != metav1.ConditionFalse || ready.Reason != "PodRecoveryExhausted" {
+			if err := r.setEnvironmentStatus(ctx, env, platformv1alpha1.EnvironmentPhaseFailed, env.Status.PodName, "", "PodRecoveryExhausted", message); err != nil {
+				return ctrl.Result{}, true, err
+			}
+		}
 		return ctrl.Result{}, true, nil
 	}
 	nextAttemptAt := env.Status.PodRecoveryNextAttemptAt
@@ -229,19 +235,27 @@ func (r *EnvironmentReconciler) reconcilePendingPodRecovery(ctx context.Context,
 	}
 	now := r.now()
 	if now.Before(nextAttemptAt.Time) {
+		if ready == nil || ready.ObservedGeneration != env.Generation || ready.Status != metav1.ConditionFalse || ready.Reason != "PodRecoveryPending" {
+			message := fmt.Sprintf("terminal pod recovery attempt %d of %d is scheduled for %s", env.Status.PodRecoveryAttempts+1, podRecoveryLimit, nextAttemptAt.Time.UTC().Format(time.RFC3339))
+			if err := r.setEnvironmentStatus(ctx, env, platformv1alpha1.EnvironmentPhaseCreating, "", "", "PodRecoveryPending", message); err != nil {
+				return ctrl.Result{}, true, err
+			}
+		}
 		return ctrl.Result{RequeueAfter: nextAttemptAt.Sub(now)}, true, nil
 	}
 
 	attempts := env.Status.PodRecoveryAttempts + 1
 	message := fmt.Sprintf("replacing terminal environment pod (recovery attempt %d of %d)", attempts, podRecoveryLimit)
-	if err := r.updateEnvironmentStatus(ctx, env, func(current *platformv1alpha1.Environment) {
+	if err := r.updatePodRecoveryStatus(ctx, env, func(current *platformv1alpha1.Environment) {
 		applyEnvironmentStatus(current, platformv1alpha1.EnvironmentPhaseCreating, "", "", "PodRecovering", message, env.Status.LastActiveAt)
 		current.Status.PodRecoveryAttempts = attempts
-		current.Status.PodRecoveryObservedGeneration = current.Generation
 		current.Status.PodRecoveryUID = env.Status.PodRecoveryUID
 		current.Status.PodRecoveryNextAttemptAt = nil
 		clearChildOwnershipCollision(current)
 	}); err != nil {
+		if stderrors.Is(err, errPodRecoveryChanged) {
+			return ctrl.Result{Requeue: true}, true, nil
+		}
 		return ctrl.Result{}, true, err
 	}
 	// Reconcile again before deleting or creating so the persisted attempt marker
@@ -250,7 +264,7 @@ func (r *EnvironmentReconciler) reconcilePendingPodRecovery(ctx context.Context,
 }
 
 // reconcileTerminalPod replaces an owned terminal Pod using a persisted,
-// generation-scoped retry budget. The Pod UID fences both the delay and delete
+// bounded retry budget. The Pod UID fences both the delay and delete
 // so retries after controller or API failures cannot consume the budget twice
 // or delete a same-name replacement.
 func (r *EnvironmentReconciler) reconcileTerminalPod(ctx context.Context, env *platformv1alpha1.Environment, pod *corev1.Pod) (ctrl.Result, error) {
@@ -258,16 +272,18 @@ func (r *EnvironmentReconciler) reconcileTerminalPod(ctx context.Context, env *p
 	attempts := env.Status.PodRecoveryAttempts
 	recoveryUID := env.Status.PodRecoveryUID
 	nextAttemptAt := env.Status.PodRecoveryNextAttemptAt
-	if env.Status.PodRecoveryObservedGeneration != env.Generation {
-		attempts = 0
-		recoveryUID = ""
-		nextAttemptAt = nil
-	}
 
 	if recoveryUID != pod.UID {
 		if attempts >= podRecoveryLimit {
 			message := fmt.Sprintf("environment pod %s after %d recovery attempts; automatic recovery is exhausted", strings.ToLower(string(pod.Status.Phase)), attempts)
-			if err := r.setEnvironmentStatus(ctx, env, platformv1alpha1.EnvironmentPhaseFailed, pod.Name, "", "PodRecoveryExhausted", message); err != nil {
+			if err := r.updatePodRecoveryStatus(ctx, env, func(current *platformv1alpha1.Environment) {
+				applyEnvironmentStatus(current, platformv1alpha1.EnvironmentPhaseFailed, pod.Name, "", "PodRecoveryExhausted", message, env.Status.LastActiveAt)
+				current.Status.PodRecoveryExhausted = true
+				clearChildOwnershipCollision(current)
+			}); err != nil {
+				if stderrors.Is(err, errPodRecoveryChanged) {
+					return ctrl.Result{Requeue: true}, nil
+				}
 				return ctrl.Result{}, err
 			}
 			log.FromContext(ctx).Info("environment pod recovery exhausted", "environment", env.Name, "pod", pod.Name, "attempts", attempts)
@@ -275,14 +291,17 @@ func (r *EnvironmentReconciler) reconcileTerminalPod(ctx context.Context, env *p
 		}
 		next := metav1.NewTime(now.Add(podRecoveryBackoff(attempts)))
 		message := fmt.Sprintf("environment pod %s; recovery attempt %d of %d is scheduled for %s", strings.ToLower(string(pod.Status.Phase)), attempts+1, podRecoveryLimit, next.Time.UTC().Format(time.RFC3339))
-		if err := r.updateEnvironmentStatus(ctx, env, func(current *platformv1alpha1.Environment) {
+		if err := r.updatePodRecoveryStatus(ctx, env, func(current *platformv1alpha1.Environment) {
 			applyEnvironmentStatus(current, platformv1alpha1.EnvironmentPhaseCreating, "", "", "PodRecoveryPending", message, env.Status.LastActiveAt)
 			current.Status.PodRecoveryAttempts = attempts
-			current.Status.PodRecoveryObservedGeneration = current.Generation
+			current.Status.PodRecoveryExhausted = false
 			current.Status.PodRecoveryUID = pod.UID
 			current.Status.PodRecoveryNextAttemptAt = &next
 			clearChildOwnershipCollision(current)
 		}); err != nil {
+			if stderrors.Is(err, errPodRecoveryChanged) {
+				return ctrl.Result{Requeue: true}, nil
+			}
 			return ctrl.Result{}, err
 		}
 		log.FromContext(ctx).Info("scheduled environment pod recovery", "environment", env.Name, "pod", pod.Name, "attempt", attempts+1, "maxAttempts", podRecoveryLimit, "nextAttemptAt", next.Time)
@@ -525,6 +544,15 @@ func (r *EnvironmentReconciler) ensurePod(ctx context.Context, env *platformv1al
 	err := r.Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: podName}, &pod)
 	if err == nil {
 		if metav1.IsControlledBy(&pod, env) && !pod.DeletionTimestamp.IsZero() {
+			if pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodSucceeded {
+				secure, err := r.currentSandboxdPod(ctx, env, &pod)
+				if err != nil {
+					return nil, err
+				}
+				if secure {
+					return &pod, nil
+				}
+			}
 			if err := r.setEnvironmentStatus(ctx, env, platformv1alpha1.EnvironmentPhaseCreating, "", "", "PodTerminating", "the previous environment pod is terminating"); err != nil {
 				return nil, err
 			}
@@ -984,7 +1012,7 @@ func (r *EnvironmentReconciler) syncStatus(ctx context.Context, env *platformv1a
 		current.Status.ImageID = environmentImageID(pod)
 		if phase == platformv1alpha1.EnvironmentPhaseReady {
 			current.Status.PodRecoveryAttempts = 0
-			current.Status.PodRecoveryObservedGeneration = 0
+			current.Status.PodRecoveryExhausted = false
 			current.Status.PodRecoveryUID = ""
 			current.Status.PodRecoveryNextAttemptAt = nil
 		}
@@ -1179,6 +1207,40 @@ func (r *EnvironmentReconciler) updateEnvironmentStatus(ctx context.Context, env
 		env.Status = updated.Status
 	}
 	return err
+}
+
+// updatePodRecoveryStatus permits spec generation changes while refusing to
+// overwrite a concurrent recovery transition. Recovery is incarnation state:
+// only sandboxd readiness, not an ordinary spec edit, resets it.
+func (r *EnvironmentReconciler) updatePodRecoveryStatus(ctx context.Context, env *platformv1alpha1.Environment, mutate func(*platformv1alpha1.Environment)) error {
+	key := client.ObjectKeyFromObject(env)
+	expected := env.Status
+	var updated platformv1alpha1.Environment
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		if err := r.Get(ctx, key, &updated); err != nil {
+			return err
+		}
+		if !samePodRecoveryState(&expected, &updated.Status) {
+			return errPodRecoveryChanged
+		}
+		before := updated.DeepCopy()
+		mutate(&updated)
+		if apiequality.Semantic.DeepEqual(before.Status, updated.Status) {
+			return nil
+		}
+		return r.Status().Update(ctx, &updated)
+	})
+	if err == nil {
+		env.Status = updated.Status
+	}
+	return err
+}
+
+func samePodRecoveryState(left, right *platformv1alpha1.EnvironmentStatus) bool {
+	return left.PodRecoveryAttempts == right.PodRecoveryAttempts &&
+		left.PodRecoveryExhausted == right.PodRecoveryExhausted &&
+		left.PodRecoveryUID == right.PodRecoveryUID &&
+		apiequality.Semantic.DeepEqual(left.PodRecoveryNextAttemptAt, right.PodRecoveryNextAttemptAt)
 }
 
 func applyEnvironmentStatus(env *platformv1alpha1.Environment, phase platformv1alpha1.EnvironmentPhase, podName, sandboxdEndpoint, reason, message string, lastActiveAt *metav1.Time) {

--- a/internal/controllers/environment_controller.go
+++ b/internal/controllers/environment_controller.go
@@ -54,6 +54,8 @@ const (
 	defaultIdleTimeout = 15 * time.Minute
 	projectHookTimeout = "30m"
 	hookKillAfter      = "5s"
+	podRecoveryLimit   = int32(3)
+	podRecoveryDelay   = 5 * time.Second
 	templateRefField   = "spec.templateRef"
 	warmPoolLabel      = "swe.dev/warm-pool"
 	projectAnnotation  = "swe.dev/project"
@@ -114,6 +116,7 @@ type EnvironmentReconciler struct {
 	ControlPlaneNamespace string
 	ControlPlaneName      string
 	ControlPlaneInstance  string
+	Now                   func() time.Time
 }
 
 // +kubebuilder:rbac:groups=swe.dev,resources=environments,verbs=get;list;watch;create;update;patch;delete
@@ -152,6 +155,9 @@ func (r *EnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			return ctrl.Result{}, r.fail(ctx, &env, fmt.Errorf("pause environment: %w", err))
 		}
 		return result, nil
+	}
+	if result, handled, err := r.reconcilePendingPodRecovery(ctx, &env); handled || err != nil {
+		return result, err
 	}
 	var tmpl platformv1alpha1.EnvironmentTemplate
 	if err := r.Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: env.Spec.TemplateRef}, &tmpl); err != nil {
@@ -193,6 +199,9 @@ func (r *EnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if pod == nil {
 		return ctrl.Result{Requeue: true}, nil
 	}
+	if pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodSucceeded {
+		return r.reconcileTerminalPod(ctx, &env, pod)
+	}
 
 	if err := r.syncStatus(ctx, &env, pod); err != nil {
 		return ctrl.Result{}, err
@@ -201,6 +210,107 @@ func (r *EnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, nil
 	}
 	return r.reconcileIdle(ctx, &env, &tmpl)
+}
+
+// reconcilePendingPodRecovery advances persisted recovery before ensurePod can
+// create a replacement. This keeps backoff and exhaustion effective even when
+// a terminal Pod disappears without the controller deleting it.
+func (r *EnvironmentReconciler) reconcilePendingPodRecovery(ctx context.Context, env *platformv1alpha1.Environment) (ctrl.Result, bool, error) {
+	if env.Status.PodRecoveryObservedGeneration != env.Generation {
+		return ctrl.Result{}, false, nil
+	}
+	ready := apimeta.FindStatusCondition(env.Status.Conditions, platformv1alpha1.EnvironmentConditionReady)
+	if ready != nil && ready.ObservedGeneration == env.Generation && ready.Status == metav1.ConditionFalse && ready.Reason == "PodRecoveryExhausted" {
+		return ctrl.Result{}, true, nil
+	}
+	nextAttemptAt := env.Status.PodRecoveryNextAttemptAt
+	if nextAttemptAt == nil {
+		return ctrl.Result{}, false, nil
+	}
+	now := r.now()
+	if now.Before(nextAttemptAt.Time) {
+		return ctrl.Result{RequeueAfter: nextAttemptAt.Sub(now)}, true, nil
+	}
+
+	attempts := env.Status.PodRecoveryAttempts + 1
+	message := fmt.Sprintf("replacing terminal environment pod (recovery attempt %d of %d)", attempts, podRecoveryLimit)
+	if err := r.updateEnvironmentStatus(ctx, env, func(current *platformv1alpha1.Environment) {
+		applyEnvironmentStatus(current, platformv1alpha1.EnvironmentPhaseCreating, "", "", "PodRecovering", message, env.Status.LastActiveAt)
+		current.Status.PodRecoveryAttempts = attempts
+		current.Status.PodRecoveryObservedGeneration = current.Generation
+		current.Status.PodRecoveryUID = env.Status.PodRecoveryUID
+		current.Status.PodRecoveryNextAttemptAt = nil
+		clearChildOwnershipCollision(current)
+	}); err != nil {
+		return ctrl.Result{}, true, err
+	}
+	// Reconcile again before deleting or creating so the persisted attempt marker
+	// is always observed, including across a concurrent generation change.
+	return ctrl.Result{Requeue: true}, true, nil
+}
+
+// reconcileTerminalPod replaces an owned terminal Pod using a persisted,
+// generation-scoped retry budget. The Pod UID fences both the delay and delete
+// so retries after controller or API failures cannot consume the budget twice
+// or delete a same-name replacement.
+func (r *EnvironmentReconciler) reconcileTerminalPod(ctx context.Context, env *platformv1alpha1.Environment, pod *corev1.Pod) (ctrl.Result, error) {
+	now := r.now()
+	attempts := env.Status.PodRecoveryAttempts
+	recoveryUID := env.Status.PodRecoveryUID
+	nextAttemptAt := env.Status.PodRecoveryNextAttemptAt
+	if env.Status.PodRecoveryObservedGeneration != env.Generation {
+		attempts = 0
+		recoveryUID = ""
+		nextAttemptAt = nil
+	}
+
+	if recoveryUID != pod.UID {
+		if attempts >= podRecoveryLimit {
+			message := fmt.Sprintf("environment pod %s after %d recovery attempts; automatic recovery is exhausted", strings.ToLower(string(pod.Status.Phase)), attempts)
+			if err := r.setEnvironmentStatus(ctx, env, platformv1alpha1.EnvironmentPhaseFailed, pod.Name, "", "PodRecoveryExhausted", message); err != nil {
+				return ctrl.Result{}, err
+			}
+			log.FromContext(ctx).Info("environment pod recovery exhausted", "environment", env.Name, "pod", pod.Name, "attempts", attempts)
+			return ctrl.Result{}, nil
+		}
+		next := metav1.NewTime(now.Add(podRecoveryBackoff(attempts)))
+		message := fmt.Sprintf("environment pod %s; recovery attempt %d of %d is scheduled for %s", strings.ToLower(string(pod.Status.Phase)), attempts+1, podRecoveryLimit, next.Time.UTC().Format(time.RFC3339))
+		if err := r.updateEnvironmentStatus(ctx, env, func(current *platformv1alpha1.Environment) {
+			applyEnvironmentStatus(current, platformv1alpha1.EnvironmentPhaseCreating, "", "", "PodRecoveryPending", message, env.Status.LastActiveAt)
+			current.Status.PodRecoveryAttempts = attempts
+			current.Status.PodRecoveryObservedGeneration = current.Generation
+			current.Status.PodRecoveryUID = pod.UID
+			current.Status.PodRecoveryNextAttemptAt = &next
+			clearChildOwnershipCollision(current)
+		}); err != nil {
+			return ctrl.Result{}, err
+		}
+		log.FromContext(ctx).Info("scheduled environment pod recovery", "environment", env.Name, "pod", pod.Name, "attempt", attempts+1, "maxAttempts", podRecoveryLimit, "nextAttemptAt", next.Time)
+		return ctrl.Result{RequeueAfter: podRecoveryBackoff(attempts)}, nil
+	}
+
+	if nextAttemptAt != nil {
+		if now.Before(nextAttemptAt.Time) {
+			return ctrl.Result{RequeueAfter: nextAttemptAt.Sub(now)}, nil
+		}
+		return ctrl.Result{Requeue: true}, nil
+	}
+	if err := r.deleteObservedChild(ctx, pod); err != nil && !errors.IsNotFound(err) {
+		return ctrl.Result{}, fmt.Errorf("delete terminal pod for recovery: %w", err)
+	}
+	log.FromContext(ctx).Info("replacing terminal environment pod", "environment", env.Name, "pod", pod.Name, "attempt", attempts, "maxAttempts", podRecoveryLimit)
+	return ctrl.Result{Requeue: true}, nil
+}
+
+func podRecoveryBackoff(attempts int32) time.Duration {
+	return podRecoveryDelay * time.Duration(1<<attempts)
+}
+
+func (r *EnvironmentReconciler) now() time.Time {
+	if r.Now != nil {
+		return r.Now()
+	}
+	return time.Now()
 }
 
 // reconcileUnsupportedBackend withdraws the published connection identity
@@ -872,6 +982,12 @@ func (r *EnvironmentReconciler) syncStatus(ctx context.Context, env *platformv1a
 	return r.updateEnvironmentStatus(ctx, env, func(current *platformv1alpha1.Environment) {
 		applyEnvironmentStatus(current, phase, pod.Name, sandboxdEndpoint, reason, message, env.Status.LastActiveAt)
 		current.Status.ImageID = environmentImageID(pod)
+		if phase == platformv1alpha1.EnvironmentPhaseReady {
+			current.Status.PodRecoveryAttempts = 0
+			current.Status.PodRecoveryObservedGeneration = 0
+			current.Status.PodRecoveryUID = ""
+			current.Status.PodRecoveryNextAttemptAt = nil
+		}
 		clearChildOwnershipCollision(current)
 	})
 }

--- a/internal/controllers/environment_controller.go
+++ b/internal/controllers/environment_controller.go
@@ -134,7 +134,14 @@ type EnvironmentReconciler struct {
 
 // Reconcile drives an Environment toward its desired state:
 // pod + PVC present when active, pod deleted (PVC retained) when paused.
-func (r *EnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *EnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
+	defer func() {
+		if stderrors.Is(err, errEnvironmentIncarnationChanged) {
+			result = ctrl.Result{}
+			err = nil
+		}
+	}()
+
 	var env platformv1alpha1.Environment
 	if err := r.Get(ctx, req.NamespacedName, &env); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)

--- a/internal/controllers/environment_controller.go
+++ b/internal/controllers/environment_controller.go
@@ -62,8 +62,9 @@ const (
 )
 
 var (
-	errPodReplacing       = stderrors.New("environment pod is being replaced")
-	errPodRecoveryChanged = stderrors.New("environment pod recovery state changed")
+	errPodReplacing                  = stderrors.New("environment pod is being replaced")
+	errPodRecoveryChanged            = stderrors.New("environment pod recovery state changed")
+	errEnvironmentIncarnationChanged = stderrors.New("environment incarnation changed")
 )
 
 type childOwnershipCollisionError struct {
@@ -1187,11 +1188,15 @@ func (r *EnvironmentReconciler) setEnvironmentStatus(ctx context.Context, env *p
 
 func (r *EnvironmentReconciler) updateEnvironmentStatus(ctx context.Context, env *platformv1alpha1.Environment, mutate func(*platformv1alpha1.Environment)) error {
 	key := client.ObjectKeyFromObject(env)
+	expectedUID := env.UID
 	expectedGeneration := env.Generation
 	var updated platformv1alpha1.Environment
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		if err := r.Get(ctx, key, &updated); err != nil {
 			return err
+		}
+		if updated.UID != expectedUID {
+			return errEnvironmentIncarnationChanged
 		}
 		if updated.Generation != expectedGeneration {
 			return nil
@@ -1214,11 +1219,15 @@ func (r *EnvironmentReconciler) updateEnvironmentStatus(ctx context.Context, env
 // only sandboxd readiness, not an ordinary spec edit, resets it.
 func (r *EnvironmentReconciler) updatePodRecoveryStatus(ctx context.Context, env *platformv1alpha1.Environment, mutate func(*platformv1alpha1.Environment)) error {
 	key := client.ObjectKeyFromObject(env)
+	expectedUID := env.UID
 	expected := env.Status
 	var updated platformv1alpha1.Environment
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		if err := r.Get(ctx, key, &updated); err != nil {
 			return err
+		}
+		if updated.UID != expectedUID {
+			return errEnvironmentIncarnationChanged
 		}
 		if !samePodRecoveryState(&expected, &updated.Status) {
 			return errPodRecoveryChanged

--- a/internal/controllers/environment_controller_test.go
+++ b/internal/controllers/environment_controller_test.go
@@ -1062,6 +1062,76 @@ func TestTerminalPodRecoveryPersistsAcrossConcurrentGenerationChange(t *testing.
 	}
 }
 
+func TestTerminalPodRecoveryRejectsSameNameReplacementEnvironment(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	stored := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "environment-u2", Generation: 1}}
+	stale := stored.DeepCopy()
+	stale.UID = "environment-u1"
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "env-test", Namespace: "default", UID: "u1-terminal-pod"}, Status: corev1.PodStatus{Phase: corev1.PodFailed}}
+	reconciler := &EnvironmentReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(stored).WithObjects(stored).Build(),
+		Scheme: scheme,
+	}
+
+	result, err := reconciler.reconcileTerminalPod(context.Background(), stale, pod)
+	if !stderrors.Is(err, errEnvironmentIncarnationChanged) || result.Requeue || result.RequeueAfter != 0 {
+		t.Fatalf("stale terminal recovery = (%#v, %v), want incarnation rejection", result, err)
+	}
+	var replacement platformv1alpha1.Environment
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(stored), &replacement); err != nil {
+		t.Fatal(err)
+	}
+	if replacement.Status.PodRecoveryAttempts != 0 || replacement.Status.PodRecoveryExhausted || replacement.Status.PodRecoveryUID != "" || replacement.Status.PodRecoveryNextAttemptAt != nil || len(replacement.Status.Conditions) != 0 {
+		t.Fatalf("U1 terminal marker was written into U2: %#v", replacement.Status)
+	}
+}
+
+func TestHealthReadyResetRejectsSameNameReplacementEnvironment(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	next := metav1.Now()
+	stored := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "environment-u2", Generation: 2}, Status: platformv1alpha1.EnvironmentStatus{
+		ObservedGeneration: 2, Phase: platformv1alpha1.EnvironmentPhaseCreating,
+		PodRecoveryAttempts: 2, PodRecoveryUID: "u2-terminal-pod", PodRecoveryNextAttemptAt: &next,
+		Conditions: []metav1.Condition{{Type: platformv1alpha1.EnvironmentConditionReady, Status: metav1.ConditionFalse,
+			ObservedGeneration: 2, Reason: "PodRecoveryPending", Message: "U2 recovery is pending"}},
+	}}
+	stale := stored.DeepCopy()
+	stale.UID = "environment-u1"
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "env-test", Namespace: "default"}, Status: corev1.PodStatus{
+		Phase: corev1.PodRunning, PodIP: "10.0.0.1",
+		Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+	}}
+	reconciler := &EnvironmentReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(stored).WithObjects(stored).Build(),
+		Scheme: scheme,
+	}
+
+	if err := reconciler.syncStatus(context.Background(), stale, pod); !stderrors.Is(err, errEnvironmentIncarnationChanged) {
+		t.Fatalf("stale health-ready reset error = %v, want incarnation rejection", err)
+	}
+	var replacement platformv1alpha1.Environment
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(stored), &replacement); err != nil {
+		t.Fatal(err)
+	}
+	ready := apimeta.FindStatusCondition(replacement.Status.Conditions, platformv1alpha1.EnvironmentConditionReady)
+	if replacement.Status.PodRecoveryAttempts != 2 || replacement.Status.PodRecoveryUID != "u2-terminal-pod" || replacement.Status.PodRecoveryNextAttemptAt == nil ||
+		replacement.Status.Endpoints.Sandboxd != "" || ready == nil || ready.Status != metav1.ConditionFalse || ready.Reason != "PodRecoveryPending" {
+		t.Fatalf("U1 health readiness reset U2 recovery: %#v", replacement.Status)
+	}
+}
+
 func TestNewEnvironmentRefusesTerminatingPriorIncarnationPVC(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := corev1.AddToScheme(scheme); err != nil {

--- a/internal/controllers/environment_controller_test.go
+++ b/internal/controllers/environment_controller_test.go
@@ -1132,6 +1132,117 @@ func TestHealthReadyResetRejectsSameNameReplacementEnvironment(t *testing.T) {
 	}
 }
 
+func TestReconcileDropsStaleEnvironmentIncarnationStatusWrites(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		terminal bool
+	}{
+		{name: "terminal recovery marker", terminal: true},
+		{name: "health ready reset"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			if err := corev1.AddToScheme(scheme); err != nil {
+				t.Fatal(err)
+			}
+			if err := networkingv1.AddToScheme(scheme); err != nil {
+				t.Fatal(err)
+			}
+			if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+				t.Fatal(err)
+			}
+			next := metav1.Now()
+			replacementStatus := platformv1alpha1.EnvironmentStatus{}
+			if !test.terminal {
+				replacementStatus = platformv1alpha1.EnvironmentStatus{
+					ObservedGeneration: 1, Phase: platformv1alpha1.EnvironmentPhaseCreating,
+					PodRecoveryAttempts: 2, PodRecoveryUID: "u2-terminal-pod", PodRecoveryNextAttemptAt: &next,
+					Conditions: []metav1.Condition{{Type: platformv1alpha1.EnvironmentConditionReady, Status: metav1.ConditionFalse,
+						ObservedGeneration: 1, Reason: "PodRecoveryPending", Message: "U2 recovery is pending"}},
+				}
+			}
+			replacement := &platformv1alpha1.Environment{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "environment-u2", Generation: 1, Finalizers: []string{environmentFinalizer}},
+				Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small"},
+				Status:     replacementStatus,
+			}
+			stale := replacement.DeepCopy()
+			stale.UID = "environment-u1"
+			if !test.terminal {
+				stale.Status = platformv1alpha1.EnvironmentStatus{}
+			}
+			template := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: stale.Namespace}}
+			pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: envPVCName(stale), Namespace: stale.Namespace, UID: "u1-workspace-pvc"}}
+			pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Name: envPodName(stale), Namespace: stale.Namespace, UID: "u1-pod",
+				Annotations: map[string]string{
+					sandboxdRevisionAnnotation:        sandboxdSecurityRevision,
+					sandboxdauth.IdentityAnnotation:   "sandboxd.u1",
+					sandboxdauth.TrustAnnotation:      "trust",
+					sandboxdauth.TokenAnnotation:      "token",
+					sandboxdauth.SecretNameAnnotation: envCredentialName(stale),
+					sandboxdauth.SecretUIDAnnotation:  "u1-secret",
+				},
+			}}
+			if test.terminal {
+				pod.Status.Phase = corev1.PodFailed
+			} else {
+				pod.Status = corev1.PodStatus{
+					Phase: corev1.PodRunning, PodIP: "10.0.0.1",
+					Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+				}
+			}
+			secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name: envCredentialName(stale), Namespace: stale.Namespace, UID: "u1-secret",
+				Annotations: map[string]string{sandboxdauth.IdentityAnnotation: "sandboxd.u1", sandboxdauth.PodUIDAnnotation: string(pod.UID)},
+			}, Data: map[string][]byte{
+				sandboxdauth.TLSCertKey: []byte("cert"), sandboxdauth.TLSKeyKey: []byte("key"),
+				sandboxdauth.CapabilitiesKey: []byte("capabilities"), sandboxdauth.HealthTokenKey: []byte("health"), sandboxdauth.ProcessTokenKey: []byte("process"),
+			}}
+			for _, object := range []client.Object{pvc, pod, secret} {
+				if err := controllerutil.SetControllerReference(stale, object, scheme); err != nil {
+					t.Fatal(err)
+				}
+			}
+			baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(replacement).WithObjects(replacement, template, pvc, pod, secret).Build()
+			initialEnvironmentRead := true
+			interceptedClient := interceptor.NewClient(baseClient, interceptor.Funcs{
+				Get: func(ctx context.Context, underlying client.WithWatch, key client.ObjectKey, object client.Object, options ...client.GetOption) error {
+					if initialEnvironmentRead && key == client.ObjectKeyFromObject(stale) {
+						if environment, ok := object.(*platformv1alpha1.Environment); ok {
+							initialEnvironmentRead = false
+							*environment = *stale.DeepCopy()
+							return nil
+						}
+					}
+					return underlying.Get(ctx, key, object, options...)
+				},
+			})
+			reconciler := &EnvironmentReconciler{Client: interceptedClient, Scheme: scheme}
+
+			result, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(stale)})
+			if err != nil || result != (ctrl.Result{}) {
+				t.Fatalf("stale U1 Reconcile() = (%#v, %v), want successful empty drop", result, err)
+			}
+			var retained platformv1alpha1.Environment
+			if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(replacement), &retained); err != nil {
+				t.Fatal(err)
+			}
+			if test.terminal {
+				if retained.Status.PodRecoveryAttempts != 0 || retained.Status.PodRecoveryUID != "" || retained.Status.PodRecoveryNextAttemptAt != nil || len(retained.Status.Conditions) != 0 {
+					t.Fatalf("stale U1 terminal marker mutated U2: %#v", retained.Status)
+				}
+			} else {
+				ready := apimeta.FindStatusCondition(retained.Status.Conditions, platformv1alpha1.EnvironmentConditionReady)
+				if retained.Status.PodRecoveryAttempts != 2 || retained.Status.PodRecoveryUID != "u2-terminal-pod" || retained.Status.PodRecoveryNextAttemptAt == nil ||
+					retained.Status.Endpoints.Sandboxd != "" || ready == nil || ready.Status != metav1.ConditionFalse || ready.Reason != "PodRecoveryPending" {
+					t.Fatalf("stale U1 health readiness mutated U2: %#v", retained.Status)
+				}
+			}
+		})
+	}
+}
+
 func TestNewEnvironmentRefusesTerminatingPriorIncarnationPVC(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := corev1.AddToScheme(scheme); err != nil {

--- a/internal/controllers/environment_controller_test.go
+++ b/internal/controllers/environment_controller_test.go
@@ -362,7 +362,7 @@ func TestEnsurePodRefusesWrongOwnerPod(t *testing.T) {
 			APIVersion: platformv1alpha1.GroupVersion.String(), Kind: "Environment", Name: env.Name,
 			UID: "old-environment", Controller: ptr(true),
 		}},
-	}}
+	}, Status: corev1.PodStatus{Phase: corev1.PodFailed}}
 	reconciler := &EnvironmentReconciler{
 		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(legacyPod).Build(), Scheme: scheme,
 	}
@@ -663,6 +663,230 @@ func TestTerminatingPodCannotRemainReady(t *testing.T) {
 	ready := apimeta.FindStatusCondition(updated.Status.Conditions, platformv1alpha1.EnvironmentConditionReady)
 	if platformv1alpha1.IsEnvironmentReady(&updated) || updated.Status.PodName != "" || updated.Status.Endpoints.Sandboxd != "" || ready == nil || ready.Reason != "PodTerminating" {
 		t.Fatalf("terminating pod status = %#v", updated.Status)
+	}
+}
+
+func TestTerminalPodsRecoverAfterBackoffAndRetainPVC(t *testing.T) {
+	for _, phase := range []corev1.PodPhase{corev1.PodFailed, corev1.PodSucceeded} {
+		t.Run(string(phase), func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			if err := corev1.AddToScheme(scheme); err != nil {
+				t.Fatal(err)
+			}
+			if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+				t.Fatal(err)
+			}
+			now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+			env := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{
+				Name: "test", Namespace: "default", UID: "env-uid", Generation: 4,
+			}, Status: platformv1alpha1.EnvironmentStatus{
+				ObservedGeneration: 4, Phase: platformv1alpha1.EnvironmentPhaseReady, PodName: "env-test",
+				Endpoints: platformv1alpha1.EnvironmentEndpoints{Sandboxd: "10.0.0.1:50051"},
+				Conditions: []metav1.Condition{{Type: platformv1alpha1.EnvironmentConditionReady, Status: metav1.ConditionTrue,
+					ObservedGeneration: 4, Reason: "SandboxdReady", Message: "sandboxd is ready"}},
+			}}
+			pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: envPodName(env), Namespace: env.Namespace, UID: "dead-pod"}, Status: corev1.PodStatus{Phase: phase}}
+			pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: envPVCName(env), Namespace: env.Namespace, UID: "workspace-pvc"}}
+			if err := controllerutil.SetControllerReference(env, pod, scheme); err != nil {
+				t.Fatal(err)
+			}
+			if err := controllerutil.SetControllerReference(env, pvc, scheme); err != nil {
+				t.Fatal(err)
+			}
+			reconciler := &EnvironmentReconciler{
+				Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env, pod, pvc).Build(),
+				Scheme: scheme, Now: func() time.Time { return now },
+			}
+
+			result, err := reconciler.reconcileTerminalPod(context.Background(), env, pod)
+			if err != nil || result.Requeue || result.RequeueAfter != podRecoveryDelay {
+				t.Fatalf("schedule recovery = (%#v, %v), want %s delay", result, err, podRecoveryDelay)
+			}
+			var pending platformv1alpha1.Environment
+			if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(env), &pending); err != nil {
+				t.Fatal(err)
+			}
+			ready := apimeta.FindStatusCondition(pending.Status.Conditions, platformv1alpha1.EnvironmentConditionReady)
+			if platformv1alpha1.IsEnvironmentReady(&pending) || pending.Status.PodName != "" || pending.Status.Endpoints.Sandboxd != "" ||
+				pending.Status.PodRecoveryUID != pod.UID || pending.Status.PodRecoveryAttempts != 0 || pending.Status.PodRecoveryNextAttemptAt == nil ||
+				ready == nil || ready.Reason != "PodRecoveryPending" {
+				t.Fatalf("pending recovery status = %#v", pending.Status)
+			}
+			if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(pod), &corev1.Pod{}); err != nil {
+				t.Fatalf("terminal Pod deleted before backoff: %v", err)
+			}
+
+			now = now.Add(podRecoveryDelay)
+			result, handled, err := reconciler.reconcilePendingPodRecovery(context.Background(), &pending)
+			if err != nil || !handled || !result.Requeue {
+				t.Fatalf("advance recovery = (%#v, %t, %v), want immediate requeue", result, handled, err)
+			}
+			if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(env), &pending); err != nil {
+				t.Fatal(err)
+			}
+			result, err = reconciler.reconcileTerminalPod(context.Background(), &pending, pod)
+			if err != nil || !result.Requeue {
+				t.Fatalf("perform recovery = (%#v, %v), want immediate requeue", result, err)
+			}
+			if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(pod), &corev1.Pod{}); !apierrors.IsNotFound(err) {
+				t.Fatalf("terminal Pod still exists after recovery: %v", err)
+			}
+			if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(pvc), &corev1.PersistentVolumeClaim{}); err != nil {
+				t.Fatalf("workspace PVC was not retained: %v", err)
+			}
+			var recovering platformv1alpha1.Environment
+			if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(env), &recovering); err != nil {
+				t.Fatal(err)
+			}
+			ready = apimeta.FindStatusCondition(recovering.Status.Conditions, platformv1alpha1.EnvironmentConditionReady)
+			if recovering.Status.PodRecoveryAttempts != 1 || recovering.Status.PodRecoveryNextAttemptAt != nil || ready == nil || ready.Reason != "PodRecovering" {
+				t.Fatalf("recovering status = %#v", recovering.Status)
+			}
+		})
+	}
+}
+
+func TestReconcileHonorsRecoveryWhenTerminalPodIsMissing(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		exhausted  bool
+		due        bool
+		wantDelay  time.Duration
+		wantReason string
+	}{
+		{name: "pending backoff", wantDelay: 10 * time.Second, wantReason: "PodRecoveryPending"},
+		{name: "due attempt is counted before creation", due: true, wantReason: "PodRecovering"},
+		{name: "exhaustion remains latched", exhausted: true, wantReason: "PodRecoveryExhausted"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			if err := corev1.AddToScheme(scheme); err != nil {
+				t.Fatal(err)
+			}
+			if err := networkingv1.AddToScheme(scheme); err != nil {
+				t.Fatal(err)
+			}
+			if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+				t.Fatal(err)
+			}
+			now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+			next := metav1.NewTime(now.Add(10 * time.Second))
+			if test.due {
+				next = metav1.NewTime(now)
+			}
+			reason := "PodRecoveryPending"
+			attempts := int32(1)
+			if test.exhausted {
+				reason = "PodRecoveryExhausted"
+				attempts = podRecoveryLimit
+				next = metav1.Time{}
+			}
+			env := &platformv1alpha1.Environment{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "env-uid", Generation: 3, Finalizers: []string{environmentFinalizer}},
+				Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small"},
+				Status: platformv1alpha1.EnvironmentStatus{
+					ObservedGeneration: 3, Phase: platformv1alpha1.EnvironmentPhaseCreating,
+					PodRecoveryAttempts: attempts, PodRecoveryObservedGeneration: 3, PodRecoveryUID: "missing-dead-pod",
+					Conditions: []metav1.Condition{{Type: platformv1alpha1.EnvironmentConditionReady, Status: metav1.ConditionFalse,
+						ObservedGeneration: 3, Reason: reason, Message: "recovering"}},
+				},
+			}
+			if !test.exhausted {
+				env.Status.PodRecoveryNextAttemptAt = &next
+			}
+			template := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: env.Namespace}}
+			pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: envPVCName(env), Namespace: env.Namespace, UID: "workspace-pvc"}}
+			if err := controllerutil.SetControllerReference(env, pvc, scheme); err != nil {
+				t.Fatal(err)
+			}
+			objects := []client.Object{env, pvc}
+			if !test.exhausted {
+				objects = append(objects, template)
+			}
+			reconciler := &EnvironmentReconciler{
+				Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(objects...).Build(),
+				Scheme: scheme, Now: func() time.Time { return now },
+			}
+
+			result, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(env)})
+			if err != nil || result.RequeueAfter != test.wantDelay || (test.due && !result.Requeue) {
+				t.Fatalf("Reconcile() = (%#v, %v), want delay %s", result, err, test.wantDelay)
+			}
+			if err := reconciler.Get(context.Background(), types.NamespacedName{Namespace: env.Namespace, Name: envPodName(env)}, &corev1.Pod{}); !apierrors.IsNotFound(err) {
+				t.Fatalf("missing terminal Pod was replaced before recovery allowed it: %v", err)
+			}
+			var updated platformv1alpha1.Environment
+			if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(env), &updated); err != nil {
+				t.Fatal(err)
+			}
+			ready := apimeta.FindStatusCondition(updated.Status.Conditions, platformv1alpha1.EnvironmentConditionReady)
+			if ready == nil || ready.Reason != test.wantReason {
+				t.Fatalf("recovery condition = %#v, want %s", ready, test.wantReason)
+			}
+			if test.due && (updated.Status.PodRecoveryAttempts != attempts+1 || updated.Status.PodRecoveryNextAttemptAt != nil) {
+				t.Fatalf("due recovery status = %#v", updated.Status)
+			}
+		})
+	}
+}
+
+func TestTerminalPodRecoveryUsesPersistedExponentialBackoff(t *testing.T) {
+	if got := []time.Duration{podRecoveryBackoff(0), podRecoveryBackoff(1), podRecoveryBackoff(2)}; got[0] != 5*time.Second || got[1] != 10*time.Second || got[2] != 20*time.Second {
+		t.Fatalf("recovery backoff = %v, want [5s 10s 20s]", got)
+	}
+
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+	next := metav1.NewTime(now.Add(10 * time.Second))
+	env := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", Generation: 2}, Status: platformv1alpha1.EnvironmentStatus{
+		PodRecoveryAttempts: 1, PodRecoveryObservedGeneration: 2, PodRecoveryUID: "dead-pod", PodRecoveryNextAttemptAt: &next,
+	}}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "env-test", Namespace: "default", UID: "dead-pod"}, Status: corev1.PodStatus{Phase: corev1.PodFailed}}
+	reconciler := &EnvironmentReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env, pod).Build(), Scheme: scheme, Now: func() time.Time { return now }}
+
+	result, err := reconciler.reconcileTerminalPod(context.Background(), env, pod)
+	if err != nil || result.RequeueAfter != 10*time.Second {
+		t.Fatalf("persisted backoff = (%#v, %v), want 10s", result, err)
+	}
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(pod), &corev1.Pod{}); err != nil {
+		t.Fatalf("Pod deleted before persisted deadline: %v", err)
+	}
+}
+
+func TestTerminalPodRecoveryStopsAfterBoundedAttempts(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	env := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", Generation: 3}, Status: platformv1alpha1.EnvironmentStatus{
+		PodRecoveryAttempts: podRecoveryLimit, PodRecoveryObservedGeneration: 3, PodRecoveryUID: "previous-dead-pod",
+	}}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "env-test", Namespace: "default", UID: "final-dead-pod"}, Status: corev1.PodStatus{Phase: corev1.PodFailed}}
+	reconciler := &EnvironmentReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env, pod).Build(), Scheme: scheme}
+
+	result, err := reconciler.reconcileTerminalPod(context.Background(), env, pod)
+	if err != nil || result.Requeue || result.RequeueAfter != 0 {
+		t.Fatalf("exhausted recovery = (%#v, %v), want terminal success", result, err)
+	}
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(pod), &corev1.Pod{}); err != nil {
+		t.Fatalf("exhausted terminal Pod was deleted: %v", err)
+	}
+	var exhausted platformv1alpha1.Environment
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(env), &exhausted); err != nil {
+		t.Fatal(err)
+	}
+	ready := apimeta.FindStatusCondition(exhausted.Status.Conditions, platformv1alpha1.EnvironmentConditionReady)
+	if exhausted.Status.Phase != platformv1alpha1.EnvironmentPhaseFailed || exhausted.Status.PodName != pod.Name || ready == nil || ready.Reason != "PodRecoveryExhausted" {
+		t.Fatalf("exhausted status = %#v", exhausted.Status)
 	}
 }
 
@@ -1009,7 +1233,10 @@ func TestSyncStatusPublishesSandboxdEndpoint(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	env := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", Generation: 4}}
+	nextRecovery := metav1.Now()
+	env := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", Generation: 4}, Status: platformv1alpha1.EnvironmentStatus{
+		PodRecoveryAttempts: 2, PodRecoveryObservedGeneration: 4, PodRecoveryUID: "old-pod", PodRecoveryNextAttemptAt: &nextRecovery,
+	}}
 	reconciler := &EnvironmentReconciler{
 		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env).Build(),
 		Scheme: scheme,
@@ -1039,6 +1266,9 @@ func TestSyncStatusPublishesSandboxdEndpoint(t *testing.T) {
 	ready := apimeta.FindStatusCondition(updated.Status.Conditions, platformv1alpha1.EnvironmentConditionReady)
 	if updated.Status.ObservedGeneration != updated.Generation || ready == nil || ready.Status != metav1.ConditionTrue || ready.ObservedGeneration != updated.Generation || ready.Reason != "SandboxdReady" {
 		t.Fatalf("generation-aware Ready condition = %#v, status generation = %d", ready, updated.Status.ObservedGeneration)
+	}
+	if updated.Status.PodRecoveryAttempts != 0 || updated.Status.PodRecoveryObservedGeneration != 0 || updated.Status.PodRecoveryUID != "" || updated.Status.PodRecoveryNextAttemptAt != nil {
+		t.Fatalf("recovery budget was not reset after health-aware readiness: %#v", updated.Status)
 	}
 }
 

--- a/internal/controllers/environment_controller_test.go
+++ b/internal/controllers/environment_controller_test.go
@@ -746,17 +746,124 @@ func TestTerminalPodsRecoverAfterBackoffAndRetainPVC(t *testing.T) {
 	}
 }
 
+func TestTerminatingFailedPodPersistsRecoveryBeforeReplacement(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := networkingv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+	deletedAt := metav1.NewTime(now.Add(-time.Second))
+	env := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "env-uid", Generation: 2, Finalizers: []string{environmentFinalizer}},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small"},
+		Status: platformv1alpha1.EnvironmentStatus{
+			ObservedGeneration: 1, Phase: platformv1alpha1.EnvironmentPhaseReady, PodName: "env-test",
+			Endpoints: platformv1alpha1.EnvironmentEndpoints{Sandboxd: "10.0.0.1:50051"},
+			Conditions: []metav1.Condition{{Type: platformv1alpha1.EnvironmentConditionReady, Status: metav1.ConditionTrue,
+				ObservedGeneration: 1, Reason: "SandboxdReady", Message: "sandboxd is ready"}},
+		},
+	}
+	template := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: env.Namespace}}
+	pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: envPVCName(env), Namespace: env.Namespace, UID: "workspace-pvc"}}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: envPodName(env), Namespace: env.Namespace, UID: "dead-pod", DeletionTimestamp: &deletedAt, Finalizers: []string{"test/hold"},
+		Annotations: map[string]string{
+			sandboxdRevisionAnnotation:        sandboxdSecurityRevision,
+			sandboxdauth.IdentityAnnotation:   "sandboxd.test",
+			sandboxdauth.TrustAnnotation:      "trust",
+			sandboxdauth.TokenAnnotation:      "token",
+			sandboxdauth.SecretNameAnnotation: envCredentialName(env),
+			sandboxdauth.SecretUIDAnnotation:  "secret-uid",
+		},
+	}, Status: corev1.PodStatus{Phase: corev1.PodFailed}}
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Name: envCredentialName(env), Namespace: env.Namespace, UID: "secret-uid",
+		Annotations: map[string]string{sandboxdauth.IdentityAnnotation: "sandboxd.test", sandboxdauth.PodUIDAnnotation: string(pod.UID)},
+	}, Data: map[string][]byte{
+		sandboxdauth.TLSCertKey: []byte("cert"), sandboxdauth.TLSKeyKey: []byte("key"),
+		sandboxdauth.CapabilitiesKey: []byte("capabilities"), sandboxdauth.HealthTokenKey: []byte("health"), sandboxdauth.ProcessTokenKey: []byte("process"),
+	}}
+	for _, object := range []client.Object{pvc, pod, secret} {
+		if err := controllerutil.SetControllerReference(env, object, scheme); err != nil {
+			t.Fatal(err)
+		}
+	}
+	reconciler := &EnvironmentReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env, template, pvc, pod, secret).Build(),
+		Scheme: scheme, Now: func() time.Time { return now },
+	}
+	request := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(env)}
+
+	result, err := reconciler.Reconcile(context.Background(), request)
+	if err != nil || result.RequeueAfter != podRecoveryDelay {
+		t.Fatalf("terminating failed Pod recovery = (%#v, %v), want %s delay", result, err, podRecoveryDelay)
+	}
+	var pending platformv1alpha1.Environment
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(env), &pending); err != nil {
+		t.Fatal(err)
+	}
+	if pending.Status.PodRecoveryUID != pod.UID || pending.Status.PodRecoveryNextAttemptAt == nil || pending.Status.PodName != "" || pending.Status.Endpoints.Sandboxd != "" {
+		t.Fatalf("terminating failed Pod recovery status = %#v", pending.Status)
+	}
+	var disappearing corev1.Pod
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(pod), &disappearing); err != nil {
+		t.Fatal(err)
+	}
+	disappearing.Finalizers = nil
+	if err := reconciler.Update(context.Background(), &disappearing); err != nil && !apierrors.IsNotFound(err) {
+		t.Fatal(err)
+	}
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(pod), &corev1.Pod{}); err == nil {
+		if err := reconciler.Delete(context.Background(), &disappearing); err != nil && !apierrors.IsNotFound(err) {
+			t.Fatal(err)
+		}
+	}
+
+	result, err = reconciler.Reconcile(context.Background(), request)
+	if err != nil || result.RequeueAfter != podRecoveryDelay {
+		t.Fatalf("missing terminating Pod before deadline = (%#v, %v), want delayed", result, err)
+	}
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(pod), &corev1.Pod{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("replacement Pod created before recovery deadline: %v", err)
+	}
+
+	now = now.Add(podRecoveryDelay)
+	result, err = reconciler.Reconcile(context.Background(), request)
+	if err != nil || !result.Requeue {
+		t.Fatalf("due missing Pod recovery = (%#v, %v), want persisted attempt and requeue", result, err)
+	}
+	var due platformv1alpha1.Environment
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(env), &due); err != nil {
+		t.Fatal(err)
+	}
+	if due.Status.PodRecoveryAttempts != 1 || due.Status.PodRecoveryNextAttemptAt != nil {
+		t.Fatalf("due recovery attempt was not persisted: %#v", due.Status)
+	}
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(pod), &corev1.Pod{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("replacement Pod created in the same reconcile as attempt persistence: %v", err)
+	}
+}
+
 func TestReconcileHonorsRecoveryWhenTerminalPodIsMissing(t *testing.T) {
 	for _, test := range []struct {
-		name       string
-		exhausted  bool
-		due        bool
-		wantDelay  time.Duration
-		wantReason string
+		name                string
+		exhausted           bool
+		due                 bool
+		conditionGeneration int64
+		wantDelay           time.Duration
+		wantReason          string
 	}{
 		{name: "pending backoff", wantDelay: 10 * time.Second, wantReason: "PodRecoveryPending"},
+		{name: "pending backoff survives generation change", conditionGeneration: 2, wantDelay: 10 * time.Second, wantReason: "PodRecoveryPending"},
 		{name: "due attempt is counted before creation", due: true, wantReason: "PodRecovering"},
 		{name: "exhaustion remains latched", exhausted: true, wantReason: "PodRecoveryExhausted"},
+		{name: "exhaustion survives generation change", exhausted: true, conditionGeneration: 2, wantReason: "PodRecoveryExhausted"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			scheme := runtime.NewScheme()
@@ -781,14 +888,18 @@ func TestReconcileHonorsRecoveryWhenTerminalPodIsMissing(t *testing.T) {
 				attempts = podRecoveryLimit
 				next = metav1.Time{}
 			}
+			conditionGeneration := test.conditionGeneration
+			if conditionGeneration == 0 {
+				conditionGeneration = 3
+			}
 			env := &platformv1alpha1.Environment{
 				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "env-uid", Generation: 3, Finalizers: []string{environmentFinalizer}},
 				Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small"},
 				Status: platformv1alpha1.EnvironmentStatus{
-					ObservedGeneration: 3, Phase: platformv1alpha1.EnvironmentPhaseCreating,
-					PodRecoveryAttempts: attempts, PodRecoveryObservedGeneration: 3, PodRecoveryUID: "missing-dead-pod",
+					ObservedGeneration: conditionGeneration, Phase: platformv1alpha1.EnvironmentPhaseCreating,
+					PodRecoveryAttempts: attempts, PodRecoveryExhausted: test.exhausted, PodRecoveryUID: "missing-dead-pod",
 					Conditions: []metav1.Condition{{Type: platformv1alpha1.EnvironmentConditionReady, Status: metav1.ConditionFalse,
-						ObservedGeneration: 3, Reason: reason, Message: "recovering"}},
+						ObservedGeneration: conditionGeneration, Reason: reason, Message: "recovering"}},
 				},
 			}
 			if !test.exhausted {
@@ -820,11 +931,17 @@ func TestReconcileHonorsRecoveryWhenTerminalPodIsMissing(t *testing.T) {
 				t.Fatal(err)
 			}
 			ready := apimeta.FindStatusCondition(updated.Status.Conditions, platformv1alpha1.EnvironmentConditionReady)
-			if ready == nil || ready.Reason != test.wantReason {
+			if ready == nil || ready.Reason != test.wantReason || ready.ObservedGeneration != env.Generation || updated.Status.ObservedGeneration != env.Generation {
 				t.Fatalf("recovery condition = %#v, want %s", ready, test.wantReason)
 			}
 			if test.due && (updated.Status.PodRecoveryAttempts != attempts+1 || updated.Status.PodRecoveryNextAttemptAt != nil) {
 				t.Fatalf("due recovery status = %#v", updated.Status)
+			}
+			if !test.due && !test.exhausted && (updated.Status.PodRecoveryAttempts != attempts || updated.Status.PodRecoveryNextAttemptAt == nil || !updated.Status.PodRecoveryNextAttemptAt.Equal(&next)) {
+				t.Fatalf("generation change altered pending recovery budget: %#v", updated.Status)
+			}
+			if test.exhausted && (!updated.Status.PodRecoveryExhausted || updated.Status.PodRecoveryAttempts != podRecoveryLimit) {
+				t.Fatalf("generation change cleared exhausted recovery budget: %#v", updated.Status)
 			}
 		})
 	}
@@ -845,7 +962,7 @@ func TestTerminalPodRecoveryUsesPersistedExponentialBackoff(t *testing.T) {
 	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
 	next := metav1.NewTime(now.Add(10 * time.Second))
 	env := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", Generation: 2}, Status: platformv1alpha1.EnvironmentStatus{
-		PodRecoveryAttempts: 1, PodRecoveryObservedGeneration: 2, PodRecoveryUID: "dead-pod", PodRecoveryNextAttemptAt: &next,
+		PodRecoveryAttempts: 1, PodRecoveryUID: "dead-pod", PodRecoveryNextAttemptAt: &next,
 	}}
 	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "env-test", Namespace: "default", UID: "dead-pod"}, Status: corev1.PodStatus{Phase: corev1.PodFailed}}
 	reconciler := &EnvironmentReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env, pod).Build(), Scheme: scheme, Now: func() time.Time { return now }}
@@ -868,7 +985,7 @@ func TestTerminalPodRecoveryStopsAfterBoundedAttempts(t *testing.T) {
 		t.Fatal(err)
 	}
 	env := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", Generation: 3}, Status: platformv1alpha1.EnvironmentStatus{
-		PodRecoveryAttempts: podRecoveryLimit, PodRecoveryObservedGeneration: 3, PodRecoveryUID: "previous-dead-pod",
+		PodRecoveryAttempts: podRecoveryLimit, PodRecoveryUID: "previous-dead-pod",
 	}}
 	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "env-test", Namespace: "default", UID: "final-dead-pod"}, Status: corev1.PodStatus{Phase: corev1.PodFailed}}
 	reconciler := &EnvironmentReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env, pod).Build(), Scheme: scheme}
@@ -885,8 +1002,63 @@ func TestTerminalPodRecoveryStopsAfterBoundedAttempts(t *testing.T) {
 		t.Fatal(err)
 	}
 	ready := apimeta.FindStatusCondition(exhausted.Status.Conditions, platformv1alpha1.EnvironmentConditionReady)
-	if exhausted.Status.Phase != platformv1alpha1.EnvironmentPhaseFailed || exhausted.Status.PodName != pod.Name || ready == nil || ready.Reason != "PodRecoveryExhausted" {
+	if exhausted.Status.Phase != platformv1alpha1.EnvironmentPhaseFailed || !exhausted.Status.PodRecoveryExhausted || exhausted.Status.PodName != pod.Name || ready == nil || ready.Reason != "PodRecoveryExhausted" {
 		t.Fatalf("exhausted status = %#v", exhausted.Status)
+	}
+}
+
+func TestTerminalPodRecoveryPersistsAcrossConcurrentGenerationChange(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		attempts  int32
+		exhausted bool
+	}{
+		{name: "pending marker", attempts: 1},
+		{name: "exhaustion latch", attempts: podRecoveryLimit, exhausted: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			if err := corev1.AddToScheme(scheme); err != nil {
+				t.Fatal(err)
+			}
+			if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+				t.Fatal(err)
+			}
+			now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+			stored := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", Generation: 2}, Status: platformv1alpha1.EnvironmentStatus{
+				ObservedGeneration: 1, PodRecoveryAttempts: test.attempts, PodRecoveryUID: "previous-pod",
+			}}
+			stale := stored.DeepCopy()
+			stale.Generation = 1
+			pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "env-test", Namespace: "default", UID: "terminal-pod"}, Status: corev1.PodStatus{Phase: corev1.PodFailed}}
+			reconciler := &EnvironmentReconciler{
+				Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(stored).WithObjects(stored).Build(),
+				Scheme: scheme, Now: func() time.Time { return now },
+			}
+
+			result, err := reconciler.reconcileTerminalPod(context.Background(), stale, pod)
+			if err != nil || (!test.exhausted && result.RequeueAfter != podRecoveryBackoff(test.attempts)) {
+				t.Fatalf("reconcileTerminalPod() = (%#v, %v)", result, err)
+			}
+			var updated platformv1alpha1.Environment
+			if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(stored), &updated); err != nil {
+				t.Fatal(err)
+			}
+			ready := apimeta.FindStatusCondition(updated.Status.Conditions, platformv1alpha1.EnvironmentConditionReady)
+			if updated.Status.ObservedGeneration != updated.Generation || ready == nil || ready.ObservedGeneration != updated.Generation {
+				t.Fatalf("recovery marker did not observe concurrent generation: %#v", updated.Status)
+			}
+			if test.exhausted {
+				if !updated.Status.PodRecoveryExhausted || ready.Reason != "PodRecoveryExhausted" {
+					t.Fatalf("exhaustion was not persisted across generation change: %#v", updated.Status)
+				}
+			} else if updated.Status.PodRecoveryUID != pod.UID || updated.Status.PodRecoveryNextAttemptAt == nil || ready.Reason != "PodRecoveryPending" {
+				t.Fatalf("deadline was not persisted across generation change: %#v", updated.Status)
+			}
+			if _, handled, err := reconciler.reconcilePendingPodRecovery(context.Background(), &updated); err != nil || !handled {
+				t.Fatalf("persisted recovery did not block replacement: handled=%t, err=%v", handled, err)
+			}
+		})
 	}
 }
 
@@ -1235,7 +1407,7 @@ func TestSyncStatusPublishesSandboxdEndpoint(t *testing.T) {
 
 	nextRecovery := metav1.Now()
 	env := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", Generation: 4}, Status: platformv1alpha1.EnvironmentStatus{
-		PodRecoveryAttempts: 2, PodRecoveryObservedGeneration: 4, PodRecoveryUID: "old-pod", PodRecoveryNextAttemptAt: &nextRecovery,
+		PodRecoveryAttempts: 2, PodRecoveryExhausted: true, PodRecoveryUID: "old-pod", PodRecoveryNextAttemptAt: &nextRecovery,
 	}}
 	reconciler := &EnvironmentReconciler{
 		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env).Build(),
@@ -1267,7 +1439,7 @@ func TestSyncStatusPublishesSandboxdEndpoint(t *testing.T) {
 	if updated.Status.ObservedGeneration != updated.Generation || ready == nil || ready.Status != metav1.ConditionTrue || ready.ObservedGeneration != updated.Generation || ready.Reason != "SandboxdReady" {
 		t.Fatalf("generation-aware Ready condition = %#v, status generation = %d", ready, updated.Status.ObservedGeneration)
 	}
-	if updated.Status.PodRecoveryAttempts != 0 || updated.Status.PodRecoveryObservedGeneration != 0 || updated.Status.PodRecoveryUID != "" || updated.Status.PodRecoveryNextAttemptAt != nil {
+	if updated.Status.PodRecoveryAttempts != 0 || updated.Status.PodRecoveryExhausted || updated.Status.PodRecoveryUID != "" || updated.Status.PodRecoveryNextAttemptAt != nil {
 		t.Fatalf("recovery budget was not reset after health-aware readiness: %#v", updated.Status)
 	}
 }


### PR DESCRIPTION
## Summary

- recover securely owned `Failed` and `Succeeded` Environment pods instead of leaving the Environment permanently terminal, including terminal pods already carrying a deletion timestamp
- persist an incarnation-scoped recovery budget and Pod UID with 5s/10s/20s backoff, exposing pending, active, and exhausted recovery through status and the generation-aware `Ready` condition
- preserve attempts, deadlines, and exhaustion across ordinary or concurrent spec-generation changes; only current-incarnation sandboxd health-aware readiness clears recovery state
- fence every refetched status update by Environment UID so a stale reconcile cannot write recovery or readiness from deleted U1 into a same-name replacement U2; the outer reconcile boundary drops this stale work successfully without rate-limited requeueing U2
- withdraw the sandboxd endpoint/readiness before replacement, retain the workspace PVC, and continue using UID-preconditioned deletion
- latch exhaustion after three replacements even if Kubernetes removes the final terminal pod
- preserve foreign same-name pod ownership rejection and existing pause/resume fencing semantics

## Verification

- `go test ./internal/controllers -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `make check-chart-crds`
- `git diff --check origin/main...HEAD`

Tests cover failed and succeeded pods, terminating failed pods, retained PVCs, foreign terminal pods, persisted exponential backoff, ordinary and concurrent generation changes, missing terminal pods, full-Reconcile same-name/different-UID stale status drops, readiness withdrawal/reset, and terminal exhaustion.

Rebased onto main after #34 merged so Windows CI includes its containment repair.

Closes #24