### PR TITLE
Embed the operations console in the control plane

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+bin/
+ui/dist/
+ui/node_modules/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,10 @@ jobs:
           node-version: "24.18.0"
           cache: npm
           cache-dependency-path: ui/package-lock.json
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: true
       - name: Verify bundled npm
         run: test "$(npm --version)" = "11.16.0"
       - name: Install and check operations console
@@ -28,6 +32,14 @@ jobs:
           npm test -- --run
           npm run build
           npm audit
+      - name: Test production asset embedding
+        run: |
+          make check-ui-assets
+          go test -tags console ./internal/controlplane ./ui
+          make build-control-plane-production
+
+      - name: Build production control-plane image
+        run: make docker-build-control-plane
 
   sandboxd-windows:
     runs-on: windows-latest

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -7,6 +7,7 @@ on:
       - "cmd/**"
       - "internal/**"
       - "sandboxd/**"
+      - "ui/**"
       - "images/**"
       - "config/**"
       - "charts/**"
@@ -14,6 +15,7 @@ on:
       - "go.mod"
       - "go.sum"
       - "Makefile"
+      - ".dockerignore"
   workflow_dispatch:
 
 permissions: {}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,10 @@ runs both via `make` targets:
 - **Unit tests:** `make test` · **Vet:** `make vet`
 - **Operations console:** from `ui/`, install with `npm ci`; use `npm run lint`,
   `npm run typecheck`, `npm test -- --run`, and `npm run build`. Start the standalone
-  Vite development server with `npm run dev`.
+  Vite development server with `npm run dev`. Production uses `make ui-build`
+  followed by `make build-control-plane-production`; the tagged build embeds `ui/dist`,
+  while ordinary Go builds intentionally work without generated assets. The control-plane
+  image performs both stages in one multi-stage build.
 - **Windows portability:** CI runs focused sandboxd process, Exec, and filesystem tests
   on `windows-latest`; keep OS-specific tests behind build tags.
 - **Regenerate deepcopy:** `make generate` · **CRDs + RBAC:** `make manifests`
@@ -114,7 +117,8 @@ runs both via `make` targets:
 - **E2E acceptance:** `./hack/e2e.sh` — full kind + operator + `swe run` pass with the
   env-base image built and loaded locally (no registry credentials needed). It also verifies
   control-plane TokenReview/SAR scoping, opaque browser session exchange/logout and CSRF,
-  typed Run list/get/create/retry/cancel, Environment get, transcript SSE, and terminal attach.
+  the embedded console entry point/SPA fallback/static assets, typed Run
+  list/get/create/retry/cancel, Environment get, transcript SSE, and terminal attach.
   Runs in CI as the `e2e` workflow on relevant PRs and via `workflow_dispatch`.
 - **Images:** `make docker-build` (operator + env-base). The env-base image builds
   its pinned tmux with `images/env-base/tmux-control-output-drain.patch`; keep the

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@
 CONTROLLER_GEN_VERSION ?= v0.21.0
 PROTOC_GEN_GO_VERSION ?= latest
 PROTOC_GEN_GO_GRPC_VERSION ?= latest
+NODE_VERSION ?= 24.18.0
+NPM_VERSION ?= 11.16.0
 
 LOCALBIN := $(abspath bin)
 CONTROLLER_GEN := $(LOCALBIN)/controller-gen
@@ -27,6 +29,10 @@ build-operator: ## Build the operator
 .PHONY: build-control-plane
 build-control-plane: ## Build the control-plane API
 	go build -o $(LOCALBIN)/control-plane ./cmd/control-plane
+
+.PHONY: build-control-plane-production
+build-control-plane-production: check-ui-assets ## Build the control plane with the embedded operations console
+	go build -tags console -o $(LOCALBIN)/control-plane ./cmd/control-plane
 
 .PHONY: build-cli
 build-cli: ## Build the swe CLI
@@ -54,6 +60,22 @@ test: ## Run unit tests in both modules
 vet: ## Run go vet in both modules
 	go vet ./...
 	cd sandboxd && go vet ./...
+
+.PHONY: check-ui-toolchain ui-install ui-build check-ui-assets
+check-ui-toolchain: ## Verify the pinned operations-console Node and npm versions
+	@test "$$(node --version)" = "v$(NODE_VERSION)" || { echo "Node v$(NODE_VERSION) is required" >&2; exit 1; }
+	@test "$$(npm --version)" = "$(NPM_VERSION)" || { echo "npm $(NPM_VERSION) is required" >&2; exit 1; }
+
+ui-install: check-ui-toolchain ## Install the pinned operations-console dependencies
+	cd ui && npm ci
+
+ui-build: ui-install ## Build fresh Vite assets for the production control plane
+	cd ui && npm run build
+
+check-ui-assets: ## Fail if generated Vite assets are absent or older than their inputs
+	@test -f ui/dist/index.html || { echo "ui/dist is missing; run 'make ui-build' before the tagged production build" >&2; exit 1; }
+	@stale="$$(find ui -type f ! -path 'ui/dist/*' ! -path 'ui/node_modules/*' ! -name '*.go' ! -name '*.tsbuildinfo' -newer ui/dist/index.html -print -quit)"; \
+		test -z "$$stale" || { echo "ui/dist is stale because $$stale is newer; run 'make ui-build'" >&2; exit 1; }
 
 ##@ Code generation
 

--- a/charts/swe-platform/README.md
+++ b/charts/swe-platform/README.md
@@ -163,6 +163,22 @@ subjects:
 Create the ServiceAccount, then mint a short-lived credential with
 `kubectl create token run-123-adapter -n project-a --audience=swe-platform`.
 
+## Operations console
+
+The production control-plane binary and image embed the React operations console and serve it
+from `/` on the same origin as the resource API, transcript SSE stream, and terminal WebSocket.
+There is no separate UI workload or Service. For local access, forward the existing Service and
+open `http://127.0.0.1:8080/`:
+
+```sh
+kubectl port-forward service/swe-platform-swe-platform-control-plane 8080:80
+```
+
+The kind preset permits HTTP browser sessions for this local flow. Production browser sessions
+still require HTTPS. To build the embedded binary outside the image build, run `make ui-build`
+followed by `make build-control-plane-production`; ordinary Go builds intentionally omit the UI
+and do not require generated Vite assets.
+
 ## Run and Environment resource API
 
 The console-facing resource API exposes explicit DTOs rather than Kubernetes objects:

--- a/cmd/control-plane/main.go
+++ b/cmd/control-plane/main.go
@@ -23,6 +23,7 @@ import (
 
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
 	"github.com/Chris-Cullins/swe-platform/internal/controlplane"
+	consoleui "github.com/Chris-Cullins/swe-platform/ui"
 )
 
 const shutdownTimeout = 10 * time.Second
@@ -77,6 +78,7 @@ func main() {
 			Runs:                  controlplane.KubernetesRunResolver{Client: kubeClient},
 			TranscriptStore:       transcripts,
 			TerminalDialer:        controlplane.KubernetesTerminalDialer{Client: kubeClient},
+			ConsoleAssets:         consoleui.Assets(),
 			TrustProxy:            strings.EqualFold(os.Getenv("SWE_TRUST_PROXY_HEADERS"), "true"),
 			AllowInsecureSessions: strings.EqualFold(os.Getenv("SWE_ALLOW_INSECURE_SESSIONS"), "true"),
 			StreamLifecycle:       streamLifecycle,

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -301,6 +301,36 @@ for _ in $(seq 1 30); do
 	sleep 1
 done
 
+echo "==> verifying embedded operations console through the control-plane Service"
+ROOT_STATUS=$(curl --silent --dump-header /tmp/swe-platform-console-root.headers \
+	--output /tmp/swe-platform-console-root.html --write-out '%{http_code}' \
+	http://127.0.0.1:18080/)
+SPA_STATUS=$(curl --silent --dump-header /tmp/swe-platform-console-spa.headers \
+	--output /tmp/swe-platform-console-spa.html --write-out '%{http_code}' \
+	"http://127.0.0.1:18080/namespaces/default/runs/${RUN_NAME}/overview")
+ASSET_PATH=$(grep -oE 'src="/assets/[^"]+"' /tmp/swe-platform-console-root.html | head -1 | cut -d'"' -f2 || true)
+if [[ "$ROOT_STATUS" != "200" || "$SPA_STATUS" != "200" || -z "$ASSET_PATH" ]] || \
+	! cmp -s /tmp/swe-platform-console-root.html /tmp/swe-platform-console-spa.html || \
+	! tr -d '\r' < /tmp/swe-platform-console-root.headers | grep -Eiq '^Cache-Control: no-store$' || \
+	! grep -Eiq '^Content-Security-Policy: ' /tmp/swe-platform-console-root.headers; then
+	echo "FAIL: control-plane image did not serve the secured SPA entry point and client-route fallback"
+	exit 1
+fi
+ASSET_STATUS=$(curl --silent --dump-header /tmp/swe-platform-console-asset.headers \
+	--output /tmp/swe-platform-console-asset --write-out '%{http_code}' \
+	"http://127.0.0.1:18080${ASSET_PATH}")
+if [[ "$ASSET_STATUS" != "200" || ! -s /tmp/swe-platform-console-asset ]] || \
+	! tr -d '\r' < /tmp/swe-platform-console-asset.headers | grep -Eiq '^Cache-Control: public, max-age=31536000, immutable$'; then
+	echo "FAIL: control-plane image did not serve the immutable Vite asset ${ASSET_PATH}"
+	exit 1
+fi
+UNKNOWN_API_STATUS=$(curl --silent --output /tmp/swe-platform-console-unknown-api \
+	--write-out '%{http_code}' http://127.0.0.1:18080/api/not-a-console-route)
+if [[ "$UNKNOWN_API_STATUS" != "404" ]] || grep -q 'SWE Operations' /tmp/swe-platform-console-unknown-api; then
+	echo "FAIL: unknown API route was swallowed by the SPA fallback"
+	exit 1
+fi
+
 echo "==> verifying browser session and typed resource APIs"
 COOKIE_JAR=/tmp/swe-platform-console-cookies
 rm -f "$COOKIE_JAR"

--- a/images/control-plane/Dockerfile
+++ b/images/control-plane/Dockerfile
@@ -1,3 +1,13 @@
+FROM --platform=$BUILDPLATFORM node:24.18.0-bookworm-slim AS console-build
+WORKDIR /src/ui
+
+RUN test "$(node --version)" = "v24.18.0" && test "$(npm --version)" = "11.16.0"
+COPY ui/package.json ui/package-lock.json ./
+RUN npm ci
+COPY ui/index.html ui/tsconfig.json ui/tsconfig.app.json ui/tsconfig.node.json ui/vite.config.ts ./
+COPY ui/src/ src/
+RUN npm run build
+
 FROM --platform=$BUILDPLATFORM golang:1.26 AS build
 WORKDIR /src
 
@@ -9,11 +19,13 @@ COPY api/ api/
 COPY cmd/control-plane/ cmd/control-plane/
 COPY internal/controlplane/ internal/controlplane/
 COPY internal/sandboxclient/ internal/sandboxclient/
+COPY ui/*.go ui/
+COPY --from=console-build /src/ui/dist ui/dist/
 COPY sandboxd/auth/ sandboxd/auth/
 COPY sandboxd/gen/ sandboxd/gen/
 ARG TARGETOS
 ARG TARGETARCH
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /out/control-plane ./cmd/control-plane
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags console -o /out/control-plane ./cmd/control-plane
 
 FROM gcr.io/distroless/static:nonroot
 COPY --from=build /out/control-plane /control-plane

--- a/internal/controlplane/console.go
+++ b/internal/controlplane/console.go
@@ -14,10 +14,8 @@ import (
 
 // xterm's DOM renderer creates generated style elements for dimensions, ANSI
 // colors, and cursor state, so styles need unsafe-inline. Scripts remain
-// self-only. The ws/wss sources keep same-origin terminals working in browsers
-// that do not treat a scheme-changing WebSocket URL as 'self'; the terminal
-// handler still enforces its existing same-origin policy before upgrading.
-const consoleCSP = "default-src 'none'; base-uri 'none'; connect-src 'self' ws: wss:; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; img-src 'self' data:; manifest-src 'self'; object-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; worker-src 'none'"
+// self-only.
+const consoleCSP = "default-src 'none'; base-uri 'none'; connect-src 'self'; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; img-src 'self' data:; manifest-src 'self'; object-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; worker-src 'none'"
 
 var viteHashedAsset = regexp.MustCompile(`^assets/(?:.*/)?[^/]+-[A-Za-z0-9_-]{8,}\.[^/]+$`)
 
@@ -50,7 +48,7 @@ func (h *consoleHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	name := strings.TrimPrefix(r.URL.Path, "/")
-	if name == "" {
+	if name == "" || name == "index.html" {
 		h.serve(w, r, "index.html", h.index, "no-store")
 		return
 	}
@@ -84,7 +82,7 @@ func (h *consoleHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "operations console is unavailable", http.StatusInternalServerError)
 		return
 	}
-	if strings.HasPrefix(name, "assets/") {
+	if strings.HasPrefix(name, "assets/") || path.Ext(name) != "" {
 		w.Header().Set("Cache-Control", "no-store")
 		http.NotFound(w, r)
 		return

--- a/internal/controlplane/console.go
+++ b/internal/controlplane/console.go
@@ -1,0 +1,117 @@
+package controlplane
+
+import (
+	"bytes"
+	"errors"
+	"io/fs"
+	"mime"
+	"net/http"
+	"path"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// xterm's DOM renderer creates generated style elements for dimensions, ANSI
+// colors, and cursor state, so styles need unsafe-inline. Scripts remain
+// self-only. The ws/wss sources keep same-origin terminals working in browsers
+// that do not treat a scheme-changing WebSocket URL as 'self'; the terminal
+// handler still enforces its existing same-origin policy before upgrading.
+const consoleCSP = "default-src 'none'; base-uri 'none'; connect-src 'self' ws: wss:; font-src 'self' data:; form-action 'self'; frame-ancestors 'none'; img-src 'self' data:; manifest-src 'self'; object-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; worker-src 'none'"
+
+var viteHashedAsset = regexp.MustCompile(`^assets/(?:.*/)?[^/]+-[A-Za-z0-9_-]{8,}\.[^/]+$`)
+
+type consoleHandler struct {
+	assets fs.FS
+	index  []byte
+	err    error
+}
+
+func newConsoleHandler(assets fs.FS) http.Handler {
+	index, err := fs.ReadFile(assets, "index.html")
+	return &consoleHandler{assets: assets, index: index, err: err}
+}
+
+func (h *consoleHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if isReservedServerPath(r.URL.Path) {
+		http.NotFound(w, r)
+		return
+	}
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", "GET, HEAD")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	setConsoleSecurityHeaders(w.Header())
+	if h.err != nil {
+		w.Header().Set("Cache-Control", "no-store")
+		http.Error(w, "operations console is unavailable", http.StatusInternalServerError)
+		return
+	}
+
+	name := strings.TrimPrefix(r.URL.Path, "/")
+	if name == "" {
+		h.serve(w, r, "index.html", h.index, "no-store")
+		return
+	}
+	if !fs.ValidPath(name) || strings.Contains(name, `\`) {
+		w.Header().Set("Cache-Control", "no-store")
+		http.NotFound(w, r)
+		return
+	}
+	info, err := fs.Stat(h.assets, name)
+	if err == nil && info.IsDir() {
+		w.Header().Set("Cache-Control", "no-store")
+		http.NotFound(w, r)
+		return
+	}
+	if err == nil {
+		data, readErr := fs.ReadFile(h.assets, name)
+		if readErr != nil {
+			w.Header().Set("Cache-Control", "no-store")
+			http.Error(w, "operations console is unavailable", http.StatusInternalServerError)
+			return
+		}
+		cacheControl := "no-cache"
+		if viteHashedAsset.MatchString(name) {
+			cacheControl = "public, max-age=31536000, immutable"
+		}
+		h.serve(w, r, name, data, cacheControl)
+		return
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		w.Header().Set("Cache-Control", "no-store")
+		http.Error(w, "operations console is unavailable", http.StatusInternalServerError)
+		return
+	}
+	if strings.HasPrefix(name, "assets/") {
+		w.Header().Set("Cache-Control", "no-store")
+		http.NotFound(w, r)
+		return
+	}
+	h.serve(w, r, "index.html", h.index, "no-store")
+}
+
+func (h *consoleHandler) serve(w http.ResponseWriter, r *http.Request, name string, data []byte, cacheControl string) {
+	contentType := mime.TypeByExtension(path.Ext(name))
+	if contentType == "" {
+		contentType = http.DetectContentType(data)
+	}
+	w.Header().Set("Cache-Control", cacheControl)
+	w.Header().Set("Content-Type", contentType)
+	http.ServeContent(w, r, name, time.Time{}, bytes.NewReader(data))
+}
+
+func isReservedServerPath(requestPath string) bool {
+	return requestPath == "/api" || strings.HasPrefix(requestPath, "/api/") ||
+		requestPath == "/healthz" || strings.HasPrefix(requestPath, "/healthz/")
+}
+
+func setConsoleSecurityHeaders(header http.Header) {
+	header.Set("Content-Security-Policy", consoleCSP)
+	header.Set("Cross-Origin-Resource-Policy", "same-origin")
+	header.Set("Permissions-Policy", "camera=(), display-capture=(), geolocation=(), microphone=(), payment=(), usb=()")
+	header.Set("Referrer-Policy", "no-referrer")
+	header.Set("X-Content-Type-Options", "nosniff")
+	header.Set("X-Frame-Options", "DENY")
+}

--- a/internal/controlplane/console_test.go
+++ b/internal/controlplane/console_test.go
@@ -1,0 +1,142 @@
+package controlplane
+
+import (
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+const testConsoleIndex = `<!doctype html><title>SWE Operations</title><div id="root"></div>`
+
+func TestConsoleServesEntryPointFallbackAndAssets(t *testing.T) {
+	handler := NewServer(nil, ServerOptions{ConsoleAssets: testConsoleAssets()}).Handler()
+	for _, test := range []struct {
+		name        string
+		requestPath string
+		wantBody    string
+		wantCache   string
+		wantType    string
+	}{
+		{name: "entry point", requestPath: "/", wantBody: testConsoleIndex, wantCache: "no-store", wantType: "text/html; charset=utf-8"},
+		{name: "client route fallback", requestPath: "/namespaces/default/runs/run-1/overview", wantBody: testConsoleIndex, wantCache: "no-store", wantType: "text/html; charset=utf-8"},
+		{name: "hashed Vite asset", requestPath: "/assets/index-AbCdEf12.js", wantBody: "console.log('ok')", wantCache: "public, max-age=31536000, immutable", wantType: "text/javascript; charset=utf-8"},
+		{name: "other asset", requestPath: "/favicon.svg", wantBody: "<svg></svg>", wantCache: "no-cache", wantType: "image/svg+xml"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			response := requestConsole(handler, http.MethodGet, test.requestPath)
+			if response.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d", response.Code, http.StatusOK)
+			}
+			if body := response.Body.String(); body != test.wantBody {
+				t.Fatalf("body = %q, want %q", body, test.wantBody)
+			}
+			if cache := response.Header().Get("Cache-Control"); cache != test.wantCache {
+				t.Fatalf("Cache-Control = %q, want %q", cache, test.wantCache)
+			}
+			if contentType := response.Header().Get("Content-Type"); contentType != test.wantType {
+				t.Fatalf("Content-Type = %q, want %q", contentType, test.wantType)
+			}
+			assertConsoleSecurityHeaders(t, response.Header())
+		})
+	}
+}
+
+func TestConsoleFallbackDoesNotSwallowServerRoutesOrMethods(t *testing.T) {
+	handler := NewServer(nil, ServerOptions{ConsoleAssets: testConsoleAssets()}).Handler()
+	for _, test := range []struct {
+		name        string
+		method      string
+		requestPath string
+		wantStatus  int
+	}{
+		{name: "API root", method: http.MethodGet, requestPath: "/api", wantStatus: http.StatusNotFound},
+		{name: "unknown API", method: http.MethodGet, requestPath: "/api/v2/unknown", wantStatus: http.StatusNotFound},
+		{name: "existing API handler error", method: http.MethodGet, requestPath: "/api/v1/namespaces/default/unknown", wantStatus: http.StatusNotFound},
+		{name: "health subtree", method: http.MethodGet, requestPath: "/healthz/unknown", wantStatus: http.StatusNotFound},
+		{name: "health method error", method: http.MethodPost, requestPath: "/healthz", wantStatus: http.StatusMethodNotAllowed},
+		{name: "unsupported SPA method", method: http.MethodPost, requestPath: "/namespaces/default/runs", wantStatus: http.StatusMethodNotAllowed},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			response := requestConsole(handler, test.method, test.requestPath)
+			if response.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d", response.Code, test.wantStatus)
+			}
+			if strings.Contains(response.Body.String(), testConsoleIndex) {
+				t.Fatalf("server route returned the SPA entry point: %s", response.Body.String())
+			}
+			if response.Header().Get("Content-Security-Policy") != "" {
+				t.Fatal("non-UI response received UI security headers")
+			}
+		})
+	}
+}
+
+func TestConsoleRejectsMissingAndTraversalAssetPaths(t *testing.T) {
+	handler := NewServer(nil, ServerOptions{ConsoleAssets: testConsoleAssets()}).Handler()
+	for _, requestPath := range []string{
+		"/assets",
+		"/assets/missing.js",
+		"/assets/%2e%2e/index.html",
+		"/assets/..%5cindex.html",
+	} {
+		response := requestConsole(handler, http.MethodGet, requestPath)
+		if response.Code != http.StatusNotFound {
+			t.Fatalf("%s status = %d, want %d", requestPath, response.Code, http.StatusNotFound)
+		}
+		if strings.Contains(response.Body.String(), testConsoleIndex) {
+			t.Fatalf("%s exposed the SPA entry point", requestPath)
+		}
+	}
+}
+
+func TestConsoleSupportsHeadWithoutBody(t *testing.T) {
+	response := requestConsole(NewServer(nil, ServerOptions{ConsoleAssets: testConsoleAssets()}).Handler(), http.MethodHead, "/")
+	if response.Code != http.StatusOK || response.Body.Len() != 0 {
+		t.Fatalf("HEAD status/body = %d/%q, want 200 with an empty body", response.Code, response.Body.String())
+	}
+	if response.Header().Get("Cache-Control") != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", response.Header().Get("Cache-Control"))
+	}
+}
+
+func testConsoleAssets() fs.FS {
+	return fstest.MapFS{
+		"index.html":               {Data: []byte(testConsoleIndex)},
+		"assets/index-AbCdEf12.js": {Data: []byte("console.log('ok')")},
+		"favicon.svg":              {Data: []byte("<svg></svg>")},
+	}
+}
+
+func requestConsole(handler http.Handler, method, requestPath string) *httptest.ResponseRecorder {
+	request := httptest.NewRequest(method, requestPath, nil)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+	return response
+}
+
+func assertConsoleSecurityHeaders(t *testing.T, header http.Header) {
+	t.Helper()
+	want := map[string]string{
+		"Cross-Origin-Resource-Policy": "same-origin",
+		"Referrer-Policy":              "no-referrer",
+		"X-Content-Type-Options":       "nosniff",
+		"X-Frame-Options":              "DENY",
+	}
+	for name, value := range want {
+		if got := header.Get(name); got != value {
+			t.Errorf("%s = %q, want %q", name, got, value)
+		}
+	}
+	csp := header.Get("Content-Security-Policy")
+	for _, directive := range []string{"default-src 'none'", "script-src 'self'", "style-src 'self' 'unsafe-inline'", "connect-src 'self' ws: wss:", "frame-ancestors 'none'"} {
+		if !strings.Contains(csp, directive) {
+			t.Errorf("Content-Security-Policy %q does not contain %q", csp, directive)
+		}
+	}
+	if strings.Contains(csp, "script-src 'self' 'unsafe-inline'") || strings.Contains(csp, "'unsafe-eval'") {
+		t.Errorf("Content-Security-Policy is weaker than the Vite output requires: %q", csp)
+	}
+}

--- a/internal/controlplane/console_test.go
+++ b/internal/controlplane/console_test.go
@@ -21,6 +21,7 @@ func TestConsoleServesEntryPointFallbackAndAssets(t *testing.T) {
 		wantType    string
 	}{
 		{name: "entry point", requestPath: "/", wantBody: testConsoleIndex, wantCache: "no-store", wantType: "text/html; charset=utf-8"},
+		{name: "direct entry point", requestPath: "/index.html", wantBody: testConsoleIndex, wantCache: "no-store", wantType: "text/html; charset=utf-8"},
 		{name: "client route fallback", requestPath: "/namespaces/default/runs/run-1/overview", wantBody: testConsoleIndex, wantCache: "no-store", wantType: "text/html; charset=utf-8"},
 		{name: "hashed Vite asset", requestPath: "/assets/index-AbCdEf12.js", wantBody: "console.log('ok')", wantCache: "public, max-age=31536000, immutable", wantType: "text/javascript; charset=utf-8"},
 		{name: "other asset", requestPath: "/favicon.svg", wantBody: "<svg></svg>", wantCache: "no-cache", wantType: "image/svg+xml"},
@@ -74,31 +75,44 @@ func TestConsoleFallbackDoesNotSwallowServerRoutesOrMethods(t *testing.T) {
 	}
 }
 
-func TestConsoleRejectsMissingAndTraversalAssetPaths(t *testing.T) {
+func TestConsoleRejectsMissingAssetPaths(t *testing.T) {
 	handler := NewServer(nil, ServerOptions{ConsoleAssets: testConsoleAssets()}).Handler()
-	for _, requestPath := range []string{
-		"/assets",
-		"/assets/missing.js",
-		"/assets/%2e%2e/index.html",
-		"/assets/..%5cindex.html",
-	} {
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		for _, requestPath := range []string{"/assets/missing.js", "/manifest.webmanifest"} {
+			response := requestConsole(handler, method, requestPath)
+			if response.Code != http.StatusNotFound {
+				t.Fatalf("%s %s status = %d, want %d", method, requestPath, response.Code, http.StatusNotFound)
+			}
+			if response.Header().Get("Cache-Control") != "no-store" {
+				t.Fatalf("%s %s Cache-Control = %q, want no-store", method, requestPath, response.Header().Get("Cache-Control"))
+			}
+			if strings.Contains(response.Body.String(), testConsoleIndex) {
+				t.Fatalf("%s %s exposed the SPA entry point", method, requestPath)
+			}
+		}
+	}
+}
+
+func TestConsoleRejectsDirectoriesAndTraversal(t *testing.T) {
+	handler := NewServer(nil, ServerOptions{ConsoleAssets: testConsoleAssets()}).Handler()
+	for _, requestPath := range []string{"/assets", "/assets/%2e%2e/index.html", "/assets/..%5cindex.html"} {
 		response := requestConsole(handler, http.MethodGet, requestPath)
 		if response.Code != http.StatusNotFound {
 			t.Fatalf("%s status = %d, want %d", requestPath, response.Code, http.StatusNotFound)
-		}
-		if strings.Contains(response.Body.String(), testConsoleIndex) {
-			t.Fatalf("%s exposed the SPA entry point", requestPath)
 		}
 	}
 }
 
 func TestConsoleSupportsHeadWithoutBody(t *testing.T) {
-	response := requestConsole(NewServer(nil, ServerOptions{ConsoleAssets: testConsoleAssets()}).Handler(), http.MethodHead, "/")
-	if response.Code != http.StatusOK || response.Body.Len() != 0 {
-		t.Fatalf("HEAD status/body = %d/%q, want 200 with an empty body", response.Code, response.Body.String())
-	}
-	if response.Header().Get("Cache-Control") != "no-store" {
-		t.Fatalf("Cache-Control = %q, want no-store", response.Header().Get("Cache-Control"))
+	handler := NewServer(nil, ServerOptions{ConsoleAssets: testConsoleAssets()}).Handler()
+	for _, requestPath := range []string{"/", "/index.html", "/namespaces/default/runs/run-1/overview"} {
+		response := requestConsole(handler, http.MethodHead, requestPath)
+		if response.Code != http.StatusOK || response.Body.Len() != 0 {
+			t.Fatalf("HEAD %s status/body = %d/%q, want 200 with an empty body", requestPath, response.Code, response.Body.String())
+		}
+		if response.Header().Get("Cache-Control") != "no-store" {
+			t.Fatalf("HEAD %s Cache-Control = %q, want no-store", requestPath, response.Header().Get("Cache-Control"))
+		}
 	}
 }
 
@@ -131,10 +145,13 @@ func assertConsoleSecurityHeaders(t *testing.T, header http.Header) {
 		}
 	}
 	csp := header.Get("Content-Security-Policy")
-	for _, directive := range []string{"default-src 'none'", "script-src 'self'", "style-src 'self' 'unsafe-inline'", "connect-src 'self' ws: wss:", "frame-ancestors 'none'"} {
+	for _, directive := range []string{"default-src 'none'", "script-src 'self'", "style-src 'self' 'unsafe-inline'", "connect-src 'self'", "frame-ancestors 'none'"} {
 		if !strings.Contains(csp, directive) {
 			t.Errorf("Content-Security-Policy %q does not contain %q", csp, directive)
 		}
+	}
+	if strings.Contains(csp, " ws:") || strings.Contains(csp, " wss:") {
+		t.Errorf("Content-Security-Policy permits WebSockets to arbitrary hosts: %q", csp)
 	}
 	if strings.Contains(csp, "script-src 'self' 'unsafe-inline'") || strings.Contains(csp, "'unsafe-eval'") {
 		t.Errorf("Content-Security-Policy is weaker than the Vite output requires: %q", csp)

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -41,6 +42,7 @@ type Server struct {
 	resources             ResourceService
 	runs                  RunResolver
 	terminalDialer        TerminalDialer
+	consoleAssets         fs.FS
 	trustProxy            bool
 	allowInsecureSessions bool
 	heartbeat             time.Duration
@@ -74,6 +76,7 @@ type ServerOptions struct {
 	Runs                  RunResolver
 	TranscriptStore       TranscriptStore
 	TerminalDialer        TerminalDialer
+	ConsoleAssets         fs.FS
 	TrustProxy            bool
 	AllowInsecureSessions bool
 	// StreamLifecycle is canceled when long-lived SSE and terminal handlers
@@ -105,6 +108,7 @@ func NewServer(log *slog.Logger, options ServerOptions) *Server {
 		resources:             options.Resources,
 		runs:                  options.Runs,
 		terminalDialer:        options.TerminalDialer,
+		consoleAssets:         options.ConsoleAssets,
 		trustProxy:            options.TrustProxy,
 		allowInsecureSessions: options.AllowInsecureSessions,
 		heartbeat:             heartbeat,
@@ -132,7 +136,17 @@ func (s *Server) Handler() http.Handler {
 	})
 	mux.HandleFunc("/api/v1/session", s.handleSession)
 	mux.HandleFunc(namespacedPathPrefix, s.handleNamespacedAPI)
-	return mux
+	if s.consoleAssets == nil {
+		return mux
+	}
+	console := newConsoleHandler(s.consoleAssets)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isReservedServerPath(r.URL.Path) {
+			mux.ServeHTTP(w, r)
+			return
+		}
+		console.ServeHTTP(w, r)
+	})
 }
 
 func (s *Server) handleNamespacedAPI(w http.ResponseWriter, r *http.Request) {

--- a/ui/assets.go
+++ b/ui/assets.go
@@ -1,0 +1,9 @@
+// Package ui exposes the production operations-console assets to the control plane.
+package ui
+
+import "io/fs"
+
+// Assets returns the embedded production console, or nil in ordinary Go builds.
+func Assets() fs.FS {
+	return assets
+}

--- a/ui/assets_disabled.go
+++ b/ui/assets_disabled.go
@@ -1,0 +1,7 @@
+//go:build !console
+
+package ui
+
+import "io/fs"
+
+var assets fs.FS

--- a/ui/assets_embedded.go
+++ b/ui/assets_embedded.go
@@ -1,0 +1,24 @@
+//go:build console
+
+package ui
+
+import (
+	"embed"
+	"io/fs"
+)
+
+// Both patterns are intentional: a tagged build fails at compile time when
+// either the Vite entry point or its generated asset directory is absent.
+//
+//go:embed dist/index.html dist/assets
+var embeddedAssets embed.FS
+
+var assets = mustSub(embeddedAssets, "dist")
+
+func mustSub(root fs.FS, dir string) fs.FS {
+	assets, err := fs.Sub(root, dir)
+	if err != nil {
+		panic(err)
+	}
+	return assets
+}

--- a/ui/assets_embedded_test.go
+++ b/ui/assets_embedded_test.go
@@ -1,0 +1,25 @@
+//go:build console
+
+package ui
+
+import (
+	"io/fs"
+	"testing"
+)
+
+func TestEmbeddedAssetsContainViteEntryPoint(t *testing.T) {
+	entry, err := fs.ReadFile(Assets(), "index.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entry) == 0 {
+		t.Fatal("embedded index.html is empty")
+	}
+	matches, err := fs.Glob(Assets(), "assets/*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) == 0 {
+		t.Fatal("embedded Vite asset directory is empty")
+	}
+}


### PR DESCRIPTION
## Summary

Embeds the React operations console into the control plane so the UI ships inside the control-plane binary/image instead of being served separately.

### What changed

- **Build-tagged nil-vs-embedded asset boundary:** a `console` build tag switches between a nil (no embedded assets, dev/test) and an embedded implementation. Production builds compile with `-tags console` so the Vite output is embedded via `go:embed`; non-tagged builds get a nil asset set so `go build ./...` stays clean with no dist checked in.
- **Custom safe SPA/static serving with API/health/method preservation:** the control plane serves embedded assets through a hand-written static handler that preserves API routes, `/healthz`, and HTTP method semantics, falls through to `index.html` for unknown client-side paths, sets immutable cache headers on hashed assets and revalidate policy on `index.html`, and applies a tight CSP. The CSP allows the runtime inline styles `xterm` requires but keeps scripts self-only (no `unsafe-inline`).
- **Pinned Node/npm BUILDPLATFORM stage + TARGETOS/TARGETARCH Go build into unchanged distroless image:** the control-plane Dockerfile adds a pinned Node/npm `BUILDPLATFORM` stage that builds the Vite assets, then cross-builds the Go binary with `TARGETOS`/`TARGETARCH` into the unchanged distroless runtime image. The base image, entrypoint, and runtime surface are unchanged.
- **Same Service/origin and extended kind acceptance/CI:** the console is served from the same control-plane Service/origin as the API — no new port, route, or ingress. `hack/e2e.sh` exercises the embedded console path, and CI gains a `Test production asset embedding` job plus image build.

### Local validations

- Clean no-dist `go build ./...` and focused tests (`internal/controlplane`, `ui`).
- Absent/stale generated-asset guard tests (`ui/assets_embedded_test.go`, `check-ui-assets` Make target).
- Frontend: `npm run lint`, `npm run typecheck`, `npm test -- --run` (28 tests), `npm run build`, `npm audit`.
- Tagged (`-tags console`) Go tests and build, plus linux amd64/arm64 cross-build from the Dockerfile.
- `make build`, `make test`, `make vet`.
- `make generate`, `make manifests`, and CRD/chart sync (`make check-chart-crds`).
- All Helm default/kind/Argo/k3s/GKE/EKS lint and render checks, plus the coordinated production-image `appVersion` check.

Docker client and `kind` were unavailable in the orb, so the Dockerfile/image-build and kind acceptance paths are covered by exact-head CI on this PR.

Closes #43
