### PR TITLE
Fix flaky concurrent filesystem read oracle

### DIFF
--- a/sandboxd/internal/server/filesystem.go
+++ b/sandboxd/internal/server/filesystem.go
@@ -312,6 +312,18 @@ func hashFile(ctx context.Context, file *os.File) (string, error) {
 	}
 }
 
+func readChunk(reader io.Reader, size uint64) ([]byte, error) {
+	data := make([]byte, int(size))
+	n, err := io.ReadFull(reader, data)
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			err = io.ErrUnexpectedEOF
+		}
+		return nil, err
+	}
+	return data[:n], nil
+}
+
 func (s *FilesystemServer) Read(ctx context.Context, req *sandboxdv1.ReadRequest) (*sandboxdv1.ReadResponse, error) {
 	if err := s.initialize(); err != nil {
 		return nil, status.Error(codes.Internal, "initialize filesystem")
@@ -367,15 +379,13 @@ func (s *FilesystemServer) Read(ctx context.Context, req *sandboxdv1.ReadRequest
 		return nil, filesystemError("seek workspace file", err)
 	}
 	want := min(uint64(maxBytes), size-req.GetOffset())
-	data := make([]byte, int(want))
-	n, err := io.ReadFull(file, data)
+	data, err := readChunk(file, want)
 	if errors.Is(err, io.ErrUnexpectedEOF) {
 		return nil, status.Error(codes.Aborted, "workspace file changed during read")
 	}
 	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, filesystemError("read workspace file", err)
 	}
-	data = data[:n]
 	next := req.GetOffset() + uint64(len(data))
 	return &sandboxdv1.ReadResponse{Data: data, Offset: req.GetOffset(), NextOffset: next, Size: size, Eof: next == size, Version: version}, nil
 }

--- a/sandboxd/internal/server/filesystem_test.go
+++ b/sandboxd/internal/server/filesystem_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -441,7 +442,21 @@ func TestFilesystemSymlinkSwapCannotEscapeRoot(t *testing.T) {
 	<-done
 }
 
-func TestFilesystemConcurrentTruncateNeverReturnsFabricatedBytes(t *testing.T) {
+func TestReadChunkRejectsShortReadWithoutExposingBufferTail(t *testing.T) {
+	for name, input := range map[string]string{"immediate EOF": "", "partial read": "x"} {
+		t.Run(name, func(t *testing.T) {
+			data, err := readChunk(strings.NewReader(input), 4)
+			if !errors.Is(err, io.ErrUnexpectedEOF) {
+				t.Fatalf("short read error = %v; want %v", err, io.ErrUnexpectedEOF)
+			}
+			if data != nil {
+				t.Fatalf("short read returned %d bytes from incomplete buffer", len(data))
+			}
+		})
+	}
+}
+
+func TestFilesystemConcurrentMutationPreservesReadResponseInvariants(t *testing.T) {
 	workspace := t.TempDir()
 	path := filepath.Join(workspace, "changing")
 	content := bytes.Repeat([]byte("x"), 256*1024)
@@ -470,10 +485,10 @@ func TestFilesystemConcurrentTruncateNeverReturnsFabricatedBytes(t *testing.T) {
 			<-done
 			t.Fatalf("read during truncate: %v", err)
 		}
-		if err == nil && bytes.IndexByte(read.Data, 0) >= 0 {
+		if err == nil && (read.Offset != 0 || read.NextOffset != uint64(len(read.Data)) || len(read.Data) > 128*1024 || read.NextOffset > read.Size || len(read.Data) == 0 && !read.Eof || read.Eof != (read.NextOffset == read.Size)) {
 			close(stop)
 			<-done
-			t.Fatal("read fabricated zero-filled bytes")
+			t.Fatalf("incoherent read response: offset=%d next=%d size=%d eof=%v data=%d", read.Offset, read.NextOffset, read.Size, read.Eof, len(read.Data))
 		}
 	}
 	close(stop)

--- a/sandboxd/proto/sandboxd/v1/FILESYSTEM.md
+++ b/sandboxd/proto/sandboxd/v1/FILESYSTEM.md
@@ -76,11 +76,14 @@ consistent and clients may restart from an empty token to obtain a fresh travers
 
 Malformed paths, tokens, headers, and limits are `InvalidArgument`; stale offsets are
 `OutOfRange`; missing objects are `NotFound`; symlinks, wrong object types, and failed
-write preconditions are `FailedPrecondition`; stream/file/concurrency bounds are
-`ResourceExhausted`; cancellation is `Canceled` or `DeadlineExceeded`; and unexpected
-host I/O failures are `Internal`. RPC contexts are checked during hashing, transfer,
-directory scans, staging, and commit.
+write preconditions are `FailedPrecondition`; a short read detected during concurrent
+mutation is `Aborted`; stream/file/concurrency bounds are `ResourceExhausted`;
+cancellation is `Canceled` or `DeadlineExceeded`; and unexpected host I/O failures are
+`Internal`. RPC contexts are checked during hashing, transfer, directory scans, staging,
+and commit.
 
-Separate ranged reads are weakly consistent when another process changes the file
-between calls. Clients that need a stable edit base request a version and use
-`MATCH_VERSION` when publishing their replacement.
+Ranged reads are weakly consistent when another process changes the file during or
+between calls. A successful call's data and metadata need not represent one filesystem
+snapshot during concurrent mutation, but `data` contains only bytes returned by the
+host read and `next_offset` advances by exactly its length. Clients that need a stable
+edit base request a version and use `MATCH_VERSION` when publishing their replacement.


### PR DESCRIPTION
## Summary

- replace the invalid value-based concurrent truncate oracle with ranged-read response invariant checks
- extract deterministic short-read coverage proving unread zero-filled allocation tails cannot reach a response
- map both immediate and partial short reads during concurrent mutation to `Aborted`, preventing successful non-progressing pages
- clarify the normative weak-consistency and `Aborted` semantics

## Root cause

The test treated every zero byte observed while another process repeatedly truncated and rewrote a file as server-fabricated. On Linux, a read racing in-place truncate/regrow/write can legitimately return zero-valued bytes from the page cache within the syscall's returned byte count. Weak consistency permits those host-returned bytes; their value cannot establish provenance.

The server already used `io.ReadFull` and sliced to the returned count. The extracted seam makes the stronger rule deterministic and explicit: any short read returns nil data and is reported as `Aborted`, so no unread zero-filled buffer tail is serialized. This also fixes immediate EOF after `Stat`, which previously could return an empty successful page with `eof=false` and no offset progress.

## Validation

- `go test ./internal/server -run '^(TestReadChunkRejectsShortReadWithoutExposingBufferTail|TestFilesystemConcurrentMutationPreservesReadResponseInvariants)$' -count=1000`
- `go test -race ./internal/server -run '^(TestReadChunkRejectsShortReadWithoutExposingBufferTail|TestFilesystemConcurrentMutationPreservesReadResponseInvariants)$' -count=100`
- `go test -race ./...` (sandboxd)
- `go test ./...` (root and sandboxd modules)
- `go vet ./...` (root and sandboxd modules)
- `GOOS=windows GOARCH=amd64 go test -c ./internal/server`
