### PR TITLE
feat: add Amp agent adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,8 +22,9 @@ browser sessions backed by repeated Kubernetes TokenReview/SAR authorization, an
 Run/Environment resource APIs for the console.
 Remaining gaps are marked `TODO(P0/P1/P2)` in code — most notably secure agent credential
 injection, additional agent adapters, GitHub App–scoped git tokens, and egress/portal
-networking. The first `claude-code` adapter is registered and uses sandboxd managed
-processes; tests use a fake process service and require no credentials.
+networking. The `claude-code` (default) and `amp` adapters are registered and use sandboxd
+managed processes; Amp's `AMP_API_KEY` delivery remains an unmet prerequisite and adapter
+tests use a fake process service with no credentials.
 
 ## Architecture invariants — do not violate these
 
@@ -128,7 +129,8 @@ runs both via `make` targets:
   its pinned tmux with `images/env-base/tmux-control-output-drain.patch`; keep the
   source checksum and patch synchronized when upgrading tmux. Its `terminal-test`
   target runs the patched-runtime terminal regression during `hack/e2e.sh`. The image
-  also includes a version-pinned Claude Code CLI for the default adapter.
+  also includes version-pinned Claude Code (the default adapter) and Amp CLIs. Amp image
+  installs must retain `AMP_SKIP_UPDATE_CHECK=1` and the pinned npm integrity check.
 - **Publish images:** pushes to `main` and `v*` tags publish multi-architecture operator
   and env-base images to GHCR via `.github/workflows/publish-images.yaml`.
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,26 @@ Non-success results, non-zero exits, missing executables, malformed/missing fina
 events, and permanent transcript rejection map to `Failed`. Transcript storage is currently
 process-local to one control-plane replica.
 
+### Amp adapter
+
+Select Amp explicitly with `swe run --agent amp ...`; `claude-code` remains the default.
+The coordinated environment image pins `@ampcode/cli@0.0.1784492094-g5d18e2` and disables
+its update check. The adapter starts `amp --execute=<prompt> --stream-json --no-ide
+--no-notifications` as a Run-UID-keyed sandboxd managed process. It forwards bounded,
+gap-aware stdout/stderr as opaque `amp.process-output` events and requires both an exit-zero
+process and Amp's final Claude-compatible JSONL `result` event with `subtype: "success"` and
+`is_error: false`. Consumers reconstruct each stream by its absolute offsets rather than event
+append order; an operator restart can replay an overlapping range because output cursors are
+process-local, while retrying an uncertain append within one operator process resends the exact
+same event and idempotency key.
+
+`AMP_API_KEY` is currently an unmet runtime prerequisite: secure Amp key delivery is deferred
+to issue #9. The platform does not mount user Amp configuration, add ambient credentials, or
+accept a credential profile for this adapter. Consequently the stock image cannot run Amp
+against its service without separately solving that prerequisite; tests use a fake executable.
+Abrupt cancellation stops only the Run-owned local process tree, but Amp's public contract does
+not guarantee that remote/server-backed thread work has also stopped.
+
 `--name` is the create idempotency key: retry an uncertain request with the same name and
 immutable task arguments. The CLI returns the existing Run only when its intent matches;
 the controller creates or claims the Environment server-side.

--- a/charts/swe-platform/README.md
+++ b/charts/swe-platform/README.md
@@ -1,5 +1,11 @@
 # swe-platform Helm chart
 
+The bundled environment image provides the default `claude-code` adapter and the explicitly
+selected `amp` adapter (`swe run --agent amp ...`). Amp's `AMP_API_KEY` is not injected by the
+chart or operator yet; secure runtime delivery remains deferred to issue #9. Do not place Amp
+credentials in chart values, Project configuration, or a custom image. The image only pins the
+public Amp CLI and disables its update check.
+
 This chart installs the swe-platform CRDs, operator, and the first control-plane API.
 The control plane accepts adapter-owned transcript events and streams them over SSE.
 Its bounded transcript store is currently process-local, so the chart requires one control-plane

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -17,6 +17,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
+	"github.com/Chris-Cullins/swe-platform/internal/adapters/amp"
 	"github.com/Chris-Cullins/swe-platform/internal/adapters/claudecode"
 	"github.com/Chris-Cullins/swe-platform/internal/controllers"
 	"github.com/Chris-Cullins/swe-platform/internal/transcriptclient"
@@ -128,5 +129,8 @@ func main() {
 }
 
 func registeredAdapters() map[string]controllers.AdapterLifecycle {
-	return map[string]controllers.AdapterLifecycle{"claude-code": &claudecode.Adapter{}}
+	return map[string]controllers.AdapterLifecycle{
+		"amp":         &amp.Adapter{},
+		"claude-code": &claudecode.Adapter{},
+	}
 }

--- a/cmd/operator/main_test.go
+++ b/cmd/operator/main_test.go
@@ -6,4 +6,7 @@ func TestDefaultClaudeCodeAdapterIsRegistered(t *testing.T) {
 	if registeredAdapters()["claude-code"] == nil {
 		t.Fatal("claude-code adapter is not registered")
 	}
+	if registeredAdapters()["amp"] == nil {
+		t.Fatal("amp adapter is not registered")
+	}
 }

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -106,11 +106,27 @@ sleep 5
 printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"result":"fake Claude Code completed"}'
 EOF
 chmod 0755 "$FAKE_ENV_CONTEXT/claude"
+cat > "$FAKE_ENV_CONTEXT/amp" <<'EOF'
+#!/bin/sh
+set -eu
+test "$#" -eq 4
+test "$1" = '--execute=fake Amp lifecycle smoke test'
+test "$2" = '--stream-json'
+test "$3" = '--no-ide'
+test "$4" = '--no-notifications'
+test -z "${AMP_API_KEY+x}"
+printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"fake-amp-stdout-marker"}]}}'
+printf '%s\n' 'fake-amp-stderr-marker' >&2
+sleep 5
+printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"result":"fake Amp completed"}'
+EOF
+chmod 0755 "$FAKE_ENV_CONTEXT/amp"
 cat > "$FAKE_ENV_CONTEXT/Dockerfile" <<'EOF'
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 USER root
 COPY claude /usr/local/bin/claude
+COPY amp /usr/local/bin/amp
 USER swe
 EOF
 docker build --build-arg BASE_IMAGE="$ENV_IMAGE" -t "$E2E_ENV_IMAGE" "$FAKE_ENV_CONTEXT" >/dev/null
@@ -727,6 +743,36 @@ if contains_e2e_key /tmp/swe-platform-resumed-workspace.tar; then
 	exit 1
 fi
 kubectl delete run "$RESUME_RUN_NAME" --wait=true >/dev/null
+
+echo "==> verifying fake Amp real Run lifecycle without credentials or network"
+AMP_RUN_NAME=e2e-fake-amp-run
+bin/swe run "fake Amp lifecycle smoke test" --name "$AMP_RUN_NAME" --environment "$ENV_NAME" \
+	--agent amp --wait=false
+kubectl wait --for=jsonpath='{.status.state}'=Running run/"$AMP_RUN_NAME" --timeout=3m
+kubectl wait --for=jsonpath='{.status.state}'=Succeeded run/"$AMP_RUN_NAME" --timeout=3m
+set +e
+curl --silent --no-buffer --max-time 2 \
+	-H "Authorization: Bearer ${E2E_BOOTSTRAP_TOKEN}" \
+	"http://127.0.0.1:18080/api/v1/namespaces/default/runs/${AMP_RUN_NAME}/transcript" \
+	> /tmp/swe-platform-amp-transcript.out
+AMP_TRANSCRIPT_STATUS=$?
+set -e
+if [[ "$AMP_TRANSCRIPT_STATUS" != "0" && "$AMP_TRANSCRIPT_STATUS" != "28" ]]; then
+	echo "FAIL: Amp transcript read failed with curl status ${AMP_TRANSCRIPT_STATUS}"
+	exit 1
+fi
+grep -F '"source":"amp"' /tmp/swe-platform-amp-transcript.out | \
+	grep -F '"type":"amp.process-output"' | \
+	grep -oE '"data":"[A-Za-z0-9+/=]+"' | sed 's/^"data":"//; s/"$//' | \
+	while IFS= read -r encoded; do printf '%s' "$encoded" | base64 --decode || exit 1; done \
+	> /tmp/swe-platform-amp-process-output.out
+if ! grep -Fq 'fake-amp-stdout-marker' /tmp/swe-platform-amp-process-output.out || \
+	! grep -Fq 'fake-amp-stderr-marker' /tmp/swe-platform-amp-process-output.out; then
+	echo "FAIL: Amp transcript did not retain both output stream markers"
+	cat /tmp/swe-platform-amp-process-output.out
+	exit 1
+fi
+kubectl delete run "$AMP_RUN_NAME" --wait=true >/dev/null
 
 echo "==> verifying idle pause and terminal wake through the control plane"
 PRE_IDLE_POD_UID=$(kubectl get pod "$POD_NAME" -o jsonpath='{.metadata.uid}')

--- a/images/env-base/Dockerfile
+++ b/images/env-base/Dockerfile
@@ -35,6 +35,23 @@ FROM node:24-bookworm-slim AS claude-code
 ARG CLAUDE_CODE_VERSION=2.1.215
 RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
 
+FROM node:24-bookworm-slim AS amp
+ARG AMP_VERSION=0.0.1784492094-g5d18e2
+ARG TARGETARCH
+RUN case "$TARGETARCH" in \
+		amd64) package=cli-linux-x64; integrity='sha512-63OLnzbYy7iZhHcw1TaEaTOcdr18XouL2RtxLTH9T8BBGOvnFVMxBTHQzl3H4sQj2X5NVnxVEsLFvODBfJD4yg==' ;; \
+		arm64) package=cli-linux-arm64; integrity='sha512-URIOwVZ6XI1fe/iH0xTAVi7KQ16xUKFlyF++fv4x8aCNKQhhR4v01RuAs4ePp8Trqt3vckLkaAPmYQY0eMkUaw==' ;; \
+		*) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; \
+	esac \
+	&& wrapper="$(npm pack "@ampcode/cli@${AMP_VERSION}" --silent)" \
+	&& node -e 'const [file, want] = process.argv.slice(1); const fs = require("fs"), crypto = require("crypto"); const got = "sha512-" + crypto.createHash("sha512").update(fs.readFileSync(file)).digest("base64"); if (got !== want) { throw new Error(`integrity mismatch for ${file}`) }' "$wrapper" 'sha512-uLTXtnFeA5ZNHe55NFuvFUS9q3o46hM8njiIF7CInzlrT+xhWnR6RcoFTjCqF6ZtXbJl2anQeK2LDpJpN1UvbQ==' \
+	&& archive="$(npm pack "@ampcode/${package}@${AMP_VERSION}" --silent)" \
+	&& node -e 'const [file, want] = process.argv.slice(1); const fs = require("fs"), crypto = require("crypto"); const got = "sha512-" + crypto.createHash("sha512").update(fs.readFileSync(file)).digest("base64"); if (got !== want) { throw new Error(`integrity mismatch for ${file}`) }' "$archive" "$integrity" \
+	&& tar -xzf "$archive" package/amp --strip-components=1 \
+	&& install -m 0755 amp /usr/local/bin/amp \
+	&& rm "$wrapper" "$archive" amp \
+	&& test "$(/usr/local/bin/amp --version | awk '{print $1}')" = "${AMP_VERSION}"
+
 # Base image for environments.
 FROM debian:12-slim AS environment
 
@@ -50,7 +67,10 @@ COPY --from=build /out/sandboxd /usr/local/bin/sandboxd
 COPY --from=tmux-build /src/tmux /usr/bin/tmux
 COPY --from=claude-code /usr/local/lib/node_modules/@anthropic-ai /usr/local/lib/node_modules/@anthropic-ai
 COPY --from=claude-code /usr/local/bin/claude /usr/local/bin/claude
-RUN claude --version
+COPY --from=amp /usr/local/bin/amp /usr/local/bin/amp
+ENV AMP_SKIP_UPDATE_CHECK=1
+RUN claude --version \
+	&& test "$(amp --version | awk '{print $1}')" = "0.0.1784492094-g5d18e2"
 
 USER swe
 WORKDIR /workspace

--- a/internal/adapters/amp/adapter.go
+++ b/internal/adapters/amp/adapter.go
@@ -82,7 +82,7 @@ func (a *Adapter) spec(task controllers.AdapterTask) *sandboxdv1.ProcessSpec {
 // EnsureAccepted duplicate-safely starts (or recovers) the Run-keyed process.
 func (a *Adapter) EnsureAccepted(ctx context.Context, task controllers.AdapterTask, sandbox controllers.AdapterSandbox, credential *controllers.AdapterCredential) error {
 	if credential != nil {
-		return errors.New("Amp credential delivery is not implemented; AMP_API_KEY is a runtime prerequisite")
+		return fmt.Errorf("%w: Amp credential delivery is not implemented; AMP_API_KEY is a runtime prerequisite", controllers.ErrAdapterTaskRejected)
 	}
 	client, closeConnection, err := sandbox.DialProcess(ctx)
 	if err != nil {

--- a/internal/adapters/amp/adapter.go
+++ b/internal/adapters/amp/adapter.go
@@ -1,0 +1,304 @@
+// Package amp implements the Amp foreground-process adapter.
+package amp
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/Chris-Cullins/swe-platform/internal/controllers"
+	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
+)
+
+const (
+	processRole = "agent"
+	pageMax     = 64 * 1024
+)
+
+// Adapter drives one non-interactive Amp process per Run UID.
+type Adapter struct {
+	Executable string
+	mu         sync.Mutex
+	cursors    map[cursor]uint64
+	pending    map[cursor]pendingEvent
+}
+
+type pendingEvent struct {
+	event      controllers.AdapterEvent
+	nextOffset uint64
+}
+
+type cursor struct {
+	environment, owner, execution string
+	stream                        sandboxdv1.OutputStream
+}
+
+type outputEvent struct {
+	ExecutionID  string `json:"executionId"`
+	Stream       string `json:"stream"`
+	Offset       uint64 `json:"offset"`
+	NextOffset   uint64 `json:"nextOffset"`
+	GapBytes     uint64 `json:"gapBytes,omitempty"`
+	RetainedFrom uint64 `json:"retainedFrom"`
+	ProducedEnd  uint64 `json:"producedEnd"`
+	EOF          bool   `json:"eof"`
+	Data         []byte `json:"data,omitempty"`
+}
+
+type resultEvent struct {
+	Type, Subtype string
+	IsError       *bool           `json:"is_error"`
+	Result        string          `json:"result"`
+	Error         json.RawMessage `json:"error"`
+}
+
+func (a *Adapter) executable() string {
+	if a.Executable != "" {
+		return a.Executable
+	}
+	return "amp"
+}
+
+func key(task controllers.AdapterTask) *sandboxdv1.ProcessKey {
+	return &sandboxdv1.ProcessKey{OwnerId: task.ID, Role: processRole}
+}
+
+func (a *Adapter) spec(task controllers.AdapterTask) *sandboxdv1.ProcessSpec {
+	// --execute=<prompt> is deliberately one argv element. The pinned CLI does
+	// not treat "--" after --execute as a flag terminator for a flag-like prompt.
+	return &sandboxdv1.ProcessSpec{
+		Argv: []string{a.executable(), "--execute=" + task.Prompt, "--stream-json", "--no-ide", "--no-notifications"},
+		Env:  map[string]string{"AMP_SKIP_UPDATE_CHECK": "1"}, EnvMode: sandboxdv1.EnvironmentMode_ENVIRONMENT_MODE_INHERIT,
+	}
+}
+
+// EnsureAccepted duplicate-safely starts (or recovers) the Run-keyed process.
+func (a *Adapter) EnsureAccepted(ctx context.Context, task controllers.AdapterTask, sandbox controllers.AdapterSandbox, credential *controllers.AdapterCredential) error {
+	if credential != nil {
+		return errors.New("Amp credential delivery is not implemented; AMP_API_KEY is a runtime prerequisite")
+	}
+	client, closeConnection, err := sandbox.DialProcess(ctx)
+	if err != nil {
+		return err
+	}
+	defer closeConnection()
+	_, err = client.Start(ctx, &sandboxdv1.StartProcessRequest{Key: key(task), Spec: a.spec(task)})
+	return err
+}
+
+// Observe forwards bounded process output and maps Amp's terminal result event.
+func (a *Adapter) Observe(ctx context.Context, task controllers.AdapterTask, sandbox controllers.AdapterSandbox) (controllers.AdapterObservation, string, error) {
+	client, closeConnection, err := sandbox.DialProcess(ctx)
+	if err != nil {
+		return "", "", err
+	}
+	defer closeConnection()
+	process, err := client.Get(ctx, &sandboxdv1.GetProcessRequest{Key: key(task)})
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return controllers.AdapterObservationFailed, "Amp execution is absent in the current sandbox epoch", nil
+		}
+		return "", "", err
+	}
+	if err := a.forward(ctx, client, task, sandbox, process); err != nil {
+		if errors.Is(err, controllers.ErrAdapterEventRejected) {
+			return controllers.AdapterObservationFailed, "Amp transcript output was permanently rejected", nil
+		}
+		return "", "", err
+	}
+	switch process.State {
+	case sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, sandboxdv1.ProcessState_PROCESS_STATE_STOPPING:
+		return controllers.AdapterObservationRunning, "Amp is running", nil
+	case sandboxdv1.ProcessState_PROCESS_STATE_FAILED:
+		return controllers.AdapterObservationFailed, message("Amp failed to start", process.Error), nil
+	case sandboxdv1.ProcessState_PROCESS_STATE_EXITED:
+		if process.ExitCode == nil {
+			return controllers.AdapterObservationFailed, "Amp exited without an exit code", nil
+		}
+		if process.GetExitCode() != 0 {
+			return controllers.AdapterObservationFailed, fmt.Sprintf("Amp exited with code %d", process.GetExitCode()), nil
+		}
+		output, err := readOutput(ctx, client, key(task), process.ExecutionId)
+		if err != nil {
+			return "", "", err
+		}
+		result, ok := finalResult(output)
+		if !ok {
+			return controllers.AdapterObservationFailed, "Amp exited without a valid result event", nil
+		}
+		if result.IsError == nil {
+			return controllers.AdapterObservationFailed, "Amp result is missing is_error", nil
+		}
+		if *result.IsError || result.Subtype != "success" {
+			detail := result.Result
+			if detail == "" {
+				detail = errorDetail(result.Error)
+			}
+			return controllers.AdapterObservationFailed, message("Amp reported "+result.Subtype, detail), nil
+		}
+		return controllers.AdapterObservationSucceeded, message("Amp completed", result.Result), nil
+	default:
+		return controllers.AdapterObservationFailed, fmt.Sprintf("Amp returned invalid process state %s", process.State), nil
+	}
+}
+
+// Cancel idempotently stops only this Run UID's managed process tree.
+func (a *Adapter) Cancel(ctx context.Context, task controllers.AdapterTask, sandbox controllers.AdapterSandbox) error {
+	client, closeConnection, err := sandbox.DialProcess(ctx)
+	if err != nil {
+		return err
+	}
+	defer closeConnection()
+	process, err := client.Stop(ctx, &sandboxdv1.StopProcessRequest{Key: key(task), Mode: sandboxdv1.StopMode_STOP_MODE_GRACEFUL, GracePeriodMs: 10_000})
+	if err != nil {
+		return err
+	}
+	switch process.State {
+	case sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, sandboxdv1.ProcessState_PROCESS_STATE_STOPPING:
+		return controllers.ErrAdapterCancellationPending
+	case sandboxdv1.ProcessState_PROCESS_STATE_EXITED, sandboxdv1.ProcessState_PROCESS_STATE_FAILED:
+		err := a.forward(ctx, client, task, sandbox, process)
+		if errors.Is(err, controllers.ErrAdapterEventRejected) {
+			return nil
+		}
+		return err
+	default:
+		return fmt.Errorf("Amp cancellation returned invalid process state %s", process.State)
+	}
+}
+
+func (a *Adapter) forward(ctx context.Context, client sandboxdv1.ProcessServiceClient, task controllers.AdapterTask, sandbox controllers.AdapterSandbox, process *sandboxdv1.Process) error {
+	if sandbox.EmitEvent == nil || process.ExecutionId == "" {
+		return nil
+	}
+	for _, stream := range []sandboxdv1.OutputStream{sandboxdv1.OutputStream_OUTPUT_STREAM_STDOUT, sandboxdv1.OutputStream_OUTPUT_STREAM_STDERR} {
+		c := cursor{string(sandbox.EnvironmentUID), task.ID, process.ExecutionId, stream}
+		offset := a.getCursor(c)
+		for {
+			if pending, ok := a.getPending(c); ok {
+				if err := sandbox.EmitEvent(ctx, pending.event); err != nil {
+					return err
+				}
+				offset = pending.nextOffset
+				a.commitPending(c, offset)
+				continue
+			}
+			response, err := client.ReadOutput(ctx, &sandboxdv1.ReadOutputRequest{Key: key(task), ExecutionId: process.ExecutionId, Stream: stream, Offset: offset, MaxBytes: pageMax})
+			if err != nil {
+				return err
+			}
+			if len(response.Data) == 0 && response.GapBytes == 0 {
+				break
+			}
+			payload, err := json.Marshal(outputEvent{process.ExecutionId, streamName(stream), response.Offset, response.NextOffset, response.GapBytes, response.RetainedStart, response.ProducedEnd, response.Eof, response.Data})
+			if err != nil {
+				return err
+			}
+			digest := sha256.Sum256(payload)
+			event := controllers.AdapterEvent{Source: "amp", IdempotencyKey: fmt.Sprintf("v1:%s:%x", streamName(stream), digest), Type: "amp.process-output", Data: payload}
+			a.setPending(c, pendingEvent{event: event, nextOffset: response.NextOffset})
+			if err := sandbox.EmitEvent(ctx, event); err != nil {
+				return err
+			}
+			offset = response.NextOffset
+			a.commitPending(c, offset)
+			if response.Eof || offset >= response.ProducedEnd {
+				break
+			}
+		}
+	}
+	return nil
+}
+
+func readOutput(ctx context.Context, client sandboxdv1.ProcessServiceClient, processKey *sandboxdv1.ProcessKey, execution string) ([]byte, error) {
+	var output bytes.Buffer
+	var offset uint64
+	for {
+		response, err := client.ReadOutput(ctx, &sandboxdv1.ReadOutputRequest{Key: processKey, ExecutionId: execution, Stream: sandboxdv1.OutputStream_OUTPUT_STREAM_STDOUT, Offset: offset, MaxBytes: pageMax})
+		if err != nil {
+			return nil, err
+		}
+		output.Write(response.Data)
+		offset = response.NextOffset
+		if response.Eof || offset >= response.ProducedEnd {
+			return output.Bytes(), nil
+		}
+	}
+}
+
+func finalResult(output []byte) (resultEvent, bool) {
+	lines := bytes.Split(output, []byte("\n"))
+	for i := len(lines) - 1; i >= 0; i-- {
+		if len(bytes.TrimSpace(lines[i])) == 0 {
+			continue
+		}
+		var result resultEvent
+		err := json.Unmarshal(lines[i], &result)
+		return result, err == nil && result.Type == "result"
+	}
+	return resultEvent{}, false
+}
+
+func streamName(stream sandboxdv1.OutputStream) string {
+	if stream == sandboxdv1.OutputStream_OUTPUT_STREAM_STDERR {
+		return "stderr"
+	}
+	return "stdout"
+}
+func message(summary, detail string) string {
+	if detail == "" {
+		return summary
+	}
+	if len(detail) > 512 {
+		detail = detail[:512] + "…"
+	}
+	return summary + ": " + detail
+}
+func errorDetail(raw json.RawMessage) string {
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return ""
+	}
+	var text string
+	if json.Unmarshal(raw, &text) == nil {
+		return text
+	}
+	return string(raw)
+}
+func (a *Adapter) getCursor(c cursor) uint64 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.cursors == nil {
+		a.cursors = make(map[cursor]uint64)
+	}
+	return a.cursors[c]
+}
+func (a *Adapter) getPending(c cursor) (pendingEvent, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	p, ok := a.pending[c]
+	return p, ok
+}
+func (a *Adapter) setPending(c cursor, p pendingEvent) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.pending == nil {
+		a.pending = make(map[cursor]pendingEvent)
+	}
+	a.pending[c] = p
+}
+func (a *Adapter) commitPending(c cursor, offset uint64) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.cursors == nil {
+		a.cursors = make(map[cursor]uint64)
+	}
+	a.cursors[c] = offset
+	delete(a.pending, c)
+}

--- a/internal/adapters/amp/adapter_test.go
+++ b/internal/adapters/amp/adapter_test.go
@@ -132,7 +132,7 @@ func TestCredentialIsRejectedWithoutDial(t *testing.T) {
 		return nil, nil, nil
 	}}
 	err := (&Adapter{}).EnsureAccepted(context.Background(), controllers.AdapterTask{}, sandbox, &controllers.AdapterCredential{APIKey: []byte("secret")})
-	if err == nil || dials != 0 {
+	if !errors.Is(err, controllers.ErrAdapterTaskRejected) || dials != 0 {
 		t.Fatalf("error/dials = %v/%d", err, dials)
 	}
 }

--- a/internal/adapters/amp/adapter_test.go
+++ b/internal/adapters/amp/adapter_test.go
@@ -1,0 +1,267 @@
+package amp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/Chris-Cullins/swe-platform/internal/controllers"
+	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
+)
+
+type fakeClient struct {
+	process      *sandboxdv1.Process
+	stdout       []byte
+	stderr       []byte
+	gapBytes     uint64
+	retainedFrom uint64
+	getErr       error
+	starts       int
+	launches     int
+	startedKey   *sandboxdv1.ProcessKey
+	startedSpec  *sandboxdv1.ProcessSpec
+	stoppedKey   *sandboxdv1.ProcessKey
+	readRequests []*sandboxdv1.ReadOutputRequest
+}
+
+func (f *fakeClient) Start(_ context.Context, request *sandboxdv1.StartProcessRequest, _ ...grpc.CallOption) (*sandboxdv1.Process, error) {
+	f.starts++
+	if f.startedKey == nil {
+		f.launches++
+		f.startedKey, f.startedSpec = request.Key, request.Spec
+	} else if !reflect.DeepEqual(f.startedKey, request.Key) || !reflect.DeepEqual(f.startedSpec, request.Spec) {
+		return nil, status.Error(codes.FailedPrecondition, "conflicting start")
+	}
+	if f.process == nil {
+		f.process = &sandboxdv1.Process{Key: request.Key, Spec: request.Spec, State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"}
+	}
+	return f.process, nil
+}
+
+func (f *fakeClient) StartWithLaunchMaterial(context.Context, *sandboxdv1.StartProcessWithLaunchMaterialRequest, ...grpc.CallOption) (*sandboxdv1.Process, error) {
+	return nil, errors.New("unexpected launch material")
+}
+func (f *fakeClient) Get(context.Context, *sandboxdv1.GetProcessRequest, ...grpc.CallOption) (*sandboxdv1.Process, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	return f.process, nil
+}
+func (f *fakeClient) Stop(_ context.Context, request *sandboxdv1.StopProcessRequest, _ ...grpc.CallOption) (*sandboxdv1.Process, error) {
+	f.stoppedKey = request.Key
+	if f.process == nil {
+		return &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED}, nil
+	}
+	return f.process, nil
+}
+func (f *fakeClient) ReadOutput(_ context.Context, request *sandboxdv1.ReadOutputRequest, _ ...grpc.CallOption) (*sandboxdv1.ReadOutputResponse, error) {
+	f.readRequests = append(f.readRequests, request)
+	data := f.stdout
+	if request.Stream == sandboxdv1.OutputStream_OUTPUT_STREAM_STDERR {
+		data = f.stderr
+	}
+	gapBytes, retainedFrom := f.gapBytes, f.retainedFrom
+	if request.Stream == sandboxdv1.OutputStream_OUTPUT_STREAM_STDERR {
+		gapBytes, retainedFrom = 0, 0
+	}
+	start := request.Offset
+	if start > uint64(len(data)) {
+		return nil, status.Error(codes.OutOfRange, "offset")
+	}
+	end := min(len(data), int(start)+int(request.MaxBytes))
+	return &sandboxdv1.ReadOutputResponse{Data: append([]byte(nil), data[start:end]...), Offset: start, NextOffset: uint64(end), GapBytes: gapBytes, RetainedStart: retainedFrom, ProducedEnd: uint64(len(data)), Eof: end == len(data)}, nil
+}
+
+func TestOutputIncludesGapMetadata(t *testing.T) {
+	client := &fakeClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"}, stdout: []byte("kept"), gapBytes: 9, retainedFrom: 9}
+	var event controllers.AdapterEvent
+	sandbox := testSandbox(client)
+	sandbox.EmitEvent = func(_ context.Context, got controllers.AdapterEvent) error { event = got; return nil }
+	if _, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err != nil {
+		t.Fatal(err)
+	}
+	var output outputEvent
+	if err := json.Unmarshal(event.Data, &output); err != nil || output.GapBytes != 9 || output.RetainedFrom != 9 || string(output.Data) != "kept" {
+		t.Fatalf("output = %#v, error = %v", output, err)
+	}
+}
+
+func testSandbox(client sandboxdv1.ProcessServiceClient) controllers.AdapterSandbox {
+	return controllers.AdapterSandbox{EnvironmentUID: "epoch", DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
+		return client, func() error { return nil }, nil
+	}}
+}
+
+func TestAcceptanceIsDuplicateSafePromptSafeAndFreshEpoch(t *testing.T) {
+	task := controllers.AdapterTask{ID: "run-uid", Prompt: "--version\nsecond line"}
+	adapter := &Adapter{Executable: "fake-amp"}
+	first := &fakeClient{}
+	for range 2 {
+		if err := adapter.EnsureAccepted(context.Background(), task, testSandbox(first), nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if first.starts != 2 || first.launches != 1 || first.startedKey.OwnerId != task.ID || first.startedKey.Role != processRole {
+		t.Fatalf("start/launch/key = %d/%d/%#v", first.starts, first.launches, first.startedKey)
+	}
+	want := []string{"fake-amp", "--execute=" + task.Prompt, "--stream-json", "--no-ide", "--no-notifications"}
+	if !reflect.DeepEqual(first.startedSpec.Argv, want) || first.startedSpec.Env["AMP_SKIP_UPDATE_CHECK"] != "1" {
+		t.Fatalf("spec = %#v", first.startedSpec)
+	}
+	second := &fakeClient{}
+	if err := adapter.EnsureAccepted(context.Background(), task, testSandbox(second), nil); err != nil {
+		t.Fatal(err)
+	}
+	if second.launches != 1 || second.startedKey.OwnerId != task.ID {
+		t.Fatalf("fresh epoch = %d/%#v", second.launches, second.startedKey)
+	}
+}
+
+func TestCredentialIsRejectedWithoutDial(t *testing.T) {
+	dials := 0
+	sandbox := controllers.AdapterSandbox{DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
+		dials++
+		return nil, nil, nil
+	}}
+	err := (&Adapter{}).EnsureAccepted(context.Background(), controllers.AdapterTask{}, sandbox, &controllers.AdapterCredential{APIKey: []byte("secret")})
+	if err == nil || dials != 0 {
+		t.Fatalf("error/dials = %v/%d", err, dials)
+	}
+}
+
+func TestObservationOutcomes(t *testing.T) {
+	exit0, exit1 := int32(0), int32(1)
+	tests := []struct {
+		name    string
+		process *sandboxdv1.Process
+		output  string
+		want    controllers.AdapterObservation
+	}{
+		{"running", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "e"}, "", controllers.AdapterObservationRunning},
+		{"success", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, `{"type":"result","subtype":"success","is_error":false,"result":"done"}` + "\n", controllers.AdapterObservationSucceeded},
+		{"truncated prefix then success", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, "{truncated\n" + `{"type":"result","subtype":"success","is_error":false,"result":"done"}`, controllers.AdapterObservationSucceeded},
+		{"success then assistant", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, `{"type":"result","subtype":"success","is_error":false}` + "\n" + `{"type":"assistant"}`, controllers.AdapterObservationFailed},
+		{"success then malformed", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, `{"type":"result","subtype":"success","is_error":false}` + "\ntruncated", controllers.AdapterObservationFailed},
+		{"failed result", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, `{"type":"result","subtype":"error_during_execution","is_error":true}` + "\n", controllers.AdapterObservationFailed},
+		{"malformed", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, "not json\n", controllers.AdapterObservationFailed},
+		{"missing terminal", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, `{"type":"assistant"}` + "\n", controllers.AdapterObservationFailed},
+		{"nonzero", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit1, ExecutionId: "e"}, `{"type":"result","subtype":"success","is_error":false}` + "\n", controllers.AdapterObservationFailed},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, testSandbox(&fakeClient{process: test.process, stdout: []byte(test.output)}))
+			if err != nil || got != test.want {
+				t.Fatalf("Observe = %q, %v", got, err)
+			}
+		})
+	}
+	absent, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, testSandbox(&fakeClient{getErr: status.Error(codes.NotFound, "gone")}))
+	if err != nil || absent != controllers.AdapterObservationFailed {
+		t.Fatalf("absent = %q, %v", absent, err)
+	}
+}
+
+func TestCancellationAndBoundedIdempotentOutput(t *testing.T) {
+	client := &fakeClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"}, stdout: []byte("stdout"), stderr: []byte("stderr")}
+	var events []controllers.AdapterEvent
+	sandbox := testSandbox(client)
+	sandbox.EmitEvent = func(_ context.Context, event controllers.AdapterEvent) error {
+		events = append(events, event)
+		return nil
+	}
+	adapter := &Adapter{}
+	for range 2 {
+		if _, _, err := adapter.Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(events) != 2 {
+		t.Fatalf("events = %d", len(events))
+	}
+	for _, event := range events {
+		if event.Source != "amp" || event.Type != "amp.process-output" || !strings.HasPrefix(event.IdempotencyKey, "v1:") {
+			t.Fatalf("event = %#v", event)
+		}
+	}
+	if client.readRequests[0].MaxBytes != pageMax {
+		t.Fatalf("read max = %d", client.readRequests[0].MaxBytes)
+	}
+	err := adapter.Cancel(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox)
+	if !errors.Is(err, controllers.ErrAdapterCancellationPending) || client.stoppedKey.OwnerId != "run" {
+		t.Fatalf("cancel = %v/%#v", err, client.stoppedKey)
+	}
+}
+
+func TestOutputRetryUsesStableKey(t *testing.T) {
+	client := &fakeClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"}, stdout: []byte("output")}
+	var events []controllers.AdapterEvent
+	sandbox := testSandbox(client)
+	sandbox.EmitEvent = func(_ context.Context, event controllers.AdapterEvent) error {
+		events = append(events, event)
+		if len(events) == 1 {
+			return errors.New("retry")
+		}
+		return nil
+	}
+	adapter := &Adapter{}
+	if _, _, err := adapter.Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err == nil {
+		t.Fatal("wanted transient error")
+	}
+	client.stdout = []byte("output appended")
+	if _, _, err := adapter.Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 3 || !reflect.DeepEqual(events[0], events[1]) {
+		t.Fatalf("events = %#v", events)
+	}
+	var retry, appended outputEvent
+	if json.Unmarshal(events[1].Data, &retry) != nil || json.Unmarshal(events[2].Data, &appended) != nil ||
+		retry.Offset != 0 || retry.NextOffset != 6 || appended.Offset != 6 || string(appended.Data) != " appended" {
+		t.Fatalf("retry/appended = %#v/%#v", retry, appended)
+	}
+}
+
+func TestRestartChangesKeyWhenSnapshotMetadataChanges(t *testing.T) {
+	client := &fakeClient{
+		process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"},
+		stdout:  bytes.Repeat([]byte("x"), pageMax+1),
+	}
+	var first controllers.AdapterEvent
+	sandbox := testSandbox(client)
+	sandbox.EmitEvent = func(_ context.Context, event controllers.AdapterEvent) error {
+		if first.Data == nil {
+			first = event
+			return errors.New("uncertain append")
+		}
+		return nil
+	}
+	if _, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err == nil {
+		t.Fatal("wanted uncertain append error")
+	}
+
+	client.stdout = append(client.stdout, 'y')
+	var replay controllers.AdapterEvent
+	sandbox.EmitEvent = func(_ context.Context, event controllers.AdapterEvent) error {
+		replay = event
+		return errors.New("stop after replay")
+	}
+	if _, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err == nil {
+		t.Fatal("wanted replay stop error")
+	}
+	if first.IdempotencyKey == replay.IdempotencyKey || bytes.Equal(first.Data, replay.Data) {
+		t.Fatalf("restart replay key/payload did not reflect changed snapshot metadata: %q/%q", first.IdempotencyKey, replay.IdempotencyKey)
+	}
+	var before, after outputEvent
+	if json.Unmarshal(first.Data, &before) != nil || json.Unmarshal(replay.Data, &after) != nil ||
+		before.Offset != after.Offset || before.NextOffset != after.NextOffset || !bytes.Equal(before.Data, after.Data) || before.ProducedEnd == after.ProducedEnd {
+		t.Fatalf("restart ranges = %#v/%#v", before, after)
+	}
+}

--- a/internal/controllers/run_controller.go
+++ b/internal/controllers/run_controller.go
@@ -45,6 +45,10 @@ var ErrAdapterCancellationPending = errors.New("adapter cancellation is pending"
 // an adapter event. Retrying the same event cannot make progress.
 var ErrAdapterEventRejected = errors.New("adapter event permanently rejected")
 
+// ErrAdapterTaskRejected means an adapter permanently rejected the immutable
+// task intent. Retrying acceptance cannot make progress.
+var ErrAdapterTaskRejected = errors.New("adapter task permanently rejected")
+
 const (
 	runConditionEnvironmentReady           = "EnvironmentReady"
 	runConditionCredentialProfileBound     = "CredentialProfileBound"
@@ -103,8 +107,9 @@ type AdapterSandbox struct {
 
 // AdapterLifecycle translates one agent's execution model into normalized Run
 // lifecycle events. Every operation must be idempotent. EnsureAccepted may be
-// repeated after an uncertain response or environment resume; Cancel succeeds
-// when work is already absent or terminal and returns
+// repeated after an uncertain response or environment resume and may wrap
+// ErrAdapterTaskRejected for permanent intent rejection; Cancel succeeds when
+// work is already absent or terminal and returns
 // ErrAdapterCancellationPending while its execution tree is still stopping.
 type AdapterLifecycle interface {
 	EnsureAccepted(context.Context, AdapterTask, AdapterSandbox, *AdapterCredential) error
@@ -281,6 +286,9 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			defer clear(credential.APIKey)
 		}
 		if err := adapter.EnsureAccepted(ctx, adapterTask(&run), r.adapterSandbox(&run, env), credential); err != nil {
+			if errors.Is(err, ErrAdapterTaskRejected) {
+				return ctrl.Result{}, r.setRunState(ctx, &run, platformv1alpha1.RunStateFailed, "AdapterRejected", err.Error(), true)
+			}
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{Requeue: true}, r.setRunState(ctx, &run, platformv1alpha1.RunStateAdapterAccepted, "AdapterAccepted", "adapter accepted the task", true)

--- a/internal/controllers/run_controller_test.go
+++ b/internal/controllers/run_controller_test.go
@@ -3,7 +3,9 @@ package controllers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -27,6 +29,7 @@ import (
 type scriptedAdapter struct {
 	observations          []AdapterObservation
 	accepted, cancelled   int
+	acceptErr             error
 	onCancel              func()
 	cancelErr             error
 	acceptedCredentials   [][]byte
@@ -94,7 +97,7 @@ func (a *scriptedAdapter) EnsureAccepted(_ context.Context, _ AdapterTask, _ Ada
 		a.acceptedCredentials = append(a.acceptedCredentials, append([]byte(nil), credential.APIKey...))
 		a.retainedCredentialKey = credential.APIKey
 	}
-	return nil
+	return a.acceptErr
 }
 func (a *scriptedAdapter) Cancel(context.Context, AdapterTask, AdapterSandbox) error {
 	a.cancelled++
@@ -685,6 +688,22 @@ func TestAdapterShapesPauseResumeAndStatus(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestPermanentAdapterAcceptanceRejectionFailsRun(t *testing.T) {
+	run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "uid", Finalizers: []string{runFinalizer}}, Spec: platformv1alpha1.RunSpec{Agent: "test"}, Status: platformv1alpha1.RunStatus{
+		State:          platformv1alpha1.RunStateEnvironmentReady,
+		EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{Name: "e", UID: "euid", Ownership: platformv1alpha1.EnvironmentOwnershipOwned},
+		Conditions:     []metav1.Condition{{Type: runConditionAdapterAcceptanceAttempted, Status: metav1.ConditionTrue}},
+	}}
+	env := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "e", Namespace: "ns", UID: "euid"}, Status: platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhaseReady}}
+	adapter := &scriptedAdapter{acceptErr: fmt.Errorf("%w: unsupported task configuration", ErrAdapterTaskRejected)}
+	r := reconciler(t, adapter, run, env)
+	got := reconcileRun(t, r, run.Name)
+	condition := apiMeta.FindStatusCondition(got.Status.Conditions, runConditionAdapterAccepted)
+	if got.Status.State != platformv1alpha1.RunStateFailed || condition == nil || condition.Status != metav1.ConditionFalse || condition.Reason != "AdapterRejected" || !strings.Contains(condition.Message, "unsupported task configuration") || adapter.accepted != 1 {
+		t.Fatalf("Run status = %#v, AdapterAccepted = %#v, accepts = %d", got.Status, condition, adapter.accepted)
 	}
 }
 


### PR DESCRIPTION
Closes #61

## Summary
- register a Run-UID-fenced Amp adapter with strict structured-result handling
- pin and verify Amp wrapper/native binaries for amd64 and arm64
- add fake-Amp unit and kind lifecycle/transcript acceptance coverage
- document selection, credentials, cancellation, and transcript replay semantics

## Validation
- `make test vet build`
- `go test -count=1 ./internal/adapters/amp ./cmd/operator`
- `bash -n hack/e2e.sh`
- `git diff --check`
- pinned x64 npm wrapper/native integrity and `amp --version` smoke

Full kind and Docker multiarch execution were not available in this orb.