### PR TITLE
Add Skaffold kind development loop

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -3,6 +3,7 @@ set -euo pipefail
 
 GO_VERSION=1.26.5
 HELM_VERSION=v4.2.3
+SKAFFOLD_VERSION=v2.23.0
 NODE_VERSION=24.18.0
 NPM_VERSION=11.16.0
 
@@ -40,4 +41,10 @@ if ! command -v helm >/dev/null 2>&1 || [[ "$(helm version --short)" != *"${HELM
 	tar -C /tmp -xzf /tmp/helm.tar.gz
 	install "/tmp/linux-${TOOL_ARCH}/helm" "$HOME/.local/bin/helm"
 	rm -rf /tmp/helm.tar.gz "/tmp/linux-${TOOL_ARCH}"
+fi
+
+if ! command -v skaffold >/dev/null 2>&1 || [[ "$(skaffold version)" != "${SKAFFOLD_VERSION}" ]]; then
+	curl -fsSL "https://storage.googleapis.com/skaffold/releases/${SKAFFOLD_VERSION}/skaffold-linux-${TOOL_ARCH}" -o /tmp/skaffold
+	install /tmp/skaffold "$HOME/.local/bin/skaffold"
+	rm -f /tmp/skaffold
 fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,8 +111,9 @@ runs both via `make` targets:
   For operator/control-plane iteration, `make dev` runs the pinned Skaffold watch loop,
   builds and loads changed images, and upgrades the same Helm release on the explicit
   `kind-swe-dev` context (or `kind-$KIND_CLUSTER`), while refusing the Argo mirror named
-  by `KIND_ARGO_CLUSTER`. Build/load `env-base:dev` separately when a test needs a fresh
-  Environment pod; apply CRD upgrades separately because Helm does not upgrade `crds/`.
+  by `KIND_ARGO_CLUSTER` or detected by its `argocd` namespace. Build/load `env-base:dev`
+  separately when a test needs a fresh Environment pod; apply CRD upgrades separately
+  because Helm does not upgrade `crds/`.
 - **Argo CD main mirror:** `make argocd-up` creates a separate `swe-argo` kind
   cluster running Argo CD + the Image Updater (`hack/argocd/`,
   `values-argocd.yaml` preset). It syncs the chart from `origin/main` and rolls

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,11 @@ runs both via `make` targets:
   `charts/swe-platform` with `values-kind.yaml` and the gVisor override printed by the
   script. Run the full acceptance suite against it with
   `KIND_CLUSTER=swe-dev E2E_USE_EXISTING_CLUSTER=true E2E_RUNTIME_CLASS=gvisor ./hack/e2e.sh`.
+  For operator/control-plane iteration, `make dev` runs the pinned Skaffold watch loop,
+  builds and loads changed images, and upgrades the same Helm release on the explicit
+  `kind-swe-dev` context (or `kind-$KIND_CLUSTER`), while refusing the Argo mirror named
+  by `KIND_ARGO_CLUSTER`. Build/load `env-base:dev` separately when a test needs a fresh
+  Environment pod; apply CRD upgrades separately because Helm does not upgrade `crds/`.
 - **Argo CD main mirror:** `make argocd-up` creates a separate `swe-argo` kind
   cluster running Argo CD + the Image Updater (`hack/argocd/`,
   `values-argocd.yaml` preset). It syncs the chart from `origin/main` and rolls

--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,9 @@ dev: ## Watch, rebuild, and redeploy operator/control-plane into the kind dev cl
 	@kind get clusters | grep -Fx -- "$(KIND_CLUSTER)" >/dev/null || { \
 		echo "kind cluster '$(KIND_CLUSTER)' does not exist; run 'make kind-up KIND_CLUSTER=$(KIND_CLUSTER)'" >&2; exit 1; \
 	}
+	@if kubectl --context "kind-$(KIND_CLUSTER)" get namespace argocd >/dev/null 2>&1; then \
+		echo "refusing to target Argo CD cluster '$(KIND_CLUSTER)'" >&2; exit 1; \
+	fi
 	skaffold dev --kube-context "kind-$(KIND_CLUSTER)" --cleanup=false
 
 ##@ Images

--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,16 @@ install-crds: manifests ## Install CRDs into the current cluster
 run: ## Run the operator locally against the current cluster
 	go run ./cmd/operator
 
+.PHONY: dev
+dev: ## Watch, rebuild, and redeploy operator/control-plane into the kind dev cluster
+	@if [ "$(KIND_CLUSTER)" = "$${KIND_ARGO_CLUSTER:-swe-argo}" ]; then \
+		echo "refusing to target the Argo CD mirror cluster '$(KIND_CLUSTER)'" >&2; exit 1; \
+	fi
+	@kind get clusters | grep -Fx -- "$(KIND_CLUSTER)" >/dev/null || { \
+		echo "kind cluster '$(KIND_CLUSTER)' does not exist; run 'make kind-up KIND_CLUSTER=$(KIND_CLUSTER)'" >&2; exit 1; \
+	}
+	skaffold dev --kube-context "kind-$(KIND_CLUSTER)" --cleanup=false
+
 ##@ Images
 
 .PHONY: docker-build

--- a/README.md
+++ b/README.md
@@ -160,6 +160,25 @@ Run the acceptance suite against the bootstrapped cluster with gVisor enabled:
 KIND_CLUSTER=swe-dev E2E_USE_EXISTING_CLUSTER=true E2E_RUNTIME_CLASS=gvisor ./hack/e2e.sh
 ```
 
+For the controller inner loop, this repository uses Skaffold v2.23.0 rather than Tilt: its
+native Docker, kind image-loading, and Helm support map directly onto the existing build
+and `values-kind.yaml` workflow without adding a cluster-side development service. After
+installing Skaffold and Helm and running `make kind-up`, start the watch loop with:
+
+```sh
+make dev
+```
+
+Skaffold builds and loads the operator and control-plane images, installs or upgrades the
+`swe-platform` Helm release with `values-kind.yaml`, and repeats that cycle when relevant
+source, chart template, or values files change. `make dev` always targets the
+`kind-swe-dev` context (or `kind-$KIND_CLUSTER` when overridden) and refuses the Argo mirror
+cluster named by `KIND_ARGO_CLUSTER` (default `swe-argo`). The environment base image is
+outside this controller loop; build and load it separately before starting Runs that need a
+fresh environment. Helm does not upgrade CRDs from a chart's `crds/` directory, so apply
+CRD changes separately with `kubectl --context "kind-${KIND_CLUSTER:-swe-dev}" apply
+--server-side --force-conflicts -f config/crd/bases`.
+
 Create runs with an explicit template, or reference a `Project` to use its default
 template:
 

--- a/README.md
+++ b/README.md
@@ -173,11 +173,12 @@ Skaffold builds and loads the operator and control-plane images, installs or upg
 `swe-platform` Helm release with `values-kind.yaml`, and repeats that cycle when relevant
 source, chart template, or values files change. `make dev` always targets the
 `kind-swe-dev` context (or `kind-$KIND_CLUSTER` when overridden) and refuses the Argo mirror
-cluster named by `KIND_ARGO_CLUSTER` (default `swe-argo`). The environment base image is
-outside this controller loop; build and load it separately before starting Runs that need a
-fresh environment. Helm does not upgrade CRDs from a chart's `crds/` directory, so apply
-CRD changes separately with `kubectl --context "kind-${KIND_CLUSTER:-swe-dev}" apply
---server-side --force-conflicts -f config/crd/bases`.
+cluster named by `KIND_ARGO_CLUSTER` (default `swe-argo`) or any target cluster containing
+the `argocd` namespace. The environment base image is outside this controller loop; build
+and load it separately before starting Runs that need a fresh environment. Helm does not
+upgrade CRDs from a chart's `crds/` directory, so apply CRD changes separately with
+`kubectl --context "kind-${KIND_CLUSTER:-swe-dev}" apply --server-side --force-conflicts -f
+config/crd/bases`.
 
 Create runs with an explicit template, or reference a `Project` to use its default
 template:

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -257,8 +257,9 @@ Cluster '$CLUSTER' is ready with RuntimeClass/gvisor and snapshot-capable
 StorageClass/csi-hostpath-sc.
 
 Next steps:
-  make docker-build
-  kind load docker-image ghcr.io/chris-cullins/swe-platform/operator:dev ghcr.io/chris-cullins/swe-platform/control-plane:dev ghcr.io/chris-cullins/swe-platform/env-base:dev --name $CLUSTER
-  helm upgrade --install swe-platform charts/swe-platform -n default -f charts/swe-platform/values-kind.yaml --set-string 'environmentTemplates[0].spec.runtimeClass=gvisor'
+  make docker-build-env-base
+  kind load docker-image ghcr.io/chris-cullins/swe-platform/env-base:dev --name $CLUSTER
+  make dev KIND_CLUSTER=$CLUSTER
+  make build-cli
   bin/swe run "fix the flaky tests" -t small
 EOF

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,29 @@
+apiVersion: skaffold/v4beta14
+kind: Config
+metadata:
+  name: swe-platform
+build:
+  local:
+    push: false
+  artifacts:
+    - image: ghcr.io/chris-cullins/swe-platform/operator
+      docker:
+        dockerfile: images/operator/Dockerfile
+    - image: ghcr.io/chris-cullins/swe-platform/control-plane
+      docker:
+        dockerfile: images/control-plane/Dockerfile
+deploy:
+  helm:
+    releases:
+      - name: swe-platform
+        chartPath: charts/swe-platform
+        namespace: default
+        valuesFiles:
+          - charts/swe-platform/values-kind.yaml
+        setValues:
+          environmentTemplates[0].spec.runtimeClass: gvisor
+        setValueTemplates:
+          image.repository: "{{.IMAGE_REPO_ghcr_io_chris_cullins_swe_platform_operator}}"
+          image.tag: "{{.IMAGE_TAG_ghcr_io_chris_cullins_swe_platform_operator}}@{{.IMAGE_DIGEST_ghcr_io_chris_cullins_swe_platform_operator}}"
+          controlPlane.image.repository: "{{.IMAGE_REPO_ghcr_io_chris_cullins_swe_platform_control_plane}}"
+          controlPlane.image.tag: "{{.IMAGE_TAG_ghcr_io_chris_cullins_swe_platform_control_plane}}@{{.IMAGE_DIGEST_ghcr_io_chris_cullins_swe_platform_control_plane}}"


### PR DESCRIPTION
## Summary
- add a pinned Skaffold configuration for operator/control-plane rebuild, kind image loading, and Helm redeploy
- expose the loop as `make dev` with an explicit kind context and an Argo mirror safety guard
- document the Skaffold decision, CRD limitation, setup requirements, and updated kind workflow

## Validation
- `skaffold diagnose --yaml-only`
- `skaffold render --offline --digest-source=tag` with image/runtime-class assertions
- `helm lint charts/swe-platform -f charts/swe-platform/values-kind.yaml --set-string 'environmentTemplates[0].spec.runtimeClass=gvisor'`
- `.agents/setup` idempotency and Skaffold v2.23.0 version check
- default and overridden Argo mirror guard checks
- `bash -n .agents/setup hack/kind-up.sh`
- `git diff --check`

A live Docker/kind cycle could not run in the implementation orb because Docker is unavailable there.

Closes #81