### PR TITLE
feat: ship Amp adapter end to end

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,8 +22,8 @@ browser sessions backed by repeated Kubernetes TokenReview/SAR authorization, an
 Run/Environment resource APIs for the console.
 Remaining gaps are marked `TODO(P0/P1/P2)` in code — most notably secure agent credential
 injection, additional agent adapters, GitHub App–scoped git tokens, and egress/portal
-networking. The first `claude-code` adapter is registered and uses sandboxd managed
-processes; tests use a fake process service and require no credentials.
+networking. The `claude-code` (default) and `amp` leaf adapters are registered and use
+sandboxd managed processes; tests use fake process services and require no credentials.
 
 ## Architecture invariants — do not violate these
 
@@ -97,6 +97,8 @@ runs both via `make` targets:
   image performs both stages in one multi-stage build.
 - **Windows portability:** CI runs focused sandboxd process, Exec, and filesystem tests
   on `windows-latest`; keep OS-specific tests behind build tags.
+- **Amp image portability:** CI builds the locked Amp CLI image stage and runs its exact
+  version smoke under `linux/amd64` and `linux/arm64` before the multi-architecture publish path.
 - **Regenerate deepcopy:** `make generate` · **CRDs + RBAC:** `make manifests`
   (`manifests` synchronizes chart CRDs; CI fails on a diff). Use `make check-chart-crds`
   to verify the checked-in Helm CRDs independently.
@@ -115,7 +117,9 @@ runs both via `make` targets:
   the chart README. Image publish runs attach a release manifest with the chart version
   and all three image digests.
 - **E2E acceptance:** `./hack/e2e.sh` — full kind + operator + `swe run` pass with the
-  env-base image built and loaded locally (no registry credentials needed). It also verifies
+  env-base image built and loaded locally (no registry credentials needed). It runs the
+  default Claude path and an explicit fake-Amp Run through Running, terminal success,
+  adapter-owned transcript replay, and cleanup. It also verifies
   control-plane TokenReview/SAR scoping, opaque browser session exchange/logout and CSRF,
   the embedded console entry point/SPA fallback/static assets, typed Run
   list/get/create/retry/cancel, Environment get, transcript SSE, and terminal attach.
@@ -124,7 +128,8 @@ runs both via `make` targets:
   its pinned tmux with `images/env-base/tmux-control-output-drain.patch`; keep the
   source checksum and patch synchronized when upgrading tmux. Its `terminal-test`
   target runs the patched-runtime terminal regression during `hack/e2e.sh`. The image
-  also includes a version-pinned Claude Code CLI for the default adapter.
+  also includes a version-pinned Claude Code CLI for the default adapter and the npm-locked,
+  integrity-pinned Amp CLI for the optional `amp` adapter.
 - **Publish images:** pushes to `main` and `v*` tags publish multi-architecture operator
   and env-base images to GHCR via `.github/workflows/publish-images.yaml`.
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ with a reviewable diff, branch, or PR.
 > plane's WebSocket terminal endpoint connect to a shared tmux session through `sandboxd`;
 > pause/resume preserves workspace disks and runs repository resume hooks, and idle
 > environments pause automatically before terminal requests wake them. Template warm
-> pools keep unclaimed environments ready for `swe run` to claim. The first agent adapter
-> runs Claude Code through sandboxd's managed-process API. Portal proxying is not built yet.
+> pools keep unclaimed environments ready for `swe run` to claim. The `claude-code` and
+> `amp` leaf adapters run through sandboxd's managed-process API. Portal proxying is not built yet.
 > The Helm chart installs the
 > operator, control plane, and CRDs. Values presets
 > cover kind, k3s, GKE with GKE Sandbox, and EKS.
@@ -162,13 +162,23 @@ swe run --environment warm-env-1 "Fix the flaky test"
 swe cancel fix-flaky-42
 ```
 
-### Claude Code adapter
+### Agent adapters
 
 `claude-code` is the default `swe run` adapter. It starts one non-interactive `claude`
 process keyed by the immutable Run UID, observes and cancels that process through sandboxd,
 and restarts the same task identity in a fresh sandboxd epoch after an Environment resume.
-The coordinated `env-base` image includes a pinned Claude Code CLI. Custom Environment
-images must provide a compatible `claude` executable on `PATH`.
+Select Amp explicitly with `swe run --agent amp ...`; the operations console's Agent field
+accepts the same key. The coordinated `env-base` image includes pinned Claude Code and Amp
+CLIs. Custom Environment images must provide the selected `claude` or `amp` executable on
+`PATH`.
+
+Both adapters use sandboxd's retry-safe `ProcessKey{owner_id: Run UID, role: agent}` rather
+than a process-global agent session. Duplicate reconciliation and uncertain start responses
+therefore recover one execution in the current sandbox epoch. Resume starts one fresh process
+with the same Run task identity against the retained workspace. It does not continue a global
+or latest harness session.
+
+#### Claude Code
 
 The adapter runs Claude Code in print mode with stream JSON output and unattended
 permissions inside the isolated Environment. Bounded stdout/stderr chunks are forwarded as
@@ -191,6 +201,31 @@ successful result remains `Succeeded` even when its history contains permission 
 Non-success results, non-zero exits, missing executables, malformed/missing final result
 events, and permanent transcript rejection map to `Failed`. Transcript storage is currently
 process-local to one control-plane replica.
+
+#### Amp
+
+The Amp adapter runs the pinned `@ampcode/cli@0.0.1784492094-g5d18e2` once in explicit
+execute mode with `--stream-json`. The prompt is passed in Amp's documented
+`--execute=<message>` assignment form so leading flags remain prompt text. Each sandbox epoch
+creates a new Amp thread; the adapter never uses `amp last` or `amp threads continue`.
+`AMP_SKIP_UPDATE_CHECK=1` is set only on the managed Amp process.
+
+Bounded stdout and stderr are forwarded as opaque `amp.process-output` events with source
+`amp`. The events carry the execution ID, stream, absolute offset and next offset, retained
+bounds, exact gap bytes, EOF, and the opaque byte payload. A natural exit with code zero is
+successful only when the last non-empty stdout line is Amp's documented `result` record with
+subtype `success`, `is_error: false`, and the required result/session/stat fields. Documented
+`error_during_execution` and `error_max_turns` results, malformed or missing terminal records,
+non-zero or non-natural exits, start failures, absent process records, and permanent transcript
+rejection map to `Failed`.
+
+Real Amp runs require `AMP_API_KEY`, but this repository does not inject it, mount personal Amp
+settings, or treat ambient Project Secrets as adapter credential delivery. Secure, Run-scoped
+delivery remains owned by issue #9; until it lands, the real Amp adapter has an unmet runtime
+credential prerequisite. Unit tests and kind acceptance use a deterministic repository-local
+fake `amp` executable and require no credential or network access. Never put a credential in a
+Run prompt. Cancellation stops the local Run-owned process tree; Amp's public contract does not
+guarantee that abruptly killing the CLI also stops remote work already dispatched by that CLI.
 
 `--name` is the create idempotency key: retry an uncertain request with the same name and
 immutable task arguments. The CLI returns the existing Run only when its intent matches;

--- a/charts/swe-platform/README.md
+++ b/charts/swe-platform/README.md
@@ -31,6 +31,14 @@ Each image publish run emits a `swe-platform-release-*` artifact containing the 
 version, app version, and the registry digest of every image for incident diagnosis and
 digest-pinned installation overrides.
 
+The published `env-base` image includes the pinned CLIs for the default `claude-code`
+adapter and the optional `amp` adapter. Select Amp with `swe run --agent amp ...` or enter
+`amp` in the operations console's Agent field. The chart and adapters do not inject agent
+provider credentials or mount personal harness settings. In particular, real Amp execution
+requires `AMP_API_KEY`, but secure Run-scoped delivery remains blocked on issue #9; ambient
+Project Secret exposure is not the credential solution. Kind acceptance uses a deterministic
+fake `amp` from its test repository and needs neither a credential nor network access.
+
 | Preset | Assumptions |
 |---|---|
 | `values-kind.yaml` | Local kind development with `:dev` images; explicitly permits insecure HTTP browser sessions. |

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -17,6 +17,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
+	"github.com/Chris-Cullins/swe-platform/internal/adapters/amp"
 	"github.com/Chris-Cullins/swe-platform/internal/adapters/claudecode"
 	"github.com/Chris-Cullins/swe-platform/internal/controllers"
 	"github.com/Chris-Cullins/swe-platform/internal/transcriptclient"
@@ -127,5 +128,8 @@ func main() {
 }
 
 func registeredAdapters() map[string]controllers.AdapterLifecycle {
-	return map[string]controllers.AdapterLifecycle{"claude-code": &claudecode.Adapter{}}
+	return map[string]controllers.AdapterLifecycle{
+		"amp":         &amp.Adapter{},
+		"claude-code": &claudecode.Adapter{},
+	}
 }

--- a/cmd/operator/main_test.go
+++ b/cmd/operator/main_test.go
@@ -2,8 +2,10 @@ package main
 
 import "testing"
 
-func TestDefaultClaudeCodeAdapterIsRegistered(t *testing.T) {
-	if registeredAdapters()["claude-code"] == nil {
-		t.Fatal("claude-code adapter is not registered")
+func TestAdaptersAreRegistered(t *testing.T) {
+	for _, name := range []string{"amp", "claude-code"} {
+		if registeredAdapters()[name] == nil {
+			t.Fatalf("%s adapter is not registered", name)
+		}
 	}
 }

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -369,52 +369,6 @@ for _ in $(seq 1 30); do
 	sleep 1
 done
 
-echo "==> running Amp adapter through allocation, transcript, and cleanup"
-bin/swe run "end-to-end Amp adapter smoke test" --name e2e-amp --project e2e --agent amp --wait=false
-kubectl wait --for=jsonpath='{.status.state}'=Running run/e2e-amp --timeout=3m
-kubectl wait --for=jsonpath='{.status.state}'=Succeeded run/e2e-amp --timeout=3m
-AMP_ENV_NAME=$(kubectl get run e2e-amp -o jsonpath='{.status.environmentRef.name}')
-AMP_ENV_OWNERSHIP=$(kubectl get run e2e-amp -o jsonpath='{.status.environmentRef.ownership}')
-if [[ -z "$AMP_ENV_NAME" || "$AMP_ENV_OWNERSHIP" != "Claimed" ]]; then
-	echo "FAIL: Amp Run allocation was ${AMP_ENV_NAME:-<empty>} (${AMP_ENV_OWNERSHIP:-<empty>}), expected a claimed warm Environment"
-	exit 1
-fi
-set +e
-curl --fail --silent --no-buffer --max-time 5 \
-	-H "Authorization: Bearer ${E2E_BOOTSTRAP_TOKEN}" \
-	"http://127.0.0.1:18080/api/v1/namespaces/default/runs/e2e-amp/transcript" \
-	> /tmp/swe-platform-amp-transcript.out
-AMP_TRANSCRIPT_STATUS=$?
-set -e
-if [[ "$AMP_TRANSCRIPT_STATUS" -ne 0 && "$AMP_TRANSCRIPT_STATUS" -ne 28 ]]; then
-	echo "FAIL: Amp transcript request exited ${AMP_TRANSCRIPT_STATUS}"
-	exit 1
-fi
-if ! grep -Fq '"source":"amp"' /tmp/swe-platform-amp-transcript.out || \
-	! grep -Fq '"type":"amp.process-output"' /tmp/swe-platform-amp-transcript.out || \
-	! grep -Fq '"stream":"stdout"' /tmp/swe-platform-amp-transcript.out || \
-	! grep -Fq '"stream":"stderr"' /tmp/swe-platform-amp-transcript.out; then
-	echo "FAIL: Amp stdout/stderr adapter-owned transcript events were not replayed"
-	cat /tmp/swe-platform-amp-transcript.out
-	exit 1
-fi
-for _ in $(seq 1 60); do
-	AMP_CLAIM_UID=$(kubectl get environment "$AMP_ENV_NAME" -o jsonpath='{.status.claimedBy.uid}' 2>/dev/null || true)
-	if [[ -z "$AMP_CLAIM_UID" ]]; then
-		break
-	fi
-	sleep 1
-done
-if [[ -n "${AMP_CLAIM_UID:-}" ]]; then
-	echo "FAIL: terminal Amp Run did not release its Environment claim"
-	exit 1
-fi
-kubectl delete run e2e-amp --wait=true >/dev/null
-if ! kubectl get environment "$AMP_ENV_NAME" >/dev/null 2>&1; then
-	echo "FAIL: deleting the Amp Run removed its claimed Environment"
-	exit 1
-fi
-
 echo "==> verifying embedded operations console through the control-plane Service"
 ROOT_STATUS=$(curl --silent --dump-header /tmp/swe-platform-console-root.headers \
 	--output /tmp/swe-platform-console-root.html --write-out '%{http_code}' \
@@ -687,5 +641,51 @@ fi
 
 echo "==> sandboxd logs from the environment pod"
 kubectl logs "$POD_NAME" -c environment | head -3
+
+echo "==> running Amp adapter through allocation, transcript, and cleanup"
+bin/swe run "end-to-end Amp adapter smoke test" --name e2e-amp --project e2e --agent amp --wait=false
+kubectl wait --for=jsonpath='{.status.state}'=Running run/e2e-amp --timeout=3m
+kubectl wait --for=jsonpath='{.status.state}'=Succeeded run/e2e-amp --timeout=3m
+AMP_ENV_NAME=$(kubectl get run e2e-amp -o jsonpath='{.status.environmentRef.name}')
+AMP_ENV_OWNERSHIP=$(kubectl get run e2e-amp -o jsonpath='{.status.environmentRef.ownership}')
+if [[ -z "$AMP_ENV_NAME" || "$AMP_ENV_OWNERSHIP" != "Claimed" ]]; then
+	echo "FAIL: Amp Run allocation was ${AMP_ENV_NAME:-<empty>} (${AMP_ENV_OWNERSHIP:-<empty>}), expected a claimed warm Environment"
+	exit 1
+fi
+set +e
+curl --fail --silent --no-buffer --max-time 5 \
+	-H "Authorization: Bearer ${E2E_BOOTSTRAP_TOKEN}" \
+	"http://127.0.0.1:18080/api/v1/namespaces/default/runs/e2e-amp/transcript" \
+	> /tmp/swe-platform-amp-transcript.out
+AMP_TRANSCRIPT_STATUS=$?
+set -e
+if [[ "$AMP_TRANSCRIPT_STATUS" -ne 0 && "$AMP_TRANSCRIPT_STATUS" -ne 28 ]]; then
+	echo "FAIL: Amp transcript request exited ${AMP_TRANSCRIPT_STATUS}"
+	exit 1
+fi
+if ! grep -Fq '"source":"amp"' /tmp/swe-platform-amp-transcript.out || \
+	! grep -Fq '"type":"amp.process-output"' /tmp/swe-platform-amp-transcript.out || \
+	! grep -Fq '"stream":"stdout"' /tmp/swe-platform-amp-transcript.out || \
+	! grep -Fq '"stream":"stderr"' /tmp/swe-platform-amp-transcript.out; then
+	echo "FAIL: Amp stdout/stderr adapter-owned transcript events were not replayed"
+	cat /tmp/swe-platform-amp-transcript.out
+	exit 1
+fi
+for _ in $(seq 1 60); do
+	AMP_CLAIM_UID=$(kubectl get environment "$AMP_ENV_NAME" -o jsonpath='{.status.claimedBy.uid}' 2>/dev/null || true)
+	if [[ -z "$AMP_CLAIM_UID" ]]; then
+		break
+	fi
+	sleep 1
+done
+if [[ -n "${AMP_CLAIM_UID:-}" ]]; then
+	echo "FAIL: terminal Amp Run did not release its Environment claim"
+	exit 1
+fi
+kubectl delete run e2e-amp --wait=true >/dev/null
+if ! kubectl get environment "$AMP_ENV_NAME" >/dev/null 2>&1; then
+	echo "FAIL: deleting the Amp Run removed its claimed Environment"
+	exit 1
+fi
 
 echo "E2E OK"

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -17,6 +17,7 @@ PORT_FORWARD_PID=""
 WEB_TERMINAL_CLIENT=""
 PROJECT_REPO=""
 PROJECT_WORKTREE=""
+AMP_CLI_BUILDER=""
 
 cleanup() {
 	if [[ -n "$PORT_FORWARD_PID" ]]; then
@@ -32,6 +33,9 @@ cleanup() {
 	if [[ -n "$PROJECT_WORKTREE" ]]; then
 		rm -rf "$PROJECT_WORKTREE"
 	fi
+	if [[ -n "$AMP_CLI_BUILDER" ]]; then
+		docker buildx rm "$AMP_CLI_BUILDER" >/dev/null 2>&1 || true
+	fi
 	if [[ "${KEEP_CLUSTER:-false}" != "true" ]]; then
 		kind delete cluster --name "$CLUSTER" >/dev/null 2>&1 || true
 	fi
@@ -46,6 +50,18 @@ make build
 echo "==> creating kind cluster '$CLUSTER'"
 kind delete cluster --name "$CLUSTER" >/dev/null 2>&1 || true
 kind create cluster --name "$CLUSTER"
+
+echo "==> verifying pinned Amp CLI for linux/amd64 and linux/arm64"
+docker run --privileged --rm \
+	tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0 \
+	--install arm64 >/dev/null
+AMP_CLI_BUILDER="swe-e2e-amp-cli-${GITHUB_RUN_ID:-$$}-${RANDOM}"
+docker buildx create --name "$AMP_CLI_BUILDER" --driver docker-container >/dev/null
+docker buildx build --builder "$AMP_CLI_BUILDER" \
+	--platform linux/amd64,linux/arm64 --target amp-cli \
+	-f images/env-base/Dockerfile . >/dev/null
+docker buildx rm "$AMP_CLI_BUILDER" >/dev/null
+AMP_CLI_BUILDER=""
 
 echo "==> building platform images"
 make docker-build >/dev/null
@@ -98,8 +114,20 @@ printf '%s\n' '{"type":"system","subtype":"init","session_id":"fake-e2e"}'
 sleep 5
 printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"result":"fake Claude Code completed"}'
 EOF
-chmod +x "$PROJECT_WORKTREE/bin/claude"
-git -C "$PROJECT_WORKTREE" add .agents/setup .agents/resume bin/claude
+cat > "$PROJECT_WORKTREE/bin/amp" <<'EOF'
+#!/bin/sh
+if [ "$#" -ne 2 ] || [ "$1" != "--stream-json" ] || [ "$2" != "--execute=end-to-end Amp adapter smoke test" ] || [ "$AMP_SKIP_UPDATE_CHECK" != "1" ]; then
+	printf '%s\n' "unexpected fake Amp invocation: $*" >&2
+	exit 2
+fi
+printf '%s\n' '{"type":"system","subtype":"init","cwd":"/workspace","session_id":"T-fake-amp-e2e","tools":[],"mcp_servers":[]}'
+printf '%s\n' 'fake Amp stderr' >&2
+sleep 5
+printf '%s\n' '{"type":"assistant","message":{"type":"message","role":"assistant","content":[{"type":"text","text":"fake Amp completed"}],"stop_reason":"end_turn"},"parent_tool_use_id":null,"session_id":"T-fake-amp-e2e"}'
+printf '%s\n' '{"type":"result","subtype":"success","duration_ms":5000,"is_error":false,"num_turns":1,"result":"fake Amp completed","session_id":"T-fake-amp-e2e"}'
+EOF
+chmod +x "$PROJECT_WORKTREE/bin/claude" "$PROJECT_WORKTREE/bin/amp"
+git -C "$PROJECT_WORKTREE" add .agents/setup .agents/resume bin/claude bin/amp
 git -C "$PROJECT_WORKTREE" commit -m "Add e2e lifecycle hooks" >/dev/null
 git -C "$PROJECT_WORKTREE" bundle create "$PROJECT_REPO/repo.bundle" main
 kubectl create configmap e2e-git-repo --from-file="$PROJECT_REPO/repo.bundle"
@@ -340,6 +368,52 @@ for _ in $(seq 1 30); do
 	fi
 	sleep 1
 done
+
+echo "==> running Amp adapter through allocation, transcript, and cleanup"
+bin/swe run "end-to-end Amp adapter smoke test" --name e2e-amp --project e2e --agent amp --wait=false
+kubectl wait --for=jsonpath='{.status.state}'=Running run/e2e-amp --timeout=3m
+kubectl wait --for=jsonpath='{.status.state}'=Succeeded run/e2e-amp --timeout=3m
+AMP_ENV_NAME=$(kubectl get run e2e-amp -o jsonpath='{.status.environmentRef.name}')
+AMP_ENV_OWNERSHIP=$(kubectl get run e2e-amp -o jsonpath='{.status.environmentRef.ownership}')
+if [[ -z "$AMP_ENV_NAME" || "$AMP_ENV_OWNERSHIP" != "Claimed" ]]; then
+	echo "FAIL: Amp Run allocation was ${AMP_ENV_NAME:-<empty>} (${AMP_ENV_OWNERSHIP:-<empty>}), expected a claimed warm Environment"
+	exit 1
+fi
+set +e
+curl --fail --silent --no-buffer --max-time 5 \
+	-H "Authorization: Bearer ${E2E_BOOTSTRAP_TOKEN}" \
+	"http://127.0.0.1:18080/api/v1/namespaces/default/runs/e2e-amp/transcript" \
+	> /tmp/swe-platform-amp-transcript.out
+AMP_TRANSCRIPT_STATUS=$?
+set -e
+if [[ "$AMP_TRANSCRIPT_STATUS" -ne 0 && "$AMP_TRANSCRIPT_STATUS" -ne 28 ]]; then
+	echo "FAIL: Amp transcript request exited ${AMP_TRANSCRIPT_STATUS}"
+	exit 1
+fi
+if ! grep -Fq '"source":"amp"' /tmp/swe-platform-amp-transcript.out || \
+	! grep -Fq '"type":"amp.process-output"' /tmp/swe-platform-amp-transcript.out || \
+	! grep -Fq '"stream":"stdout"' /tmp/swe-platform-amp-transcript.out || \
+	! grep -Fq '"stream":"stderr"' /tmp/swe-platform-amp-transcript.out; then
+	echo "FAIL: Amp stdout/stderr adapter-owned transcript events were not replayed"
+	cat /tmp/swe-platform-amp-transcript.out
+	exit 1
+fi
+for _ in $(seq 1 60); do
+	AMP_CLAIM_UID=$(kubectl get environment "$AMP_ENV_NAME" -o jsonpath='{.status.claimedBy.uid}' 2>/dev/null || true)
+	if [[ -z "$AMP_CLAIM_UID" ]]; then
+		break
+	fi
+	sleep 1
+done
+if [[ -n "${AMP_CLAIM_UID:-}" ]]; then
+	echo "FAIL: terminal Amp Run did not release its Environment claim"
+	exit 1
+fi
+kubectl delete run e2e-amp --wait=true >/dev/null
+if ! kubectl get environment "$AMP_ENV_NAME" >/dev/null 2>&1; then
+	echo "FAIL: deleting the Amp Run removed its claimed Environment"
+	exit 1
+fi
 
 echo "==> verifying embedded operations console through the control-plane Service"
 ROOT_STATUS=$(curl --silent --dump-header /tmp/swe-platform-console-root.headers \

--- a/images/env-base/Dockerfile
+++ b/images/env-base/Dockerfile
@@ -35,6 +35,12 @@ FROM node:24-bookworm-slim AS claude-code
 ARG CLAUDE_CODE_VERSION=2.1.215
 RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
 
+FROM node:24-bookworm-slim AS amp-cli
+WORKDIR /opt/amp
+COPY images/env-base/amp/package.json images/env-base/amp/package-lock.json ./
+RUN npm ci --no-audit --no-fund \
+	&& test "$(AMP_SKIP_UPDATE_CHECK=1 ./node_modules/.bin/amp --version | cut -d' ' -f1)" = '0.0.1784492094-g5d18e2'
+
 # Base image for environments.
 FROM debian:12-slim AS environment
 
@@ -50,7 +56,9 @@ COPY --from=build /out/sandboxd /usr/local/bin/sandboxd
 COPY --from=tmux-build /src/tmux /usr/bin/tmux
 COPY --from=claude-code /usr/local/lib/node_modules/@anthropic-ai /usr/local/lib/node_modules/@anthropic-ai
 COPY --from=claude-code /usr/local/bin/claude /usr/local/bin/claude
-RUN claude --version
+COPY --from=amp-cli /opt/amp/node_modules/@ampcode/cli/bin/amp.exe /usr/local/bin/amp
+RUN claude --version \
+	&& test "$(AMP_SKIP_UPDATE_CHECK=1 amp --version | cut -d' ' -f1)" = '0.0.1784492094-g5d18e2'
 
 USER swe
 WORKDIR /workspace

--- a/images/env-base/amp/package-lock.json
+++ b/images/env-base/amp/package-lock.json
@@ -1,0 +1,101 @@
+{
+  "name": "swe-platform-env-base-amp",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "swe-platform-env-base-amp",
+      "dependencies": {
+        "@ampcode/cli": "0.0.1784492094-g5d18e2"
+      }
+    },
+    "node_modules/@ampcode/cli": {
+      "version": "0.0.1784492094-g5d18e2",
+      "resolved": "https://registry.npmjs.org/@ampcode/cli/-/cli-0.0.1784492094-g5d18e2.tgz",
+      "integrity": "sha512-uLTXtnFeA5ZNHe55NFuvFUS9q3o46hM8njiIF7CInzlrT+xhWnR6RcoFTjCqF6ZtXbJl2anQeK2LDpJpN1UvbQ==",
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "bin": {
+        "amp": "bin/amp.exe"
+      },
+      "optionalDependencies": {
+        "@ampcode/cli-darwin-arm64": "0.0.1784492094-g5d18e2",
+        "@ampcode/cli-darwin-x64": "0.0.1784492094-g5d18e2",
+        "@ampcode/cli-linux-arm64": "0.0.1784492094-g5d18e2",
+        "@ampcode/cli-linux-x64": "0.0.1784492094-g5d18e2",
+        "@ampcode/cli-win32-x64": "0.0.1784492094-g5d18e2"
+      }
+    },
+    "node_modules/@ampcode/cli-darwin-arm64": {
+      "version": "0.0.1784492094-g5d18e2",
+      "resolved": "https://registry.npmjs.org/@ampcode/cli-darwin-arm64/-/cli-darwin-arm64-0.0.1784492094-g5d18e2.tgz",
+      "integrity": "sha512-iA4BPzQF6qtLJsy6UCFTWt/Xddv+PfAw35WeK1Xejxa2zibk0qorIwqQo0+qium0HdiLIfnmeq8CCeBIcL27kg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@ampcode/cli-darwin-x64": {
+      "version": "0.0.1784492094-g5d18e2",
+      "resolved": "https://registry.npmjs.org/@ampcode/cli-darwin-x64/-/cli-darwin-x64-0.0.1784492094-g5d18e2.tgz",
+      "integrity": "sha512-kF1khtyoGTMMpKhElKbyFWjAgetbfp2aQ4MoJ3hRg4H1OkQDDqa3YjZKXZMgPIwMd72g78wXW4m2OBRzbOwDTg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@ampcode/cli-linux-arm64": {
+      "version": "0.0.1784492094-g5d18e2",
+      "resolved": "https://registry.npmjs.org/@ampcode/cli-linux-arm64/-/cli-linux-arm64-0.0.1784492094-g5d18e2.tgz",
+      "integrity": "sha512-URIOwVZ6XI1fe/iH0xTAVi7KQ16xUKFlyF++fv4x8aCNKQhhR4v01RuAs4ePp8Trqt3vckLkaAPmYQY0eMkUaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ampcode/cli-linux-x64": {
+      "version": "0.0.1784492094-g5d18e2",
+      "resolved": "https://registry.npmjs.org/@ampcode/cli-linux-x64/-/cli-linux-x64-0.0.1784492094-g5d18e2.tgz",
+      "integrity": "sha512-63OLnzbYy7iZhHcw1TaEaTOcdr18XouL2RtxLTH9T8BBGOvnFVMxBTHQzl3H4sQj2X5NVnxVEsLFvODBfJD4yg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@ampcode/cli-win32-x64": {
+      "version": "0.0.1784492094-g5d18e2",
+      "resolved": "https://registry.npmjs.org/@ampcode/cli-win32-x64/-/cli-win32-x64-0.0.1784492094-g5d18e2.tgz",
+      "integrity": "sha512-WmywQ1kv+kpNUAds27+jInoBEwYuEhKeO4b495XLm0AOKle/LOXKz9Eo5a+TRQ3kxlnWsuXThgtR3Cj/iuFudQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    }
+  }
+}

--- a/images/env-base/amp/package.json
+++ b/images/env-base/amp/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "swe-platform-env-base-amp",
+  "private": true,
+  "dependencies": {
+    "@ampcode/cli": "0.0.1784492094-g5d18e2"
+  }
+}

--- a/internal/adapters/amp/adapter.go
+++ b/internal/adapters/amp/adapter.go
@@ -1,0 +1,220 @@
+// Package amp implements the Amp CLI foreground-process adapter.
+package amp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/Chris-Cullins/swe-platform/internal/adapters/processoutput"
+	"github.com/Chris-Cullins/swe-platform/internal/controllers"
+	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
+)
+
+const processRole = "agent"
+
+// Adapter drives one new, non-interactive Amp thread per Run UID and sandbox
+// epoch. It never selects or continues a global/latest Amp thread.
+type Adapter struct {
+	Executable string
+
+	output processoutput.Forwarder
+}
+
+type resultEvent struct {
+	Type       string   `json:"type"`
+	Subtype    string   `json:"subtype"`
+	DurationMS *float64 `json:"duration_ms"`
+	IsError    *bool    `json:"is_error"`
+	NumTurns   *float64 `json:"num_turns"`
+	Result     *string  `json:"result"`
+	Error      *string  `json:"error"`
+	SessionID  string   `json:"session_id"`
+}
+
+func (a *Adapter) executable() string {
+	if a.Executable != "" {
+		return a.Executable
+	}
+	return "amp"
+}
+
+func processKey(task controllers.AdapterTask) *sandboxdv1.ProcessKey {
+	return &sandboxdv1.ProcessKey{OwnerId: task.ID, Role: processRole}
+}
+
+func (a *Adapter) processSpec(task controllers.AdapterTask) *sandboxdv1.ProcessSpec {
+	return &sandboxdv1.ProcessSpec{
+		// The pinned CLI declares --execute's message as an optional option
+		// argument. Its separate-argv form treats a leading flag as another
+		// option, so assignment form is required to preserve arbitrary prompts.
+		Argv:    []string{a.executable(), "--stream-json", "--execute=" + task.Prompt},
+		Env:     map[string]string{"AMP_SKIP_UPDATE_CHECK": "1"},
+		EnvMode: sandboxdv1.EnvironmentMode_ENVIRONMENT_MODE_INHERIT,
+	}
+}
+
+// EnsureAccepted duplicate-safely starts (or recovers) this Run-keyed Amp
+// process in the current sandbox epoch.
+func (a *Adapter) EnsureAccepted(ctx context.Context, task controllers.AdapterTask, sandbox controllers.AdapterSandbox) error {
+	client, closeConnection, err := sandbox.DialProcess(ctx)
+	if err != nil {
+		return err
+	}
+	defer closeConnection()
+	_, err = client.Start(ctx, &sandboxdv1.StartProcessRequest{Key: processKey(task), Spec: a.processSpec(task)})
+	return err
+}
+
+// Observe forwards opaque process output and combines sandboxd's terminal
+// process state with Amp's documented final stream JSON result record.
+func (a *Adapter) Observe(ctx context.Context, task controllers.AdapterTask, sandbox controllers.AdapterSandbox) (controllers.AdapterObservation, string, error) {
+	client, closeConnection, err := sandbox.DialProcess(ctx)
+	if err != nil {
+		return "", "", err
+	}
+	defer closeConnection()
+	process, err := client.Get(ctx, &sandboxdv1.GetProcessRequest{Key: processKey(task)})
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return controllers.AdapterObservationFailed, "Amp execution is absent in the current sandbox epoch", nil
+		}
+		return "", "", err
+	}
+	if process.ExecutionId == "" {
+		return controllers.AdapterObservationFailed, "Amp process record is missing its execution ID", nil
+	}
+	if err := a.output.Forward(ctx, client, processKey(task), sandbox, process, "amp", "amp.process-output"); err != nil {
+		if errors.Is(err, controllers.ErrAdapterEventRejected) {
+			return controllers.AdapterObservationFailed, "Amp transcript output was permanently rejected", nil
+		}
+		return "", "", err
+	}
+
+	switch process.State {
+	case sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, sandboxdv1.ProcessState_PROCESS_STATE_STOPPING:
+		return controllers.AdapterObservationRunning, "Amp is running", nil
+	case sandboxdv1.ProcessState_PROCESS_STATE_FAILED:
+		return controllers.AdapterObservationFailed, processMessage("Amp failed to start", process.Error), nil
+	case sandboxdv1.ProcessState_PROCESS_STATE_EXITED:
+		if process.ExitCode == nil {
+			return controllers.AdapterObservationFailed, "Amp exited without an exit code", nil
+		}
+		if process.Reason != sandboxdv1.TerminationReason_TERMINATION_REASON_EXITED {
+			return controllers.AdapterObservationFailed, fmt.Sprintf("Amp process ended with termination reason %s", process.Reason), nil
+		}
+		if process.GetExitCode() != 0 {
+			return controllers.AdapterObservationFailed, fmt.Sprintf("Amp exited with code %d", process.GetExitCode()), nil
+		}
+		output, err := processoutput.ReadRetained(ctx, client, processKey(task), process.ExecutionId, sandboxdv1.OutputStream_OUTPUT_STREAM_STDOUT)
+		if err != nil {
+			return "", "", err
+		}
+		result, err := terminalResult(output)
+		if err != nil {
+			return controllers.AdapterObservationFailed, "Amp exited without a valid terminal result record: " + err.Error(), nil
+		}
+		if result.Subtype != "success" {
+			return controllers.AdapterObservationFailed, processMessage("Amp reported "+result.Subtype, *result.Error), nil
+		}
+		return controllers.AdapterObservationSucceeded, processMessage("Amp completed", *result.Result), nil
+	default:
+		return controllers.AdapterObservationFailed, fmt.Sprintf("Amp returned invalid process state %s", process.State), nil
+	}
+}
+
+// Cancel idempotently stops only this Run UID's managed process tree. Amp's
+// public contract does not guarantee that abrupt local termination also stops
+// already-dispatched remote work.
+func (a *Adapter) Cancel(ctx context.Context, task controllers.AdapterTask, sandbox controllers.AdapterSandbox) error {
+	client, closeConnection, err := sandbox.DialProcess(ctx)
+	if err != nil {
+		return err
+	}
+	defer closeConnection()
+	process, err := client.Stop(ctx, &sandboxdv1.StopProcessRequest{
+		Key:           processKey(task),
+		Mode:          sandboxdv1.StopMode_STOP_MODE_GRACEFUL,
+		GracePeriodMs: 10_000,
+	})
+	if err != nil {
+		return err
+	}
+	switch process.State {
+	case sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, sandboxdv1.ProcessState_PROCESS_STATE_STOPPING:
+		return controllers.ErrAdapterCancellationPending
+	case sandboxdv1.ProcessState_PROCESS_STATE_EXITED, sandboxdv1.ProcessState_PROCESS_STATE_FAILED:
+		err := a.output.Forward(ctx, client, processKey(task), sandbox, process, "amp", "amp.process-output")
+		if errors.Is(err, controllers.ErrAdapterEventRejected) {
+			return nil
+		}
+		return err
+	default:
+		return fmt.Errorf("Amp cancellation returned invalid process state %s", process.State)
+	}
+}
+
+func terminalResult(output []byte) (resultEvent, error) {
+	var line []byte
+	lines := bytes.Split(output, []byte("\n"))
+	for index := len(lines) - 1; index >= 0; index-- {
+		if candidate := bytes.TrimSpace(lines[index]); len(candidate) != 0 {
+			line = candidate
+			break
+		}
+	}
+	if len(line) == 0 {
+		return resultEvent{}, errors.New("stdout has no records")
+	}
+
+	var result resultEvent
+	if err := json.Unmarshal(line, &result); err != nil {
+		return resultEvent{}, errors.New("last stdout record is malformed JSON")
+	}
+	if result.Type != "result" {
+		return resultEvent{}, fmt.Errorf("last stdout record has type %q, not result", result.Type)
+	}
+	if result.DurationMS == nil || *result.DurationMS < 0 {
+		return resultEvent{}, errors.New("result is missing a valid duration_ms")
+	}
+	if result.NumTurns == nil || *result.NumTurns < 0 || math.Trunc(*result.NumTurns) != *result.NumTurns {
+		return resultEvent{}, errors.New("result is missing a valid num_turns")
+	}
+	if result.SessionID == "" {
+		return resultEvent{}, errors.New("result is missing session_id")
+	}
+	if result.IsError == nil {
+		return resultEvent{}, errors.New("result is missing is_error")
+	}
+
+	switch result.Subtype {
+	case "success":
+		if *result.IsError || result.Result == nil {
+			return resultEvent{}, errors.New("success result has inconsistent is_error or result")
+		}
+	case "error_during_execution", "error_max_turns":
+		if !*result.IsError || result.Error == nil {
+			return resultEvent{}, errors.New("error result has inconsistent is_error or error")
+		}
+	default:
+		return resultEvent{}, fmt.Errorf("result has unsupported subtype %q", result.Subtype)
+	}
+	return result, nil
+}
+
+func processMessage(summary, detail string) string {
+	if detail == "" {
+		return summary
+	}
+	const maxDetail = 512
+	if len(detail) > maxDetail {
+		detail = detail[:maxDetail] + "…"
+	}
+	return summary + ": " + detail
+}

--- a/internal/adapters/amp/adapter_test.go
+++ b/internal/adapters/amp/adapter_test.go
@@ -1,0 +1,406 @@
+package amp
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/Chris-Cullins/swe-platform/internal/controllers"
+	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
+)
+
+type fakeProcessClient struct {
+	process       *sandboxdv1.Process
+	stopProcess   *sandboxdv1.Process
+	stdout        []byte
+	stderr        []byte
+	stdoutStart   uint64
+	stderrStart   uint64
+	startCalls    int
+	launches      int
+	startedKey    *sandboxdv1.ProcessKey
+	startedSpec   *sandboxdv1.ProcessSpec
+	stoppedKey    *sandboxdv1.ProcessKey
+	stopMode      sandboxdv1.StopMode
+	getErr        error
+	startErr      error
+	stopErr       error
+	readErr       error
+	uncertainOnce bool
+	readRequests  []*sandboxdv1.ReadOutputRequest
+}
+
+func (f *fakeProcessClient) Start(_ context.Context, request *sandboxdv1.StartProcessRequest, _ ...grpc.CallOption) (*sandboxdv1.Process, error) {
+	f.startCalls++
+	if f.startErr != nil {
+		return nil, f.startErr
+	}
+	if f.startedKey == nil {
+		f.launches++
+		f.startedKey, f.startedSpec = request.Key, request.Spec
+		if f.process == nil {
+			f.process = &sandboxdv1.Process{Key: request.Key, Spec: request.Spec, State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution-1"}
+		}
+		if f.uncertainOnce {
+			f.uncertainOnce = false
+			return nil, status.Error(codes.Unavailable, "response lost")
+		}
+	} else if !reflect.DeepEqual(f.startedKey, request.Key) || !reflect.DeepEqual(f.startedSpec, request.Spec) {
+		return nil, status.Error(codes.FailedPrecondition, "conflicting start")
+	}
+	return f.process, nil
+}
+
+func (f *fakeProcessClient) Get(context.Context, *sandboxdv1.GetProcessRequest, ...grpc.CallOption) (*sandboxdv1.Process, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	return f.process, nil
+}
+
+func (f *fakeProcessClient) Stop(_ context.Context, request *sandboxdv1.StopProcessRequest, _ ...grpc.CallOption) (*sandboxdv1.Process, error) {
+	f.stoppedKey, f.stopMode = request.Key, request.Mode
+	if f.stopErr != nil {
+		return nil, f.stopErr
+	}
+	if f.stopProcess != nil {
+		return f.stopProcess, nil
+	}
+	if f.process != nil {
+		return f.process, nil
+	}
+	return &sandboxdv1.Process{Key: request.Key, State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED}, nil
+}
+
+func (f *fakeProcessClient) ReadOutput(_ context.Context, request *sandboxdv1.ReadOutputRequest, _ ...grpc.CallOption) (*sandboxdv1.ReadOutputResponse, error) {
+	f.readRequests = append(f.readRequests, request)
+	if f.readErr != nil {
+		return nil, f.readErr
+	}
+	data, retainedStart := f.stdout, f.stdoutStart
+	if request.Stream == sandboxdv1.OutputStream_OUTPUT_STREAM_STDERR {
+		data, retainedStart = f.stderr, f.stderrStart
+	}
+	producedEnd := retainedStart + uint64(len(data))
+	offset := request.Offset
+	gap := uint64(0)
+	if offset < retainedStart {
+		gap = retainedStart - offset
+		offset = retainedStart
+	}
+	if offset > producedEnd {
+		return nil, status.Error(codes.OutOfRange, "offset")
+	}
+	end := min(len(data), int(offset-retainedStart)+int(request.MaxBytes))
+	chunk := append([]byte(nil), data[offset-retainedStart:uint64(end)]...)
+	nextOffset := offset + uint64(len(chunk))
+	return &sandboxdv1.ReadOutputResponse{
+		Data: chunk, Offset: offset, NextOffset: nextOffset, GapBytes: gap,
+		RetainedStart: retainedStart, ProducedEnd: producedEnd, Eof: nextOffset == producedEnd,
+	}, nil
+}
+
+func sandboxFor(client sandboxdv1.ProcessServiceClient) controllers.AdapterSandbox {
+	return controllers.AdapterSandbox{
+		EnvironmentName: "environment",
+		EnvironmentUID:  "environment-uid",
+		DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
+			return client, func() error { return nil }, nil
+		},
+	}
+}
+
+func TestAcceptanceIsDuplicateSafeAcrossUncertainResponseAndFreshEpoch(t *testing.T) {
+	task := controllers.AdapterTask{ID: "run-uid", Prompt: "--fix the test\nwithout parsing flags"}
+	adapter := &Adapter{Executable: "fake-amp"}
+	firstEpoch := &fakeProcessClient{uncertainOnce: true}
+	if err := adapter.EnsureAccepted(context.Background(), task, sandboxFor(firstEpoch)); status.Code(err) != codes.Unavailable {
+		t.Fatalf("first acceptance error = %v, want uncertain Unavailable", err)
+	}
+	if err := adapter.EnsureAccepted(context.Background(), task, sandboxFor(firstEpoch)); err != nil {
+		t.Fatal(err)
+	}
+	if firstEpoch.startCalls != 2 || firstEpoch.launches != 1 {
+		t.Fatalf("start calls/launches = %d/%d, want 2/1", firstEpoch.startCalls, firstEpoch.launches)
+	}
+	if firstEpoch.startedKey.OwnerId != task.ID || firstEpoch.startedKey.Role != processRole {
+		t.Fatalf("process key = %#v", firstEpoch.startedKey)
+	}
+	wantArgv := []string{"fake-amp", "--stream-json", "--execute=" + task.Prompt}
+	if !reflect.DeepEqual(firstEpoch.startedSpec.Argv, wantArgv) {
+		t.Fatalf("argv = %#v, want %#v", firstEpoch.startedSpec.Argv, wantArgv)
+	}
+	if !reflect.DeepEqual(firstEpoch.startedSpec.Env, map[string]string{"AMP_SKIP_UPDATE_CHECK": "1"}) || firstEpoch.startedSpec.EnvMode != sandboxdv1.EnvironmentMode_ENVIRONMENT_MODE_INHERIT {
+		t.Fatalf("process environment = %#v mode %s", firstEpoch.startedSpec.Env, firstEpoch.startedSpec.EnvMode)
+	}
+	for _, argument := range firstEpoch.startedSpec.Argv {
+		if argument == "last" || argument == "continue" || argument == "threads" {
+			t.Fatalf("argv selects shared Amp thread: %#v", firstEpoch.startedSpec.Argv)
+		}
+	}
+
+	secondEpoch := &fakeProcessClient{}
+	if err := adapter.EnsureAccepted(context.Background(), task, sandboxFor(secondEpoch)); err != nil {
+		t.Fatal(err)
+	}
+	if secondEpoch.launches != 1 || secondEpoch.startedKey.OwnerId != task.ID || !reflect.DeepEqual(secondEpoch.startedSpec, firstEpoch.startedSpec) {
+		t.Fatalf("fresh epoch launch/key/spec = %d/%#v/%#v", secondEpoch.launches, secondEpoch.startedKey, secondEpoch.startedSpec)
+	}
+}
+
+func TestStartFailureIsReturned(t *testing.T) {
+	want := errors.New("start unavailable")
+	client := &fakeProcessClient{startErr: want}
+	err := (&Adapter{}).EnsureAccepted(context.Background(), controllers.AdapterTask{ID: "run"}, sandboxFor(client))
+	if !errors.Is(err, want) {
+		t.Fatalf("EnsureAccepted() error = %v, want %v", err, want)
+	}
+}
+
+func TestObservationMapping(t *testing.T) {
+	exit0, exit1 := int32(0), int32(1)
+	natural := sandboxdv1.TerminationReason_TERMINATION_REASON_EXITED
+	interrupted := sandboxdv1.TerminationReason_TERMINATION_REASON_INTERRUPTED
+	success := `{"type":"result","subtype":"success","duration_ms":12,"is_error":false,"num_turns":1,"result":"done","session_id":"T-success"}` + "\n"
+	errorExecution := `{"type":"result","subtype":"error_during_execution","duration_ms":12,"is_error":true,"num_turns":1,"error":"tool failed","session_id":"T-error"}` + "\n"
+	errorTurns := `{"type":"result","subtype":"error_max_turns","duration_ms":12,"is_error":true,"num_turns":4,"error":"turn limit","session_id":"T-error"}` + "\n"
+	tests := []struct {
+		name        string
+		process     *sandboxdv1.Process
+		stdout      string
+		want        controllers.AdapterObservation
+		messagePart string
+	}{
+		{name: "running", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "e"}, want: controllers.AdapterObservationRunning},
+		{name: "start failure", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_FAILED, Error: "executable not found", ExecutionId: "e"}, want: controllers.AdapterObservationFailed, messagePart: "failed to start"},
+		{name: "nonzero exit", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit1, Reason: natural, ExecutionId: "e"}, stdout: success, want: controllers.AdapterObservationFailed, messagePart: "code 1"},
+		{name: "incoherent termination", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, Reason: interrupted, ExecutionId: "e"}, stdout: success, want: controllers.AdapterObservationFailed, messagePart: "termination reason"},
+		{name: "success", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, Reason: natural, ExecutionId: "e"}, stdout: success, want: controllers.AdapterObservationSucceeded, messagePart: "done"},
+		{name: "execution error result", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, Reason: natural, ExecutionId: "e"}, stdout: errorExecution, want: controllers.AdapterObservationFailed, messagePart: "tool failed"},
+		{name: "max turns error result", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, Reason: natural, ExecutionId: "e"}, stdout: errorTurns, want: controllers.AdapterObservationFailed, messagePart: "turn limit"},
+		{name: "malformed terminal result", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, Reason: natural, ExecutionId: "e"}, stdout: "not-json\n", want: controllers.AdapterObservationFailed, messagePart: "malformed JSON"},
+		{name: "missing terminal result", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, Reason: natural, ExecutionId: "e"}, stdout: `{"type":"assistant"}` + "\n", want: controllers.AdapterObservationFailed, messagePart: "not result"},
+		{name: "record after result", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, Reason: natural, ExecutionId: "e"}, stdout: success + `{"type":"assistant"}` + "\n", want: controllers.AdapterObservationFailed, messagePart: "not result"},
+		{name: "missing exit code", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, Reason: natural, ExecutionId: "e"}, want: controllers.AdapterObservationFailed, messagePart: "without an exit code"},
+		{name: "invalid process state", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_UNSPECIFIED, ExecutionId: "e"}, want: controllers.AdapterObservationFailed, messagePart: "invalid process state"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := &fakeProcessClient{process: test.process, stdout: []byte(test.stdout)}
+			got, message, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandboxFor(client))
+			if err != nil || got != test.want || (test.messagePart != "" && !strings.Contains(message, test.messagePart)) {
+				t.Fatalf("Observe() = (%q, %q, %v), want %q containing %q", got, message, err, test.want, test.messagePart)
+			}
+		})
+	}
+}
+
+func TestTerminalResultRequiresDocumentedFieldsAndCoherentVariant(t *testing.T) {
+	tests := []struct {
+		name   string
+		record string
+	}{
+		{name: "no output"},
+		{name: "malformed", record: "{"},
+		{name: "missing duration", record: `{"type":"result","subtype":"success","is_error":false,"num_turns":1,"result":"done","session_id":"T"}`},
+		{name: "negative duration", record: `{"type":"result","subtype":"success","duration_ms":-1,"is_error":false,"num_turns":1,"result":"done","session_id":"T"}`},
+		{name: "fractional turns", record: `{"type":"result","subtype":"success","duration_ms":1,"is_error":false,"num_turns":1.5,"result":"done","session_id":"T"}`},
+		{name: "missing session", record: `{"type":"result","subtype":"success","duration_ms":1,"is_error":false,"num_turns":1,"result":"done"}`},
+		{name: "missing is error", record: `{"type":"result","subtype":"success","duration_ms":1,"num_turns":1,"result":"done","session_id":"T"}`},
+		{name: "success marked error", record: `{"type":"result","subtype":"success","duration_ms":1,"is_error":true,"num_turns":1,"result":"done","session_id":"T"}`},
+		{name: "success missing result", record: `{"type":"result","subtype":"success","duration_ms":1,"is_error":false,"num_turns":1,"session_id":"T"}`},
+		{name: "error missing error", record: `{"type":"result","subtype":"error_max_turns","duration_ms":1,"is_error":true,"num_turns":1,"session_id":"T"}`},
+		{name: "unknown subtype", record: `{"type":"result","subtype":"cancelled","duration_ms":1,"is_error":true,"num_turns":1,"error":"stop","session_id":"T"}`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := terminalResult([]byte(test.record)); err == nil {
+				t.Fatalf("terminalResult(%q) unexpectedly succeeded", test.record)
+			}
+		})
+	}
+}
+
+func TestUnavailableAbsentAndMissingExecution(t *testing.T) {
+	dialError := errors.New("sandbox unavailable")
+	sandbox := controllers.AdapterSandbox{DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
+		return nil, nil, dialError
+	}}
+	if err := (&Adapter{}).EnsureAccepted(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); !errors.Is(err, dialError) {
+		t.Fatalf("EnsureAccepted() error = %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		client *fakeProcessClient
+		part   string
+	}{
+		{name: "absent", client: &fakeProcessClient{getErr: status.Error(codes.NotFound, "absent")}, part: "absent"},
+		{name: "missing execution ID", client: &fakeProcessClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING}}, part: "execution ID"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, message, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandboxFor(test.client))
+			if err != nil || got != controllers.AdapterObservationFailed || !strings.Contains(message, test.part) {
+				t.Fatalf("Observe() = (%q, %q, %v)", got, message, err)
+			}
+		})
+	}
+}
+
+func TestOutputForwardingPreservesBoundsGapsOpaqueBytesAndRetryKeys(t *testing.T) {
+	client := &fakeProcessClient{
+		process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"},
+		stdout:  []byte{0xff, 0x00, 'x'}, stdoutStart: 7,
+		stderr: []byte("diagnostic"), stderrStart: 3,
+	}
+	var events []controllers.AdapterEvent
+	sandbox := sandboxFor(client)
+	sandbox.EmitEvent = func(_ context.Context, event controllers.AdapterEvent) error {
+		events = append(events, event)
+		return nil
+	}
+	adapter := &Adapter{}
+	if got, _, err := adapter.Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err != nil || got != controllers.AdapterObservationRunning {
+		t.Fatalf("Observe() = (%q, %v)", got, err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("events = %d, want stdout and stderr", len(events))
+	}
+	type payload struct {
+		ExecutionID  string `json:"executionId"`
+		Stream       string `json:"stream"`
+		Offset       uint64 `json:"offset"`
+		NextOffset   uint64 `json:"nextOffset"`
+		GapBytes     uint64 `json:"gapBytes"`
+		RetainedFrom uint64 `json:"retainedFrom"`
+		ProducedEnd  uint64 `json:"producedEnd"`
+		EOF          bool   `json:"eof"`
+		Data         []byte `json:"data"`
+	}
+	for index, event := range events {
+		if event.Source != "amp" || event.Type != "amp.process-output" || !strings.HasPrefix(event.IdempotencyKey, "v1:") {
+			t.Fatalf("event = %#v", event)
+		}
+		digest := sha256.Sum256(event.Data)
+		if !strings.HasSuffix(event.IdempotencyKey, fmt.Sprintf("%x", digest)) {
+			t.Fatalf("key %q does not address payload", event.IdempotencyKey)
+		}
+		var decoded payload
+		if err := json.Unmarshal(event.Data, &decoded); err != nil {
+			t.Fatal(err)
+		}
+		wantStart, wantData := uint64(7), []byte{0xff, 0x00, 'x'}
+		if index == 1 {
+			wantStart, wantData = 3, []byte("diagnostic")
+		}
+		if decoded.ExecutionID != "execution" || decoded.Offset != wantStart || decoded.GapBytes != wantStart || decoded.RetainedFrom != wantStart || decoded.NextOffset != wantStart+uint64(len(wantData)) || decoded.ProducedEnd != wantStart+uint64(len(wantData)) || !decoded.EOF || !reflect.DeepEqual(decoded.Data, wantData) {
+			t.Fatalf("payload = %#v, want retained start %d data %#v", decoded, wantStart, wantData)
+		}
+	}
+	for _, request := range client.readRequests {
+		if request.ExecutionId != "execution" || request.Key.OwnerId != "run" || request.Key.Role != processRole || request.MaxBytes == 0 || request.MaxBytes > 64*1024 {
+			t.Fatalf("read request = %#v", request)
+		}
+	}
+	if _, _, err := adapter.Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("same adapter replayed events: %d", len(events))
+	}
+
+	var replay []controllers.AdapterEvent
+	sandbox.EmitEvent = func(_ context.Context, event controllers.AdapterEvent) error {
+		replay = append(replay, event)
+		return nil
+	}
+	if _, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err != nil {
+		t.Fatal(err)
+	}
+	if len(replay) != 2 || replay[0].IdempotencyKey != events[0].IdempotencyKey || replay[1].IdempotencyKey != events[1].IdempotencyKey {
+		t.Fatalf("restart replay keys = %#v, original = %#v", replay, events)
+	}
+}
+
+func TestOutputFailuresAreRetryableOrTerminalAsDeclared(t *testing.T) {
+	process := &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"}
+	readFailure := errors.New("read unavailable")
+	client := &fakeProcessClient{process: process, readErr: readFailure}
+	readSandbox := sandboxFor(client)
+	readSandbox.EmitEvent = func(context.Context, controllers.AdapterEvent) error { return nil }
+	if _, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, readSandbox); !errors.Is(err, readFailure) {
+		t.Fatalf("read failure = %v", err)
+	}
+
+	client = &fakeProcessClient{process: process, stdout: []byte("output")}
+	transient := errors.New("transcript unavailable")
+	var keys []string
+	sandbox := sandboxFor(client)
+	sandbox.EmitEvent = func(_ context.Context, event controllers.AdapterEvent) error {
+		keys = append(keys, event.IdempotencyKey)
+		if len(keys) == 1 {
+			return transient
+		}
+		return nil
+	}
+	adapter := &Adapter{}
+	if _, _, err := adapter.Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); !errors.Is(err, transient) {
+		t.Fatalf("first append error = %v", err)
+	}
+	if got, _, err := adapter.Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err != nil || got != controllers.AdapterObservationRunning {
+		t.Fatalf("retry Observe() = (%q, %v)", got, err)
+	}
+	if len(keys) != 2 || keys[0] != keys[1] {
+		t.Fatalf("retry keys = %#v", keys)
+	}
+
+	sandbox.EmitEvent = func(context.Context, controllers.AdapterEvent) error {
+		return controllers.ErrAdapterEventRejected
+	}
+	got, message, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox)
+	if err != nil || got != controllers.AdapterObservationFailed || !strings.Contains(message, "permanently rejected") {
+		t.Fatalf("permanent rejection = (%q, %q, %v)", got, message, err)
+	}
+}
+
+func TestCancelStopsOnlyRunOwnedProcessAndWaitsForTerminal(t *testing.T) {
+	client := &fakeProcessClient{stopProcess: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_STOPPING, ExecutionId: "execution"}}
+	task := controllers.AdapterTask{ID: "run-uid"}
+	err := (&Adapter{}).Cancel(context.Background(), task, sandboxFor(client))
+	if !errors.Is(err, controllers.ErrAdapterCancellationPending) {
+		t.Fatalf("Cancel() error = %v", err)
+	}
+	if client.stoppedKey.OwnerId != task.ID || client.stoppedKey.Role != processRole || client.stopMode != sandboxdv1.StopMode_STOP_MODE_GRACEFUL {
+		t.Fatalf("stop = key %#v mode %s", client.stoppedKey, client.stopMode)
+	}
+}
+
+func TestTerminalCancelForwardsOutputAndIgnoresPermanentRejection(t *testing.T) {
+	exit0 := int32(0)
+	client := &fakeProcessClient{
+		stopProcess: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "execution"},
+		stdout:      []byte("terminal output"),
+	}
+	sandbox := sandboxFor(client)
+	var calls int
+	sandbox.EmitEvent = func(context.Context, controllers.AdapterEvent) error {
+		calls++
+		return controllers.ErrAdapterEventRejected
+	}
+	if err := (&Adapter{}).Cancel(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err != nil {
+		t.Fatalf("Cancel() error = %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("transcript calls = %d, want 1", calls)
+	}
+}

--- a/internal/adapters/claudecode/adapter.go
+++ b/internal/adapters/claudecode/adapter.go
@@ -4,49 +4,25 @@ package claudecode
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sync"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/Chris-Cullins/swe-platform/internal/adapters/processoutput"
 	"github.com/Chris-Cullins/swe-platform/internal/controllers"
 	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
 )
 
-const (
-	processRole   = "agent"
-	outputPageMax = 64 * 1024
-)
+const processRole = "agent"
 
 // Adapter drives one non-interactive Claude Code process per Run UID.
 type Adapter struct {
 	Executable string
 
-	mu      sync.Mutex
-	cursors map[outputCursor]uint64
-}
-
-type outputCursor struct {
-	environment string
-	owner       string
-	execution   string
-	stream      sandboxdv1.OutputStream
-}
-
-type outputEvent struct {
-	ExecutionID  string `json:"executionId"`
-	Stream       string `json:"stream"`
-	Offset       uint64 `json:"offset"`
-	NextOffset   uint64 `json:"nextOffset"`
-	GapBytes     uint64 `json:"gapBytes,omitempty"`
-	RetainedFrom uint64 `json:"retainedFrom"`
-	ProducedEnd  uint64 `json:"producedEnd"`
-	EOF          bool   `json:"eof"`
-	Data         []byte `json:"data,omitempty"`
+	output processoutput.Forwarder
 }
 
 type resultEvent struct {
@@ -109,7 +85,7 @@ func (a *Adapter) Observe(ctx context.Context, task controllers.AdapterTask, san
 		}
 		return "", "", err
 	}
-	if err := a.forwardOutput(ctx, client, task, sandbox, process); err != nil {
+	if err := a.output.Forward(ctx, client, processKey(task), sandbox, process, "claude-code", "claude-code.process-output"); err != nil {
 		if errors.Is(err, controllers.ErrAdapterEventRejected) {
 			return controllers.AdapterObservationFailed, "Claude Code transcript output was permanently rejected", nil
 		}
@@ -128,7 +104,7 @@ func (a *Adapter) Observe(ctx context.Context, task controllers.AdapterTask, san
 		if process.GetExitCode() != 0 {
 			return controllers.AdapterObservationFailed, fmt.Sprintf("Claude Code exited with code %d", process.GetExitCode()), nil
 		}
-		output, err := readRetainedOutput(ctx, client, processKey(task), process.ExecutionId, sandboxdv1.OutputStream_OUTPUT_STREAM_STDOUT)
+		output, err := processoutput.ReadRetained(ctx, client, processKey(task), process.ExecutionId, sandboxdv1.OutputStream_OUTPUT_STREAM_STDOUT)
 		if err != nil {
 			return "", "", err
 		}
@@ -167,67 +143,13 @@ func (a *Adapter) Cancel(ctx context.Context, task controllers.AdapterTask, sand
 	case sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, sandboxdv1.ProcessState_PROCESS_STATE_STOPPING:
 		return controllers.ErrAdapterCancellationPending
 	case sandboxdv1.ProcessState_PROCESS_STATE_EXITED, sandboxdv1.ProcessState_PROCESS_STATE_FAILED:
-		err := a.forwardOutput(ctx, client, task, sandbox, process)
+		err := a.output.Forward(ctx, client, processKey(task), sandbox, process, "claude-code", "claude-code.process-output")
 		if errors.Is(err, controllers.ErrAdapterEventRejected) {
 			return nil
 		}
 		return err
 	default:
 		return fmt.Errorf("Claude Code cancellation returned invalid process state %s", process.State)
-	}
-}
-
-func (a *Adapter) forwardOutput(ctx context.Context, client sandboxdv1.ProcessServiceClient, task controllers.AdapterTask, sandbox controllers.AdapterSandbox, process *sandboxdv1.Process) error {
-	if sandbox.EmitEvent == nil || process.ExecutionId == "" {
-		return nil
-	}
-	for _, stream := range []sandboxdv1.OutputStream{sandboxdv1.OutputStream_OUTPUT_STREAM_STDOUT, sandboxdv1.OutputStream_OUTPUT_STREAM_STDERR} {
-		cursor := outputCursor{environment: string(sandbox.EnvironmentUID), owner: task.ID, execution: process.ExecutionId, stream: stream}
-		offset := a.cursor(cursor)
-		for {
-			response, err := client.ReadOutput(ctx, &sandboxdv1.ReadOutputRequest{Key: processKey(task), ExecutionId: process.ExecutionId, Stream: stream, Offset: offset, MaxBytes: outputPageMax})
-			if err != nil {
-				return err
-			}
-			if len(response.Data) == 0 && response.GapBytes == 0 {
-				break
-			}
-			payload, err := json.Marshal(outputEvent{
-				ExecutionID: process.ExecutionId, Stream: streamName(stream), Offset: response.Offset,
-				NextOffset: response.NextOffset, GapBytes: response.GapBytes, RetainedFrom: response.RetainedStart,
-				ProducedEnd: response.ProducedEnd, EOF: response.Eof, Data: response.Data,
-			})
-			if err != nil {
-				return err
-			}
-			digest := sha256.Sum256(payload)
-			key := fmt.Sprintf("v1:%s:%x", streamName(stream), digest)
-			if err := sandbox.EmitEvent(ctx, controllers.AdapterEvent{Source: "claude-code", IdempotencyKey: key, Type: "claude-code.process-output", Data: payload}); err != nil {
-				return err
-			}
-			offset = response.NextOffset
-			a.setCursor(cursor, offset)
-			if response.Eof || offset >= response.ProducedEnd {
-				break
-			}
-		}
-	}
-	return nil
-}
-
-func readRetainedOutput(ctx context.Context, client sandboxdv1.ProcessServiceClient, key *sandboxdv1.ProcessKey, executionID string, stream sandboxdv1.OutputStream) ([]byte, error) {
-	var output bytes.Buffer
-	var offset uint64
-	for {
-		response, err := client.ReadOutput(ctx, &sandboxdv1.ReadOutputRequest{Key: key, ExecutionId: executionID, Stream: stream, Offset: offset, MaxBytes: outputPageMax})
-		if err != nil {
-			return nil, err
-		}
-		output.Write(response.Data)
-		offset = response.NextOffset
-		if response.Eof || offset >= response.ProducedEnd {
-			return output.Bytes(), nil
-		}
 	}
 }
 
@@ -243,13 +165,6 @@ func finalResult(output []byte) (resultEvent, bool) {
 	return result, found
 }
 
-func streamName(stream sandboxdv1.OutputStream) string {
-	if stream == sandboxdv1.OutputStream_OUTPUT_STREAM_STDERR {
-		return "stderr"
-	}
-	return "stdout"
-}
-
 func processMessage(summary, detail string) string {
 	if detail == "" {
 		return summary
@@ -259,22 +174,4 @@ func processMessage(summary, detail string) string {
 		detail = detail[:maxDetail] + "…"
 	}
 	return summary + ": " + detail
-}
-
-func (a *Adapter) cursor(key outputCursor) uint64 {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	if a.cursors == nil {
-		a.cursors = make(map[outputCursor]uint64)
-	}
-	return a.cursors[key]
-}
-
-func (a *Adapter) setCursor(key outputCursor, offset uint64) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	if a.cursors == nil {
-		a.cursors = make(map[outputCursor]uint64)
-	}
-	a.cursors[key] = offset
 }

--- a/internal/adapters/processoutput/output.go
+++ b/internal/adapters/processoutput/output.go
@@ -1,0 +1,141 @@
+// Package processoutput provides the bounded managed-process output transport
+// shared by foreground adapters. Agent argv and terminal records remain owned
+// by each adapter.
+package processoutput
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/Chris-Cullins/swe-platform/internal/controllers"
+	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
+)
+
+const outputPageMax = 64 * 1024
+
+// Forwarder emits bounded, cursor-based stdout and stderr events. Its zero
+// value is ready for use.
+type Forwarder struct {
+	mu      sync.Mutex
+	cursors map[outputCursor]uint64
+}
+
+type outputCursor struct {
+	environment string
+	owner       string
+	execution   string
+	stream      sandboxdv1.OutputStream
+}
+
+type outputEvent struct {
+	ExecutionID  string `json:"executionId"`
+	Stream       string `json:"stream"`
+	Offset       uint64 `json:"offset"`
+	NextOffset   uint64 `json:"nextOffset"`
+	GapBytes     uint64 `json:"gapBytes,omitempty"`
+	RetainedFrom uint64 `json:"retainedFrom"`
+	ProducedEnd  uint64 `json:"producedEnd"`
+	EOF          bool   `json:"eof"`
+	Data         []byte `json:"data,omitempty"`
+}
+
+// Forward reads all currently available retained output for process and emits
+// adapter-owned events. Cursors advance only after a successful append, while
+// content-addressed keys make replay after a restart idempotent.
+func (f *Forwarder) Forward(
+	ctx context.Context,
+	client sandboxdv1.ProcessServiceClient,
+	key *sandboxdv1.ProcessKey,
+	sandbox controllers.AdapterSandbox,
+	process *sandboxdv1.Process,
+	source string,
+	eventType string,
+) error {
+	if sandbox.EmitEvent == nil || process.ExecutionId == "" {
+		return nil
+	}
+	for _, stream := range []sandboxdv1.OutputStream{sandboxdv1.OutputStream_OUTPUT_STREAM_STDOUT, sandboxdv1.OutputStream_OUTPUT_STREAM_STDERR} {
+		cursor := outputCursor{environment: string(sandbox.EnvironmentUID), owner: key.OwnerId, execution: process.ExecutionId, stream: stream}
+		offset := f.cursor(cursor)
+		for {
+			response, err := client.ReadOutput(ctx, &sandboxdv1.ReadOutputRequest{
+				Key: key, ExecutionId: process.ExecutionId, Stream: stream, Offset: offset, MaxBytes: outputPageMax,
+			})
+			if err != nil {
+				return err
+			}
+			if len(response.Data) == 0 && response.GapBytes == 0 {
+				break
+			}
+			payload, err := json.Marshal(outputEvent{
+				ExecutionID: process.ExecutionId, Stream: streamName(stream), Offset: response.Offset,
+				NextOffset: response.NextOffset, GapBytes: response.GapBytes, RetainedFrom: response.RetainedStart,
+				ProducedEnd: response.ProducedEnd, EOF: response.Eof, Data: response.Data,
+			})
+			if err != nil {
+				return err
+			}
+			digest := sha256.Sum256(payload)
+			idempotencyKey := fmt.Sprintf("v1:%s:%x", streamName(stream), digest)
+			if err := sandbox.EmitEvent(ctx, controllers.AdapterEvent{
+				Source: source, IdempotencyKey: idempotencyKey, Type: eventType, Data: payload,
+			}); err != nil {
+				return err
+			}
+			offset = response.NextOffset
+			f.setCursor(cursor, offset)
+			if response.Eof || offset >= response.ProducedEnd {
+				break
+			}
+		}
+	}
+	return nil
+}
+
+// ReadRetained returns the currently retained bytes for one process stream.
+func ReadRetained(ctx context.Context, client sandboxdv1.ProcessServiceClient, key *sandboxdv1.ProcessKey, executionID string, stream sandboxdv1.OutputStream) ([]byte, error) {
+	var output bytes.Buffer
+	var offset uint64
+	for {
+		response, err := client.ReadOutput(ctx, &sandboxdv1.ReadOutputRequest{
+			Key: key, ExecutionId: executionID, Stream: stream, Offset: offset, MaxBytes: outputPageMax,
+		})
+		if err != nil {
+			return nil, err
+		}
+		output.Write(response.Data)
+		offset = response.NextOffset
+		if response.Eof || offset >= response.ProducedEnd {
+			return output.Bytes(), nil
+		}
+	}
+}
+
+func streamName(stream sandboxdv1.OutputStream) string {
+	if stream == sandboxdv1.OutputStream_OUTPUT_STREAM_STDERR {
+		return "stderr"
+	}
+	return "stdout"
+}
+
+func (f *Forwarder) cursor(key outputCursor) uint64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.cursors == nil {
+		f.cursors = make(map[outputCursor]uint64)
+	}
+	return f.cursors[key]
+}
+
+func (f *Forwarder) setCursor(key outputCursor, offset uint64) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.cursors == nil {
+		f.cursors = make(map[outputCursor]uint64)
+	}
+	f.cursors[key] = offset
+}

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -19,6 +19,13 @@ import (
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
 )
 
+func TestRunCommandKeepsClaudeCodeAsDefaultAdapter(t *testing.T) {
+	agent := newRunCommand().Flags().Lookup("agent")
+	if agent == nil || agent.DefValue != "claude-code" {
+		t.Fatalf("--agent default = %#v, want claude-code", agent)
+	}
+}
+
 func TestTerminalGatewayURL(t *testing.T) {
 	tests := []struct {
 		base string


### PR DESCRIPTION
## Summary

- register `amp` as a leaf Run adapter while keeping `claude-code` as the default
- run one unattended Amp prompt through sandboxd's Run-UID-keyed managed-process contract and require a coherent structured terminal `result`
- forward bounded stdout/stderr as opaque, gap-aware `amp.process-output` events with content-addressed retry keys
- npm-lock and install `@ampcode/cli@0.0.1784492094-g5d18e2` in env-base, with exact-version smoke coverage for linux/amd64 and linux/arm64
- exercise a second sequential kind Run with a deterministic repository-local fake `amp`

Closes #61

## Adapter contract

- process key: `ProcessKey{OwnerId: <immutable Run UID>, Role: "agent"}`
- lifecycle: managed `Start` / `Get` / `ReadOutput` / `Stop`; retry acceptance requires the same keyed process spec
- argv: `amp --stream-json --execute=<prompt>` where the entire arbitrary prompt is one assignment-form argv entry
- environment: `AMP_SKIP_UPDATE_CHECK=1`; this change does **not** inject `AMP_API_KEY`, mount personal settings, or expose ambient Project Secrets
- thread identity: no `last` or continuation command/flag; one new Amp thread per sandboxd epoch under the same Run identity
- success: natural exit 0 plus a final valid `result` record with subtype `success`; documented error result variants and incoherent/malformed/missing terminal records fail

Secure Run-scoped Amp credentials remain owned by #9, so real Amp Runs retain that prerequisite. Unit and kind acceptance require no credentials.

## Package and image evidence

- package: `@ampcode/cli@0.0.1784492094-g5d18e2`
- wrapper integrity: `sha512-uLTXtnFeA5ZNHe55NFuvFUS9q3o46hM8njiIF7CInzlrT+xhWnR6RcoFTjCqF6ZtXbJl2anQeK2LDpJpN1UvbQ==`
- exact package inspection confirmed execute/stream argv, prompt-option separation, JSONL terminal variants, stderr behavior, and exact version output
- lock contains the platform-specific linux-x64 and linux-arm64 packages
- wrapper unpacked size: 7,120 bytes; linux-x64 native package unpacked size: 111,311,608 bytes (tarball approximately 42.7 MB)
- e2e builds the Dockerfile's `amp-cli` stage under linux/amd64 and linux/arm64 using digest-pinned binfmt, then the existing native env-base/terminal image path

## Local verification

- `make test`
- `make vet`
- `make build`
- `go test -race ./internal/adapters/amp ./internal/adapters/claudecode ./internal/adapters/processoutput`
- focused adapter/operator/CLI tests
- `make generate manifests` and clean generated diff
- `make check-chart-crds`
- Helm lint/render for kind, argocd, k3s, gke, and eks presets
- `bash -n hack/e2e.sh`
- `git diff --check`

Docker is unavailable in the local orb, so the image and kind execution are intentionally delegated to exact-head PR e2e CI. A blocker-focused expert review found no blocker, including terminal parsing, prompt injection, retry/idempotency, cancellation, Claude hash compatibility, and package architecture selection.