### PR TITLE
feat: bootstrap kind with gVisor and snapshot CSI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,8 +102,12 @@ runs both via `make` targets:
   (`manifests` synchronizes chart CRDs; CI fails on a diff). Use `make check-chart-crds`
   to verify the checked-in Helm CRDs independently.
 - **Regenerate protobuf:** `make proto` (requires `protoc`; plugins install locally)
-- **Dev cluster:** `make kind-up`, build/load the images, then install
-  `charts/swe-platform` with `values-kind.yaml` as printed by the script.
+- **Dev cluster:** `make kind-up` creates/reuses `swe-dev`, installs the pinned gVisor
+  `gvisor` RuntimeClass plus the CSI hostpath driver and VolumeSnapshot controller, and
+  verifies both with smoke resources. Build/load the images, then install
+  `charts/swe-platform` with `values-kind.yaml` and the gVisor override printed by the
+  script. Run the full acceptance suite against it with
+  `KIND_CLUSTER=swe-dev E2E_USE_EXISTING_CLUSTER=true E2E_RUNTIME_CLASS=gvisor ./hack/e2e.sh`.
 - **Argo CD main mirror:** `make argocd-up` creates a separate `swe-argo` kind
   cluster running Argo CD + the Image Updater (`hack/argocd/`,
   `values-argocd.yaml` preset). It syncs the chart from `origin/main` and rolls

--- a/Makefile
+++ b/Makefile
@@ -114,8 +114,8 @@ $(CONTROLLER_GEN):
 ##@ Local cluster
 
 .PHONY: kind-up
-kind-up: ## Create the kind dev cluster
-	./hack/kind-up.sh
+kind-up: ## Create the kind dev cluster with gVisor and snapshot-capable CSI
+	KIND_CLUSTER=$(KIND_CLUSTER) ./hack/kind-up.sh
 
 .PHONY: kind-down
 kind-down: ## Delete the kind dev cluster

--- a/README.md
+++ b/README.md
@@ -145,11 +145,20 @@ allowed to overlap the new one.
 
 ## Local development
 
-Development targets a local [kind](https://kind.sigs.k8s.io/) cluster. Run `make kind-up`,
-build and load the operator and env-base images as printed by that command, then install
-`charts/swe-platform` with `values-kind.yaml`. The preset creates the `small` template
-in `default`. Production installation assumptions and k3s/GKE/EKS presets are documented
-in the [chart README](charts/swe-platform/README.md).
+Development targets a local [kind](https://kind.sigs.k8s.io/) cluster. Run `make kind-up`
+to create a cluster with the `gvisor` RuntimeClass and the snapshot-capable CSI hostpath
+driver, build and load the platform images, then install
+`charts/swe-platform` with `values-kind.yaml` and the printed
+`environmentTemplates[0].spec.runtimeClass=gvisor` override. The preset creates the
+`small` template in `default`; the explicit override keeps it usable in ordinary CI kind
+clusters that do not install runsc. Production installation assumptions and k3s/GKE/EKS
+presets are documented in the [chart README](charts/swe-platform/README.md).
+
+Run the acceptance suite against the bootstrapped cluster with gVisor enabled:
+
+```sh
+KIND_CLUSTER=swe-dev E2E_USE_EXISTING_CLUSTER=true E2E_RUNTIME_CLASS=gvisor ./hack/e2e.sh
+```
 
 Create runs with an explicit template, or reference a `Project` to use its default
 template:

--- a/charts/swe-platform/README.md
+++ b/charts/swe-platform/README.md
@@ -58,7 +58,7 @@ digest-pinned installation overrides.
 
 | Preset | Assumptions |
 |---|---|
-| `values-kind.yaml` | Local kind development with `:dev` images; explicitly permits insecure HTTP browser sessions. |
+| `values-kind.yaml` | Local kind development with `:dev` images; explicitly permits insecure HTTP browser sessions. `make kind-up` installs gVisor and snapshot-capable CSI; pass the printed `environmentTemplates[0].spec.runtimeClass=gvisor` override when installing the chart. |
 | `values-argocd.yaml` | Local Argo CD mirror with mutable `:latest` images and an out-of-band bootstrap Secret; explicitly permits insecure HTTP browser sessions. |
 | `values-k3s.yaml` | A default CSI-backed StorageClass is available. Uses one operator replica and the default OCI runtime because k3s does not ship gVisor. |
 | `values-gke.yaml` | GKE Sandbox is enabled on every node that can host environments. Sets `runtimeClass: gvisor` and runs two operator replicas with leader election. |

--- a/config/samples/environmenttemplate_small.yaml
+++ b/config/samples/environmenttemplate_small.yaml
@@ -1,5 +1,6 @@
 # Sample EnvironmentTemplate for local development and e2e.
-# Intentionally has no runtimeClass: kind/minikube nodes have no gVisor.
+# Intentionally has no runtimeClass so it also works in plain kind/minikube clusters.
+# The `make kind-up` development cluster supports runtimeClass: gvisor.
 apiVersion: swe.dev/v1alpha1
 kind: EnvironmentTemplate
 metadata:

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -6,7 +6,10 @@
 # loaded into the kind cluster directly.
 #
 # Prerequisites: go, docker, kind, kubectl, helm.
-# Env: KIND_CLUSTER (default swe-e2e), KEEP_CLUSTER=true to skip teardown.
+# Env: KIND_CLUSTER (default swe-e2e), KEEP_CLUSTER=true to skip teardown,
+# E2E_USE_EXISTING_CLUSTER=true to test a bootstrapped cluster, and
+# E2E_RUNTIME_CLASS (for example gvisor) to select its environment runtime. Existing
+# cluster mode expects a fresh `make kind-up` cluster without an installed platform.
 set -euo pipefail
 
 CLUSTER="${KIND_CLUSTER:-swe-e2e}"
@@ -22,6 +25,7 @@ WEB_TERMINAL_CLIENT=""
 PROJECT_REPO=""
 PROJECT_WORKTREE=""
 FAKE_ENV_CONTEXT=""
+E2E_KUBECONFIG=""
 
 cleanup() {
 	if [[ -n "$PORT_FORWARD_PID" ]]; then
@@ -44,8 +48,11 @@ cleanup() {
 	if [[ -n "$FAKE_ENV_CONTEXT" ]]; then
 		rm -rf "$FAKE_ENV_CONTEXT"
 	fi
+	if [[ -n "$E2E_KUBECONFIG" ]]; then
+		rm -f "$E2E_KUBECONFIG"
+	fi
 	rm -f /tmp/swe-platform-sandboxd-cert-"$$" /tmp/swe-platform-sandboxd-token-"$$"
-	if [[ "${KEEP_CLUSTER:-false}" != "true" ]]; then
+	if [[ "${KEEP_CLUSTER:-false}" != "true" && "${E2E_USE_EXISTING_CLUSTER:-false}" != "true" ]]; then
 		kind delete cluster --name "$CLUSTER" >/dev/null 2>&1 || true
 	fi
 }
@@ -85,9 +92,22 @@ cd "$(dirname "$0")/.."
 echo "==> building binaries"
 make build
 
-echo "==> creating kind cluster '$CLUSTER'"
-kind delete cluster --name "$CLUSTER" >/dev/null 2>&1 || true
-kind create cluster --name "$CLUSTER"
+if [[ "${E2E_USE_EXISTING_CLUSTER:-false}" == "true" ]]; then
+	echo "==> using existing kind cluster '$CLUSTER'"
+	E2E_KUBECONFIG="$(mktemp /tmp/swe-e2e-kubeconfig-XXXXXX)"
+	kubectl config view --raw > "$E2E_KUBECONFIG"
+	export KUBECONFIG="$E2E_KUBECONFIG"
+	kubectl cluster-info --context "kind-$CLUSTER" >/dev/null
+	kubectl config use-context "kind-$CLUSTER" >/dev/null
+	if kubectl get crd runs.swe.dev >/dev/null 2>&1; then
+		echo "FAIL: existing-cluster E2E requires a fresh make kind-up cluster without swe-platform CRDs" >&2
+		exit 1
+	fi
+else
+	echo "==> creating kind cluster '$CLUSTER'"
+	kind delete cluster --name "$CLUSTER" >/dev/null 2>&1 || true
+	kind create cluster --name "$CLUSTER"
+fi
 
 echo "==> building platform images"
 make docker-build >/dev/null
@@ -153,11 +173,17 @@ kubectl get crd agentcredentialprofiles.swe.dev >/dev/null
 echo "==> installing operator and kind template through Helm with upgraded CRDs"
 E2E_BOOTSTRAP_TOKEN="$(openssl rand -hex 32)"
 kubectl create secret generic swe-platform-bootstrap --from-literal=token="$E2E_BOOTSTRAP_TOKEN"
-helm upgrade --install swe-platform charts/swe-platform \
-	--namespace default --values charts/swe-platform/values-kind.yaml \
-	--set controlPlane.auth.bootstrapTokenSecret.name=swe-platform-bootstrap \
-	--set-string "environmentTemplates[0].spec.image=$E2E_ENV_IMAGE" \
+HELM_ARGS=(
+	upgrade --install swe-platform charts/swe-platform
+	--namespace default --values charts/swe-platform/values-kind.yaml
+	--set controlPlane.auth.bootstrapTokenSecret.name=swe-platform-bootstrap
+	--set-string "environmentTemplates[0].spec.image=$E2E_ENV_IMAGE"
 	--wait --timeout 2m
+)
+if [[ -n "${E2E_RUNTIME_CLASS:-}" ]]; then
+	HELM_ARGS+=(--set-string "environmentTemplates[0].spec.runtimeClass=$E2E_RUNTIME_CLASS")
+fi
+helm "${HELM_ARGS[@]}"
 
 echo "==> waiting for warm environment"
 kubectl wait --for=jsonpath='{.status.warmPoolReady}'=1 environmenttemplate/small --timeout=2m
@@ -167,6 +193,21 @@ if [[ -z "$WARM_ENV_NAME" ]]; then
 	exit 1
 fi
 WARM_POD_UID=$(kubectl get pod "env-${WARM_ENV_NAME}" -o jsonpath='{.metadata.uid}')
+if [[ -n "${E2E_RUNTIME_CLASS:-}" ]]; then
+	WARM_RUNTIME_CLASS=$(kubectl get pod "env-${WARM_ENV_NAME}" -o jsonpath='{.spec.runtimeClassName}')
+	if [[ "$WARM_RUNTIME_CLASS" != "$E2E_RUNTIME_CLASS" ]]; then
+		echo "FAIL: warm Environment uses RuntimeClass '$WARM_RUNTIME_CLASS', expected '$E2E_RUNTIME_CLASS'"
+		exit 1
+	fi
+fi
+if [[ "${E2E_USE_EXISTING_CLUSTER:-false}" == "true" ]]; then
+	WARM_PVC_NAME=$(kubectl get pod "env-${WARM_ENV_NAME}" -o jsonpath='{.spec.volumes[?(@.name=="workspace")].persistentVolumeClaim.claimName}')
+	WARM_STORAGE_CLASS=$(kubectl get pvc "$WARM_PVC_NAME" -o jsonpath='{.spec.storageClassName}')
+	if [[ "$WARM_STORAGE_CLASS" != "csi-hostpath-sc" ]]; then
+		echo "FAIL: warm Environment workspace uses StorageClass '$WARM_STORAGE_CLASS', expected 'csi-hostpath-sc'"
+		exit 1
+	fi
+fi
 
 echo "==> creating project configuration"
 PROJECT_REPO="$(mktemp -d /tmp/swe-e2e-project-XXXXXX)"

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -87,13 +87,17 @@ for node in "${NODES[@]}"; do
 		docker exec "$node" install -m 0755 "/tmp/$binary" "/usr/local/bin/$binary"
 	done
 	if ! docker exec "$node" grep -Fq 'containerd.runtimes.runsc]' /etc/containerd/config.toml; then
-		if ! docker exec "$node" grep -Eq '^[[:space:]]*version[[:space:]]*=[[:space:]]*2[[:space:]]*$' /etc/containerd/config.toml; then
-			echo "unsupported containerd config in $node: expected version = 2" >&2
+		if docker exec "$node" grep -Eq '^[[:space:]]*version[[:space:]]*=[[:space:]]*2[[:space:]]*$' /etc/containerd/config.toml; then
+			RUNTIME_PLUGIN=io.containerd.grpc.v1.cri
+		elif docker exec "$node" grep -Eq '^[[:space:]]*version[[:space:]]*=[[:space:]]*3[[:space:]]*$' /etc/containerd/config.toml; then
+			RUNTIME_PLUGIN=io.containerd.cri.v1.runtime
+		else
+			echo "unsupported containerd config in $node: expected version 2 or 3" >&2
 			exit 1
 		fi
-		docker exec -i "$node" sh -c 'cat >> /etc/containerd/config.toml' <<'EOF'
+		docker exec -i "$node" sh -c 'cat >> /etc/containerd/config.toml' <<EOF
 
-[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc]
+[plugins."$RUNTIME_PLUGIN".containerd.runtimes.runsc]
   runtime_type = "io.containerd.runsc.v1"
 EOF
 	fi

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -1,29 +1,260 @@
 #!/usr/bin/env bash
-# Create (or reuse) the local kind dev cluster.
+# Create (or reuse) the local kind dev cluster with gVisor and snapshot-capable CSI.
 set -euo pipefail
 
 CLUSTER="${KIND_CLUSTER:-swe-dev}"
+CONTEXT="kind-$CLUSTER"
+GVISOR_RELEASE="20260714"
+SNAPSHOTTER_VERSION="v8.6.0"
+HOSTPATH_VERSION="v1.18.0"
+HOSTPATH_DEPLOYMENT="kubernetes-1.34"
+TMP_DIR=""
+SMOKE_NAMESPACE=""
+
+cleanup() {
+	if [[ -n "$TMP_DIR" ]]; then
+		rm -rf "$TMP_DIR"
+	fi
+	if [[ -n "$SMOKE_NAMESPACE" ]]; then
+		kubectl --context "$CONTEXT" delete namespace "$SMOKE_NAMESPACE" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+	fi
+}
+trap cleanup EXIT
+
+for command in curl docker git kind kubectl; do
+	if ! command -v "$command" >/dev/null 2>&1; then
+		echo "required command not found: $command" >&2
+		exit 1
+	fi
+done
+
+if command -v sha512sum >/dev/null 2>&1; then
+	CHECKSUM=(sha512sum --check)
+elif command -v shasum >/dev/null 2>&1; then
+	CHECKSUM=(shasum -a 512 --check)
+else
+	echo "required command not found: sha512sum or shasum" >&2
+	exit 1
+fi
 
 if kind get clusters | grep -qx "$CLUSTER"; then
-	echo "kind cluster '$CLUSTER' already exists"
+	echo "==> reusing kind cluster '$CLUSTER'"
 else
+	echo "==> creating kind cluster '$CLUSTER'"
 	kind create cluster --name "$CLUSTER"
 fi
 
-kubectl cluster-info --context "kind-$CLUSTER" >/dev/null
+kubectl cluster-info --context "$CONTEXT" >/dev/null
+TMP_DIR="$(mktemp -d)"
+SMOKE_NAMESPACE="swe-bootstrap-check-$$-$RANDOM"
+
+NODES=()
+while IFS= read -r node; do
+	NODES+=("$node")
+done < <(kind get nodes --name "$CLUSTER")
+if [[ "${#NODES[@]}" -eq 0 ]]; then
+	echo "kind cluster '$CLUSTER' has no nodes" >&2
+	exit 1
+fi
+ARCH="$(docker exec "${NODES[0]}" uname -m)"
+case "$ARCH" in
+	x86_64|aarch64) ;;
+	arm64) ARCH=aarch64 ;;
+	*) echo "unsupported gVisor node architecture: $ARCH" >&2; exit 1 ;;
+esac
+for node in "${NODES[@]}"; do
+	node_arch="$(docker exec "$node" uname -m)"
+	if [[ "$node_arch" == arm64 ]]; then
+		node_arch=aarch64
+	fi
+	if [[ "$node_arch" != "$ARCH" ]]; then
+		echo "mixed kind node architectures are unsupported: ${NODES[0]}=$ARCH, $node=$node_arch" >&2
+		exit 1
+	fi
+done
+
+echo "==> installing gVisor release $GVISOR_RELEASE"
+GVISOR_URL="https://storage.googleapis.com/gvisor/releases/release/$GVISOR_RELEASE/$ARCH"
+for binary in runsc containerd-shim-runsc-v1; do
+	curl --fail --location --silent --show-error "$GVISOR_URL/$binary" --output "$TMP_DIR/$binary"
+	curl --fail --location --silent --show-error "$GVISOR_URL/$binary.sha512" --output "$TMP_DIR/$binary.sha512"
+	(cd "$TMP_DIR" && "${CHECKSUM[@]}" "$binary.sha512")
+done
+
+for node in "${NODES[@]}"; do
+	for binary in runsc containerd-shim-runsc-v1; do
+		docker cp "$TMP_DIR/$binary" "$node:/tmp/$binary"
+		docker exec "$node" install -m 0755 "/tmp/$binary" "/usr/local/bin/$binary"
+	done
+	if ! docker exec "$node" grep -Fq 'containerd.runtimes.runsc]' /etc/containerd/config.toml; then
+		if ! docker exec "$node" grep -Eq '^[[:space:]]*version[[:space:]]*=[[:space:]]*2[[:space:]]*$' /etc/containerd/config.toml; then
+			echo "unsupported containerd config in $node: expected version = 2" >&2
+			exit 1
+		fi
+		docker exec -i "$node" sh -c 'cat >> /etc/containerd/config.toml' <<'EOF'
+
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc]
+  runtime_type = "io.containerd.runsc.v1"
+EOF
+	fi
+	docker exec "$node" systemctl restart containerd
+done
+
+kubectl --context "$CONTEXT" wait --for=condition=Ready nodes --all --timeout=2m
+kubectl --context "$CONTEXT" apply -f - <<'EOF'
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: gvisor
+handler: runsc
+EOF
+
+echo "==> verifying the gVisor RuntimeClass"
+kubectl --context "$CONTEXT" create namespace "$SMOKE_NAMESPACE"
+kubectl --context "$CONTEXT" apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: runsc-smoke
+  namespace: $SMOKE_NAMESPACE
+spec:
+  runtimeClassName: gvisor
+  restartPolicy: Never
+  containers:
+    - name: smoke
+      image: busybox:1.36.1
+      command: [sh, -c, "sleep 300"]
+EOF
+kubectl --context "$CONTEXT" wait --for=condition=Ready pod/runsc-smoke -n "$SMOKE_NAMESPACE" --timeout=2m
+kubectl --context "$CONTEXT" exec -n "$SMOKE_NAMESPACE" runsc-smoke -- dmesg | grep -qi gvisor
+kubectl --context "$CONTEXT" delete pod/runsc-smoke -n "$SMOKE_NAMESPACE" --wait=true >/dev/null
+
+echo "==> installing VolumeSnapshot APIs and controller $SNAPSHOTTER_VERSION"
+SNAPSHOTTER_BASE="https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/$SNAPSHOTTER_VERSION"
+for manifest in \
+	client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml \
+	client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml \
+	client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml \
+	deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml \
+	deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml; do
+	kubectl --context "$CONTEXT" apply -f "$SNAPSHOTTER_BASE/$manifest"
+done
+kubectl --context "$CONTEXT" rollout status deployment/snapshot-controller -n kube-system --timeout=3m
+
+echo "==> installing CSI hostpath driver $HOSTPATH_VERSION"
+git clone --quiet --depth=1 --branch "$HOSTPATH_VERSION" \
+	https://github.com/kubernetes-csi/csi-driver-host-path.git "$TMP_DIR/csi-driver-host-path"
+REAL_KUBECTL="$(command -v kubectl)"
+mkdir "$TMP_DIR/bin"
+cat > "$TMP_DIR/bin/kubectl" <<'EOF'
+#!/usr/bin/env bash
+exec "$REAL_KUBECTL" --context "$KUBE_CONTEXT" "$@"
+EOF
+chmod +x "$TMP_DIR/bin/kubectl"
+export REAL_KUBECTL KUBE_CONTEXT="$CONTEXT"
+PATH="$TMP_DIR/bin:$PATH" "$TMP_DIR/csi-driver-host-path/deploy/$HOSTPATH_DEPLOYMENT/deploy.sh"
+kubectl --context "$CONTEXT" apply -f "$TMP_DIR/csi-driver-host-path/examples/csi-storageclass.yaml"
+kubectl --context "$CONTEXT" rollout status statefulset/csi-hostpathplugin --timeout=3m
+kubectl --context "$CONTEXT" annotate storageclass standard \
+	storageclass.kubernetes.io/is-default-class- --overwrite >/dev/null
+kubectl --context "$CONTEXT" annotate storageclass csi-hostpath-sc \
+	storageclass.kubernetes.io/is-default-class=true --overwrite >/dev/null
+
+echo "==> verifying CSI volume snapshots"
+kubectl --context "$CONTEXT" apply -f - <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: snapshot-source
+  namespace: $SMOKE_NAMESPACE
+spec:
+  storageClassName: csi-hostpath-sc
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 16Mi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: snapshot-writer
+  namespace: $SMOKE_NAMESPACE
+spec:
+  restartPolicy: Never
+  containers:
+    - name: writer
+      image: busybox:1.36.1
+      command: [sh, -c, "echo snapshot-ready > /data/marker && sleep 300"]
+      volumeMounts:
+        - name: data
+          mountPath: /data
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: snapshot-source
+EOF
+kubectl --context "$CONTEXT" wait --for=condition=Ready pod/snapshot-writer -n "$SMOKE_NAMESPACE" --timeout=2m
+kubectl --context "$CONTEXT" delete pod/snapshot-writer -n "$SMOKE_NAMESPACE" --wait=true >/dev/null
+kubectl --context "$CONTEXT" apply -f - <<EOF
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: bootstrap-smoke
+  namespace: $SMOKE_NAMESPACE
+spec:
+  volumeSnapshotClassName: csi-hostpath-snapclass
+  source:
+    persistentVolumeClaimName: snapshot-source
+EOF
+kubectl --context "$CONTEXT" wait --for=jsonpath='{.status.readyToUse}'=true \
+	volumesnapshot/bootstrap-smoke -n "$SMOKE_NAMESPACE" --timeout=2m
+kubectl --context "$CONTEXT" apply -f - <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: snapshot-restore
+  namespace: $SMOKE_NAMESPACE
+spec:
+  storageClassName: csi-hostpath-sc
+  dataSource:
+    name: bootstrap-smoke
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 16Mi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: snapshot-reader
+  namespace: $SMOKE_NAMESPACE
+spec:
+  restartPolicy: Never
+  containers:
+    - name: reader
+      image: busybox:1.36.1
+      command: [sh, -c, "grep -qx snapshot-ready /data/marker"]
+      volumeMounts:
+        - name: data
+          mountPath: /data
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: snapshot-restore
+EOF
+kubectl --context "$CONTEXT" wait --for=jsonpath='{.status.phase}'=Succeeded \
+	pod/snapshot-reader -n "$SMOKE_NAMESPACE" --timeout=2m
 
 cat <<EOF
 
-Cluster '$CLUSTER' is ready.
+Cluster '$CLUSTER' is ready with RuntimeClass/gvisor and snapshot-capable
+StorageClass/csi-hostpath-sc.
 
 Next steps:
   make docker-build
-  kind load docker-image ghcr.io/chris-cullins/swe-platform/operator:dev --name $CLUSTER
-  kind load docker-image ghcr.io/chris-cullins/swe-platform/env-base:dev --name $CLUSTER
-  helm upgrade --install swe-platform charts/swe-platform -n default -f charts/swe-platform/values-kind.yaml
+  kind load docker-image ghcr.io/chris-cullins/swe-platform/operator:dev ghcr.io/chris-cullins/swe-platform/control-plane:dev ghcr.io/chris-cullins/swe-platform/env-base:dev --name $CLUSTER
+  helm upgrade --install swe-platform charts/swe-platform -n default -f charts/swe-platform/values-kind.yaml --set-string 'environmentTemplates[0].spec.runtimeClass=gvisor'
   bin/swe run "fix the flaky tests" -t small
-
-Note: gVisor (runsc) is not installed on kind nodes by default, so the local
-dev flow runs environments without a RuntimeClass. That matches the `kind`
-values preset; gVisor is expected on anything real.
 EOF


### PR DESCRIPTION
## Summary
- install pinned, checksummed gVisor on kind nodes and validate the `gvisor` RuntimeClass
- install pinned CSI snapshot components and hostpath driver, make it the dev default, and validate snapshot restore
- allow the existing acceptance suite to target a fresh bootstrapped cluster with runtime/storage assertions

## Validation
- `bash -n hack/kind-up.sh hack/e2e.sh`
- `git diff --check`
- `helm lint charts/swe-platform --values charts/swe-platform/values-kind.yaml`
- Helm render with the gVisor override
- `make test`
- independent Oracle review: approved

Live kind acceptance was not run in the orb because Docker, kind, and kubectl are unavailable. The bootstrap performs mandatory live runsc and snapshot round-trip smoke checks.

Fixes #80