### PR TITLE
Harden control-plane stream lifecycle

### DIFF
--- a/cmd/control-plane/main.go
+++ b/cmd/control-plane/main.go
@@ -1,11 +1,18 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"flag"
+	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
+	"os/signal"
 	"strings"
+	"sync"
+	"syscall"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -17,6 +24,8 @@ import (
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
 	"github.com/Chris-Cullins/swe-platform/internal/controlplane"
 )
+
+const shutdownTimeout = 10 * time.Second
 
 func main() {
 	address := flag.String("listen-address", ":8080", "Address for the control-plane HTTP API")
@@ -54,6 +63,8 @@ func main() {
 		Audience:       os.Getenv("SWE_TOKEN_AUDIENCE"),
 	}
 	transcripts := controlplane.NewMemoryTranscriptStore(controlplane.DefaultMemoryTranscriptStoreOptions())
+	streamLifecycle, cancelStreams := context.WithCancel(context.Background())
+	defer cancelStreams()
 	server := &http.Server{
 		Addr: *address,
 		Handler: controlplane.NewServer(log, controlplane.ServerOptions{
@@ -62,13 +73,92 @@ func main() {
 			TranscriptStore: transcripts,
 			TerminalDialer:  controlplane.KubernetesTerminalDialer{Client: kubeClient},
 			TrustProxy:      strings.EqualFold(os.Getenv("SWE_TRUST_PROXY_HEADERS"), "true"),
+			StreamLifecycle: streamLifecycle,
 		}).Handler(),
 		ReadHeaderTimeout: 5 * time.Second,
 		IdleTimeout:       2 * time.Minute,
 	}
+	listener, err := net.Listen("tcp", *address)
+	if err != nil {
+		log.Error("listen for control-plane API", "address", *address, "error", err)
+		os.Exit(1)
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 	log.Info("starting control-plane API", "address", *address)
-	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+	if err := runHTTPServer(ctx, log, server, listener, shutdownTimeout, cancelStreams); err != nil {
 		log.Error("control-plane API stopped", "error", err)
 		os.Exit(1)
+	}
+}
+
+func runHTTPServer(ctx context.Context, log *slog.Logger, server *http.Server, listener net.Listener, drainTimeout time.Duration, cancelStreams context.CancelFunc) error {
+	tracker := &handlerTracker{}
+	tracker.track(server)
+
+	serveErrors := make(chan error, 1)
+	go func() {
+		serveErrors <- server.Serve(listener)
+	}()
+
+	select {
+	case err := <-serveErrors:
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return err
+	case <-ctx.Done():
+		log.Info("shutting down control-plane API", "drainTimeout", drainTimeout)
+	}
+
+	shutdownContext, cancelShutdown := context.WithTimeout(context.Background(), drainTimeout)
+	defer cancelShutdown()
+	cancelStreams()
+	shutdownErr := server.Shutdown(shutdownContext)
+	if shutdownErr != nil {
+		_ = server.Close()
+	}
+	serveErr := <-serveErrors
+	drainErr := tracker.wait(shutdownContext)
+	if shutdownErr != nil {
+		return fmt.Errorf("drain control-plane API: %w", shutdownErr)
+	}
+	if drainErr != nil {
+		_ = server.Close()
+		return fmt.Errorf("drain control-plane API handlers: %w", drainErr)
+	}
+	if serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+		return serveErr
+	}
+	return nil
+}
+
+type handlerTracker struct {
+	active sync.WaitGroup
+}
+
+func (t *handlerTracker) track(server *http.Server) {
+	handler := server.Handler
+	if handler == nil {
+		handler = http.DefaultServeMux
+	}
+	server.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.active.Add(1)
+		defer t.active.Done()
+		handler.ServeHTTP(w, r)
+	})
+}
+
+func (t *handlerTracker) wait(ctx context.Context) error {
+	done := make(chan struct{})
+	go func() {
+		t.active.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }

--- a/cmd/control-plane/main_test.go
+++ b/cmd/control-plane/main_test.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestRunHTTPServerWaitsForHijackedHandlerCleanup(t *testing.T) {
+	requestStarted := make(chan struct{})
+	requestCanceled := make(chan struct{})
+	releaseCleanup := make(chan struct{})
+	cleanupFinished := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseCleanup) }) }
+	t.Cleanup(release)
+	streamLifecycle, cancelStreams := context.WithCancel(context.Background())
+	t.Cleanup(cancelStreams)
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		connection, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer connection.Close()
+		defer close(cleanupFinished)
+		close(requestStarted)
+		<-streamLifecycle.Done()
+		close(requestCanceled)
+		<-releaseCleanup
+	})}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	serveResult := make(chan error, 1)
+	go func() {
+		serveResult <- runHTTPServer(ctx, slog.New(slog.NewTextHandler(io.Discard, nil)), server, listener, time.Second, cancelStreams)
+	}()
+
+	connection, _, err := websocket.DefaultDialer.Dial("ws://"+listener.Addr().String(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer connection.Close()
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("request did not start")
+	}
+
+	cancel()
+	select {
+	case <-requestCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("active request was not canceled during shutdown")
+	}
+	select {
+	case err := <-serveResult:
+		t.Fatalf("HTTP server returned before hijacked handler cleanup: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	release()
+	select {
+	case <-cleanupFinished:
+	case <-time.After(time.Second):
+		t.Fatal("hijacked handler cleanup did not finish")
+	}
+	select {
+	case err := <-serveResult:
+		if err != nil {
+			t.Fatalf("runHTTPServer() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("HTTP server did not shut down")
+	}
+}
+
+func TestRunHTTPServerDrainsOrdinaryRequestWithoutCancelingIt(t *testing.T) {
+	requestStarted := make(chan struct{})
+	requestContexts := make(chan context.Context, 1)
+	releaseRequest := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseRequest) }) }
+	t.Cleanup(release)
+	server := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(requestStarted)
+		requestContexts <- r.Context()
+		<-releaseRequest
+		w.WriteHeader(http.StatusNoContent)
+	})}
+	baseListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	listener := &closeNotifyListener{Listener: baseListener, closed: make(chan struct{})}
+	t.Cleanup(func() { _ = listener.Close() })
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	serveResult := make(chan error, 1)
+	go func() {
+		serveResult <- runHTTPServer(ctx, slog.New(slog.NewTextHandler(io.Discard, nil)), server, listener, time.Second, func() {})
+	}()
+	requestResult := make(chan error, 1)
+	go func() {
+		response, err := http.Get("http://" + listener.Addr().String())
+		if err == nil {
+			response.Body.Close()
+		}
+		requestResult <- err
+	}()
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("request did not start")
+	}
+	requestContext := <-requestContexts
+
+	cancel()
+	select {
+	case <-listener.closed:
+	case <-time.After(time.Second):
+		t.Fatal("shutdown did not close the listener")
+	}
+	if err := requestContext.Err(); err != nil {
+		t.Fatalf("ordinary request context canceled during graceful drain: %v", err)
+	}
+	release()
+	select {
+	case err := <-requestResult:
+		if err != nil {
+			t.Fatalf("ordinary request failed during graceful drain: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ordinary request did not complete")
+	}
+	select {
+	case err := <-serveResult:
+		if err != nil {
+			t.Fatalf("runHTTPServer() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("HTTP server did not finish graceful drain")
+	}
+}
+
+func TestRunHTTPServerUsesSingleDeadlineForStuckHandler(t *testing.T) {
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseRequest) }) }
+	t.Cleanup(release)
+	server := &http.Server{Handler: http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		close(requestStarted)
+		<-releaseRequest
+	})}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	const timeout = 300 * time.Millisecond
+	serveResult := make(chan error, 1)
+	go func() {
+		serveResult <- runHTTPServer(ctx, slog.New(slog.NewTextHandler(io.Discard, nil)), server, listener, timeout, func() {})
+	}()
+	clientResult := make(chan error, 1)
+	go func() {
+		client := &http.Client{Timeout: 2 * time.Second}
+		response, err := client.Get("http://" + listener.Addr().String())
+		if err == nil {
+			response.Body.Close()
+		}
+		clientResult <- err
+	}()
+	select {
+	case <-requestStarted:
+	case <-time.After(time.Second):
+		t.Fatal("request did not start")
+	}
+
+	started := time.Now()
+	cancel()
+	select {
+	case err = <-serveResult:
+	case <-time.After(3 * timeout):
+		t.Fatal("shutdown exceeded the bounded drain deadline")
+	}
+	elapsed := time.Since(started)
+	release()
+	if err == nil {
+		t.Fatal("runHTTPServer() returned nil for stuck handler")
+	}
+	if elapsed < timeout*3/4 || elapsed > timeout*3/2 {
+		t.Fatalf("shutdown elapsed = %v, want one %v deadline", elapsed, timeout)
+	}
+	select {
+	case <-clientResult:
+	case <-time.After(time.Second):
+		t.Fatal("client did not exit after forced close")
+	}
+}
+
+type closeNotifyListener struct {
+	net.Listener
+	closed chan struct{}
+	once   sync.Once
+}
+
+func (l *closeNotifyListener) Close() error {
+	l.once.Do(func() { close(l.closed) })
+	return l.Listener.Close()
+}

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -19,7 +19,10 @@ import (
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
 )
 
-const namespacedPathPrefix = "/api/v1/namespaces/"
+const (
+	namespacedPathPrefix               = "/api/v1/namespaces/"
+	defaultTranscriptHeartbeatInterval = 15 * time.Second
+)
 
 type appendTranscriptRequest struct {
 	Source         string          `json:"source"`
@@ -37,6 +40,8 @@ type Server struct {
 	runs           RunResolver
 	terminalDialer TerminalDialer
 	trustProxy     bool
+	heartbeat      time.Duration
+	streams        context.Context
 }
 
 // RunResolver verifies that a namespaced Run exists before transcript state is used.
@@ -65,12 +70,26 @@ type ServerOptions struct {
 	TranscriptStore TranscriptStore
 	TerminalDialer  TerminalDialer
 	TrustProxy      bool
+	// StreamLifecycle is canceled when long-lived SSE and terminal handlers
+	// must exit during process shutdown. Ordinary requests do not use it.
+	StreamLifecycle context.Context
+	// TranscriptHeartbeatInterval controls SSE keepalive comments. Values less
+	// than or equal to zero use the production default.
+	TranscriptHeartbeatInterval time.Duration
 }
 
 // NewServer constructs a control-plane API handler.
 func NewServer(log *slog.Logger, options ServerOptions) *Server {
 	if log == nil {
 		log = slog.Default()
+	}
+	heartbeat := options.TranscriptHeartbeatInterval
+	if heartbeat <= 0 {
+		heartbeat = defaultTranscriptHeartbeatInterval
+	}
+	streams := options.StreamLifecycle
+	if streams == nil {
+		streams = context.Background()
 	}
 	return &Server{
 		log:            log,
@@ -79,6 +98,20 @@ func NewServer(log *slog.Logger, options ServerOptions) *Server {
 		runs:           options.Runs,
 		terminalDialer: options.TerminalDialer,
 		trustProxy:     options.TrustProxy,
+		heartbeat:      heartbeat,
+		streams:        streams,
+	}
+}
+
+func (s *Server) withStreamLifecycle(r *http.Request) (*http.Request, func()) {
+	ctx, cancel := context.WithCancel(r.Context())
+	stop := context.AfterFunc(s.streams, cancel)
+	if s.streams.Err() != nil {
+		cancel()
+	}
+	return r.WithContext(ctx), func() {
+		stop()
+		cancel()
 	}
 }
 
@@ -250,6 +283,8 @@ func (s *Server) streamTranscript(w http.ResponseWriter, r *http.Request, run Ru
 		http.Error(w, "transcript store is unavailable", http.StatusServiceUnavailable)
 		return
 	}
+	r, cancelStream := s.withStreamLifecycle(r)
+	defer cancelStream()
 	cursor := r.Header.Get("Last-Event-ID")
 	if cursor == "" {
 		cursor = r.URL.Query().Get("after")
@@ -265,18 +300,15 @@ func (s *Server) streamTranscript(w http.ResponseWriter, r *http.Request, run Ru
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
 	w.WriteHeader(http.StatusOK)
 
 	controller := http.NewResponseController(w)
-	writeEvent := func(event TranscriptEvent) error {
+	write := func(payload string) error {
 		if err := controller.SetWriteDeadline(time.Now().Add(15 * time.Second)); err != nil && !errors.Is(err, http.ErrNotSupported) {
 			return err
 		}
-		payload, err := json.Marshal(event)
-		if err != nil {
-			return err
-		}
-		if _, err = fmt.Fprintf(w, "id: %s\nevent: transcript\ndata: %s\n\n", event.ID, payload); err != nil {
+		if _, err := io.WriteString(w, payload); err != nil {
 			return err
 		}
 		if err := controller.Flush(); err != nil {
@@ -287,12 +319,19 @@ func (s *Server) streamTranscript(w http.ResponseWriter, r *http.Request, run Ru
 		}
 		return nil
 	}
+	writeEvent := func(event TranscriptEvent) error {
+		payload, err := json.Marshal(event)
+		if err != nil {
+			return err
+		}
+		return write(fmt.Sprintf("id: %s\nevent: transcript\ndata: %s\n\n", event.ID, payload))
+	}
 	if subscription.Gap != nil {
 		payload, marshalErr := json.Marshal(subscription.Gap)
 		if marshalErr != nil {
 			return
 		}
-		if _, err = fmt.Fprintf(w, "event: transcript-gap\ndata: %s\n\n", payload); err != nil {
+		if err = write(fmt.Sprintf("event: transcript-gap\ndata: %s\n\n", payload)); err != nil {
 			return
 		}
 	}
@@ -306,6 +345,8 @@ func (s *Server) streamTranscript(w http.ResponseWriter, r *http.Request, run Ru
 	if err := controller.Flush(); err != nil {
 		return
 	}
+	heartbeats := time.NewTicker(s.heartbeat)
+	defer heartbeats.Stop()
 
 	for {
 		select {
@@ -316,6 +357,10 @@ func (s *Server) streamTranscript(w http.ResponseWriter, r *http.Request, run Ru
 		case <-subscription.Dropped:
 			s.log.Warn("closing slow transcript subscriber", "namespace", run.Namespace, "runUID", run.UID)
 			return
+		case <-heartbeats.C:
+			if err := write(": ping\n\n"); err != nil {
+				return
+			}
 		case <-r.Context().Done():
 			return
 		}

--- a/internal/controlplane/server_test.go
+++ b/internal/controlplane/server_test.go
@@ -43,6 +43,9 @@ func TestTranscriptReplayAndLiveStream(t *testing.T) {
 	if got := response.Header.Get("Content-Type"); got != "text/event-stream" {
 		t.Fatalf("Content-Type = %q, want text/event-stream", got)
 	}
+	if got := response.Header.Get("X-Accel-Buffering"); got != "no" {
+		t.Fatalf("X-Accel-Buffering = %q, want no", got)
+	}
 
 	lines := make(chan string, 8)
 	go func() {
@@ -57,6 +60,84 @@ func TestTranscriptReplayAndLiveStream(t *testing.T) {
 	assertEventText(t, nextLine(t, lines), "first")
 	postEvent(t, server.URL, `{"source":"adapter","idempotencyKey":"second","type":"output","data":{"text":"second"}}`)
 	assertEventText(t, nextLine(t, lines), "second")
+}
+
+func TestTranscriptStreamSendsHeartbeat(t *testing.T) {
+	api := NewServer(nil, ServerOptions{
+		Access:                      &fakeAccess{},
+		Runs:                        &fakeRunResolver{},
+		TranscriptStore:             NewMemoryTranscriptStore(MemoryTranscriptStoreOptions{}),
+		TranscriptHeartbeatInterval: time.Millisecond,
+	})
+	server := httptest.NewServer(api.Handler())
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+transcriptURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+
+	scanner := bufio.NewScanner(response.Body)
+	if !scanner.Scan() {
+		t.Fatalf("stream ended before heartbeat: %v", scanner.Err())
+	}
+	if got := scanner.Text(); got != ": ping" {
+		t.Fatalf("heartbeat = %q, want %q", got, ": ping")
+	}
+}
+
+func TestTranscriptStreamLifecycleUnsubscribes(t *testing.T) {
+	streamLifecycle, cancelStreams := context.WithCancel(context.Background())
+	store := NewMemoryTranscriptStore(MemoryTranscriptStoreOptions{}).(*memoryTranscriptStore)
+	api := NewServer(nil, ServerOptions{
+		Access:          &fakeAccess{},
+		Runs:            &fakeRunResolver{},
+		TranscriptStore: store,
+		StreamLifecycle: streamLifecycle,
+	})
+	server := httptest.NewServer(api.Handler())
+	defer server.Close()
+
+	response, err := http.Get(server.URL + transcriptURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	run := RunIdentity{Namespace: "project-1", UID: "run-1-uid"}
+	store.mu.Lock()
+	subscribers := len(store.subscribers[run])
+	store.mu.Unlock()
+	if subscribers != 1 {
+		t.Fatalf("subscribers before shutdown = %d, want 1", subscribers)
+	}
+
+	cancelStreams()
+	done := make(chan error, 1)
+	go func() {
+		_, err := io.Copy(io.Discard, response.Body)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("read canceled SSE stream: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("SSE stream did not exit after lifecycle cancellation")
+	}
+	store.mu.Lock()
+	_, subscribed := store.subscribers[run]
+	store.mu.Unlock()
+	if subscribed {
+		t.Fatal("SSE subscription remained after lifecycle cancellation")
+	}
 }
 
 func TestTranscriptSharedStoreFansOutAcrossServers(t *testing.T) {

--- a/internal/controlplane/terminal.go
+++ b/internal/controlplane/terminal.go
@@ -22,8 +22,9 @@ import (
 )
 
 const (
-	wakeTimeout      = 2 * time.Minute
-	wakePollInterval = 250 * time.Millisecond
+	wakeTimeout              = 2 * time.Minute
+	wakePollInterval         = 250 * time.Millisecond
+	terminalHandshakeTimeout = 5 * time.Second
 )
 
 // TerminalDialer resolves an Environment and connects to its sandboxd API.
@@ -178,9 +179,10 @@ type terminalControl struct {
 }
 
 var terminalUpgrader = websocket.Upgrader{
-	ReadBufferSize:  32 * 1024,
-	WriteBufferSize: 32 * 1024,
-	CheckOrigin:     func(*http.Request) bool { return true }, // checked before backend dial
+	HandshakeTimeout: terminalHandshakeTimeout,
+	ReadBufferSize:   32 * 1024,
+	WriteBufferSize:  32 * 1024,
+	CheckOrigin:      func(*http.Request) bool { return true }, // checked before backend dial
 }
 
 func (s *Server) handleTerminal(w http.ResponseWriter, r *http.Request, namespace, environment string) {
@@ -204,6 +206,8 @@ func (s *Server) handleTerminal(w http.ResponseWriter, r *http.Request, namespac
 		http.Error(w, "terminal gateway is unavailable", http.StatusServiceUnavailable)
 		return
 	}
+	r, cancelStream := s.withStreamLifecycle(r)
+	defer cancelStream()
 
 	terminal, closer, err := s.terminalDialer.DialTerminal(r.Context(), namespace, environment)
 	if err != nil {
@@ -218,6 +222,8 @@ func (s *Server) handleTerminal(w http.ResponseWriter, r *http.Request, namespac
 		return
 	}
 	defer connection.Close()
+	stopCloseOnCancel := context.AfterFunc(r.Context(), func() { _ = connection.Close() })
+	defer stopCloseOnCancel()
 	connection.SetReadLimit(1 << 20)
 	if err := bridgeWebTerminal(r.Context(), connection, terminal); err != nil {
 		if r.Context().Err() == nil {

--- a/internal/controlplane/terminal_test.go
+++ b/internal/controlplane/terminal_test.go
@@ -1,6 +1,7 @@
 package controlplane
 
 import (
+	"bufio"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -93,6 +94,93 @@ func TestWebTerminalBridgesSandboxd(t *testing.T) {
 	if string(backend.input) != "echo hello\n" {
 		t.Fatalf("sandboxd input = %q, want echo hello", backend.input)
 	}
+}
+
+func TestWebTerminalClosesWhileWaitingForOpenWhenContextCanceled(t *testing.T) {
+	listener := bufconn.Listen(1024 * 1024)
+	grpcServer := grpc.NewServer()
+	sandboxdv1.RegisterTerminalServiceServer(grpcServer, &terminalTestServer{})
+	go func() { _ = grpcServer.Serve(listener) }()
+	t.Cleanup(grpcServer.Stop)
+	backendConnection, err := grpc.NewClient("passthrough:///bufconn", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+		return listener.Dial()
+	}), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = backendConnection.Close() })
+
+	closed := make(chan struct{})
+	dialer := &terminalTestDialer{client: sandboxdv1.NewTerminalServiceClient(backendConnection), closer: closeFunc(func() error {
+		close(closed)
+		return nil
+	})}
+	streamLifecycle, cancelStreams := context.WithCancel(context.Background())
+	server := httptest.NewServer(NewServer(nil, ServerOptions{Access: &fakeAccess{}, TerminalDialer: dialer, StreamLifecycle: streamLifecycle}).Handler())
+	t.Cleanup(server.Close)
+
+	websocketURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/v1/namespaces/project-1/environments/env-1/terminal"
+	connection, _, err := websocket.DefaultDialer.Dial(websocketURL, http.Header{"Authorization": []string{"Bearer reader"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = connection.Close() })
+	select {
+	case <-closed:
+		t.Fatal("terminal backend closed before request cancellation")
+	default:
+	}
+
+	cancelStreams()
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("terminal backend was not closed after request cancellation")
+	}
+}
+
+func TestTerminalHandshakeTimeoutBoundsPostHijackWrite(t *testing.T) {
+	if terminalUpgrader.HandshakeTimeout != terminalHandshakeTimeout || terminalHandshakeTimeout >= shutdownTimeoutForTest {
+		t.Fatalf("terminal handshake timeout = %v, want positive and below shutdown budget", terminalUpgrader.HandshakeTimeout)
+	}
+	upgrader := terminalUpgrader
+	upgrader.HandshakeTimeout = 10 * time.Millisecond
+	serverConnection, stalledPeer := net.Pipe()
+	defer serverConnection.Close()
+	defer stalledPeer.Close()
+	w := &hijackResponseWriter{header: make(http.Header), connection: serverConnection}
+	request := httptest.NewRequest(http.MethodGet, "/terminal", nil)
+	setWebSocketUpgrade(request)
+	request.Header.Set("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+	request.Header.Set("Sec-WebSocket-Version", "13")
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := upgrader.Upgrade(w, request, nil)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("stalled post-hijack handshake unexpectedly succeeded")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("stalled post-hijack handshake ignored its timeout")
+	}
+}
+
+const shutdownTimeoutForTest = 10 * time.Second
+
+type hijackResponseWriter struct {
+	header     http.Header
+	connection net.Conn
+}
+
+func (w *hijackResponseWriter) Header() http.Header             { return w.header }
+func (*hijackResponseWriter) Write(payload []byte) (int, error) { return len(payload), nil }
+func (*hijackResponseWriter) WriteHeader(int)                   {}
+func (w *hijackResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.connection, bufio.NewReadWriter(bufio.NewReader(w.connection), bufio.NewWriter(w.connection)), nil
 }
 
 func TestWebTerminalRequiresDialer(t *testing.T) {
@@ -383,6 +471,7 @@ func ptrTo[T any](value T) *T { return &value }
 type terminalTestDialer struct {
 	mu          sync.Mutex
 	client      sandboxdv1.TerminalServiceClient
+	closer      io.Closer
 	namespace   string
 	environment string
 	calls       int
@@ -394,7 +483,11 @@ func (d *terminalTestDialer) DialTerminal(_ context.Context, namespace, environm
 	d.namespace = namespace
 	d.environment = environment
 	d.mu.Unlock()
-	return d.client, io.NopCloser(strings.NewReader("")), nil
+	closer := d.closer
+	if closer == nil {
+		closer = io.NopCloser(strings.NewReader(""))
+	}
+	return d.client, closer, nil
 }
 
 type terminalTestServer struct {


### PR DESCRIPTION
## Summary

- send periodic SSE `: ping` comments and disable nginx response buffering
- make heartbeat intervals injectable so coverage stays fast and deterministic
- handle SIGTERM/SIGINT with a shared 10-second shutdown and handler drain budget
- cancel and await SSE and hijacked WebSocket handlers so transcript subscriptions and terminal backends clean up
- close WebSocket transports on request cancellation, including clients stalled before their initial terminal `open` message

## Issue reassessment

The unbounded transcript-store concern in #28 was already addressed by #8. The current `TranscriptStore` contract and memory implementation bound retained runs, per-run and aggregate events/bytes, idempotency entries, replay, subscribers, and subscriber buffers. This PR leaves that contract and its cursor/durability semantics unchanged rather than adding a second cleanup API at the HTTP layer.

Authentication, authorization, transcript cursor/replay behavior, adapter-owned payloads, and normal WebSocket behavior are unchanged.

## Checks

- `go test -race ./internal/controlplane ./cmd/control-plane`
- `make test`
- `make vet`
- `make check-chart-crds`

Closes #28
