### PR TITLE
Resolve remaining issue #30 audit findings

### DIFF
--- a/charts/swe-platform/values-kind.yaml
+++ b/charts/swe-platform/values-kind.yaml
@@ -8,6 +8,11 @@ controlPlane:
     tag: dev
   auth:
     allowInsecureSessions: true
+  # Keep CPU headroom for the claimed environment and its immediate warm-pool
+  # replacement on kind's single control-plane node.
+  resources:
+    requests:
+      cpu: 10m
 
 leaderElection: false
 

--- a/charts/swe-platform/values.yaml
+++ b/charts/swe-platform/values.yaml
@@ -27,7 +27,13 @@ controlPlane:
     bootstrapTokenSecret:
       name: ""
       key: token
-  resources: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
 
 imagePullSecrets: []
 nameOverride: ""

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -26,7 +26,8 @@ func newLogsCommand() *cobra.Command {
 }
 
 // streamLogs follows the logs of the environment pod.
-// TODO(P1): stream the agent transcript via the control plane instead of raw pod logs.
+// TODO(#57): define a compatible Run-selecting transcript mode before replacing
+// this kubeconfig-authenticated Environment log stream.
 func streamLogs(cmd *cobra.Command, namespace, envName string) error {
 	clients, err := newKubeClients()
 	if err != nil {

--- a/internal/controllers/environment_controller_test.go
+++ b/internal/controllers/environment_controller_test.go
@@ -540,6 +540,14 @@ func TestChildNamesAreBoundedAndScopedToEnvironmentUID(t *testing.T) {
 	if envPodName(first) == envPodName(second) || envPVCName(first) == envPVCName(second) {
 		t.Fatal("same-name Environment recreations share child names")
 	}
+	firstLabel := envLabels(first)["swe.dev/environment"]
+	secondLabel := envLabels(second)["swe.dev/environment"]
+	if problems := validation.IsValidLabelValue(firstLabel); len(problems) != 0 {
+		t.Fatalf("long Environment label %q is invalid: %v", firstLabel, problems)
+	}
+	if firstLabel == secondLabel {
+		t.Fatal("same-name Environment recreations share selector labels")
+	}
 
 	legacy := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: strings.Repeat("a", 63), UID: "legacy-uid"}}
 	wantPodName := "env-" + legacy.Name
@@ -554,6 +562,9 @@ func TestChildNamesAreBoundedAndScopedToEnvironmentUID(t *testing.T) {
 		if problems := validation.IsDNS1123Subdomain(name); len(problems) != 0 {
 			t.Errorf("legacy child name %q is invalid: %v", name, problems)
 		}
+	}
+	if got := envLabels(legacy)["swe.dev/environment"]; got != legacy.Name {
+		t.Fatalf("63-character Environment label = %q, want preserved name", got)
 	}
 }
 

--- a/internal/controlplane/terminal.go
+++ b/internal/controlplane/terminal.go
@@ -23,6 +23,7 @@ import (
 const (
 	wakeTimeout              = 2 * time.Minute
 	wakePollInterval         = 250 * time.Millisecond
+	terminalHealthTimeout    = 5 * time.Second
 	terminalHandshakeTimeout = 5 * time.Second
 )
 
@@ -30,7 +31,7 @@ var errTerminalEnvironmentIncarnationChanged = errors.New("environment incarnati
 
 // TerminalDialer resolves an Environment and connects to its sandboxd API.
 type TerminalDialer interface {
-	DialTerminal(context.Context, string, string) (sandboxdv1.TerminalServiceClient, io.Closer, error)
+	DialTerminal(context.Context, string, string) (sandboxdv1.TerminalServiceClient, sandboxdv1.HealthServiceClient, io.Closer, error)
 }
 
 // KubernetesTerminalDialer resolves environment pods through the Kubernetes API.
@@ -55,18 +56,18 @@ func (c *activeTerminalConnection) Close() error {
 // DialTerminal records terminal activity, wakes a paused environment, and then
 // requests an authenticated sandboxd connection through the environment
 // connector. Backend transport details stay out of terminal feature code.
-func (d KubernetesTerminalDialer) DialTerminal(ctx context.Context, namespace, name string) (sandboxdv1.TerminalServiceClient, io.Closer, error) {
+func (d KubernetesTerminalDialer) DialTerminal(ctx context.Context, namespace, name string) (sandboxdv1.TerminalServiceClient, sandboxdv1.HealthServiceClient, io.Closer, error) {
 	var environment platformv1alpha1.Environment
 	if err := d.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &environment); err != nil {
-		return nil, nil, fmt.Errorf("get environment: %w", err)
+		return nil, nil, nil, fmt.Errorf("get environment: %w", err)
 	}
 	expectedUID := environment.UID
 	if err := d.markActive(ctx, &environment, expectedUID); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	heartbeatInterval, err := d.activityHeartbeatInterval(ctx, &environment)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	heartbeatContext, cancelHeartbeat := context.WithCancel(ctx)
 	heartbeatTransferred := false
@@ -80,25 +81,25 @@ func (d KubernetesTerminalDialer) DialTerminal(ctx context.Context, namespace, n
 		before := environment.DeepCopy()
 		environment.Spec.Paused = false
 		if err := d.Client.Patch(ctx, &environment, client.MergeFrom(before)); err != nil {
-			return nil, nil, fmt.Errorf("wake environment: %w", err)
+			return nil, nil, nil, fmt.Errorf("wake environment: %w", err)
 		}
 		if err := d.waitUntilReady(ctx, namespace, name, expectedUID, &environment); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		if err := d.markActive(ctx, &environment, expectedUID); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 	}
 	if !platformv1alpha1.IsEnvironmentReady(&environment) {
-		return nil, nil, fmt.Errorf("environment is not ready for its current generation")
+		return nil, nil, nil, fmt.Errorf("environment is not ready for its current generation")
 	}
-	terminal, closeConnection, err := (sandboxclient.Connector{Reader: d.Client}).DialTerminal(ctx, namespace, name, expectedUID)
+	terminal, health, closeConnection, err := (sandboxclient.Connector{Reader: d.Client}).DialTerminal(ctx, namespace, name, expectedUID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("connect to sandboxd: %w", err)
+		return nil, nil, nil, fmt.Errorf("connect to sandboxd: %w", err)
 	}
 	closer := &activeTerminalConnection{Closer: closeFunc(closeConnection), cancel: cancelHeartbeat}
 	heartbeatTransferred = true
-	return terminal, closer, nil
+	return terminal, health, closer, nil
 }
 
 func (d KubernetesTerminalDialer) activityHeartbeatInterval(ctx context.Context, environment *platformv1alpha1.Environment) (time.Duration, error) {
@@ -224,13 +225,18 @@ func (s *Server) handleTerminal(w http.ResponseWriter, r *http.Request, namespac
 	r, cancelStream := s.withStreamLifecycle(r)
 	defer cancelStream()
 
-	terminal, closer, err := s.terminalDialer.DialTerminal(r.Context(), namespace, environment)
+	terminal, health, closer, err := s.terminalDialer.DialTerminal(r.Context(), namespace, environment)
 	if err != nil {
 		s.log.Warn("resolve terminal backend", "namespace", namespace, "environment", environment, "error", err)
 		http.Error(w, "environment terminal is unavailable", http.StatusBadGateway)
 		return
 	}
 	defer closer.Close()
+	if err := checkTerminalHealth(r.Context(), health, terminalHealthTimeout); err != nil {
+		s.log.Warn("check terminal backend health", "namespace", namespace, "environment", environment, "error", err)
+		http.Error(w, "environment terminal is unavailable", http.StatusBadGateway)
+		return
+	}
 
 	connection, err := terminalUpgrader.Upgrade(w, r, nil)
 	if err != nil {
@@ -249,6 +255,19 @@ func (s *Server) handleTerminal(w http.ResponseWriter, r *http.Request, namespac
 	_ = connection.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""), time.Now().Add(time.Second))
 }
 
+func checkTerminalHealth(ctx context.Context, health sandboxdv1.HealthServiceClient, timeout time.Duration) error {
+	checkContext, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	response, err := health.Check(checkContext, &sandboxdv1.HealthCheckRequest{})
+	if err != nil {
+		return fmt.Errorf("check sandboxd health: %w", err)
+	}
+	if !response.GetOk() {
+		return fmt.Errorf("sandboxd reported unhealthy")
+	}
+	return nil
+}
+
 func (s *Server) checkWebSocketOrigin(r *http.Request) bool {
 	origins := r.Header.Values("Origin")
 	if len(origins) == 0 || (len(origins) == 1 && origins[0] == "") {
@@ -259,8 +278,8 @@ func (s *Server) checkWebSocketOrigin(r *http.Request) bool {
 }
 
 func bridgeWebTerminal(ctx context.Context, connection *websocket.Conn, client sandboxdv1.TerminalServiceClient) error {
-	streamContext, cancel := context.WithCancel(ctx)
-	defer cancel()
+	streamContext, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
 	stream, err := client.Terminal(streamContext)
 	if err != nil {
 		return fmt.Errorf("open sandboxd terminal: %w", err)
@@ -268,6 +287,9 @@ func bridgeWebTerminal(ctx context.Context, connection *websocket.Conn, client s
 
 	messageType, payload, err := connection.ReadMessage()
 	if err != nil {
+		if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+			return nil
+		}
 		return fmt.Errorf("read terminal open: %w", err)
 	}
 	control, err := decodeTerminalControl(messageType, payload, "open")
@@ -280,13 +302,11 @@ func bridgeWebTerminal(ctx context.Context, connection *websocket.Conn, client s
 		return fmt.Errorf("open sandboxd terminal: %w", err)
 	}
 
-	inputDone := make(chan error, 1)
 	go func() {
-		defer cancel()
 		for {
 			messageType, payload, err := connection.ReadMessage()
 			if err != nil {
-				inputDone <- err
+				cancel(err)
 				return
 			}
 			var message *sandboxdv1.TerminalMessage
@@ -296,7 +316,7 @@ func bridgeWebTerminal(ctx context.Context, connection *websocket.Conn, client s
 			case websocket.TextMessage:
 				control, err := decodeTerminalControl(messageType, payload, "resize")
 				if err != nil {
-					inputDone <- err
+					cancel(err)
 					return
 				}
 				message = &sandboxdv1.TerminalMessage{Kind: &sandboxdv1.TerminalMessage_Resize{
@@ -306,7 +326,7 @@ func bridgeWebTerminal(ctx context.Context, connection *websocket.Conn, client s
 				continue
 			}
 			if err := stream.Send(message); err != nil {
-				inputDone <- err
+				cancel(err)
 				return
 			}
 		}
@@ -318,13 +338,11 @@ func bridgeWebTerminal(ctx context.Context, connection *websocket.Conn, client s
 			if err == io.EOF {
 				return nil
 			}
-			select {
-			case inputErr := <-inputDone:
+			if inputErr := context.Cause(streamContext); inputErr != nil {
 				if websocket.IsCloseError(inputErr, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
 					return nil
 				}
 				return inputErr
-			default:
 			}
 			return fmt.Errorf("sandboxd terminal: %w", err)
 		}

--- a/internal/controlplane/terminal_test.go
+++ b/internal/controlplane/terminal_test.go
@@ -17,6 +17,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -39,7 +40,7 @@ import (
 )
 
 func TestWebTerminalBridgesSandboxd(t *testing.T) {
-	backend := &terminalTestServer{}
+	backend := &terminalTestServer{requireHealth: true}
 	listener := bufconn.Listen(1024 * 1024)
 	grpcServer := grpc.NewServer()
 	sandboxdv1.RegisterTerminalServiceServer(grpcServer, backend)
@@ -852,16 +853,22 @@ func (d *terminalTestDialer) DialTerminal(_ context.Context, namespace, environm
 type terminalTestServer struct {
 	sandboxdv1.UnimplementedTerminalServiceServer
 	sandboxdv1.UnimplementedHealthServiceServer
-	open   *sandboxdv1.TerminalOpen
-	resize *sandboxdv1.TerminalResize
-	input  []byte
+	requireHealth bool
+	healthChecked atomic.Bool
+	open          *sandboxdv1.TerminalOpen
+	resize        *sandboxdv1.TerminalResize
+	input         []byte
 }
 
-func (*terminalTestServer) Check(context.Context, *sandboxdv1.HealthCheckRequest) (*sandboxdv1.HealthCheckResponse, error) {
+func (s *terminalTestServer) Check(context.Context, *sandboxdv1.HealthCheckRequest) (*sandboxdv1.HealthCheckResponse, error) {
+	s.healthChecked.Store(true)
 	return &sandboxdv1.HealthCheckResponse{Ok: true}, nil
 }
 
 func (s *terminalTestServer) Terminal(stream sandboxdv1.TerminalService_TerminalServer) error {
+	if s.requireHealth && !s.healthChecked.Load() {
+		return errors.New("terminal opened before health check")
+	}
 	message, err := stream.Recv()
 	if err != nil {
 		return err

--- a/internal/controlplane/terminal_test.go
+++ b/internal/controlplane/terminal_test.go
@@ -43,6 +43,7 @@ func TestWebTerminalBridgesSandboxd(t *testing.T) {
 	listener := bufconn.Listen(1024 * 1024)
 	grpcServer := grpc.NewServer()
 	sandboxdv1.RegisterTerminalServiceServer(grpcServer, backend)
+	sandboxdv1.RegisterHealthServiceServer(grpcServer, backend)
 	go func() { _ = grpcServer.Serve(listener) }()
 	t.Cleanup(grpcServer.Stop)
 
@@ -53,7 +54,10 @@ func TestWebTerminalBridgesSandboxd(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = connection.Close() })
-	dialer := &terminalTestDialer{client: sandboxdv1.NewTerminalServiceClient(connection)}
+	dialer := &terminalTestDialer{
+		client: sandboxdv1.NewTerminalServiceClient(connection),
+		health: sandboxdv1.NewHealthServiceClient(connection),
+	}
 	server := httptest.NewServer(NewServer(nil, ServerOptions{Access: &fakeAccess{}, TerminalDialer: dialer}).Handler())
 	t.Cleanup(server.Close)
 
@@ -94,6 +98,53 @@ func TestWebTerminalBridgesSandboxd(t *testing.T) {
 	}
 	if string(backend.input) != "echo hello\n" {
 		t.Fatalf("sandboxd input = %q, want echo hello", backend.input)
+	}
+}
+
+func TestBridgeWebTerminalTreatsCausalNormalClientCloseAsClean(t *testing.T) {
+	listener := bufconn.Listen(1024 * 1024)
+	grpcServer := grpc.NewServer()
+	sandboxdv1.RegisterTerminalServiceServer(grpcServer, &terminalCancelServer{})
+	go func() { _ = grpcServer.Serve(listener) }()
+	t.Cleanup(grpcServer.Stop)
+	backendConnection, err := grpc.NewClient("passthrough:///bufconn", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+		return listener.Dial()
+	}), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = backendConnection.Close() })
+
+	bridgeResult := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		connection, err := terminalUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			bridgeResult <- err
+			return
+		}
+		defer connection.Close()
+		bridgeResult <- bridgeWebTerminal(r.Context(), connection, sandboxdv1.NewTerminalServiceClient(backendConnection))
+	}))
+	t.Cleanup(server.Close)
+
+	connection, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(server.URL, "http"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = connection.Close() })
+	if err := connection.WriteJSON(terminalControl{Type: "open", Cols: 80, Rows: 24}); err != nil {
+		t.Fatal(err)
+	}
+	if err := connection.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""), time.Now().Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-bridgeResult:
+		if err != nil {
+			t.Fatalf("bridge error after normal client close = %v, want nil", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("bridge did not stop after normal client close")
 	}
 }
 
@@ -191,6 +242,50 @@ func TestWebTerminalRequiresDialer(t *testing.T) {
 	NewServer(nil, ServerOptions{Access: &fakeAccess{}}).Handler().ServeHTTP(response, request)
 	if response.Code != 503 {
 		t.Fatalf("status = %d, want 503", response.Code)
+	}
+}
+
+func TestWebTerminalChecksSandboxdHealthBeforeUpgrade(t *testing.T) {
+	checked := make(chan struct{})
+	closed := make(chan struct{})
+	dialer := &terminalTestDialer{
+		health: terminalTestHealthClient{check: func(ctx context.Context) (*sandboxdv1.HealthCheckResponse, error) {
+			defer close(checked)
+			deadline, ok := ctx.Deadline()
+			remaining := time.Until(deadline)
+			if !ok || remaining <= 0 || remaining > terminalHealthTimeout {
+				return nil, errors.New("health check has no bounded deadline")
+			}
+			return nil, errors.New("sandboxd unavailable")
+		}},
+		closer: closeFunc(func() error {
+			close(closed)
+			return nil
+		}),
+	}
+	server := httptest.NewServer(NewServer(nil, ServerOptions{Access: &fakeAccess{}, TerminalDialer: dialer}).Handler())
+	t.Cleanup(server.Close)
+
+	websocketURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/v1/namespaces/project-1/environments/env-1/terminal"
+	connection, response, err := websocket.DefaultDialer.Dial(websocketURL, http.Header{"Authorization": []string{"Bearer reader"}})
+	if connection != nil {
+		_ = connection.Close()
+	}
+	if err == nil {
+		t.Fatal("terminal upgraded despite failed sandboxd health check")
+	}
+	if response == nil || response.StatusCode != http.StatusBadGateway {
+		t.Fatalf("pre-upgrade response = %#v, want HTTP 502", response)
+	}
+	select {
+	case <-checked:
+	default:
+		t.Fatal("sandboxd health was not checked")
+	}
+	select {
+	case <-closed:
+	default:
+		t.Fatal("sandboxd connection was not closed after failed health check")
 	}
 }
 
@@ -346,7 +441,7 @@ func TestKubernetesTerminalDialerUsesRecreatedPodCredentialsAfterWake(t *testing
 	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment, template, newPod).Build()
 	dialer := KubernetesTerminalDialer{Client: wakeReadyClient{Client: baseClient, podName: newPod.Name}}
 
-	_, closer, err := dialer.DialTerminal(context.Background(), environment.Namespace, environment.Name)
+	_, _, closer, err := dialer.DialTerminal(context.Background(), environment.Namespace, environment.Name)
 	if err != nil {
 		t.Fatalf("DialTerminal() error = %v; wake did not use the recreated pod credential bundle", err)
 	}
@@ -391,7 +486,7 @@ func TestTerminalHeartbeatProtectsSlowWakeBeforeConnection(t *testing.T) {
 	wakeClient := &heartbeatWakeReadyClient{activityCountingClient: activityClient, podName: pod.Name, minimumActivityWrites: 3}
 	dialer := KubernetesTerminalDialer{Client: wakeClient}
 
-	_, closer, err := dialer.DialTerminal(context.Background(), environment.Namespace, environment.Name)
+	_, _, closer, err := dialer.DialTerminal(context.Background(), environment.Namespace, environment.Name)
 	if err != nil {
 		t.Fatalf("DialTerminal() error = %v", err)
 	}
@@ -442,7 +537,7 @@ func TestTerminalHeartbeatCancelsWhenWakeOrDialFails(t *testing.T) {
 			}
 			dialer := KubernetesTerminalDialer{Client: kubeClient}
 
-			if _, _, err := dialer.DialTerminal(context.Background(), environment.Namespace, environment.Name); err == nil {
+			if _, _, _, err := dialer.DialTerminal(context.Background(), environment.Namespace, environment.Name); err == nil {
 				t.Fatalf("DialTerminal() succeeded during %s failure", test.name)
 			}
 			writesAfterFailure := waitForActivityWritesToQuiesce(t, activityClient, 60*time.Millisecond)
@@ -719,7 +814,7 @@ func TestKubernetesTerminalDialerRejectsPodOwnedByAnotherEnvironmentIncarnation(
 	template := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "project-1"}}
 	dialer := KubernetesTerminalDialer{Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment, pod, template).Build()}
 
-	_, _, err := dialer.DialTerminal(context.Background(), "project-1", "env-1")
+	_, _, _, err := dialer.DialTerminal(context.Background(), "project-1", "env-1")
 	if err == nil || !strings.Contains(err.Error(), "not owned by the current environment") {
 		t.Fatalf("DialTerminal() error = %v, want stale pod rejection", err)
 	}
@@ -730,30 +825,40 @@ func ptrTo[T any](value T) *T { return &value }
 type terminalTestDialer struct {
 	mu          sync.Mutex
 	client      sandboxdv1.TerminalServiceClient
+	health      sandboxdv1.HealthServiceClient
 	closer      io.Closer
 	namespace   string
 	environment string
 	calls       int
 }
 
-func (d *terminalTestDialer) DialTerminal(_ context.Context, namespace, environment string) (sandboxdv1.TerminalServiceClient, io.Closer, error) {
+func (d *terminalTestDialer) DialTerminal(_ context.Context, namespace, environment string) (sandboxdv1.TerminalServiceClient, sandboxdv1.HealthServiceClient, io.Closer, error) {
 	d.mu.Lock()
 	d.calls++
 	d.namespace = namespace
 	d.environment = environment
 	d.mu.Unlock()
+	health := d.health
+	if health == nil {
+		health = terminalTestHealthClient{}
+	}
 	closer := d.closer
 	if closer == nil {
 		closer = io.NopCloser(strings.NewReader(""))
 	}
-	return d.client, closer, nil
+	return d.client, health, closer, nil
 }
 
 type terminalTestServer struct {
 	sandboxdv1.UnimplementedTerminalServiceServer
+	sandboxdv1.UnimplementedHealthServiceServer
 	open   *sandboxdv1.TerminalOpen
 	resize *sandboxdv1.TerminalResize
 	input  []byte
+}
+
+func (*terminalTestServer) Check(context.Context, *sandboxdv1.HealthCheckRequest) (*sandboxdv1.HealthCheckResponse, error) {
+	return &sandboxdv1.HealthCheckResponse{Ok: true}, nil
 }
 
 func (s *terminalTestServer) Terminal(stream sandboxdv1.TerminalService_TerminalServer) error {
@@ -773,4 +878,31 @@ func (s *terminalTestServer) Terminal(stream sandboxdv1.TerminalService_Terminal
 	}
 	s.input = append([]byte(nil), message.GetData()...)
 	return stream.Send(&sandboxdv1.TerminalMessage{Kind: &sandboxdv1.TerminalMessage_Data{Data: []byte("terminal output")}})
+}
+
+type terminalCancelServer struct {
+	sandboxdv1.UnimplementedTerminalServiceServer
+}
+
+func (*terminalCancelServer) Terminal(stream sandboxdv1.TerminalService_TerminalServer) error {
+	message, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+	if message.GetOpen() == nil {
+		return errors.New("missing terminal open")
+	}
+	<-stream.Context().Done()
+	return stream.Context().Err()
+}
+
+type terminalTestHealthClient struct {
+	check func(context.Context) (*sandboxdv1.HealthCheckResponse, error)
+}
+
+func (c terminalTestHealthClient) Check(ctx context.Context, _ *sandboxdv1.HealthCheckRequest, _ ...grpc.CallOption) (*sandboxdv1.HealthCheckResponse, error) {
+	if c.check != nil {
+		return c.check(ctx)
+	}
+	return &sandboxdv1.HealthCheckResponse{Ok: true}, nil
 }

--- a/internal/sandboxclient/credentials.go
+++ b/internal/sandboxclient/credentials.go
@@ -14,8 +14,9 @@ import (
 )
 
 // DialOptions pins the current pod incarnation's TLS identity and attaches its
-// terminal capability. The client bundle is published atomically on the Pod;
-// callers never receive the server's private credential Secret.
+// terminal token, which grants only terminal and health capabilities. The
+// client bundle is published atomically on the Pod; callers never receive the
+// server's private credential Secret.
 func DialOptions(pod *corev1.Pod) ([]grpc.DialOption, error) {
 	identity := pod.Annotations[sandboxdauth.IdentityAnnotation]
 	if identity == "" {

--- a/internal/sandboxclient/process.go
+++ b/internal/sandboxclient/process.go
@@ -32,21 +32,21 @@ type Connector struct {
 }
 
 // DialTerminal resolves the current ready Environment incarnation and returns
-// a terminal-capable sandboxd client.
-func (c Connector) DialTerminal(ctx context.Context, namespace, environment string, environmentUID types.UID) (sandboxdv1.TerminalServiceClient, func() error, error) {
+// terminal and health clients sharing one authenticated, pod-pinned connection.
+func (c Connector) DialTerminal(ctx context.Context, namespace, environment string, environmentUID types.UID) (sandboxdv1.TerminalServiceClient, sandboxdv1.HealthServiceClient, func() error, error) {
 	env, pod, err := c.resolvePod(ctx, namespace, environment, environmentUID)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	dialOptions, err := DialOptions(pod)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	conn, err := grpc.NewClient(env.Status.Endpoints.Sandboxd, dialOptions...)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	return sandboxdv1.NewTerminalServiceClient(conn), conn.Close, nil
+	return sandboxdv1.NewTerminalServiceClient(conn), sandboxdv1.NewHealthServiceClient(conn), conn.Close, nil
 }
 
 // DialProcess resolves the exact Environment UID immediately before dialing

--- a/sandboxd/internal/server/terminal.go
+++ b/sandboxd/internal/server/terminal.go
@@ -21,6 +21,7 @@ import (
 const defaultTmuxSocket = "swe-platform"
 const tmuxEnableOutputDrainCommand = "pipe-pane -t swe: 'cat >/dev/null'"
 const tmuxOutputDrainReady = "swe-output-drain-ready:"
+const tmuxSendKeysChunkBytes = 512
 
 var errTerminalUnavailable = errors.New("terminal backend unavailable")
 
@@ -312,7 +313,7 @@ func (s *tmuxTerminalSession) Read() ([]byte, error) {
 
 func (s *tmuxTerminalSession) Write(data []byte) error {
 	for len(data) > 0 {
-		n := min(len(data), 512)
+		n := min(len(data), tmuxSendKeysChunkBytes)
 		if err := s.writeCommand(sendKeysCommand(data[:n])); err != nil {
 			return err
 		}
@@ -392,6 +393,8 @@ func tmuxOutput(line string) ([]byte, bool) {
 		if i+1 < len(escaped) {
 			i++
 			data = append(data, escaped[i])
+		} else {
+			data = append(data, '\\')
 		}
 	}
 	return data, true

--- a/sandboxd/internal/server/terminal_test.go
+++ b/sandboxd/internal/server/terminal_test.go
@@ -160,10 +160,10 @@ func TestTmuxSessionEncodesBinaryInputAndResize(t *testing.T) {
 	if len(lines) != 3 {
 		t.Fatalf("control-mode commands = %d, want 3", len(lines))
 	}
-	if got := string(lines[0]); got != sendKeysCommand(input[:512]) {
+	if got := string(lines[0]); got != sendKeysCommand(input[:tmuxSendKeysChunkBytes]) {
 		t.Fatalf("first input command was not binary-safe")
 	}
-	if got := string(lines[1]); got != sendKeysCommand(input[512:]) {
+	if got := string(lines[1]); got != sendKeysCommand(input[tmuxSendKeysChunkBytes:]) {
 		t.Fatalf("second input command = %q", got)
 	}
 	if got := string(lines[2]); got != "refresh-client -C 120,40" {
@@ -205,6 +205,10 @@ func TestTmuxOutputDecodesBinaryData(t *testing.T) {
 	want := []byte{'A', 0x00, '\\', 0xff, 'Z'}
 	if !bytes.Equal(got, want) {
 		t.Fatalf("decoded output = %v, want %v", got, want)
+	}
+	got, ok = tmuxOutput("%output %0 trailing\\")
+	if !ok || string(got) != "trailing\\" {
+		t.Fatalf("decoded trailing backslash = (%q, %t), want preserved backslash", got, ok)
 	}
 	if _, ok := tmuxOutput("%begin 1 2 3"); ok {
 		t.Fatal("decoded a non-output control record")


### PR DESCRIPTION
## Summary

Re-audits every issue #30 finding against exact base `a83c84aa436f10326f206d089277823564b5efeb` instead of applying the 2025-era recommendations blindly.

This PR fixes the remaining reproducible terminal/tmux/chart items, strengthens coverage for the already-fixed Environment label scheme, and links the two contract-level deferrals to authoritative focused issues. It does not change Argo-owned files, CRDs, local docs, or CLI behavior.

Base: `a83c84aa436f10326f206d089277823564b5efeb`  
Head: `78769cae4eba8d5bea883a2665b8a4bde73dde35`

## Finding dispositions and evidence

### Controller

- **Environment name used as a label value — already fixed; coverage completed.** Current main bounds names over 63 characters and appends a deterministic 12-hex Environment-UID hash while preserving a useful name prefix; `envSelectorLabel` uses that bounded identity ([implementation](https://github.com/Chris-Cullins/swe-platform/blob/78769cae4eba8d5bea883a2665b8a4bde73dde35/internal/controllers/environment_controller.go#L1422-L1453)). This PR adds exact-63 preservation, max-length validity, and same-name/different-UID collision coverage ([test](https://github.com/Chris-Cullins/swe-platform/blob/78769cae4eba8d5bea883a2665b8a4bde73dde35/internal/controllers/environment_controller_test.go#L527-L568)).
- **PVC disk/storage-class updates — intentionally deferred to authoritative #6.** Existing PVCs remain create-only and disk size is read only during creation ([current behavior](https://github.com/Chris-Cullins/swe-platform/blob/78769cae4eba8d5bea883a2665b8a4bde73dde35/internal/controllers/environment_controller.go#L564-L602)). #6 already requires explicit provisioning mutability, PVC expansion, and rollout semantics; this PR does not invent resize, shrink, or StorageClass migration behavior.

### sandboxd

- **Filesystem `Read` permission mapping — already fixed by portable filesystem work.** `Read` routes host errors through `filesystemError`, which maps `os.ErrPermission` to `PermissionDenied` and sanitizes host paths ([mapping/call site](https://github.com/Chris-Cullins/swe-platform/blob/78769cae4eba8d5bea883a2665b8a4bde73dde35/sandboxd/internal/server/filesystem.go#L252-L271), [Read](https://github.com/Chris-Cullins/swe-platform/blob/78769cae4eba8d5bea883a2665b8a4bde73dde35/sandboxd/internal/server/filesystem.go#L327-L390), [test](https://github.com/Chris-Cullins/swe-platform/blob/78769cae4eba8d5bea883a2665b8a4bde73dde35/sandboxd/internal/server/filesystem_test.go#L336-L352)). No change needed.
- **Trailing lone tmux backslash — fixed.** The decoder now preserves the final `\\`, with a focused regression test ([implementation](https://github.com/Chris-Cullins/swe-platform/blob/78769cae4eba8d5bea883a2665b8a4bde73dde35/sandboxd/internal/server/terminal.go#L372-L400), [test](https://github.com/Chris-Cullins/swe-platform/blob/78769cae4eba8d5bea883a2665b8a4bde73dde35/sandboxd/internal/server/terminal_test.go#L200-L215)).
- **512-byte send-keys chunk — fixed without abstraction churn.** The local `tmuxSendKeysChunkBytes` constant is used by implementation and the existing boundary test ([implementation](https://github.com/Chris-Cullins/swe-platform/blob/78769cae4eba8d5bea883a2665b8a4bde73dde35/sandboxd/internal/server/terminal.go#L21-L24), [chunking](https://github.com/Chris-Cullins/swe-platform/blob/78769cae4eba8d5bea883a2665b8a4bde73dde35/sandboxd/internal/server/terminal.go#L314-L322), [test](https://github.com/Chris-Cullins/swe-platform/blob/78769cae4eba8d5bea883a2665b8a4bde73dde35/sandboxd/internal/server/terminal_test.go#L142-L172)).

### Control plane

- **Terminal disconnect classification race — fixed deterministically.** The WebSocket input reader now cancels the stream with its exact cause; `stream.Recv` classifies the causally recorded normal-close error instead of racing a non-blocking channel probe. Independent backend errors still retain the `sandboxd terminal` classification ([implementation](https://github.com/Chris-Cullins/swe-platform/blob/78769cae4eba8d5bea883a2665b8a4bde73dde35/internal/controlplane/terminal.go#L280-L352), [no-sleep regression test](https://github.com/Chris-Cullins/swe-platform/blob/78769cae4eba8d5bea883a2665b8a4bde73dde35/internal/controlplane/terminal_test.go#L104-L149)).
- **Lazy terminal dial / post-upgrade failure — fixed.** Before WebSocket upgrade, the handler performs a bounded 5-second authenticated `Health.Check` and returns HTTP 502 on failure ([handler/check](https://github.com/Chris-Cullins/swe-platform/blob/78769cae4eba8d5bea883a2665b8a4bde73dde35/internal/controlplane/terminal.go#L228-L269), [pre-upgrade test](https://github.com/Chris-Cullins/swe-platform/blob/78769cae4eba8d5bea883a2665b8a4bde73dde35/internal/controlplane/terminal_test.go#L248-L290)). Health and terminal clients share the same connection ([connector](https://github.com/Chris-Cullins/swe-platform/blob/78769cae4eba8d5bea883a2665b8a4bde73dde35/internal/sandboxclient/process.go#L34-L50)), so the check preserves current Environment UID, exact owner/Pod UID/readiness/PodIP endpoint fencing ([resolution](https://github.com/Chris-Cullins/swe-platform/blob/78769cae4eba8d5bea883a2665b8a4bde73dde35/internal/sandboxclient/process.go#L89-L115)) and pod-pinned TLS identity/bearer authentication ([dial options](https://github.com/Chris-Cullins/swe-platform/blob/78769cae4eba8d5bea883a2665b8a4bde73dde35/internal/sandboxclient/credentials.go#L16-L40)). The terminal token already grants only health + terminal capabilities ([grant](https://github.com/Chris-Cullins/swe-platform/blob/78769cae4eba8d5bea883a2665b8a4bde73dde35/internal/controllers/environment_controller.go#L911-L914)).
- **Explicit WebSocket origin decision — already fixed.** The upgrader explicitly records that origin is checked before backend dial, and the handler enforces bearer-without-Origin or exact same-origin policy before dialing ([ordering/comment](https://github.com/Chris-Cullins/swe-platform/blob/78769cae4eba8d5bea883a2665b8a4bde73dde35/internal/controlplane/terminal.go#L197-L218), [policy](https://github.com/Chris-Cullins/swe-platform/blob/78769cae4eba8d5bea883a2665b8a4bde73dde35/internal/controlplane/terminal.go#L271-L277)).
- **Global transcript `nextID` sparse per-run streams — stale/already resolved.** Current state stores `highWater` inside each `memoryRunTranscript` and increments it per Run ([state/allocation](https://github.com/Chris-Cullins/swe-platform/blob/78769cae4eba8d5bea883a2665b8a4bde73dde35/internal/controlplane/transcript.go#L117-L134), [append](https://github.com/Chris-Cullins/swe-platform/blob/78769cae4eba8d5bea883a2665b8a4bde73dde35/internal/controlplane/transcript.go#L201-L270)); the tenant test explicitly verifies another Run starts at sequence 1 ([test](https://github.com/Chris-Cullins/swe-platform/blob/78769cae4eba8d5bea883a2665b8a4bde73dde35/internal/controlplane/transcript_test.go#L94-L109)). No misleading comment added.

### Chart / CLI

- **Control-plane resources — fixed.** Base values now provide conservative `100m`/`128Mi` requests and `500m`/`512Mi` limits ([values](https://github.com/Chris-Cullins/swe-platform/blob/78769cae4eba8d5bea883a2665b8a4bde73dde35/charts/swe-platform/values.yaml#L9-L36)). The capacity-constrained kind preset overrides only the CPU request to `10m` so its single node retains warm-pool replacement headroom ([kind values](https://github.com/Chris-Cullins/swe-platform/blob/78769cae4eba8d5bea883a2665b8a4bde73dde35/charts/swe-platform/values-kind.yaml#L6-L17)); every preset renders the remaining defaults, and no Argo file changed.
- **`swe logs` transcript migration — moved to focused #57.** A direct replacement is not small or compatible: the command identifies an Environment and uses kubeconfig-authenticated Pod logs, while transcripts identify an immutable Run and remain adapter-owned/process-local. The TODO now links that scoped decision without changing behavior ([current command/TODO](https://github.com/Chris-Cullins/swe-platform/blob/78769cae4eba8d5bea883a2665b8a4bde73dde35/internal/cli/logs.go#L15-L31)). #57 constrains the follow-up to existing explicit control-plane bearer auth and forbids Environment→Run inference or a shared transcript schema.

## Changes

- Preserve lone trailing backslashes in tmux control output and name the send-keys chunk size.
- Use causal cancellation for WebSocket input termination.
- Perform bounded authenticated sandboxd health before terminal upgrade.
- Add deterministic terminal, tmux, and long-label regression coverage.
- Add conservative control-plane resources.
- Link the logs migration TODO to #57.

## Validation

- `make test`
- `make vet`
- `go test -race ./internal/controlplane -run 'TestBridgeWebTerminalTreatsCausalNormalClientCloseAsClean|TestWebTerminalChecksSandboxdHealthBeforeUpgrade|TestWebTerminalBridgesSandboxd' -count=25`
- `go test ./internal/controlplane -run 'TestBridgeWebTerminalTreatsCausalNormalClientCloseAsClean|TestWebTerminalChecksSandboxdHealthBeforeUpgrade' -count=100`
- `go test -race ./internal/server -run 'TestTmuxSessionEncodesBinaryInputAndResize|TestTmuxOutputDecodesBinaryData' -count=50` (from `sandboxd/`)
- `go test ./internal/controllers -run TestChildNamesAreBoundedAndScopedToEnvironmentUID -count=100`
- `GOOS=windows GOARCH=amd64 go test -c ./internal/server` (from `sandboxd/`)
- `make generate manifests` plus clean generated diff for `api`, `config`, and chart CRDs
- `make check-chart-crds`
- Helm lint + render for base, kind, Argo, k3s, GKE, and EKS; all render the new control-plane resources
- `git diff --check`
- Expert blocker review: approved with no merge blockers\n- Exact-head CI (`78769cae4eba8d5bea883a2665b8a4bde73dde35`): `build-test`, `sandboxd-windows`, `operations-console`, and kind E2E all passed

Closes #30.
