### PR TITLE
Stabilize terminal heartbeat cancellation tests

### DIFF
--- a/internal/controlplane/terminal_test.go
+++ b/internal/controlplane/terminal_test.go
@@ -401,10 +401,10 @@ func TestTerminalHeartbeatProtectsSlowWakeBeforeConnection(t *testing.T) {
 	if err := closer.Close(); err != nil {
 		t.Fatal(err)
 	}
-	writesAfterClose := activityClient.count()
+	writesAfterClose := waitForActivityWritesToQuiesce(t, activityClient, 60*time.Millisecond)
 	time.Sleep(60 * time.Millisecond)
 	if writes := activityClient.count(); writes != writesAfterClose {
-		t.Fatalf("activity writes after terminal close = %d, want %d", writes, writesAfterClose)
+		t.Fatalf("activity writes continued after terminal close = %d, want %d", writes, writesAfterClose)
 	}
 }
 
@@ -445,13 +445,29 @@ func TestTerminalHeartbeatCancelsWhenWakeOrDialFails(t *testing.T) {
 			if _, _, err := dialer.DialTerminal(context.Background(), environment.Namespace, environment.Name); err == nil {
 				t.Fatalf("DialTerminal() succeeded during %s failure", test.name)
 			}
-			writesAfterFailure := activityClient.count()
+			writesAfterFailure := waitForActivityWritesToQuiesce(t, activityClient, 60*time.Millisecond)
 			time.Sleep(60 * time.Millisecond)
 			if writes := activityClient.count(); writes != writesAfterFailure {
-				t.Fatalf("activity writes after %s failure = %d, want %d", test.name, writes, writesAfterFailure)
+				t.Fatalf("activity writes continued after %s failure = %d, want %d", test.name, writes, writesAfterFailure)
 			}
 		})
 	}
+}
+
+func waitForActivityWritesToQuiesce(t *testing.T, activityClient *activityCountingClient, quietFor time.Duration) int {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	writes := activityClient.count()
+	for time.Now().Before(deadline) {
+		time.Sleep(quietFor)
+		next := activityClient.count()
+		if next == writes {
+			return next
+		}
+		writes = next
+	}
+	t.Fatal("terminal activity writes did not quiesce after cancellation")
+	return 0
 }
 
 type activityCountingClient struct {


### PR DESCRIPTION
## Summary

- accept one cancellation-adjacent heartbeat that was already selected or in flight
- wait for activity writes to quiesce, then separately prove periodic writes remain stopped
- apply the same oracle to terminal close and wake/dial failure paths
- leave production terminal and heartbeat behavior unchanged

## Root cause

Cancellation is asynchronous. The previous tests snapshotted the write count immediately after cancellation, even though a heartbeat could already be inside the fake Kubernetes status update and increment the test counter just afterward. That imposed a synchronous-close contract the implementation does not provide.

The replacement oracle still fails if heartbeat writes continue: it requires a 60 ms quiet period (three 20 ms heartbeat intervals), then checks another independent 60 ms interval.

## Validation

- focused heartbeat tests: 100 runs
- focused heartbeat race tests: 20 runs
- `make test`
- `make vet`
- `git diff --check`

This repairs the inherited main test flake that blocked PR #47's otherwise-green exact-head cycle.