### PR TITLE
Harden warm-pool cleanup and retry behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,9 +180,9 @@ contract. GitHub App token minting is not implemented yet.
 
 Transient operational reconciliation errors withdraw readiness with an `OperationalError`
 reason and use controller-runtime's rate-limited retry; they do not put the Environment in the
-terminal `Failed` phase. Invalid references and specifications report `Failed` with an
-`InvalidConfiguration` reason and wait for the referenced Template or Project, or the
-Environment spec, to change.
+terminal `Failed` phase. Missing or blank references, invalid specifications, and deterministic
+Kubernetes `Invalid` or `BadRequest` responses report `Failed` with an `InvalidConfiguration`
+reason and wait for the referenced Template or Project, or the Environment spec, to change.
 
 Environments without an active Run are automatically paused after their template's
 `idleTimeout` (15 minutes by default). An exact non-terminal Run owner or claim always
@@ -198,8 +198,10 @@ against its existing workspace volume so repository setup completes before the r
 reported ready. Deleting members never count as ready or active. Unclaimed failed, terminated,
 or explicitly paused members are replaced immediately, retained for a five-minute recovery
 grace, then deleted if they remain unusable; the persisted cleanup timestamp keeps that bound
-stable across operator restarts. Cleanup requires exact Template ownership and UID/resourceVersion
-preconditions, so concurrent claims and promotions win without being deleted.
+stable across operator restarts. Replacement surge is bounded to the configured minimum, so at
+most twice the minimum exact, unclaimed members remain while an entire replacement set is also
+quarantined. Cleanup requires exact Template ownership and UID/resourceVersion preconditions, so
+concurrent claims and promotions win without being deleted.
 
 Only the `pod` environment backend is currently supported. An explicit
 `Environment.spec.backend` takes precedence over its template's backend; unsupported

--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ the current-generation `Ready` condition only after initialization completes and
 startup/readiness probes pass; `status.phase` is a display summary rather than the scheduling
 contract. GitHub App token minting is not implemented yet.
 
+Transient operational reconciliation errors withdraw readiness with an `OperationalError`
+reason and use controller-runtime's rate-limited retry; they do not put the Environment in the
+terminal `Failed` phase. Invalid references and specifications report `Failed` with an
+`InvalidConfiguration` reason and wait for the referenced Template or Project, or the
+Environment spec, to change.
+
 Environments without an active Run are automatically paused after their template's
 `idleTimeout` (15 minutes by default). An exact non-terminal Run owner or claim always
 prevents an automatic idle pause, while explicit pause requests remain authoritative.
@@ -189,7 +195,11 @@ Set `EnvironmentTemplate.spec.warmPool.min` to keep that many unclaimed environm
 ready. `swe run` claims a ready environment before creating a cold one, and the operator
 immediately replenishes the pool. Claiming for a Project recreates the generic warm pod
 against its existing workspace volume so repository setup completes before the run is
-reported ready.
+reported ready. Deleting members never count as ready or active. Unclaimed failed, terminated,
+or explicitly paused members are replaced immediately, retained for a five-minute recovery
+grace, then deleted if they remain unusable; the persisted cleanup timestamp keeps that bound
+stable across operator restarts. Cleanup requires exact Template ownership and UID/resourceVersion
+preconditions, so concurrent claims and promotions win without being deleted.
 
 Only the `pod` environment backend is currently supported. An explicit
 `Environment.spec.backend` takes precedence over its template's backend; unsupported

--- a/api/v1alpha1/environment_types.go
+++ b/api/v1alpha1/environment_types.go
@@ -43,6 +43,7 @@ type EnvironmentSpec struct {
 	ProjectRef string `json:"projectRef,omitempty"`
 
 	// TemplateRef is the name of the EnvironmentTemplate to build from.
+	// +kubebuilder:validation:MinLength=1
 	TemplateRef string `json:"templateRef"`
 
 	// Backend overrides the template's backend when set. Only pod is currently

--- a/api/v1alpha1/environmenttemplate_types.go
+++ b/api/v1alpha1/environmenttemplate_types.go
@@ -15,6 +15,7 @@ type WarmPoolSpec struct {
 // EnvironmentTemplateSpec defines a class of environments.
 type EnvironmentTemplateSpec struct {
 	// Image is the container image for the environment.
+	// +kubebuilder:validation:MinLength=1
 	Image string `json:"image"`
 
 	// Size names a resource preset (tiny | small | medium | large).

--- a/charts/swe-platform/crds/swe.dev_environments.yaml
+++ b/charts/swe-platform/crds/swe.dev_environments.yaml
@@ -67,6 +67,7 @@ spec:
               templateRef:
                 description: TemplateRef is the name of the EnvironmentTemplate to
                   build from.
+                minLength: 1
                 type: string
             required:
             - templateRef

--- a/charts/swe-platform/crds/swe.dev_environmenttemplates.yaml
+++ b/charts/swe-platform/crds/swe.dev_environmenttemplates.yaml
@@ -61,6 +61,7 @@ spec:
                 type: string
               image:
                 description: Image is the container image for the environment.
+                minLength: 1
                 type: string
               runtimeClass:
                 description: RuntimeClass is the RuntimeClass used for isolation (e.g.

--- a/config/crd/bases/swe.dev_environments.yaml
+++ b/config/crd/bases/swe.dev_environments.yaml
@@ -67,6 +67,7 @@ spec:
               templateRef:
                 description: TemplateRef is the name of the EnvironmentTemplate to
                   build from.
+                minLength: 1
                 type: string
             required:
             - templateRef

--- a/config/crd/bases/swe.dev_environmenttemplates.yaml
+++ b/config/crd/bases/swe.dev_environmenttemplates.yaml
@@ -61,6 +61,7 @@ spec:
                 type: string
               image:
                 description: Image is the container image for the environment.
+                minLength: 1
                 type: string
               runtimeClass:
                 description: RuntimeClass is the RuntimeClass used for isolation (e.g.

--- a/internal/controllers/environment_controller.go
+++ b/internal/controllers/environment_controller.go
@@ -57,6 +57,7 @@ const (
 	podRecoveryLimit   = int32(3)
 	podRecoveryDelay   = 5 * time.Second
 	templateRefField   = "spec.templateRef"
+	projectRefField    = "spec.projectRef"
 	warmPoolLabel      = "swe.dev/warm-pool"
 	projectAnnotation  = "swe.dev/project"
 )
@@ -74,6 +75,17 @@ type childOwnershipCollisionError struct {
 
 func (e *childOwnershipCollisionError) Error() string {
 	return fmt.Sprintf("%s %q is not owned by this environment", e.kind, e.name)
+}
+
+type terminalEnvironmentError struct {
+	err error
+}
+
+func (e *terminalEnvironmentError) Error() string { return e.err.Error() }
+func (e *terminalEnvironmentError) Unwrap() error { return e.err }
+
+func terminalEnvironment(err error) error {
+	return &terminalEnvironmentError{err: err}
 }
 
 const (
@@ -173,7 +185,11 @@ func (r *EnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 	var tmpl platformv1alpha1.EnvironmentTemplate
 	if err := r.Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: env.Spec.TemplateRef}, &tmpl); err != nil {
-		return ctrl.Result{}, r.fail(ctx, &env, fmt.Errorf("get template %q: %w", env.Spec.TemplateRef, err))
+		wrapped := fmt.Errorf("get template %q: %w", env.Spec.TemplateRef, err)
+		if errors.IsNotFound(err) {
+			wrapped = terminalEnvironment(wrapped)
+		}
+		return ctrl.Result{}, r.fail(ctx, &env, wrapped)
 	}
 	backend := platformv1alpha1.EffectiveEnvironmentBackend(&env, &tmpl)
 	if backend != platformv1alpha1.EnvironmentBackendPod {
@@ -221,7 +237,15 @@ func (r *EnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if pod.Status.Phase != corev1.PodRunning {
 		return ctrl.Result{}, nil
 	}
-	return r.reconcileIdle(ctx, &env, &tmpl)
+	result, err = r.reconcileIdle(ctx, &env, &tmpl)
+	if errors.IsConflict(err) {
+		// A concurrent claim or activity update won the optimistic pause race.
+		return ctrl.Result{Requeue: true}, nil
+	}
+	if err != nil {
+		return ctrl.Result{}, r.fail(ctx, &env, fmt.Errorf("reconcile idle policy: %w", err))
+	}
+	return result, nil
 }
 
 // reconcilePendingPodRecovery advances persisted recovery before ensurePod can
@@ -773,10 +797,14 @@ func (r *EnvironmentReconciler) ensurePod(ctx context.Context, env *platformv1al
 	if env.Spec.ProjectRef != "" {
 		var project platformv1alpha1.Project
 		if err := r.Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: env.Spec.ProjectRef}, &project); err != nil {
-			return nil, fmt.Errorf("get project %q: %w", env.Spec.ProjectRef, err)
+			wrapped := fmt.Errorf("get project %q: %w", env.Spec.ProjectRef, err)
+			if errors.IsNotFound(err) {
+				wrapped = terminalEnvironment(wrapped)
+			}
+			return nil, wrapped
 		}
 		if len(project.Spec.Repositories) != 1 {
-			return nil, fmt.Errorf("project %q must have exactly one repository, got %d", env.Spec.ProjectRef, len(project.Spec.Repositories))
+			return nil, terminalEnvironment(fmt.Errorf("project %q must have exactly one repository, got %d", env.Spec.ProjectRef, len(project.Spec.Repositories)))
 		}
 		repository := project.Spec.Repositories[0]
 		projectEnv := []corev1.EnvVar{
@@ -1208,12 +1236,18 @@ func (r *EnvironmentReconciler) setPhase(ctx context.Context, env *platformv1alp
 func (r *EnvironmentReconciler) fail(ctx context.Context, env *platformv1alpha1.Environment, err error) error {
 	log.FromContext(ctx).Error(err, "reconcile failed", "environment", env.Name)
 	var collision *childOwnershipCollisionError
-	reason := "ReconcileFailed"
-	if invalidEnvironmentConfiguration(err) {
+	var terminal *terminalEnvironmentError
+	phase := platformv1alpha1.EnvironmentPhaseCreating
+	reason := "OperationalError"
+	if stderrors.As(err, &terminal) {
+		phase = platformv1alpha1.EnvironmentPhaseFailed
 		reason = "InvalidConfiguration"
+	} else if stderrors.As(err, &collision) {
+		phase = platformv1alpha1.EnvironmentPhaseFailed
+		reason = "ResourceCollision"
 	}
 	statusErr := r.updateEnvironmentStatus(ctx, env, func(current *platformv1alpha1.Environment) {
-		applyEnvironmentStatus(current, platformv1alpha1.EnvironmentPhaseFailed, "", "", reason, err.Error(), env.Status.LastActiveAt)
+		applyEnvironmentStatus(current, phase, "", "", reason, err.Error(), env.Status.LastActiveAt)
 		if stderrors.As(err, &collision) {
 			apimeta.SetStatusCondition(&current.Status.Conditions, metav1.Condition{
 				Type:               "ChildOwnershipConflict",
@@ -1227,7 +1261,7 @@ func (r *EnvironmentReconciler) fail(ctx context.Context, env *platformv1alpha1.
 	if statusErr != nil {
 		return statusErr
 	}
-	if collision != nil {
+	if collision != nil || terminal != nil {
 		return nil
 	}
 	return err
@@ -1345,11 +1379,6 @@ func phaseReadiness(phase platformv1alpha1.EnvironmentPhase) (string, string) {
 	}
 }
 
-func invalidEnvironmentConfiguration(err error) bool {
-	message := err.Error()
-	return strings.Contains(message, "get template ") || strings.Contains(message, "get project ") || strings.Contains(message, " has no repositories")
-}
-
 func clearChildOwnershipCollision(env *platformv1alpha1.Environment) bool {
 	if apimeta.FindStatusCondition(env.Status.Conditions, "ChildOwnershipConflict") == nil {
 		return false
@@ -1431,6 +1460,15 @@ func (r *EnvironmentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}); err != nil {
 		return fmt.Errorf("index environments by template: %w", err)
 	}
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &platformv1alpha1.Environment{}, projectRefField, func(object client.Object) []string {
+		environment := object.(*platformv1alpha1.Environment)
+		if environment.Spec.ProjectRef == "" {
+			return nil
+		}
+		return []string{environment.Spec.ProjectRef}
+	}); err != nil {
+		return fmt.Errorf("index environments by project: %w", err)
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&platformv1alpha1.Environment{}).
 		Owns(&corev1.Pod{}).
@@ -1447,6 +1485,18 @@ func (r *EnvironmentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			var environments platformv1alpha1.EnvironmentList
 			if err := r.List(ctx, &environments, client.InNamespace(object.GetNamespace()), client.MatchingFields{templateRefField: object.GetName()}); err != nil {
 				log.FromContext(ctx).Error(err, "list environments for template", "template", object.GetName())
+				return nil
+			}
+			requests := make([]reconcile.Request, 0, len(environments.Items))
+			for i := range environments.Items {
+				requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&environments.Items[i])})
+			}
+			return requests
+		})).
+		Watches(&platformv1alpha1.Project{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
+			var environments platformv1alpha1.EnvironmentList
+			if err := r.List(ctx, &environments, client.InNamespace(object.GetNamespace()), client.MatchingFields{projectRefField: object.GetName()}); err != nil {
+				log.FromContext(ctx).Error(err, "list environments for project", "project", object.GetName())
 				return nil
 			}
 			requests := make([]reconcile.Request, 0, len(environments.Items))

--- a/internal/controllers/environment_controller.go
+++ b/internal/controllers/environment_controller.go
@@ -183,6 +183,9 @@ func (r *EnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if result, handled, err := r.reconcilePendingPodRecovery(ctx, &env); handled || err != nil {
 		return result, err
 	}
+	if strings.TrimSpace(env.Spec.TemplateRef) == "" {
+		return ctrl.Result{}, r.fail(ctx, &env, terminalEnvironment(fmt.Errorf("environment templateRef must not be blank")))
+	}
 	var tmpl platformv1alpha1.EnvironmentTemplate
 	if err := r.Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: env.Spec.TemplateRef}, &tmpl); err != nil {
 		wrapped := fmt.Errorf("get template %q: %w", env.Spec.TemplateRef, err)
@@ -1239,7 +1242,7 @@ func (r *EnvironmentReconciler) fail(ctx context.Context, env *platformv1alpha1.
 	var terminal *terminalEnvironmentError
 	phase := platformv1alpha1.EnvironmentPhaseCreating
 	reason := "OperationalError"
-	if stderrors.As(err, &terminal) {
+	if stderrors.As(err, &terminal) || errors.IsInvalid(err) || errors.IsBadRequest(err) {
 		phase = platformv1alpha1.EnvironmentPhaseFailed
 		reason = "InvalidConfiguration"
 	} else if stderrors.As(err, &collision) {
@@ -1261,7 +1264,7 @@ func (r *EnvironmentReconciler) fail(ctx context.Context, env *platformv1alpha1.
 	if statusErr != nil {
 		return statusErr
 	}
-	if collision != nil || terminal != nil {
+	if collision != nil || terminal != nil || errors.IsInvalid(err) || errors.IsBadRequest(err) {
 		return nil
 	}
 	return err
@@ -1452,21 +1455,41 @@ func envLabels(env *platformv1alpha1.Environment) map[string]string {
 
 func ptr[T any](v T) *T { return &v }
 
+func environmentTemplateRefIndex(object client.Object) []string {
+	environment := object.(*platformv1alpha1.Environment)
+	if environment.Spec.TemplateRef == "" {
+		return nil
+	}
+	return []string{environment.Spec.TemplateRef}
+}
+
+func environmentProjectRefIndex(object client.Object) []string {
+	environment := object.(*platformv1alpha1.Environment)
+	if environment.Spec.ProjectRef == "" {
+		return nil
+	}
+	return []string{environment.Spec.ProjectRef}
+}
+
+func (r *EnvironmentReconciler) environmentReferenceRequests(ctx context.Context, namespace, field, name string) []reconcile.Request {
+	var environments platformv1alpha1.EnvironmentList
+	if err := r.List(ctx, &environments, client.InNamespace(namespace), client.MatchingFields{field: name}); err != nil {
+		log.FromContext(ctx).Error(err, "list environments for reference", "field", field, "name", name)
+		return nil
+	}
+	requests := make([]reconcile.Request, 0, len(environments.Items))
+	for i := range environments.Items {
+		requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&environments.Items[i])})
+	}
+	return requests
+}
+
 // SetupWithManager registers the controller with the manager.
 func (r *EnvironmentReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &platformv1alpha1.Environment{}, templateRefField, func(object client.Object) []string {
-		environment := object.(*platformv1alpha1.Environment)
-		return []string{environment.Spec.TemplateRef}
-	}); err != nil {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &platformv1alpha1.Environment{}, templateRefField, environmentTemplateRefIndex); err != nil {
 		return fmt.Errorf("index environments by template: %w", err)
 	}
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &platformv1alpha1.Environment{}, projectRefField, func(object client.Object) []string {
-		environment := object.(*platformv1alpha1.Environment)
-		if environment.Spec.ProjectRef == "" {
-			return nil
-		}
-		return []string{environment.Spec.ProjectRef}
-	}); err != nil {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &platformv1alpha1.Environment{}, projectRefField, environmentProjectRefIndex); err != nil {
 		return fmt.Errorf("index environments by project: %w", err)
 	}
 	return ctrl.NewControllerManagedBy(mgr).
@@ -1482,28 +1505,10 @@ func (r *EnvironmentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			return []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: run.Namespace, Name: run.Status.EnvironmentRef.Name}}}
 		})).
 		Watches(&platformv1alpha1.EnvironmentTemplate{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
-			var environments platformv1alpha1.EnvironmentList
-			if err := r.List(ctx, &environments, client.InNamespace(object.GetNamespace()), client.MatchingFields{templateRefField: object.GetName()}); err != nil {
-				log.FromContext(ctx).Error(err, "list environments for template", "template", object.GetName())
-				return nil
-			}
-			requests := make([]reconcile.Request, 0, len(environments.Items))
-			for i := range environments.Items {
-				requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&environments.Items[i])})
-			}
-			return requests
+			return r.environmentReferenceRequests(ctx, object.GetNamespace(), templateRefField, object.GetName())
 		})).
 		Watches(&platformv1alpha1.Project{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
-			var environments platformv1alpha1.EnvironmentList
-			if err := r.List(ctx, &environments, client.InNamespace(object.GetNamespace()), client.MatchingFields{projectRefField: object.GetName()}); err != nil {
-				log.FromContext(ctx).Error(err, "list environments for project", "project", object.GetName())
-				return nil
-			}
-			requests := make([]reconcile.Request, 0, len(environments.Items))
-			for i := range environments.Items {
-				requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&environments.Items[i])})
-			}
-			return requests
+			return r.environmentReferenceRequests(ctx, object.GetNamespace(), projectRefField, object.GetName())
 		})).
 		Complete(r)
 }

--- a/internal/controllers/environment_controller_test.go
+++ b/internal/controllers/environment_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	stderrors "errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1331,6 +1332,121 @@ func TestReconcileReportsStableChildOwnershipCondition(t *testing.T) {
 	}
 	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(foreignPVC), &corev1.PersistentVolumeClaim{}); err != nil {
 		t.Fatal("foreign PVC was modified or deleted")
+	}
+}
+
+func TestOperationalFailureRetriesAndRecoversReadiness(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := networkingv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	env := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "environment-uid", Generation: 2, Finalizers: []string{environmentFinalizer}},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small"},
+	}
+	template := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: "default"}}
+	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env, template).Build()
+	transient := apierrors.NewServiceUnavailable("temporary template API failure")
+	failTemplateGet := true
+	interceptedClient := interceptor.NewClient(baseClient, interceptor.Funcs{
+		Get: func(ctx context.Context, underlying client.WithWatch, key client.ObjectKey, object client.Object, options ...client.GetOption) error {
+			if failTemplateGet && key == client.ObjectKeyFromObject(template) {
+				failTemplateGet = false
+				return transient
+			}
+			return underlying.Get(ctx, key, object, options...)
+		},
+	})
+	reconciler := &EnvironmentReconciler{Client: interceptedClient, Scheme: scheme}
+	request := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(env)}
+	if _, err := reconciler.Reconcile(context.Background(), request); !stderrors.Is(err, transient) {
+		t.Fatalf("Reconcile() error = %v, want transient retry", err)
+	}
+	var retrying platformv1alpha1.Environment
+	if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(env), &retrying); err != nil {
+		t.Fatal(err)
+	}
+	condition := apimeta.FindStatusCondition(retrying.Status.Conditions, platformv1alpha1.EnvironmentConditionReady)
+	if retrying.Status.Phase != platformv1alpha1.EnvironmentPhaseCreating || condition == nil || condition.Status != metav1.ConditionFalse || condition.Reason != "OperationalError" {
+		t.Fatalf("transient failure status = phase %q, condition %#v", retrying.Status.Phase, condition)
+	}
+	if result, err := reconciler.Reconcile(context.Background(), request); err != nil {
+		t.Fatalf("recovery Reconcile() = (%#v, %v), want provisioning to resume", result, err)
+	}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod"}, Status: corev1.PodStatus{
+		Phase: corev1.PodRunning,
+		PodIP: "10.0.0.1",
+		Conditions: []corev1.PodCondition{{
+			Type: corev1.PodReady, Status: corev1.ConditionTrue,
+		}},
+	}}
+	if err := reconciler.syncStatus(context.Background(), &retrying, pod); err != nil {
+		t.Fatal(err)
+	}
+	if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(env), &retrying); err != nil {
+		t.Fatal(err)
+	}
+	condition = apimeta.FindStatusCondition(retrying.Status.Conditions, platformv1alpha1.EnvironmentConditionReady)
+	if !platformv1alpha1.IsEnvironmentReady(&retrying) || condition == nil || condition.Reason != "SandboxdReady" {
+		t.Fatalf("recovered status = %#v", retrying.Status)
+	}
+}
+
+func TestMissingTemplateIsTerminalValidationFailure(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	env := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "environment-uid", Generation: 1, Finalizers: []string{environmentFinalizer}},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "missing"},
+	}
+	reconciler := &EnvironmentReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env).Build(), Scheme: scheme}
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(env)})
+	if err != nil || result.Requeue || result.RequeueAfter != 0 {
+		t.Fatalf("Reconcile() = (%#v, %v), want terminal success without retry", result, err)
+	}
+	var failed platformv1alpha1.Environment
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(env), &failed); err != nil {
+		t.Fatal(err)
+	}
+	condition := apimeta.FindStatusCondition(failed.Status.Conditions, platformv1alpha1.EnvironmentConditionReady)
+	if failed.Status.Phase != platformv1alpha1.EnvironmentPhaseFailed || condition == nil || condition.Reason != "InvalidConfiguration" || condition.ObservedGeneration != env.Generation {
+		t.Fatalf("validation failure status = phase %q, condition %#v", failed.Status.Phase, condition)
+	}
+}
+
+func TestProjectRepositoryValidationIsTerminal(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "project", Namespace: "default"}}
+	env := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "environment-uid", Generation: 1}, Spec: platformv1alpha1.EnvironmentSpec{TemplateRef: "small", ProjectRef: project.Name}}
+	reconciler := &EnvironmentReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env, project).Build(), Scheme: scheme}
+	_, err := reconciler.ensurePod(context.Background(), env, &platformv1alpha1.EnvironmentTemplate{Spec: platformv1alpha1.EnvironmentTemplateSpec{Image: "example/environment:dev"}})
+	if err == nil {
+		t.Fatal("ensurePod() accepted a project without exactly one repository")
+	}
+	if err := reconciler.fail(context.Background(), env, fmt.Errorf("ensure pod: %w", err)); err != nil {
+		t.Fatalf("terminal validation requested retry: %v", err)
+	}
+	var failed platformv1alpha1.Environment
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(env), &failed); err != nil {
+		t.Fatal(err)
+	}
+	condition := apimeta.FindStatusCondition(failed.Status.Conditions, platformv1alpha1.EnvironmentConditionReady)
+	if failed.Status.Phase != platformv1alpha1.EnvironmentPhaseFailed || condition == nil || condition.Reason != "InvalidConfiguration" {
+		t.Fatalf("project validation status = phase %q, condition %#v", failed.Status.Phase, condition)
 	}
 }
 

--- a/internal/controllers/environment_controller_test.go
+++ b/internal/controllers/environment_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -1419,6 +1420,141 @@ func TestMissingTemplateIsTerminalValidationFailure(t *testing.T) {
 	condition := apimeta.FindStatusCondition(failed.Status.Conditions, platformv1alpha1.EnvironmentConditionReady)
 	if failed.Status.Phase != platformv1alpha1.EnvironmentPhaseFailed || condition == nil || condition.Reason != "InvalidConfiguration" || condition.ObservedGeneration != env.Generation {
 		t.Fatalf("validation failure status = phase %q, condition %#v", failed.Status.Phase, condition)
+	}
+}
+
+func TestBlankTemplateRefIsTerminalAndCorrectedSpecRecovers(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := networkingv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	env := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "environment-uid", Generation: 1, Finalizers: []string{environmentFinalizer}},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "   "},
+	}
+	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env).Build()
+	reconciler := &EnvironmentReconciler{Client: baseClient, Scheme: scheme}
+	request := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(env)}
+	if result, err := reconciler.Reconcile(context.Background(), request); err != nil || result != (ctrl.Result{}) {
+		t.Fatalf("blank-ref Reconcile() = (%#v, %v), want terminal success", result, err)
+	}
+	var failed platformv1alpha1.Environment
+	if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(env), &failed); err != nil {
+		t.Fatal(err)
+	}
+	condition := apimeta.FindStatusCondition(failed.Status.Conditions, platformv1alpha1.EnvironmentConditionReady)
+	if failed.Status.Phase != platformv1alpha1.EnvironmentPhaseFailed || condition == nil || condition.Reason != "InvalidConfiguration" {
+		t.Fatalf("blank reference status = phase %q, condition %#v", failed.Status.Phase, condition)
+	}
+
+	failed.Spec.TemplateRef = "small"
+	if err := baseClient.Update(context.Background(), &failed); err != nil {
+		t.Fatal(err)
+	}
+	template := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: "default"}, Spec: platformv1alpha1.EnvironmentTemplateSpec{Image: "example/environment:dev"}}
+	if err := baseClient.Create(context.Background(), template); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reconciler.Reconcile(context.Background(), request); err != nil {
+		t.Fatalf("corrected spec did not recover: %v", err)
+	}
+	var recovering platformv1alpha1.Environment
+	if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(env), &recovering); err != nil {
+		t.Fatal(err)
+	}
+	if recovering.Status.Phase == platformv1alpha1.EnvironmentPhaseFailed {
+		t.Fatalf("corrected spec remained terminal: %#v", recovering.Status)
+	}
+}
+
+func TestReferenceWatchMappersWakeTerminalEnvironments(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	templateEnv := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "template-failed", Namespace: "default"},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small"},
+		Status:     platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhaseFailed},
+	}
+	projectEnv := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "project-failed", Namespace: "default"},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "large", ProjectRef: "project"},
+		Status:     platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhaseFailed},
+	}
+	baseClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithIndex(&platformv1alpha1.Environment{}, templateRefField, environmentTemplateRefIndex).
+		WithIndex(&platformv1alpha1.Environment{}, projectRefField, environmentProjectRefIndex).
+		WithObjects(templateEnv, projectEnv).Build()
+	reconciler := &EnvironmentReconciler{Client: baseClient}
+
+	templateRequests := reconciler.environmentReferenceRequests(context.Background(), "default", templateRefField, "small")
+	if len(templateRequests) != 1 || templateRequests[0].Name != templateEnv.Name {
+		t.Fatalf("template watch requests = %#v, want %q", templateRequests, templateEnv.Name)
+	}
+	projectRequests := reconciler.environmentReferenceRequests(context.Background(), "default", projectRefField, "project")
+	if len(projectRequests) != 1 || projectRequests[0].Name != projectEnv.Name {
+		t.Fatalf("project watch requests = %#v, want %q", projectRequests, projectEnv.Name)
+	}
+}
+
+func TestInvalidChildCreationIsTerminalValidationFailure(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		createErr error
+	}{
+		{
+			name: "invalid",
+			createErr: apierrors.NewInvalid(schema.GroupKind{Kind: "Pod"}, "env-test", field.ErrorList{
+				field.Invalid(field.NewPath("spec", "containers").Index(0).Child("image"), "", "must not be blank"),
+			}),
+		},
+		{name: "bad request", createErr: apierrors.NewBadRequest("pod specification is malformed")},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			if err := corev1.AddToScheme(scheme); err != nil {
+				t.Fatal(err)
+			}
+			if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+				t.Fatal(err)
+			}
+			env := &platformv1alpha1.Environment{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "environment-uid", Generation: 1},
+				Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small"},
+			}
+			baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env).Build()
+			intercepted := interceptor.NewClient(baseClient, interceptor.Funcs{
+				Create: func(ctx context.Context, underlying client.WithWatch, object client.Object, options ...client.CreateOption) error {
+					if _, ok := object.(*corev1.Pod); ok {
+						return test.createErr
+					}
+					return underlying.Create(ctx, object, options...)
+				},
+			})
+			reconciler := &EnvironmentReconciler{Client: intercepted, Scheme: scheme}
+			_, err := reconciler.ensurePod(context.Background(), env, &platformv1alpha1.EnvironmentTemplate{Spec: platformv1alpha1.EnvironmentTemplateSpec{Image: "example/environment:dev"}})
+			if err == nil {
+				t.Fatal("ensurePod() accepted invalid child specification")
+			}
+			if err := reconciler.fail(context.Background(), env, fmt.Errorf("ensure pod: %w", err)); err != nil {
+				t.Fatalf("deterministic child error requested retry: %v", err)
+			}
+			var failed platformv1alpha1.Environment
+			if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(env), &failed); err != nil {
+				t.Fatal(err)
+			}
+			condition := apimeta.FindStatusCondition(failed.Status.Conditions, platformv1alpha1.EnvironmentConditionReady)
+			if failed.Status.Phase != platformv1alpha1.EnvironmentPhaseFailed || condition == nil || condition.Reason != "InvalidConfiguration" {
+				t.Fatalf("invalid child status = phase %q, condition %#v", failed.Status.Phase, condition)
+			}
+		})
 	}
 }
 

--- a/internal/controllers/warmpool_controller.go
+++ b/internal/controllers/warmpool_controller.go
@@ -27,8 +27,9 @@ const (
 // provisioned for each EnvironmentTemplate.
 type WarmPoolReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
-	Now    func() time.Time
+	APIReader client.Reader
+	Scheme    *runtime.Scheme
+	Now       func() time.Time
 }
 
 // +kubebuilder:rbac:groups=swe.dev,resources=environmenttemplates,verbs=get;list;watch
@@ -47,9 +48,16 @@ func (r *WarmPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 	if platformv1alpha1.EffectiveEnvironmentBackend(&platformv1alpha1.Environment{}, &tmpl) != platformv1alpha1.EnvironmentBackendPod {
 		if tmpl.Status.WarmPoolReady != 0 {
+			if current, err := r.templateCurrent(ctx, &tmpl); err != nil {
+				return ctrl.Result{}, err
+			} else if !current {
+				return ctrl.Result{Requeue: true}, nil
+			}
 			before := tmpl.DeepCopy()
 			tmpl.Status.WarmPoolReady = 0
-			if err := r.Status().Patch(ctx, &tmpl, client.MergeFrom(before)); err != nil {
+			if err := r.Status().Patch(ctx, &tmpl, client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{})); errors.IsConflict(err) || errors.IsNotFound(err) {
+				return ctrl.Result{Requeue: true}, nil
+			} else if err != nil {
 				return ctrl.Result{}, fmt.Errorf("clear unsupported warm pool status: %w", err)
 			}
 		}
@@ -72,14 +80,22 @@ func (r *WarmPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 	}
 	if tmpl.Status.WarmPoolReady != ready {
+		if current, err := r.templateCurrent(ctx, &tmpl); err != nil {
+			return ctrl.Result{}, err
+		} else if !current {
+			return ctrl.Result{Requeue: true}, nil
+		}
 		before := tmpl.DeepCopy()
 		tmpl.Status.WarmPoolReady = ready
-		if err := r.Status().Patch(ctx, &tmpl, client.MergeFrom(before)); err != nil {
+		if err := r.Status().Patch(ctx, &tmpl, client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{})); errors.IsConflict(err) || errors.IsNotFound(err) {
+			return ctrl.Result{Requeue: true}, nil
+		} else if err != nil {
 			return ctrl.Result{}, fmt.Errorf("update warm pool status: %w", err)
 		}
 	}
 
 	active := make([]*platformv1alpha1.Environment, 0, len(environments.Items))
+	quarantined := int32(0)
 	var requeueAfter time.Duration
 	now := r.now()
 	for i := range environments.Items {
@@ -89,8 +105,14 @@ func (r *WarmPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 		statusCurrent := env.Status.ObservedGeneration == env.Generation
 		if env.Spec.Paused || statusCurrent && (env.Status.Phase == platformv1alpha1.EnvironmentPhaseFailed || env.Status.Phase == platformv1alpha1.EnvironmentPhaseTerminated) {
+			quarantined++
 			unusableSince, marked := warmPoolUnusableSince(env)
 			if !marked || unusableSince.After(now) {
+				if current, err := r.templateCurrent(ctx, &tmpl); err != nil {
+					return ctrl.Result{}, err
+				} else if !current {
+					return ctrl.Result{Requeue: true}, nil
+				}
 				before := env.DeepCopy()
 				if env.Annotations == nil {
 					env.Annotations = make(map[string]string)
@@ -110,6 +132,11 @@ func (r *WarmPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				}
 				continue
 			}
+			if current, err := r.templateCurrent(ctx, &tmpl); err != nil {
+				return ctrl.Result{}, err
+			} else if !current {
+				return ctrl.Result{Requeue: true}, nil
+			}
 			resourceVersion := env.ResourceVersion
 			uid := env.UID
 			if err := r.Delete(ctx, env, client.Preconditions{UID: &uid, ResourceVersion: &resourceVersion}); errors.IsConflict(err) || errors.IsNotFound(err) {
@@ -117,9 +144,15 @@ func (r *WarmPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			} else if err != nil {
 				return ctrl.Result{}, fmt.Errorf("delete unusable warm environment %q: %w", env.Name, err)
 			}
+			quarantined--
 			continue
 		}
 		if _, marked := warmPoolUnusableSince(env); marked {
+			if current, err := r.templateCurrent(ctx, &tmpl); err != nil {
+				return ctrl.Result{}, err
+			} else if !current {
+				return ctrl.Result{Requeue: true}, nil
+			}
 			before := env.DeepCopy()
 			delete(env.Annotations, warmPoolCleanupAnnotation)
 			if err := r.Patch(ctx, env, client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{})); errors.IsConflict(err) || errors.IsNotFound(err) {
@@ -130,7 +163,16 @@ func (r *WarmPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 		active = append(active, env)
 	}
-	for int32(len(active)) < minimum {
+	// Keep replacement capacity bounded while unusable members remain during
+	// grace. maxSurge=minimum permits one complete replacement set, bounding
+	// exact unclaimed membership at 2*minimum even when every replacement fails.
+	maxSurge := minimum
+	for int32(len(active)) < minimum && int32(len(active))+quarantined < minimum+maxSurge {
+		if current, err := r.templateCurrent(ctx, &tmpl); err != nil {
+			return ctrl.Result{}, err
+		} else if !current {
+			return ctrl.Result{Requeue: true}, nil
+		}
 		env := &platformv1alpha1.Environment{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:    tmpl.Namespace,
@@ -155,6 +197,11 @@ func (r *WarmPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			return active[i].CreationTimestamp.After(active[j].CreationTimestamp.Time)
 		})
 		for _, env := range active[:int32(len(active))-minimum] {
+			if current, err := r.templateCurrent(ctx, &tmpl); err != nil {
+				return ctrl.Result{}, err
+			} else if !current {
+				return ctrl.Result{Requeue: true}, nil
+			}
 			resourceVersion := env.ResourceVersion
 			uid := env.UID
 			if err := r.Delete(ctx, env, client.Preconditions{UID: &uid, ResourceVersion: &resourceVersion}); errors.IsConflict(err) || errors.IsNotFound(err) {
@@ -189,16 +236,49 @@ func warmPoolUnusableSince(env *platformv1alpha1.Environment) (time.Time, bool) 
 	return markedAt, err == nil
 }
 
+func (r *WarmPoolReconciler) templateCurrent(ctx context.Context, observed *platformv1alpha1.EnvironmentTemplate) (bool, error) {
+	reader := r.APIReader
+	if reader == nil {
+		// Unit tests construct reconcilers without a manager. Production always
+		// installs the uncached API reader in SetupWithManager.
+		reader = r.Client
+	}
+	var current platformv1alpha1.EnvironmentTemplate
+	if err := reader.Get(ctx, client.ObjectKeyFromObject(observed), &current); errors.IsNotFound(err) {
+		return false, nil
+	} else if err != nil {
+		return false, fmt.Errorf("revalidate environment template: %w", err)
+	}
+	return current.UID == observed.UID && current.Generation == observed.Generation && current.DeletionTimestamp.IsZero(), nil
+}
+
+func warmPoolTemplateRequests(object client.Object) []reconcile.Request {
+	env := object.(*platformv1alpha1.Environment)
+	templates := make(map[string]struct{}, 3)
+	for _, name := range []string{env.Spec.TemplateRef, env.Labels[warmPoolLabel]} {
+		if name != "" {
+			templates[name] = struct{}{}
+		}
+	}
+	if owner := metav1.GetControllerOf(env); owner != nil && owner.APIVersion == platformv1alpha1.GroupVersion.String() && owner.Kind == "EnvironmentTemplate" && owner.Name != "" {
+		templates[owner.Name] = struct{}{}
+	}
+	requests := make([]reconcile.Request, 0, len(templates))
+	for name := range templates {
+		requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKey{Namespace: env.Namespace, Name: name}})
+	}
+	return requests
+}
+
 // SetupWithManager registers the warm-pool controller with the manager.
 func (r *WarmPoolReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.APIReader = mgr.GetAPIReader()
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&platformv1alpha1.EnvironmentTemplate{}).
+		// EnqueueRequestsFromMapFunc applies the mapper to both old and new
+		// objects on updates, so identity changes replenish both pools.
 		Watches(&platformv1alpha1.Environment{}, handler.EnqueueRequestsFromMapFunc(func(_ context.Context, object client.Object) []reconcile.Request {
-			template := object.(*platformv1alpha1.Environment).Spec.TemplateRef
-			if template == "" {
-				return nil
-			}
-			return []reconcile.Request{{NamespacedName: client.ObjectKey{Namespace: object.GetNamespace(), Name: template}}}
+			return warmPoolTemplateRequests(object)
 		})).
 		Complete(r)
 }

--- a/internal/controllers/warmpool_controller.go
+++ b/internal/controllers/warmpool_controller.go
@@ -65,7 +65,13 @@ func (r *WarmPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	var environments platformv1alpha1.EnvironmentList
-	if err := r.List(ctx, &environments,
+	reader := r.APIReader
+	if reader == nil {
+		// Unit tests construct reconcilers without a manager. Production always
+		// installs the uncached API reader in SetupWithManager.
+		reader = r.Client
+	}
+	if err := reader.List(ctx, &environments,
 		client.InNamespace(tmpl.Namespace),
 		client.MatchingLabels{warmPoolLabel: tmpl.Name},
 	); err != nil {

--- a/internal/controllers/warmpool_controller.go
+++ b/internal/controllers/warmpool_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,16 +18,22 @@ import (
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
 )
 
+const (
+	warmPoolCleanupAnnotation = "swe.dev/warm-pool-unusable-since"
+	warmPoolCleanupGrace      = 5 * time.Minute
+)
+
 // WarmPoolReconciler keeps the requested number of unclaimed environments
 // provisioned for each EnvironmentTemplate.
 type WarmPoolReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+	Now    func() time.Time
 }
 
 // +kubebuilder:rbac:groups=swe.dev,resources=environmenttemplates,verbs=get;list;watch
 // +kubebuilder:rbac:groups=swe.dev,resources=environmenttemplates/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=swe.dev,resources=environments,verbs=get;list;watch;create;delete
+// +kubebuilder:rbac:groups=swe.dev,resources=environments,verbs=get;list;watch;create;patch;delete
 
 func (r *WarmPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var tmpl platformv1alpha1.EnvironmentTemplate
@@ -59,7 +66,8 @@ func (r *WarmPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	ready := int32(0)
 	for i := range environments.Items {
-		if platformv1alpha1.IsEnvironmentReady(&environments.Items[i]) && environments.Items[i].Status.ClaimedBy == nil {
+		env := &environments.Items[i]
+		if warmPoolMember(env, &tmpl) && platformv1alpha1.IsEnvironmentReady(env) && env.Status.ClaimedBy == nil {
 			ready++
 		}
 	}
@@ -72,20 +80,53 @@ func (r *WarmPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	active := make([]*platformv1alpha1.Environment, 0, len(environments.Items))
+	var requeueAfter time.Duration
+	now := r.now()
 	for i := range environments.Items {
 		env := &environments.Items[i]
-		if env.Status.ClaimedBy != nil || !env.DeletionTimestamp.IsZero() {
+		if !warmPoolMember(env, &tmpl) || env.Status.ClaimedBy != nil || !env.DeletionTimestamp.IsZero() {
 			continue
 		}
 		statusCurrent := env.Status.ObservedGeneration == env.Generation
 		if env.Spec.Paused || statusCurrent && (env.Status.Phase == platformv1alpha1.EnvironmentPhaseFailed || env.Status.Phase == platformv1alpha1.EnvironmentPhaseTerminated) {
+			unusableSince, marked := warmPoolUnusableSince(env)
+			if !marked || unusableSince.After(now) {
+				before := env.DeepCopy()
+				if env.Annotations == nil {
+					env.Annotations = make(map[string]string)
+				}
+				env.Annotations[warmPoolCleanupAnnotation] = now.UTC().Format(time.RFC3339Nano)
+				if err := r.Patch(ctx, env, client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{})); errors.IsConflict(err) || errors.IsNotFound(err) {
+					return ctrl.Result{Requeue: true}, nil
+				} else if err != nil {
+					return ctrl.Result{}, fmt.Errorf("mark unusable warm environment %q: %w", env.Name, err)
+				}
+				unusableSince = now
+			}
+			remaining := unusableSince.Add(warmPoolCleanupGrace).Sub(now)
+			if remaining > 0 {
+				if requeueAfter == 0 || remaining < requeueAfter {
+					requeueAfter = remaining
+				}
+				continue
+			}
 			resourceVersion := env.ResourceVersion
-			if err := r.Delete(ctx, env, client.Preconditions{ResourceVersion: &resourceVersion}); errors.IsConflict(err) || errors.IsNotFound(err) {
+			uid := env.UID
+			if err := r.Delete(ctx, env, client.Preconditions{UID: &uid, ResourceVersion: &resourceVersion}); errors.IsConflict(err) || errors.IsNotFound(err) {
 				return ctrl.Result{Requeue: true}, nil
 			} else if err != nil {
 				return ctrl.Result{}, fmt.Errorf("delete unusable warm environment %q: %w", env.Name, err)
 			}
 			continue
+		}
+		if _, marked := warmPoolUnusableSince(env); marked {
+			before := env.DeepCopy()
+			delete(env.Annotations, warmPoolCleanupAnnotation)
+			if err := r.Patch(ctx, env, client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{})); errors.IsConflict(err) || errors.IsNotFound(err) {
+				return ctrl.Result{Requeue: true}, nil
+			} else if err != nil {
+				return ctrl.Result{}, fmt.Errorf("clear warm environment cleanup marker %q: %w", env.Name, err)
+			}
 		}
 		active = append(active, env)
 	}
@@ -115,7 +156,8 @@ func (r *WarmPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		})
 		for _, env := range active[:int32(len(active))-minimum] {
 			resourceVersion := env.ResourceVersion
-			if err := r.Delete(ctx, env, client.Preconditions{ResourceVersion: &resourceVersion}); errors.IsConflict(err) || errors.IsNotFound(err) {
+			uid := env.UID
+			if err := r.Delete(ctx, env, client.Preconditions{UID: &uid, ResourceVersion: &resourceVersion}); errors.IsConflict(err) || errors.IsNotFound(err) {
 				return ctrl.Result{Requeue: true}, nil
 			} else if err != nil {
 				return ctrl.Result{}, fmt.Errorf("delete excess warm environment %q: %w", env.Name, err)
@@ -123,7 +165,28 @@ func (r *WarmPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 	}
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: requeueAfter}, nil
+}
+
+func (r *WarmPoolReconciler) now() time.Time {
+	if r.Now != nil {
+		return r.Now()
+	}
+	return time.Now()
+}
+
+func warmPoolMember(env *platformv1alpha1.Environment, tmpl *platformv1alpha1.EnvironmentTemplate) bool {
+	return env.Labels[warmPoolLabel] == tmpl.Name && env.Spec.TemplateRef == tmpl.Name &&
+		exactControllerOwner(env, platformv1alpha1.GroupVersion.String(), "EnvironmentTemplate", tmpl.Name, tmpl.UID)
+}
+
+func warmPoolUnusableSince(env *platformv1alpha1.Environment) (time.Time, bool) {
+	value := env.Annotations[warmPoolCleanupAnnotation]
+	if value == "" {
+		return time.Time{}, false
+	}
+	markedAt, err := time.Parse(time.RFC3339Nano, value)
+	return markedAt, err == nil
 }
 
 // SetupWithManager registers the warm-pool controller with the manager.

--- a/internal/controllers/warmpool_controller_test.go
+++ b/internal/controllers/warmpool_controller_test.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -502,6 +503,239 @@ func TestWarmPoolCleanupIsFencedByConcurrentClaimOrPromotion(t *testing.T) {
 				t.Fatalf("concurrently allocated member was deleted: %v", err)
 			}
 		})
+	}
+}
+
+func TestWarmPoolReplacementSurgeRemainsBoundedWhenEveryMemberFails(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &platformv1alpha1.EnvironmentTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: "default", UID: "template-uid"},
+		Spec:       platformv1alpha1.EnvironmentTemplateSpec{WarmPool: &platformv1alpha1.WarmPoolSpec{Min: 2}},
+	}
+	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(tmpl, &platformv1alpha1.Environment{}).WithObjects(tmpl).Build()
+	r := &WarmPoolReconciler{Client: baseClient, Scheme: scheme, Now: func() time.Time { return time.Unix(4_000, 0) }}
+	request := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(tmpl)}
+	if _, err := r.Reconcile(context.Background(), request); err != nil {
+		t.Fatal(err)
+	}
+
+	for cycle := 0; cycle < 4; cycle++ {
+		var members platformv1alpha1.EnvironmentList
+		if err := baseClient.List(context.Background(), &members, client.MatchingLabels{warmPoolLabel: tmpl.Name}); err != nil {
+			t.Fatal(err)
+		}
+		for i := range members.Items {
+			env := &members.Items[i]
+			if env.Status.Phase == platformv1alpha1.EnvironmentPhaseFailed {
+				continue
+			}
+			env.Status.ObservedGeneration = env.Generation
+			env.Status.Phase = platformv1alpha1.EnvironmentPhaseFailed
+			if err := baseClient.Status().Update(context.Background(), env); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if _, err := r.Reconcile(context.Background(), request); err != nil {
+			t.Fatal(err)
+		}
+		if err := baseClient.List(context.Background(), &members, client.MatchingLabels{warmPoolLabel: tmpl.Name}); err != nil {
+			t.Fatal(err)
+		}
+		if len(members.Items) > 4 {
+			t.Fatalf("cycle %d pool size = %d, want at most 2*min", cycle, len(members.Items))
+		}
+	}
+	var bounded platformv1alpha1.EnvironmentList
+	if err := baseClient.List(context.Background(), &bounded, client.MatchingLabels{warmPoolLabel: tmpl.Name}); err != nil {
+		t.Fatal(err)
+	}
+	if len(bounded.Items) != 4 {
+		t.Fatalf("fully failed pool size = %d, want bounded surge of 4", len(bounded.Items))
+	}
+}
+
+func TestWarmPoolIdentityUpdateEnqueuesOldAndNewPools(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	small := &platformv1alpha1.EnvironmentTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: "default", UID: "small-uid"},
+		Spec:       platformv1alpha1.EnvironmentTemplateSpec{WarmPool: &platformv1alpha1.WarmPoolSpec{Min: 1}},
+	}
+	large := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "large", Namespace: "default", UID: "large-uid"}}
+	oldEnv := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "warm", Namespace: "default", UID: "env-uid", Labels: map[string]string{warmPoolLabel: small.Name}},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: small.Name},
+	}
+	setWarmPoolOwner(t, scheme, small, oldEnv)
+	newEnv := oldEnv.DeepCopy()
+	newEnv.Spec.TemplateRef = large.Name
+	newEnv.Labels[warmPoolLabel] = large.Name
+	newEnv.OwnerReferences = nil
+	setWarmPoolOwner(t, scheme, large, newEnv)
+
+	requests := append(warmPoolTemplateRequests(oldEnv), warmPoolTemplateRequests(newEnv)...)
+	requested := make(map[string]bool)
+	for _, request := range requests {
+		requested[request.Name] = true
+	}
+	if !requested[small.Name] || !requested[large.Name] {
+		t.Fatalf("identity update requests = %#v, want old and new pools", requests)
+	}
+
+	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(small, large).WithObjects(small, large, newEnv).Build()
+	r := &WarmPoolReconciler{Client: baseClient, Scheme: scheme}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(small)}); err != nil {
+		t.Fatal(err)
+	}
+	var environments platformv1alpha1.EnvironmentList
+	if err := baseClient.List(context.Background(), &environments, client.MatchingLabels{warmPoolLabel: small.Name}); err != nil {
+		t.Fatal(err)
+	}
+	if len(environments.Items) != 1 || !warmPoolMember(&environments.Items[0], small) {
+		t.Fatalf("old pool was not immediately replenished: %#v", environments.Items)
+	}
+}
+
+func TestWarmPoolStaleTemplateIncarnationCannotMutateReplacement(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	stale := &platformv1alpha1.EnvironmentTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: "default", UID: "template-t1", Generation: 1, ResourceVersion: "1"},
+		Spec:       platformv1alpha1.EnvironmentTemplateSpec{WarmPool: &platformv1alpha1.WarmPoolSpec{Min: 1}},
+		Status:     platformv1alpha1.EnvironmentTemplateStatus{WarmPoolReady: 1},
+	}
+	replacement := stale.DeepCopy()
+	replacement.UID = "template-t2"
+	replacement.ResourceVersion = "2"
+	replacement.Status.WarmPoolReady = 7
+	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(replacement).WithObjects(replacement).Build()
+	initialRead := true
+	intercepted := interceptor.NewClient(baseClient, interceptor.Funcs{
+		Get: func(ctx context.Context, underlying client.WithWatch, key client.ObjectKey, object client.Object, options ...client.GetOption) error {
+			if initialRead && key == client.ObjectKeyFromObject(stale) {
+				if template, ok := object.(*platformv1alpha1.EnvironmentTemplate); ok {
+					initialRead = false
+					*template = *stale.DeepCopy()
+					return nil
+				}
+			}
+			return underlying.Get(ctx, key, object, options...)
+		},
+	})
+	r := &WarmPoolReconciler{Client: intercepted, APIReader: baseClient, Scheme: scheme}
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(stale)})
+	if err != nil || !result.Requeue {
+		t.Fatalf("stale Reconcile() = (%#v, %v), want clean requeue", result, err)
+	}
+	var retained platformv1alpha1.EnvironmentTemplate
+	if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(replacement), &retained); err != nil {
+		t.Fatal(err)
+	}
+	if retained.UID != replacement.UID || retained.Status.WarmPoolReady != 7 {
+		t.Fatalf("replacement template was mutated by stale reconcile: %#v", retained)
+	}
+	var environments platformv1alpha1.EnvironmentList
+	if err := baseClient.List(context.Background(), &environments); err != nil {
+		t.Fatal(err)
+	}
+	if len(environments.Items) != 0 {
+		t.Fatalf("stale template created old-UID members: %#v", environments.Items)
+	}
+}
+
+func TestWarmPoolTemplateStatusPatchConflictRequeuesWithoutMutatingReplacement(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	stale := &platformv1alpha1.EnvironmentTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: "default", UID: "template-t1", Generation: 1},
+		Status:     platformv1alpha1.EnvironmentTemplateStatus{WarmPoolReady: 1},
+	}
+	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(stale).WithObjects(stale).Build()
+	replacementUID := types.UID("template-t2")
+	intercepted := interceptor.NewClient(baseClient, interceptor.Funcs{
+		SubResourcePatch: func(ctx context.Context, underlying client.Client, subresource string, object client.Object, patch client.Patch, options ...client.SubResourcePatchOption) error {
+			if subresource != "status" {
+				return underlying.SubResource(subresource).Patch(ctx, object, patch, options...)
+			}
+			data, err := patch.Data(object)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(data), `"resourceVersion"`) {
+				t.Fatalf("status patch lacks optimistic resourceVersion: %s", data)
+			}
+			var current platformv1alpha1.EnvironmentTemplate
+			if err := underlying.Get(ctx, client.ObjectKeyFromObject(stale), &current); err != nil {
+				return err
+			}
+			if err := underlying.Delete(ctx, &current); err != nil {
+				return err
+			}
+			replacement := stale.DeepCopy()
+			replacement.UID = replacementUID
+			replacement.ResourceVersion = ""
+			replacement.Status = platformv1alpha1.EnvironmentTemplateStatus{}
+			if err := underlying.Create(ctx, replacement); err != nil {
+				return err
+			}
+			return apierrors.NewConflict(schema.GroupResource{Group: platformv1alpha1.GroupVersion.Group, Resource: "environmenttemplates"}, object.GetName(), errors.New("template replaced"))
+		},
+	})
+	r := &WarmPoolReconciler{Client: intercepted, APIReader: baseClient, Scheme: scheme}
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(stale)})
+	if err != nil || !result.Requeue {
+		t.Fatalf("conflicted Reconcile() = (%#v, %v), want clean requeue", result, err)
+	}
+	var replacement platformv1alpha1.EnvironmentTemplate
+	if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(stale), &replacement); err != nil {
+		t.Fatal(err)
+	}
+	if replacement.UID != replacementUID || replacement.Status.WarmPoolReady != 0 {
+		t.Fatalf("replacement template was mutated: %#v", replacement)
+	}
+}
+
+func TestWarmPoolTemplateGenerationChangePreventsMemberCreation(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &platformv1alpha1.EnvironmentTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: "default", UID: "template-uid", Generation: 1},
+		Spec:       platformv1alpha1.EnvironmentTemplateSpec{WarmPool: &platformv1alpha1.WarmPoolSpec{Min: 1}},
+	}
+	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(tmpl).WithObjects(tmpl).Build()
+	liveReader := interceptor.NewClient(baseClient, interceptor.Funcs{
+		Get: func(ctx context.Context, underlying client.WithWatch, key client.ObjectKey, object client.Object, options ...client.GetOption) error {
+			if err := underlying.Get(ctx, key, object, options...); err != nil {
+				return err
+			}
+			if template, ok := object.(*platformv1alpha1.EnvironmentTemplate); ok {
+				template.Generation++
+			}
+			return nil
+		},
+	})
+	r := &WarmPoolReconciler{Client: baseClient, APIReader: liveReader, Scheme: scheme}
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(tmpl)})
+	if err != nil || !result.Requeue {
+		t.Fatalf("generation-change Reconcile() = (%#v, %v), want clean requeue", result, err)
+	}
+	var environments platformv1alpha1.EnvironmentList
+	if err := baseClient.List(context.Background(), &environments); err != nil {
+		t.Fatal(err)
+	}
+	if len(environments.Items) != 0 {
+		t.Fatalf("stale generation created members: %#v", environments.Items)
 	}
 }
 

--- a/internal/controllers/warmpool_controller_test.go
+++ b/internal/controllers/warmpool_controller_test.go
@@ -2,14 +2,20 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
 )
@@ -97,18 +103,19 @@ func TestWarmPoolReconcileReportsReadyAndRemovesExcess(t *testing.T) {
 	}
 	environments := []client.Object{
 		&platformv1alpha1.Environment{
-			ObjectMeta: metav1.ObjectMeta{Name: "warm-old", Namespace: "default", Labels: map[string]string{warmPoolLabel: "small"}, CreationTimestamp: metav1.Unix(1, 0)},
+			ObjectMeta: metav1.ObjectMeta{Name: "warm-old", Namespace: "default", UID: "warm-old-uid", Labels: map[string]string{warmPoolLabel: "small"}, CreationTimestamp: metav1.Unix(1, 0)},
 			Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small"},
 			Status:     platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhaseReady},
 		},
 		&platformv1alpha1.Environment{
-			ObjectMeta: metav1.ObjectMeta{Name: "warm-new", Namespace: "default", Labels: map[string]string{warmPoolLabel: "small"}, CreationTimestamp: metav1.Unix(2, 0)},
+			ObjectMeta: metav1.ObjectMeta{Name: "warm-new", Namespace: "default", UID: "warm-new-uid", Labels: map[string]string{warmPoolLabel: "small"}, CreationTimestamp: metav1.Unix(2, 0)},
 			Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small"},
 			Status:     platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhaseReady},
 		},
 	}
 	for _, object := range environments {
 		env := object.(*platformv1alpha1.Environment)
+		setWarmPoolOwner(t, scheme, tmpl, env)
 		applyEnvironmentStatus(env, platformv1alpha1.EnvironmentPhaseReady, "env-"+env.Name, "10.0.0.1:50051", "SandboxdReady", "sandboxd is ready", nil)
 	}
 	objects := append([]client.Object{tmpl}, environments...)
@@ -149,6 +156,7 @@ func TestWarmPoolReconcileExcludesClaimedEnvironment(t *testing.T) {
 			ClaimedBy: &platformv1alpha1.RunReference{Name: "run", UID: "run-uid"},
 		},
 	}
+	setWarmPoolOwner(t, scheme, tmpl, claimed)
 	reconciler := &WarmPoolReconciler{
 		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(tmpl, claimed).WithObjects(tmpl, claimed).Build(),
 		Scheme: scheme,
@@ -174,12 +182,13 @@ func TestWarmPoolKeepsStaleGenerationFailure(t *testing.T) {
 	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
 		t.Fatal(err)
 	}
-	tmpl := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: "default"}, Spec: platformv1alpha1.EnvironmentTemplateSpec{
+	tmpl := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: "default", UID: "template-uid"}, Spec: platformv1alpha1.EnvironmentTemplateSpec{
 		WarmPool: &platformv1alpha1.WarmPoolSpec{Min: 1},
 	}}
 	env := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "warm-stale", Namespace: "default", Generation: 2, Labels: map[string]string{warmPoolLabel: "small"}}, Spec: platformv1alpha1.EnvironmentSpec{TemplateRef: "small"}, Status: platformv1alpha1.EnvironmentStatus{
 		ObservedGeneration: 1, Phase: platformv1alpha1.EnvironmentPhaseFailed,
 	}}
+	setWarmPoolOwner(t, scheme, tmpl, env)
 	reconciler := &WarmPoolReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(tmpl).WithObjects(tmpl, env).Build(), Scheme: scheme}
 	if _, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(tmpl)}); err != nil {
 		t.Fatal(err)
@@ -200,16 +209,21 @@ func TestWarmPoolReconcileDeletesOnlyUnclaimedUnusableEnvironment(t *testing.T) 
 	}
 	failed := func(name string, claim *platformv1alpha1.RunReference) *platformv1alpha1.Environment {
 		return &platformv1alpha1.Environment{
-			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", Labels: map[string]string{warmPoolLabel: "small"}},
-			Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small"},
-			Status:     platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhaseFailed, ClaimedBy: claim},
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", UID: types.UID(name + "-uid"), Labels: map[string]string{warmPoolLabel: "small"}, Annotations: map[string]string{
+				warmPoolCleanupAnnotation: time.Unix(1, 0).UTC().Format(time.RFC3339Nano),
+			}},
+			Spec:   platformv1alpha1.EnvironmentSpec{TemplateRef: "small"},
+			Status: platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhaseFailed, ClaimedBy: claim},
 		}
 	}
 	unclaimed := failed("warm-unclaimed", nil)
 	claimed := failed("warm-claimed", &platformv1alpha1.RunReference{Name: "run", UID: "run-uid"})
+	setWarmPoolOwner(t, scheme, tmpl, unclaimed)
+	setWarmPoolOwner(t, scheme, tmpl, claimed)
 	reconciler := &WarmPoolReconciler{
 		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(tmpl, unclaimed, claimed).WithObjects(tmpl, unclaimed, claimed).Build(),
 		Scheme: scheme,
+		Now:    func() time.Time { return time.Unix(1, 0).Add(warmPoolCleanupGrace) },
 	}
 	if _, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(tmpl)}); err != nil {
 		t.Fatal(err)
@@ -226,5 +240,274 @@ func TestWarmPoolReconcileDeletesOnlyUnclaimedUnusableEnvironment(t *testing.T) 
 	}
 	if len(environments.Items) != 2 {
 		t.Fatalf("pool environments = %d, want claimed plus replacement", len(environments.Items))
+	}
+}
+
+func TestWarmPoolCleanupGracePersistsAcrossRestart(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Unix(1_000, 0)
+	tmpl := &platformv1alpha1.EnvironmentTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: "default", UID: "template-uid"},
+		Spec:       platformv1alpha1.EnvironmentTemplateSpec{WarmPool: &platformv1alpha1.WarmPoolSpec{Min: 1}},
+	}
+	failed := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "warm-failed", Namespace: "default", UID: "failed-uid", Labels: map[string]string{warmPoolLabel: tmpl.Name}},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: tmpl.Name},
+		Status:     platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhaseFailed},
+	}
+	setWarmPoolOwner(t, scheme, tmpl, failed)
+	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(tmpl, failed).WithObjects(tmpl, failed).Build()
+	request := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(tmpl)}
+
+	first := &WarmPoolReconciler{Client: baseClient, Scheme: scheme, Now: func() time.Time { return now }}
+	result, err := first.Reconcile(context.Background(), request)
+	if err != nil || result.RequeueAfter != warmPoolCleanupGrace {
+		t.Fatalf("first Reconcile() = (%#v, %v), want cleanup grace", result, err)
+	}
+	var marked platformv1alpha1.Environment
+	if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(failed), &marked); err != nil {
+		t.Fatal(err)
+	}
+	if marked.Annotations[warmPoolCleanupAnnotation] != now.UTC().Format(time.RFC3339Nano) {
+		t.Fatalf("cleanup marker = %q", marked.Annotations[warmPoolCleanupAnnotation])
+	}
+	var environments platformv1alpha1.EnvironmentList
+	if err := baseClient.List(context.Background(), &environments, client.MatchingLabels{warmPoolLabel: tmpl.Name}); err != nil || len(environments.Items) != 2 {
+		t.Fatalf("replacement did not converge during grace: count %d, error %v", len(environments.Items), err)
+	}
+
+	restartedNow := now.Add(warmPoolCleanupGrace - time.Second)
+	restarted := &WarmPoolReconciler{Client: baseClient, Scheme: scheme, Now: func() time.Time { return restartedNow }}
+	result, err = restarted.Reconcile(context.Background(), request)
+	if err != nil || result.RequeueAfter != time.Second {
+		t.Fatalf("restarted Reconcile() = (%#v, %v), want one-second remainder", result, err)
+	}
+	restarted.Now = func() time.Time { return now.Add(warmPoolCleanupGrace) }
+	if _, err := restarted.Reconcile(context.Background(), request); err != nil {
+		t.Fatal(err)
+	}
+	if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(failed), &platformv1alpha1.Environment{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("failed member survived grace: %v", err)
+	}
+}
+
+func TestWarmPoolCleanupGraceResetsFutureMarker(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Unix(1_500, 0)
+	tmpl := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: "default", UID: "template-uid"}}
+	env := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "warm-failed", Namespace: "default", UID: "failed-uid", Labels: map[string]string{warmPoolLabel: tmpl.Name}, Annotations: map[string]string{
+			warmPoolCleanupAnnotation: now.Add(24 * time.Hour).UTC().Format(time.RFC3339Nano),
+		}},
+		Spec:   platformv1alpha1.EnvironmentSpec{TemplateRef: tmpl.Name},
+		Status: platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhaseFailed},
+	}
+	setWarmPoolOwner(t, scheme, tmpl, env)
+	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(tmpl, env).WithObjects(tmpl, env).Build()
+	r := &WarmPoolReconciler{Client: baseClient, Scheme: scheme, Now: func() time.Time { return now }}
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(tmpl)})
+	if err != nil || result.RequeueAfter != warmPoolCleanupGrace {
+		t.Fatalf("Reconcile() = (%#v, %v), want bounded grace", result, err)
+	}
+	var marked platformv1alpha1.Environment
+	if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(env), &marked); err != nil {
+		t.Fatal(err)
+	}
+	if marked.Annotations[warmPoolCleanupAnnotation] != now.UTC().Format(time.RFC3339Nano) {
+		t.Fatalf("future cleanup marker was not reset: %q", marked.Annotations[warmPoolCleanupAnnotation])
+	}
+}
+
+func TestWarmPoolCleansPausedMemberAfterGrace(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Unix(2_000, 0)
+	tmpl := &platformv1alpha1.EnvironmentTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: "default", UID: "template-uid"},
+		Spec:       platformv1alpha1.EnvironmentTemplateSpec{WarmPool: &platformv1alpha1.WarmPoolSpec{Min: 1}},
+	}
+	paused := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "warm-paused", Namespace: "default", UID: "paused-uid", Labels: map[string]string{warmPoolLabel: tmpl.Name}, Annotations: map[string]string{
+			warmPoolCleanupAnnotation: now.Add(-warmPoolCleanupGrace).UTC().Format(time.RFC3339Nano),
+		}},
+		Spec: platformv1alpha1.EnvironmentSpec{TemplateRef: tmpl.Name, Paused: true},
+	}
+	setWarmPoolOwner(t, scheme, tmpl, paused)
+	r := &WarmPoolReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(tmpl).WithObjects(tmpl, paused).Build(), Scheme: scheme, Now: func() time.Time { return now }}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(tmpl)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(paused), &platformv1alpha1.Environment{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("paused member survived grace: %v", err)
+	}
+}
+
+func TestWarmPoolTransientFailureRecoversDuringGrace(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Unix(2_500, 0)
+	tmpl := &platformv1alpha1.EnvironmentTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: "default", UID: "template-uid"},
+		Spec:       platformv1alpha1.EnvironmentTemplateSpec{WarmPool: &platformv1alpha1.WarmPoolSpec{Min: 1}},
+	}
+	env := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "warm-recovering", Namespace: "default", UID: "recovering-uid", Labels: map[string]string{warmPoolLabel: tmpl.Name}},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: tmpl.Name},
+		Status:     platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhaseFailed},
+	}
+	setWarmPoolOwner(t, scheme, tmpl, env)
+	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(tmpl, env).WithObjects(tmpl, env).Build()
+	r := &WarmPoolReconciler{Client: baseClient, Scheme: scheme, Now: func() time.Time { return now }}
+	request := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(tmpl)}
+	if _, err := r.Reconcile(context.Background(), request); err != nil {
+		t.Fatal(err)
+	}
+	var members platformv1alpha1.EnvironmentList
+	if err := baseClient.List(context.Background(), &members, client.MatchingLabels{warmPoolLabel: tmpl.Name}); err != nil {
+		t.Fatal(err)
+	}
+	for i := range members.Items {
+		if members.Items[i].Name != env.Name {
+			if err := baseClient.Delete(context.Background(), &members.Items[i]); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	var recovering platformv1alpha1.Environment
+	if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(env), &recovering); err != nil {
+		t.Fatal(err)
+	}
+	applyEnvironmentStatus(&recovering, platformv1alpha1.EnvironmentPhaseReady, "pod", "10.0.0.1:50051", "SandboxdReady", "ready", nil)
+	if err := baseClient.Status().Update(context.Background(), &recovering); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Reconcile(context.Background(), request); err != nil {
+		t.Fatal(err)
+	}
+	if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(env), &recovering); err != nil {
+		t.Fatal(err)
+	}
+	if _, marked := recovering.Annotations[warmPoolCleanupAnnotation]; marked || !platformv1alpha1.IsEnvironmentReady(&recovering) {
+		t.Fatalf("recovered member retained cleanup marker or readiness was lost: %#v", recovering)
+	}
+}
+
+func TestWarmPoolDeletingAndForeignMembersDoNotCount(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &platformv1alpha1.EnvironmentTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: "default", UID: "template-uid"},
+		Spec:       platformv1alpha1.EnvironmentTemplateSpec{WarmPool: &platformv1alpha1.WarmPoolSpec{Min: 1}},
+	}
+	deletingAt := metav1.Now()
+	deleting := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "warm-deleting", Namespace: "default", UID: "deleting-uid", Labels: map[string]string{warmPoolLabel: tmpl.Name}, DeletionTimestamp: &deletingAt, Finalizers: []string{"test"}},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: tmpl.Name},
+	}
+	applyEnvironmentStatus(deleting, platformv1alpha1.EnvironmentPhaseReady, "pod", "10.0.0.1:50051", "SandboxdReady", "ready", nil)
+	setWarmPoolOwner(t, scheme, tmpl, deleting)
+	foreign := deleting.DeepCopy()
+	foreign.Name = "warm-foreign"
+	foreign.UID = "foreign-uid"
+	foreign.DeletionTimestamp = nil
+	foreign.Finalizers = nil
+	foreign.OwnerReferences = nil
+	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(tmpl).WithObjects(tmpl, deleting, foreign).Build()
+	r := &WarmPoolReconciler{Client: baseClient, Scheme: scheme}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(tmpl)}); err != nil {
+		t.Fatal(err)
+	}
+	var updated platformv1alpha1.EnvironmentTemplate
+	if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(tmpl), &updated); err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status.WarmPoolReady != 0 {
+		t.Fatalf("WarmPoolReady = %d, want deleting and foreign excluded", updated.Status.WarmPoolReady)
+	}
+	var environments platformv1alpha1.EnvironmentList
+	if err := baseClient.List(context.Background(), &environments); err != nil || len(environments.Items) != 3 {
+		t.Fatalf("members = %d, want deleting, foreign, and replacement: %v", len(environments.Items), err)
+	}
+}
+
+func TestWarmPoolCleanupIsFencedByConcurrentClaimOrPromotion(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*platformv1alpha1.Environment)
+	}{
+		{name: "claim", mutate: func(env *platformv1alpha1.Environment) {
+			env.Status.ClaimedBy = &platformv1alpha1.RunReference{Name: "run", UID: "run-uid"}
+		}},
+		{name: "promotion", mutate: func(env *platformv1alpha1.Environment) {
+			delete(env.Labels, warmPoolLabel)
+			env.OwnerReferences = nil
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+				t.Fatal(err)
+			}
+			now := time.Unix(3_000, 0)
+			tmpl := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: "default", UID: "template-uid"}}
+			env := &platformv1alpha1.Environment{
+				ObjectMeta: metav1.ObjectMeta{Name: "warm-failed", Namespace: "default", UID: "env-uid", Labels: map[string]string{warmPoolLabel: tmpl.Name}, Annotations: map[string]string{
+					warmPoolCleanupAnnotation: now.Add(-warmPoolCleanupGrace).UTC().Format(time.RFC3339Nano),
+				}},
+				Spec:   platformv1alpha1.EnvironmentSpec{TemplateRef: tmpl.Name},
+				Status: platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhaseFailed},
+			}
+			setWarmPoolOwner(t, scheme, tmpl, env)
+			baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(tmpl, env).WithObjects(tmpl, env).Build()
+			intercepted := interceptor.NewClient(baseClient, interceptor.Funcs{
+				Delete: func(ctx context.Context, underlying client.WithWatch, object client.Object, options ...client.DeleteOption) error {
+					deleteOptions := (&client.DeleteOptions{}).ApplyOptions(options)
+					if deleteOptions.Preconditions == nil || deleteOptions.Preconditions.UID == nil || *deleteOptions.Preconditions.UID != object.GetUID() ||
+						deleteOptions.Preconditions.ResourceVersion == nil || *deleteOptions.Preconditions.ResourceVersion != object.GetResourceVersion() {
+						t.Fatalf("delete preconditions = %#v, want UID %q and resourceVersion %q", deleteOptions.Preconditions, object.GetUID(), object.GetResourceVersion())
+					}
+					var current platformv1alpha1.Environment
+					if err := underlying.Get(ctx, client.ObjectKeyFromObject(object), &current); err != nil {
+						return err
+					}
+					test.mutate(&current)
+					if test.name == "claim" {
+						if err := underlying.Status().Update(ctx, &current); err != nil {
+							return err
+						}
+					} else if err := underlying.Update(ctx, &current); err != nil {
+						return err
+					}
+					return apierrors.NewConflict(schema.GroupResource{Group: platformv1alpha1.GroupVersion.Group, Resource: "environments"}, object.GetName(), errors.New("concurrent allocation"))
+				},
+			})
+			r := &WarmPoolReconciler{Client: intercepted, Scheme: scheme, Now: func() time.Time { return now }}
+			result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(tmpl)})
+			if err != nil || !result.Requeue {
+				t.Fatalf("Reconcile() = (%#v, %v), want conflict requeue", result, err)
+			}
+			if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(env), &platformv1alpha1.Environment{}); err != nil {
+				t.Fatalf("concurrently allocated member was deleted: %v", err)
+			}
+		})
+	}
+}
+
+func setWarmPoolOwner(t *testing.T, scheme *runtime.Scheme, tmpl *platformv1alpha1.EnvironmentTemplate, env *platformv1alpha1.Environment) {
+	t.Helper()
+	if err := controllerutil.SetControllerReference(tmpl, env, scheme, controllerutil.WithBlockOwnerDeletion(false)); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/controllers/warmpool_controller_test.go
+++ b/internal/controllers/warmpool_controller_test.go
@@ -557,6 +557,113 @@ func TestWarmPoolReplacementSurgeRemainsBoundedWhenEveryMemberFails(t *testing.T
 	}
 }
 
+func TestWarmPoolLiveMembershipSnapshotBoundsSurgeWithStaleCache(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &platformv1alpha1.EnvironmentTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: "default", UID: "template-uid"},
+		Spec:       platformv1alpha1.EnvironmentTemplateSpec{WarmPool: &platformv1alpha1.WarmPoolSpec{Min: 2}},
+	}
+	liveClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(tmpl, &platformv1alpha1.Environment{}).WithObjects(tmpl).Build()
+	cachedMembershipLists := 0
+	staleCache := interceptor.NewClient(liveClient, interceptor.Funcs{
+		List: func(ctx context.Context, underlying client.WithWatch, list client.ObjectList, options ...client.ListOption) error {
+			if environments, ok := list.(*platformv1alpha1.EnvironmentList); ok {
+				cachedMembershipLists++
+				*environments = platformv1alpha1.EnvironmentList{}
+				return nil
+			}
+			return underlying.List(ctx, list, options...)
+		},
+	})
+	r := &WarmPoolReconciler{Client: staleCache, APIReader: liveClient, Scheme: scheme, Now: func() time.Time { return time.Unix(4_500, 0) }}
+	request := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(tmpl)}
+	liveMembers := func() platformv1alpha1.EnvironmentList {
+		t.Helper()
+		var members platformv1alpha1.EnvironmentList
+		if err := liveClient.List(context.Background(), &members, client.MatchingLabels{warmPoolLabel: tmpl.Name}); err != nil {
+			t.Fatal(err)
+		}
+		return members
+	}
+	assertBounded := func() {
+		t.Helper()
+		exact := 0
+		members := liveMembers()
+		for i := range members.Items {
+			env := &members.Items[i]
+			if warmPoolMember(env, tmpl) && env.Status.ClaimedBy == nil && env.DeletionTimestamp.IsZero() {
+				exact++
+			}
+		}
+		if exact > 4 {
+			t.Fatalf("live exact membership = %d, want at most 2*min", exact)
+		}
+	}
+
+	if _, err := r.Reconcile(context.Background(), request); err != nil {
+		t.Fatal(err)
+	}
+	initial := liveMembers()
+	if len(initial.Items) != 2 {
+		t.Fatalf("initial live membership = %d, want min 2", len(initial.Items))
+	}
+	for i := range initial.Items {
+		env := &initial.Items[i]
+		env.Status.ObservedGeneration = env.Generation
+		env.Status.Phase = platformv1alpha1.EnvironmentPhaseFailed
+		if err := liveClient.Status().Update(context.Background(), env); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := r.Reconcile(context.Background(), request); err != nil {
+		t.Fatal(err)
+	}
+	assertBounded()
+
+	// Reconcile repeatedly while the simulated informer still omits every
+	// created member. The live snapshot must prevent additional surge.
+	for range 3 {
+		if _, err := r.Reconcile(context.Background(), request); err != nil {
+			t.Fatal(err)
+		}
+		assertBounded()
+	}
+
+	members := liveMembers()
+	ready := 0
+	for i := range members.Items {
+		env := &members.Items[i]
+		if env.Status.Phase == platformv1alpha1.EnvironmentPhaseFailed {
+			continue
+		}
+		applyEnvironmentStatus(env, platformv1alpha1.EnvironmentPhaseReady, "pod-"+env.Name, "10.0.0.1:50051", "SandboxdReady", "ready", nil)
+		if err := liveClient.Status().Update(context.Background(), env); err != nil {
+			t.Fatal(err)
+		}
+		ready++
+	}
+	if ready != 2 {
+		t.Fatalf("healthy replacements = %d, want min 2", ready)
+	}
+	if _, err := r.Reconcile(context.Background(), request); err != nil {
+		t.Fatal(err)
+	}
+	assertBounded()
+	if cachedMembershipLists != 0 {
+		t.Fatalf("membership accounting used stale cache %d times", cachedMembershipLists)
+	}
+	var updated platformv1alpha1.EnvironmentTemplate
+	if err := liveClient.Get(context.Background(), client.ObjectKeyFromObject(tmpl), &updated); err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status.WarmPoolReady != 2 {
+		t.Fatalf("WarmPoolReady = %d, want healthy min 2", updated.Status.WarmPoolReady)
+	}
+}
+
 func TestWarmPoolIdentityUpdateEnqueuesOldAndNewPools(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := platformv1alpha1.AddToScheme(scheme); err != nil {


### PR DESCRIPTION
## Summary

- exclude deleting, claimed, promoted, non-pool, and foreign Environments from warm-pool readiness/capacity and cleanup
- quarantine current-generation failed/terminated or explicitly paused pool members for a persisted, bounded five-minute grace while immediately converging replacement capacity
- fence cleanup/downscale deletes with exact Template ownership plus Environment UID and resourceVersion preconditions
- report transient operational reconciliation failures as `Ready=False` / `OperationalError` with rate-limited retry instead of terminal `Failed`
- keep missing references, invalid Project repository configuration, ownership collisions, and unsupported backends terminal and observable; watch referenced Projects so corrections wake Environments
- preserve terminal-Pod recovery ordering/backoff and active-Run/terminal-activity idle protection

Closes #26.

## Verification

- `go test -race ./internal/controllers -run 'Test(WarmPool|OperationalFailure|MissingTemplate|ProjectRepository|TerminalPod|ReconcileIdle)'`
- `go test ./... -skip '^TestTerminalHeartbeatProtectsSlowWakeBeforeConnection$'`
- `(cd sandboxd && go test ./...)`
- `make vet`
- `make manifests`
- `make check-chart-crds`
- focused terminal/control-plane tests passed before the full suite

`make test` encountered the unrelated existing timing failure `TestTerminalHeartbeatProtectsSlowWakeBeforeConnection` (`activity writes after terminal close = 14, want 13`); it was not repeatedly retriggered. The rest of the root suite passes with that one test skipped. Kind e2e was unavailable in the orb because neither `kind` nor Docker is installed.

## Merge ordering

Built directly on current `main` after #35 (closes #24) and #41 (closes #25) were merged. It should merge after those protections (already satisfied); no other ordering dependency is known.
