### PR TITLE
fix(sandboxd): wipe Windows launch environment buffer

### DIFF
--- a/sandboxd/internal/server/process_windows.go
+++ b/sandboxd/internal/server/process_windows.go
@@ -111,6 +111,9 @@ func (d *processDomain) start() error {
 		env = append(env, 0)
 	}
 	env = append(env, 0)
+	// CreateProcess copies the environment block; wipe our UTF-16 copy on every
+	// return path after the final append so launch material is not retained.
+	defer func() { clear(env) }()
 	si := windows.StartupInfoEx{ProcThreadAttributeList: attrs.List()}
 	si.StartupInfo.Cb = uint32(unsafe.Sizeof(si))
 	si.StartupInfo.Flags = windows.STARTF_USESTDHANDLES


### PR DESCRIPTION
## Summary

- wipe sandboxd's final UTF-16 environment block on every Windows process-launch return path
- preserve the buffer until after CreateProcess has copied it
- close the best-effort launch-material cleanup gap found during follow-up review of #84

## Verification

- `go test ./internal/server -run LaunchMaterial -count=1`
- `go vet ./internal/server`
- `GOOS=windows GOARCH=amd64 go test -c ./internal/server`
- focused Oracle review: approve

Follow-up to #84.