### PR TITLE
Wait for Unix process-tree fencing to complete

### DIFF
--- a/sandboxd/internal/server/process.go
+++ b/sandboxd/internal/server/process.go
@@ -399,7 +399,7 @@ func (s *ProcessServer) shutdownManaged(key processKey, p *managedProcess) {
 	leaderWaited := p.leaderWaited
 	s.mu.Unlock()
 	if leaderWaited {
-		s.finalizeWait(key, p)
+		go s.finalizeWait(key, p)
 	}
 }
 

--- a/sandboxd/internal/server/process_group_linux.go
+++ b/sandboxd/internal/server/process_group_linux.go
@@ -1,0 +1,46 @@
+//go:build linux
+
+package server
+
+import (
+	"errors"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+func processGroupRunning(pgid int) bool {
+	// Signal zero includes zombies, which may persist when sandboxd is PID 1.
+	// Linux procfs lets close wait for running members without waiting for reap.
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return processGroupExists(pgid)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if _, err := strconv.Atoi(entry.Name()); err != nil {
+			continue
+		}
+		stat, err := os.ReadFile("/proc/" + entry.Name() + "/stat")
+		if err != nil {
+			continue
+		}
+		fields := strings.Fields(string(stat[strings.LastIndexByte(string(stat), ')')+1:]))
+		if len(fields) < 3 || fields[0] == "Z" || fields[0] == "X" {
+			continue
+		}
+		group, err := strconv.Atoi(fields[2])
+		if err == nil && group == pgid {
+			return true
+		}
+	}
+	return false
+}
+
+func processGroupExists(pgid int) bool {
+	err := syscall.Kill(-pgid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}

--- a/sandboxd/internal/server/process_group_unix.go
+++ b/sandboxd/internal/server/process_group_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows && !linux
+
+package server
+
+import (
+	"errors"
+	"syscall"
+)
+
+func processGroupRunning(pgid int) bool {
+	err := syscall.Kill(-pgid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}

--- a/sandboxd/internal/server/process_unix.go
+++ b/sandboxd/internal/server/process_unix.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"sync"
 	"syscall"
+	"time"
 )
 
 var errInterruptUnsupported = errors.New("interrupt unsupported")
@@ -17,6 +18,9 @@ type processDomain struct {
 	mu       sync.Mutex
 	terminal bool
 	closed   bool
+	forced   bool
+	closing  chan struct{}
+	closeErr error
 }
 
 func newProcessDomain(cmd *exec.Cmd) *processDomain {
@@ -39,7 +43,7 @@ func (d *processDomain) wait() error {
 func (d *processDomain) signal(sig syscall.Signal) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	if d.cmd.Process == nil || d.terminal || d.closed {
+	if d.cmd.Process == nil || d.terminal || d.closed || d.closing != nil {
 		return nil
 	}
 	return syscall.Kill(-d.cmd.Process.Pid, sig)
@@ -47,11 +51,59 @@ func (d *processDomain) signal(sig syscall.Signal) error {
 
 func (d *processDomain) interrupt() error { return d.signal(syscall.SIGINT) }
 func (d *processDomain) terminate() error { return d.signal(syscall.SIGTERM) }
-func (d *processDomain) force() error     { return d.signal(syscall.SIGKILL) }
+func (d *processDomain) force() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.cmd.Process == nil || d.terminal || d.closed || d.forced || d.closing != nil {
+		return nil
+	}
+	err := syscall.Kill(-d.cmd.Process.Pid, syscall.SIGKILL)
+	if err == nil || errors.Is(err, syscall.ESRCH) {
+		d.forced = true
+		return nil
+	}
+	return err
+}
+
+// close does not publish a terminal domain until SIGKILL has taken effect for
+// every running member. Signal delivery alone is asynchronous.
 func (d *processDomain) close() error {
+	forceErr := d.force()
+	d.mu.Lock()
+	if d.closed {
+		err := d.closeErr
+		d.mu.Unlock()
+		return err
+	}
+	if d.closing != nil {
+		closing := d.closing
+		d.mu.Unlock()
+		<-closing
+		d.mu.Lock()
+		err := d.closeErr
+		d.mu.Unlock()
+		return err
+	}
+	d.closing = make(chan struct{})
+	closing := d.closing
+	pid := 0
+	if d.cmd.Process != nil {
+		pid = d.cmd.Process.Pid
+	}
+	d.mu.Unlock()
+
+	if pid != 0 {
+		for processGroupRunning(pid) {
+			time.Sleep(time.Millisecond)
+		}
+	}
+
 	d.mu.Lock()
 	d.terminal = true
 	d.closed = true
+	d.closeErr = forceErr
+	close(closing)
+	d.closing = nil
 	d.mu.Unlock()
-	return nil
+	return forceErr
 }

--- a/sandboxd/internal/server/process_unix.go
+++ b/sandboxd/internal/server/process_unix.go
@@ -54,7 +54,14 @@ func (d *processDomain) terminate() error { return d.signal(syscall.SIGTERM) }
 func (d *processDomain) force() error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	if d.cmd.Process == nil || d.terminal || d.closed || d.forced || d.closing != nil {
+	if d.closing != nil {
+		return nil
+	}
+	return d.forceLocked()
+}
+
+func (d *processDomain) forceLocked() error {
+	if d.cmd.Process == nil || d.terminal || d.closed || d.forced {
 		return nil
 	}
 	err := syscall.Kill(-d.cmd.Process.Pid, syscall.SIGKILL)
@@ -68,7 +75,6 @@ func (d *processDomain) force() error {
 // close does not publish a terminal domain until SIGKILL has taken effect for
 // every running member. Signal delivery alone is asynchronous.
 func (d *processDomain) close() error {
-	forceErr := d.force()
 	d.mu.Lock()
 	if d.closed {
 		err := d.closeErr
@@ -86,6 +92,7 @@ func (d *processDomain) close() error {
 	}
 	d.closing = make(chan struct{})
 	closing := d.closing
+	forceErr := d.forceLocked()
 	pid := 0
 	if d.cmd.Process != nil {
 		pid = d.cmd.Process.Pid

--- a/sandboxd/internal/server/process_unix.go
+++ b/sandboxd/internal/server/process_unix.go
@@ -10,7 +10,10 @@ import (
 	"time"
 )
 
-var errInterruptUnsupported = errors.New("interrupt unsupported")
+var (
+	errInterruptUnsupported = errors.New("interrupt unsupported")
+	signalProcessGroup      = syscall.Kill
+)
 
 // Each launched command owns a private process group.
 type processDomain struct {
@@ -46,7 +49,7 @@ func (d *processDomain) signal(sig syscall.Signal) error {
 	if d.cmd.Process == nil || d.terminal || d.closed || d.closing != nil {
 		return nil
 	}
-	return syscall.Kill(-d.cmd.Process.Pid, sig)
+	return signalProcessGroup(-d.cmd.Process.Pid, sig)
 }
 
 func (d *processDomain) interrupt() error { return d.signal(syscall.SIGINT) }
@@ -64,7 +67,7 @@ func (d *processDomain) forceLocked() error {
 	if d.cmd.Process == nil || d.terminal || d.closed || d.forced {
 		return nil
 	}
-	err := syscall.Kill(-d.cmd.Process.Pid, syscall.SIGKILL)
+	err := signalProcessGroup(-d.cmd.Process.Pid, syscall.SIGKILL)
 	if err == nil || errors.Is(err, syscall.ESRCH) {
 		d.forced = true
 		return nil

--- a/sandboxd/internal/server/process_unix_test.go
+++ b/sandboxd/internal/server/process_unix_test.go
@@ -1,0 +1,35 @@
+//go:build !windows
+
+package server
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+)
+
+func TestProcessDomainCloseClaimsBeforeForce(t *testing.T) {
+	domain := newProcessDomain(exec.Command("unused"))
+	domain.cmd.Process = &os.Process{Pid: 1 << 30}
+	originalSignal := signalProcessGroup
+	t.Cleanup(func() { signalProcessGroup = originalSignal })
+
+	closingClaimed := false
+	signalProcessGroup = func(_ int, signal syscall.Signal) error {
+		if signal != syscall.SIGKILL {
+			t.Fatalf("teardown signal = %v, want SIGKILL", signal)
+		}
+		// forceLocked calls this while holding domain.mu, so this observes the
+		// exact ordering without racing the production state.
+		closingClaimed = domain.closing != nil
+		return syscall.ESRCH
+	}
+
+	if err := domain.close(); err != nil {
+		t.Fatal(err)
+	}
+	if !closingClaimed {
+		t.Fatal("close issued SIGKILL before claiming teardown ownership")
+	}
+}


### PR DESCRIPTION
## Summary

- make Unix domain close wait until no running process-group members remain
- make force delivery and close completion single-flight to prevent stale-PGID re-signaling
- distinguish Linux zombies from running descendants when sandboxd is PID 1
- keep managed shutdown finalization asynchronous so `CloseContext` remains bounded

## Root cause

Unix `processDomain.force` only submitted `SIGKILL`, and `processDomain.close` immediately marked the domain terminal. Signal delivery is asynchronous. The leader waiter and pipe drains could therefore unregister the domain, allowing `Supervisor.Close` to return while a descendant was still transitioning out. That races the portable guarantee that no running descendants remain after close and caused alternating failures in `TestSupervisorCloseFencesExecAndManaged` and `TestCloseContextCancelsLongGracePeriod` on main and unrelated PRs.

The completion barrier checks the private process group. Linux scans `/proc` for non-zombie members because signal-zero treats zombies as existing and sandboxd may run as PID 1; other Unix targets retain a portable process-group existence probe.

Regression evidence: main Actions run 29689446076 and PR run 29689692727.

## Validation

- focused lifecycle tests: `-count=1000 -failfast`
- focused lifecycle tests with race detector: `-race -count=100 -failfast`
- full `sandboxd/internal/server` race suite
- full sandboxd tests and vet
- full root tests and vet
- Darwin amd64 and Windows amd64 test cross-compilation
- GitHub `build-test`, `sandboxd-windows`, and kind E2E checks passed on head `8ab8530`