### PR TITLE
Preserve final terminal output when tmux panes exit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,9 @@ runs both via `make` targets:
 - **E2E acceptance:** `./hack/e2e.sh` — full kind + operator + `swe run` pass with the
   env-base image built and loaded locally (no registry credentials needed). Runs in CI
   as the `e2e` workflow on relevant PRs and via `workflow_dispatch`.
-- **Images:** `make docker-build` (operator + env-base)
+- **Images:** `make docker-build` (operator + env-base). The env-base image builds
+  its pinned tmux with `images/env-base/tmux-control-output-drain.patch`; keep the
+  source checksum and patch synchronized when upgrading tmux.
 - **Publish images:** pushes to `main` and `v*` tags publish multi-architecture operator
   and env-base images to GHCR via `.github/workflows/publish-images.yaml`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,8 @@ runs both via `make` targets:
   as the `e2e` workflow on relevant PRs and via `workflow_dispatch`.
 - **Images:** `make docker-build` (operator + env-base). The env-base image builds
   its pinned tmux with `images/env-base/tmux-control-output-drain.patch`; keep the
-  source checksum and patch synchronized when upgrading tmux.
+  source checksum and patch synchronized when upgrading tmux. Its `terminal-test`
+  target runs the patched-runtime terminal regression during `hack/e2e.sh`.
 - **Publish images:** pushes to `main` and `v*` tags publish multi-architecture operator
   and env-base images to GHCR via `.github/workflows/publish-images.yaml`.
 

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -50,6 +50,11 @@ kind create cluster --name "$CLUSTER"
 echo "==> building platform images"
 make docker-build >/dev/null
 
+echo "==> verifying terminal drain against patched env-base runtime"
+docker build --target terminal-test -t swe-platform-terminal-test -f images/env-base/Dockerfile . >/dev/null
+docker run --rm -e SWE_REQUIRE_PATCHED_TMUX=1 swe-platform-terminal-test \
+	-test.run '^TestTerminalDrains(OutputWhenShellExits|ImmediateOutputAfterFirstOpen)$' -test.count=1 -test.v
+
 echo "==> loading images into kind"
 kind load docker-image "$ENV_IMAGE" "$OPERATOR_IMAGE" "$CONTROL_PLANE_IMAGE" --name "$CLUSTER"
 

--- a/images/env-base/Dockerfile
+++ b/images/env-base/Dockerfile
@@ -9,6 +9,23 @@ ARG TARGETOS
 ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /out/sandboxd ./cmd/sandboxd
 
+FROM debian:12-slim AS tmux-build
+
+ARG TMUX_VERSION=3.3a
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		build-essential ca-certificates curl libevent-dev libncurses-dev patch pkg-config \
+	&& rm -rf /var/lib/apt/lists/*
+WORKDIR /src
+RUN curl -fsSL "https://github.com/tmux/tmux/releases/download/${TMUX_VERSION}/tmux-${TMUX_VERSION}.tar.gz" -o tmux.tar.gz \
+	&& echo "e4fd347843bd0772c4f48d6dde625b0b109b7a380ff15db21e97c11a4dcdf93f  tmux.tar.gz" | sha256sum -c - \
+	&& tar -xzf tmux.tar.gz --strip-components=1
+COPY images/env-base/tmux-control-output-drain.patch ./
+RUN patch -p1 <tmux-control-output-drain.patch \
+	&& ./configure \
+	&& sed -i '/DTMUX_VERSION/s/3\.3a/3.3a-swe-drain/' Makefile \
+	&& make -j"$(nproc)" \
+	&& test "$(./tmux -V)" = "tmux 3.3a-swe-drain"
+
 # Base image for environments.
 FROM debian:12-slim
 
@@ -21,6 +38,7 @@ RUN useradd --create-home --uid 10001 swe \
 	&& chown swe:swe /workspace
 
 COPY --from=build /out/sandboxd /usr/local/bin/sandboxd
+COPY --from=tmux-build /src/tmux /usr/bin/tmux
 
 USER swe
 WORKDIR /workspace

--- a/images/env-base/Dockerfile
+++ b/images/env-base/Dockerfile
@@ -9,6 +9,11 @@ ARG TARGETOS
 ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /out/sandboxd ./cmd/sandboxd
 
+FROM build AS terminal-test-build
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go test -c -o /out/server.test ./internal/server
+
 FROM debian:12-slim AS tmux-build
 
 ARG TMUX_VERSION=3.3a
@@ -27,7 +32,7 @@ RUN patch -p1 <tmux-control-output-drain.patch \
 	&& test "$(./tmux -V)" = "tmux 3.3a-swe-drain"
 
 # Base image for environments.
-FROM debian:12-slim
+FROM debian:12-slim AS environment
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		git ca-certificates curl tmux jq ripgrep \
@@ -46,3 +51,9 @@ WORKDIR /workspace
 # sandboxd is the environment's entrypoint: it is the single contract the
 # control plane uses to reach inside (exec / fs / terminal / ports / health).
 ENTRYPOINT ["sandboxd", "serve"]
+
+FROM environment AS terminal-test
+COPY --from=terminal-test-build /out/server.test /usr/local/bin/server.test
+ENTRYPOINT ["/usr/local/bin/server.test"]
+
+FROM environment AS release

--- a/images/env-base/tmux-control-output-drain.patch
+++ b/images/env-base/tmux-control-output-drain.patch
@@ -1,0 +1,41 @@
+--- a/control.c
++++ b/control.c
+@@ -719,0 +720,30 @@
++/* Flush all queued output for a pane before it is destroyed. */
++void
++control_flush_pane_output(struct window_pane *wp)
++{
++	struct client		*c;
++	struct control_state	*cs;
++	struct control_pane	*cp;
++
++	TAILQ_FOREACH(c, &clients, entry) {
++		if (c->session == NULL || c->control_state == NULL ||
++		    (~c->flags & CLIENT_CONTROL) || (c->flags & CONTROL_IGNORE_FLAGS))
++			continue;
++		if (winlink_find_by_window(&c->session->windows,
++		    wp->window) == NULL)
++			continue;
++
++		control_write_output(c, wp);
++
++		cs = c->control_state;
++		cp = control_get_pane(c, wp);
++		if (cp == NULL || !cp->pending_flag)
++			continue;
++		if (control_write_pending(c, cp, SIZE_MAX))
++			continue;
++		TAILQ_REMOVE(&cs->pending_list, cp, pending_entry);
++		cp->pending_flag = 0;
++		cs->pending_count--;
++	}
++}
++
+--- a/server-fn.c
++++ b/server-fn.c
+@@ -319,0 +320 @@
++		control_flush_pane_output(wp);
+--- a/tmux.h
++++ b/tmux.h
+@@ -3123,0 +3124 @@
++void	control_flush_pane_output(struct window_pane *);

--- a/sandboxd/internal/server/server_test.go
+++ b/sandboxd/internal/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -31,7 +32,7 @@ var testSocketCounter atomic.Uint64
 // and returns a client connection to it.
 func newConn(t *testing.T, workspace string) *grpc.ClientConn {
 	t.Helper()
-	socketName := fmt.Sprintf("swe-test-%d", testSocketCounter.Add(1))
+	socketName := fmt.Sprintf("swe-test-%d-%d", os.Getpid(), testSocketCounter.Add(1))
 	t.Cleanup(func() {
 		_ = exec.Command("tmux", "-L", socketName, "kill-server").Run()
 	})
@@ -278,6 +279,87 @@ func receiveTerminalMarker(t *testing.T, stream interface {
 		}
 		output = append(output, message.GetData()...)
 	}
+}
+
+func TestTerminalDrainsOutputWhenShellExits(t *testing.T) {
+	tmuxPath, err := exec.LookPath("tmux")
+	if err != nil {
+		t.Skip("tmux is not installed")
+	}
+	version, err := exec.Command(tmuxPath, "-V").Output()
+	if err != nil || !strings.Contains(string(version), "swe-drain") {
+		t.Skip("tmux does not include the control output drain fix")
+	}
+
+	socketName := fmt.Sprintf("swe-drain-test-%d-%d", os.Getpid(), testSocketCounter.Add(1))
+	t.Cleanup(func() {
+		_ = exec.Command("tmux", "-L", socketName, "kill-server").Run()
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	backend := newTmuxTerminalBackend(t.TempDir(), socketName, []string{"sh"})
+	session, err := backend.Open(ctx, 80, 24)
+	if err != nil {
+		t.Fatalf("open terminal backend: %v", err)
+	}
+	defer session.Close()
+	if err := session.Write([]byte("printf 'shell-ready\\n'\n")); err != nil {
+		t.Fatalf("write terminal readiness input: %v", err)
+	}
+	var output []byte
+	for !strings.Contains(string(output), "shell-ready") {
+		data, err := session.Read()
+		output = append(output, data...)
+		if err != nil {
+			t.Fatalf("wait for shell readiness: %v (output %q)", err, output)
+		}
+	}
+	second, err := backend.Open(ctx, 80, 24)
+	if err != nil {
+		t.Fatalf("open second terminal backend: %v", err)
+	}
+	defer second.Close()
+	if err := session.Write([]byte("printf 'both-ready\\n'\n")); err != nil {
+		t.Fatalf("write shared readiness input: %v", err)
+	}
+	for i, attachment := range []terminalSession{session, second} {
+		if _, err := readTerminalSessionThrough(attachment, []byte("both-ready"), false); err != nil {
+			t.Fatalf("wait for attachment %d: %v", i+1, err)
+		}
+	}
+	if pipe, err := exec.Command("tmux", "-L", socketName, "display-message", "-p", "-t", "swe:", "#{pane_pipe}").Output(); err != nil {
+		t.Fatalf("inspect pane output pipe: %v", err)
+	} else if strings.TrimSpace(string(pipe)) != "1" {
+		t.Fatalf("pane output drain was not active before terminal input: %q", pipe)
+	}
+	if err := session.Write([]byte("printf '\\106\\111\\116\\101\\114\\055\\104\\122\\101\\111\\116'; exit\n")); err != nil {
+		t.Fatalf("write terminal input: %v", err)
+	}
+
+	for i, attachment := range []terminalSession{session, second} {
+		output, err := readTerminalSessionThrough(attachment, nil, true)
+		if err != nil {
+			t.Fatalf("receive attachment %d output: %v", i+1, err)
+		}
+		if !strings.Contains(string(output), "FINAL-DRAIN") {
+			t.Fatalf("attachment %d output missing final marker after shell exit: %q", i+1, output)
+		}
+	}
+}
+
+func readTerminalSessionThrough(session terminalSession, marker []byte, throughEOF bool) ([]byte, error) {
+	var output []byte
+	for throughEOF || !bytes.Contains(output, marker) {
+		data, err := session.Read()
+		output = append(output, data...)
+		if err != nil {
+			if err == io.EOF && throughEOF {
+				return output, nil
+			}
+			return output, err
+		}
+	}
+	return output, nil
 }
 
 func TestTerminalCloseSendDetaches(t *testing.T) {

--- a/sandboxd/internal/server/server_test.go
+++ b/sandboxd/internal/server/server_test.go
@@ -282,14 +282,7 @@ func receiveTerminalMarker(t *testing.T, stream interface {
 }
 
 func TestTerminalDrainsOutputWhenShellExits(t *testing.T) {
-	tmuxPath, err := exec.LookPath("tmux")
-	if err != nil {
-		t.Skip("tmux is not installed")
-	}
-	version, err := exec.Command(tmuxPath, "-V").Output()
-	if err != nil || !strings.Contains(string(version), "swe-drain") {
-		t.Skip("tmux does not include the control output drain fix")
-	}
+	requirePatchedTmux(t)
 
 	socketName := fmt.Sprintf("swe-drain-test-%d-%d", os.Getpid(), testSocketCounter.Add(1))
 	t.Cleanup(func() {
@@ -341,10 +334,59 @@ func TestTerminalDrainsOutputWhenShellExits(t *testing.T) {
 		if err != nil {
 			t.Fatalf("receive attachment %d output: %v", i+1, err)
 		}
-		if !strings.Contains(string(output), "FINAL-DRAIN") {
-			t.Fatalf("attachment %d output missing final marker after shell exit: %q", i+1, output)
+		if count := bytes.Count(output, []byte("FINAL-DRAIN")); count != 1 {
+			t.Fatalf("attachment %d final marker count = %d, want 1: %q", i+1, count, output)
 		}
 	}
+}
+
+func TestTerminalDrainsImmediateOutputAfterFirstOpen(t *testing.T) {
+	requirePatchedTmux(t)
+
+	socketName := fmt.Sprintf("swe-immediate-drain-test-%d-%d", os.Getpid(), testSocketCounter.Add(1))
+	t.Cleanup(func() {
+		_ = exec.Command("tmux", "-L", socketName, "kill-server").Run()
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	backend := newTmuxTerminalBackend(t.TempDir(), socketName, []string{`sh -c 'IFS= read -r line; eval "$line"'`})
+	session, err := backend.Open(ctx, 80, 24)
+	if err != nil {
+		t.Fatalf("open terminal backend: %v", err)
+	}
+	defer session.Close()
+	if err := session.Write([]byte("printf '\\111\\115\\115\\105\\104\\111\\101\\124\\105\\055\\104\\122\\101\\111\\116'; exit\n")); err != nil {
+		t.Fatalf("write immediate terminal input: %v", err)
+	}
+	output, err := readTerminalSessionThrough(session, nil, true)
+	if err != nil {
+		t.Fatalf("receive immediate output: %v", err)
+	}
+	if count := bytes.Count(output, []byte("IMMEDIATE-DRAIN")); count != 1 {
+		t.Fatalf("immediate final marker count = %d, want 1: %q", count, output)
+	}
+}
+
+func requirePatchedTmux(t *testing.T) {
+	t.Helper()
+	tmuxPath, err := exec.LookPath("tmux")
+	detail := err
+	if err == nil {
+		var version []byte
+		version, err = exec.Command(tmuxPath, "-V").Output()
+		if err == nil && strings.Contains(string(version), "swe-drain") {
+			return
+		}
+		if err == nil {
+			detail = fmt.Errorf("unexpected version %q", strings.TrimSpace(string(version)))
+		} else {
+			detail = err
+		}
+	}
+	if os.Getenv("SWE_REQUIRE_PATCHED_TMUX") == "1" {
+		t.Fatalf("patched tmux is required: %v", detail)
+	}
+	t.Skip("tmux does not include the control output drain fix")
 }
 
 func readTerminalSessionThrough(session terminalSession, marker []byte, throughEOF bool) ([]byte, error) {

--- a/sandboxd/internal/server/terminal.go
+++ b/sandboxd/internal/server/terminal.go
@@ -20,6 +20,7 @@ import (
 
 const defaultTmuxSocket = "swe-platform"
 const tmuxEnableOutputDrainCommand = "pipe-pane -t swe: 'cat >/dev/null'"
+const tmuxOutputDrainReady = "swe-output-drain-ready:"
 
 var errTerminalUnavailable = errors.New("terminal backend unavailable")
 
@@ -169,6 +170,7 @@ func (b *tmuxTerminalBackend) Open(ctx context.Context, cols, rows uint32) (term
 	args = append(args, b.shell...)
 	args = append(args,
 		";", "if-shell", "-F", "-t", "swe:", "#{?pane_pipe,0,1}", tmuxEnableOutputDrainCommand,
+		";", "display-message", "-p", "-t", "swe:", tmuxOutputDrainReady+"#{pane_pipe}",
 	)
 
 	commandCtx, cancel := context.WithCancel(ctx)
@@ -191,7 +193,7 @@ func (b *tmuxTerminalBackend) Open(ctx context.Context, cols, rows uint32) (term
 	}
 	scanner := bufio.NewScanner(stdout)
 	scanner.Buffer(make([]byte, 4096), 1024*1024)
-	initialOutput, err := waitForTmuxReady(scanner, 2, "swe")
+	initialOutput, err := waitForTmuxReady(scanner, "swe")
 	if err != nil {
 		cancel()
 		_ = stdin.Close()
@@ -215,12 +217,14 @@ func (b *tmuxTerminalBackend) Open(ctx context.Context, cols, rows uint32) (term
 	return session, nil
 }
 
-func waitForTmuxReady(scanner *bufio.Scanner, count int, sessionName string) ([]byte, error) {
-	completed := 0
+func waitForTmuxReady(scanner *bufio.Scanner, sessionName string) ([]byte, error) {
 	attached := false
+	ready := false
 	response := ""
+	probeSeen := false
+	probeValue := ""
 	var output []byte
-	for (completed < count || !attached) && scanner.Scan() {
+	for (!ready || !attached) && scanner.Scan() {
 		line := scanner.Text()
 		switch {
 		case strings.HasPrefix(line, "%begin "):
@@ -230,10 +234,17 @@ func waitForTmuxReady(scanner *bufio.Scanner, count int, sessionName string) ([]
 			response = strings.TrimPrefix(line, "%begin ")
 		case strings.HasPrefix(line, "%end "):
 			if response != "" && strings.TrimPrefix(line, "%end ") == response {
-				completed++
+				if probeSeen {
+					if probeValue != "1" {
+						return nil, fmt.Errorf("tmux output drain is inactive")
+					}
+					ready = true
+				}
 				response = ""
+				probeSeen = false
+				probeValue = ""
 			}
-		case strings.HasPrefix(scanner.Text(), "%session-changed "):
+		case strings.HasPrefix(line, "%session-changed "):
 			fields := strings.Fields(line)
 			attached = len(fields) == 3 && fields[2] == sessionName
 		case strings.HasPrefix(line, "%error "):
@@ -243,7 +254,10 @@ func waitForTmuxReady(scanner *bufio.Scanner, count int, sessionName string) ([]
 		case strings.HasPrefix(line, "%exit"):
 			return nil, fmt.Errorf("tmux exited during setup")
 		default:
-			if data, ok := tmuxOutput(line); ok {
+			if response != "" && strings.HasPrefix(line, tmuxOutputDrainReady) {
+				probeSeen = true
+				probeValue = strings.TrimPrefix(line, tmuxOutputDrainReady)
+			} else if data, ok := tmuxOutput(line); ok {
 				output = append(output, data...)
 			}
 		}
@@ -251,7 +265,7 @@ func waitForTmuxReady(scanner *bufio.Scanner, count int, sessionName string) ([]
 	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("read command response: %w", err)
 	}
-	if completed < count || !attached {
+	if !ready || !attached {
 		return nil, io.ErrUnexpectedEOF
 	}
 	return output, nil

--- a/sandboxd/internal/server/terminal.go
+++ b/sandboxd/internal/server/terminal.go
@@ -19,6 +19,7 @@ import (
 )
 
 const defaultTmuxSocket = "swe-platform"
+const tmuxEnableOutputDrainCommand = "pipe-pane -t swe: 'cat >/dev/null'"
 
 var errTerminalUnavailable = errors.New("terminal backend unavailable")
 
@@ -166,6 +167,9 @@ func (b *tmuxTerminalBackend) Open(ctx context.Context, cols, rows uint32) (term
 		args = append(args, "-c", b.workspace)
 	}
 	args = append(args, b.shell...)
+	args = append(args,
+		";", "if-shell", "-F", "-t", "swe:", "#{?pane_pipe,0,1}", tmuxEnableOutputDrainCommand,
+	)
 
 	commandCtx, cancel := context.WithCancel(ctx)
 	cmd := exec.CommandContext(commandCtx, "tmux", args...)
@@ -185,24 +189,72 @@ func (b *tmuxTerminalBackend) Open(ctx context.Context, cols, rows uint32) (term
 		cancel()
 		return nil, fmt.Errorf("%w: start tmux: %v", errTerminalUnavailable, err)
 	}
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 4096), 1024*1024)
+	initialOutput, err := waitForTmuxReady(scanner, 2, "swe")
+	if err != nil {
+		cancel()
+		_ = stdin.Close()
+		_ = cmd.Wait()
+		return nil, fmt.Errorf("%w: configure tmux output drain: %v", errTerminalUnavailable, err)
+	}
 
 	session := &tmuxTerminalSession{
-		ctx:    ctx,
-		cancel: cancel,
-		cmd:    cmd,
-		stdin:  stdin,
-		stderr: &stderr,
-		scanner: func() *bufio.Scanner {
-			scanner := bufio.NewScanner(stdout)
-			scanner.Buffer(make([]byte, 4096), 1024*1024)
-			return scanner
-		}(),
+		ctx:     ctx,
+		cancel:  cancel,
+		cmd:     cmd,
+		stdin:   stdin,
+		stderr:  &stderr,
+		scanner: scanner,
+		pending: initialOutput,
 	}
 	if err := session.Resize(cols, rows); err != nil {
 		session.abortAndWait()
 		return nil, fmt.Errorf("size terminal: %w", err)
 	}
 	return session, nil
+}
+
+func waitForTmuxReady(scanner *bufio.Scanner, count int, sessionName string) ([]byte, error) {
+	completed := 0
+	attached := false
+	response := ""
+	var output []byte
+	for (completed < count || !attached) && scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "%begin "):
+			if response != "" {
+				return nil, fmt.Errorf("nested command response")
+			}
+			response = strings.TrimPrefix(line, "%begin ")
+		case strings.HasPrefix(line, "%end "):
+			if response != "" && strings.TrimPrefix(line, "%end ") == response {
+				completed++
+				response = ""
+			}
+		case strings.HasPrefix(scanner.Text(), "%session-changed "):
+			fields := strings.Fields(line)
+			attached = len(fields) == 3 && fields[2] == sessionName
+		case strings.HasPrefix(line, "%error "):
+			if response != "" && strings.TrimPrefix(line, "%error ") == response {
+				return nil, fmt.Errorf("command failed: %s", line)
+			}
+		case strings.HasPrefix(line, "%exit"):
+			return nil, fmt.Errorf("tmux exited during setup")
+		default:
+			if data, ok := tmuxOutput(line); ok {
+				output = append(output, data...)
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read command response: %w", err)
+	}
+	if completed < count || !attached {
+		return nil, io.ErrUnexpectedEOF
+	}
+	return output, nil
 }
 
 type tmuxTerminalSession struct {
@@ -212,6 +264,7 @@ type tmuxTerminalSession struct {
 	stdin   io.WriteCloser
 	scanner *bufio.Scanner
 	stderr  *strings.Builder
+	pending []byte
 
 	writeMu  sync.Mutex
 	closed   atomic.Bool
@@ -220,6 +273,11 @@ type tmuxTerminalSession struct {
 }
 
 func (s *tmuxTerminalSession) Read() ([]byte, error) {
+	if len(s.pending) > 0 {
+		data := s.pending
+		s.pending = nil
+		return data, nil
+	}
 	for s.scanner.Scan() {
 		if data, ok := tmuxOutput(s.scanner.Text()); ok {
 			return data, nil

--- a/sandboxd/internal/server/terminal_test.go
+++ b/sandboxd/internal/server/terminal_test.go
@@ -1,12 +1,14 @@
 package server
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"net"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -207,6 +209,37 @@ func TestTmuxOutputDecodesBinaryData(t *testing.T) {
 	if _, ok := tmuxOutput("%begin 1 2 3"); ok {
 		t.Fatal("decoded a non-output control record")
 	}
+}
+
+func TestWaitForTmuxReady(t *testing.T) {
+	t.Run("waits for commands and attachment", func(t *testing.T) {
+		scanner := bufio.NewScanner(strings.NewReader("%begin 1 1 0\n%output %0 ready\\015\\012\n%end 1 1 0\n%begin 1 2 0\n%end 1 2 0\n%session-changed $0 swe\n"))
+		output, err := waitForTmuxReady(scanner, 2, "swe")
+		if err != nil {
+			t.Fatalf("wait for tmux: %v", err)
+		}
+		if string(output) != "ready\r\n" {
+			t.Fatalf("startup output = %q", output)
+		}
+	})
+	t.Run("reports setup failure", func(t *testing.T) {
+		scanner := bufio.NewScanner(strings.NewReader("%begin 1 1 0\n%error 1 1 0\n"))
+		if _, err := waitForTmuxReady(scanner, 1, "swe"); err == nil {
+			t.Fatal("expected command failure")
+		}
+	})
+	t.Run("rejects missing attachment", func(t *testing.T) {
+		scanner := bufio.NewScanner(strings.NewReader("%begin 1 1 0\n%end 1 1 0\n"))
+		if _, err := waitForTmuxReady(scanner, 1, "swe"); !errors.Is(err, io.ErrUnexpectedEOF) {
+			t.Fatalf("incomplete setup error = %v, want unexpected EOF", err)
+		}
+	})
+	t.Run("ignores mismatched completion and error records", func(t *testing.T) {
+		scanner := bufio.NewScanner(strings.NewReader("%begin 1 1 0\n%end 1 9 0\n%error 1 9 0\n%end 1 1 0\n%session-changed $0 swe\n"))
+		if _, err := waitForTmuxReady(scanner, 1, "swe"); err != nil {
+			t.Fatalf("wait for matching response: %v", err)
+		}
+	})
 }
 
 func TestTerminalStatusMapsBackendErrors(t *testing.T) {

--- a/sandboxd/internal/server/terminal_test.go
+++ b/sandboxd/internal/server/terminal_test.go
@@ -212,9 +212,9 @@ func TestTmuxOutputDecodesBinaryData(t *testing.T) {
 }
 
 func TestWaitForTmuxReady(t *testing.T) {
-	t.Run("waits for commands and attachment", func(t *testing.T) {
-		scanner := bufio.NewScanner(strings.NewReader("%begin 1 1 0\n%output %0 ready\\015\\012\n%end 1 1 0\n%begin 1 2 0\n%end 1 2 0\n%session-changed $0 swe\n"))
-		output, err := waitForTmuxReady(scanner, 2, "swe")
+	t.Run("waits for tagged probe after delayed pipe setup", func(t *testing.T) {
+		scanner := bufio.NewScanner(strings.NewReader("%begin 1 1 0\n%end 1 1 0\n%begin 1 2 0\n%end 1 2 0\n%session-changed $0 swe\n%begin 1 3 0\n%output %0 ready\\015\\012\n%end 1 3 0\n%begin 1 4 0\nswe-output-drain-ready:1\n%end 1 4 0\n"))
+		output, err := waitForTmuxReady(scanner, "swe")
 		if err != nil {
 			t.Fatalf("wait for tmux: %v", err)
 		}
@@ -222,22 +222,22 @@ func TestWaitForTmuxReady(t *testing.T) {
 			t.Fatalf("startup output = %q", output)
 		}
 	})
-	t.Run("reports setup failure", func(t *testing.T) {
-		scanner := bufio.NewScanner(strings.NewReader("%begin 1 1 0\n%error 1 1 0\n"))
-		if _, err := waitForTmuxReady(scanner, 1, "swe"); err == nil {
+	t.Run("reports delayed pipe setup failure", func(t *testing.T) {
+		scanner := bufio.NewScanner(strings.NewReader("%begin 1 1 0\n%end 1 1 0\n%begin 1 2 0\n%end 1 2 0\n%begin 1 3 0\n%error 1 3 0\n"))
+		if _, err := waitForTmuxReady(scanner, "swe"); err == nil {
 			t.Fatal("expected command failure")
 		}
 	})
-	t.Run("rejects missing attachment", func(t *testing.T) {
-		scanner := bufio.NewScanner(strings.NewReader("%begin 1 1 0\n%end 1 1 0\n"))
-		if _, err := waitForTmuxReady(scanner, 1, "swe"); !errors.Is(err, io.ErrUnexpectedEOF) {
+	t.Run("rejects completion before readiness probe", func(t *testing.T) {
+		scanner := bufio.NewScanner(strings.NewReader("%begin 1 1 0\n%end 1 1 0\n%begin 1 2 0\n%end 1 2 0\n%session-changed $0 swe\n"))
+		if _, err := waitForTmuxReady(scanner, "swe"); !errors.Is(err, io.ErrUnexpectedEOF) {
 			t.Fatalf("incomplete setup error = %v, want unexpected EOF", err)
 		}
 	})
-	t.Run("ignores mismatched completion and error records", func(t *testing.T) {
-		scanner := bufio.NewScanner(strings.NewReader("%begin 1 1 0\n%end 1 9 0\n%error 1 9 0\n%end 1 1 0\n%session-changed $0 swe\n"))
-		if _, err := waitForTmuxReady(scanner, 1, "swe"); err != nil {
-			t.Fatalf("wait for matching response: %v", err)
+	t.Run("rejects inactive drain probe", func(t *testing.T) {
+		scanner := bufio.NewScanner(strings.NewReader("%begin 1 3 0\nswe-output-drain-ready:0\n%end 1 3 0\n%session-changed $0 swe\n"))
+		if _, err := waitForTmuxReady(scanner, "swe"); err == nil {
+			t.Fatal("expected inactive drain failure")
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- keep a tmux output pipe active for the lifetime of the shared pane so tmux drains PTY bytes before pane destruction
- pin and patch tmux 3.3a in env-base to serialize each eligible control client's pending raw output before closing the pane fd
- wait for matched tmux setup acknowledgements without dropping startup output
- cover immediate output-plus-exit with two shared-session attachments

## Root cause
On pane exit, tmux can destroy the pane before pending control-mode blocks are serialized. `control_write_pending` then sees the missing/closed pane and discards those blocks, so `swe attach` can receive the echoed command but lose results emitted immediately before `exit`. The e2e assertion is valid; this was a tmux drain/serialization race.

`pipe-pane` closes the earlier unread-PTY window, and the small tmux patch flushes pending per-client blocks into each control client's output buffer before fd teardown. Normal pane/session destruction and client detach behavior remain unchanged.

## Checks
- patched tmux final-output test: `-count=500` (two simultaneous attachments)
- focused terminal race tests: `-race -count=20`
- `sandboxd`: test, vet, build
- root module: test, vet, build
- Linux and Windows sandboxd builds
- Windows cross-compiled server tests (`GOOS=windows ... -exec=true`)
- tmux patch applies/builds from the checksum-pinned 3.3a source and reports `tmux 3.3a-swe-drain`

Kind e2e is expected to exercise the fixed env-base image in required CI.
