### PR TITLE
feat: add OpenAI Codex adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,9 +22,9 @@ browser sessions backed by repeated Kubernetes TokenReview/SAR authorization, an
 Run/Environment resource APIs for the console.
 Remaining gaps are marked `TODO(P0/P1/P2)` in code — most notably secure agent credential
 injection, additional agent adapters, GitHub App–scoped git tokens, and egress/portal
-networking. The `claude-code` (default) and `amp` adapters are registered and use sandboxd
+networking. The `claude-code` (default), `amp`, and `codex` adapters are registered and use sandboxd
 managed processes; Amp's `AMP_API_KEY` delivery remains an unmet prerequisite and adapter
-tests use a fake process service with no credentials.
+tests use fake process services; Codex supports process-scoped `CODEX_API_KEY` delivery.
 
 ## Architecture invariants — do not violate these
 

--- a/README.md
+++ b/README.md
@@ -270,6 +270,30 @@ against its service without separately solving that prerequisite; tests use a fa
 Abrupt cancellation stops only the Run-owned local process tree, but Amp's public contract does
 not guarantee that remote/server-backed thread work has also stopped.
 
+### Codex adapter
+
+Select Codex with `swe run --agent codex ...`. The coordinated image pins
+`@openai/codex@0.144.6`; the adapter invokes `codex exec --json --ephemeral
+--ignore-user-config --ignore-rules --sandbox workspace-write --color never
+--skip-git-repo-check -- PROMPT`. Exactly `-` is rejected because it is Codex's stdin sentinel,
+while other leading-hyphen prompts are protected by `--`. Each Run starts an ephemeral thread:
+the adapter never resumes latest or shared state, and requires exit zero, a nonempty
+`thread.started` ID, and a final coherent `turn.completed` with usage and no later terminal
+failure, error, or malformed line.
+
+Stdout and stderr are forwarded as bounded, gap-visible `codex.process-output` events with
+absolute offsets and exact uncertain-append retry behavior. On resume, the same Run identity
+starts a fresh process and thread in the new sandbox epoch against the retained workspace.
+Codex's nested `workspace-write` sandbox is defense in depth inside the outer Environment;
+gVisor availability and its current limitation are tracked in issue #10.
+
+An API-key profile is delivered as `CODEX_API_KEY` only through sandboxd launch material to the
+Run-owned process. It is never included in the public process spec or ambient environment, and
+other credential types are rejected before dialing. The selected agent and same-UID descendants
+can still read or disclose it; stronger credential isolation and additional credential forms
+remain issue #9 limitations. Acceptance tests use a fake Codex executable and no provider or
+network access.
+
 `--name` is the create idempotency key: retry an uncertain request with the same name and
 immutable task arguments. The CLI returns the existing Run only when its intent matches;
 the controller creates or claims the Environment server-side.

--- a/charts/swe-platform/README.md
+++ b/charts/swe-platform/README.md
@@ -6,6 +6,10 @@ chart or operator yet; secure runtime delivery remains deferred to issue #9. Do 
 credentials in chart values, Project configuration, or a custom image. The image only pins the
 public Amp CLI and disables its update check.
 
+The image also bundles the explicitly selected `codex` adapter and pinned Codex CLI. Codex API
+key profiles use sandboxd's process-scoped launch-material path as `CODEX_API_KEY`; never put the
+key in chart values, Project configuration, or custom-image ambient environment variables.
+
 This chart installs the swe-platform CRDs, operator, and the first control-plane API.
 The control plane accepts adapter-owned transcript events and streams them over SSE.
 Its bounded transcript store is currently process-local, so the chart requires one control-plane

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -19,6 +19,7 @@ import (
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
 	"github.com/Chris-Cullins/swe-platform/internal/adapters/amp"
 	"github.com/Chris-Cullins/swe-platform/internal/adapters/claudecode"
+	"github.com/Chris-Cullins/swe-platform/internal/adapters/codex"
 	"github.com/Chris-Cullins/swe-platform/internal/controllers"
 	"github.com/Chris-Cullins/swe-platform/internal/transcriptclient"
 )
@@ -132,5 +133,6 @@ func registeredAdapters() map[string]controllers.AdapterLifecycle {
 	return map[string]controllers.AdapterLifecycle{
 		"amp":         &amp.Adapter{},
 		"claude-code": &claudecode.Adapter{},
+		"codex":       &codex.Adapter{},
 	}
 }

--- a/cmd/operator/main_test.go
+++ b/cmd/operator/main_test.go
@@ -9,4 +9,7 @@ func TestDefaultClaudeCodeAdapterIsRegistered(t *testing.T) {
 	if registeredAdapters()["amp"] == nil {
 		t.Fatal("amp adapter is not registered")
 	}
+	if registeredAdapters()["codex"] == nil {
+		t.Fatal("codex adapter is not registered")
+	}
 }

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -141,12 +141,40 @@ sleep 5
 printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"result":"fake Amp completed"}'
 EOF
 chmod 0755 "$FAKE_ENV_CONTEXT/amp"
+cat > "$FAKE_ENV_CONTEXT/codex" <<'EOF'
+#!/bin/sh
+set -eu
+test "$#" -eq 12
+test "$1" = exec
+test "$2" = --json
+test "$3" = --ephemeral
+test "$4" = --ignore-user-config
+test "$5" = --ignore-rules
+test "$6" = --sandbox
+test "$7" = workspace-write
+test "$8" = --color
+test "$9" = never
+test "${10}" = --skip-git-repo-check
+test "${11}" = --
+test -z "${CODEX_API_KEY+x}"
+printf '%s\n' '{"type":"thread.started","thread_id":"fake-codex-thread"}'
+printf '%s\n' 'fake-codex-stderr-marker' >&2
+if [ "${12}" = 'fake Codex failure smoke test' ]; then
+	printf '%s\n' '{"type":"turn.failed","error":{"message":"fake Codex failed"}}'
+	exit 0
+fi
+test "${12}" = 'fake Codex lifecycle smoke test'
+sleep 5
+printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":2}}'
+EOF
+chmod 0755 "$FAKE_ENV_CONTEXT/codex"
 cat > "$FAKE_ENV_CONTEXT/Dockerfile" <<'EOF'
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 USER root
 COPY claude /usr/local/bin/claude
 COPY amp /usr/local/bin/amp
+COPY codex /usr/local/bin/codex
 USER swe
 EOF
 docker build --build-arg BASE_IMAGE="$ENV_IMAGE" -t "$E2E_ENV_IMAGE" "$FAKE_ENV_CONTEXT" >/dev/null
@@ -814,6 +842,28 @@ if ! grep -Fq 'fake-amp-stdout-marker' /tmp/swe-platform-amp-process-output.out 
 	exit 1
 fi
 kubectl delete run "$AMP_RUN_NAME" --wait=true >/dev/null
+
+echo "==> verifying fake Codex real Run lifecycle without credentials or network"
+CODEX_RUN_NAME=e2e-fake-codex-run
+bin/swe run "fake Codex lifecycle smoke test" --name "$CODEX_RUN_NAME" --environment "$ENV_NAME" --agent codex --wait=false
+kubectl wait --for=jsonpath='{.status.state}'=Running run/"$CODEX_RUN_NAME" --timeout=3m
+kubectl wait --for=jsonpath='{.status.state}'=Succeeded run/"$CODEX_RUN_NAME" --timeout=3m
+set +e
+curl --silent --no-buffer --max-time 2 -H "Authorization: Bearer ${E2E_BOOTSTRAP_TOKEN}" \
+	"http://127.0.0.1:18080/api/v1/namespaces/default/runs/${CODEX_RUN_NAME}/transcript" > /tmp/swe-platform-codex-transcript.out
+CODEX_TRANSCRIPT_STATUS=$?
+set -e
+if [[ "$CODEX_TRANSCRIPT_STATUS" != "0" && "$CODEX_TRANSCRIPT_STATUS" != "28" ]]; then echo "FAIL: Codex transcript read failed"; exit 1; fi
+grep -F '"source":"codex"' /tmp/swe-platform-codex-transcript.out | grep -F '"type":"codex.process-output"' | \
+	grep -oE '"data":"[A-Za-z0-9+/=]+"' | sed 's/^"data":"//; s/"$//' | while IFS= read -r encoded; do printf '%s' "$encoded" | base64 --decode || exit 1; done > /tmp/swe-platform-codex-process-output.out
+for marker in fake-codex-thread fake-codex-stderr-marker turn.completed; do grep -Fq "$marker" /tmp/swe-platform-codex-process-output.out || { echo "FAIL: missing Codex marker $marker"; exit 1; }; done
+kubectl delete run "$CODEX_RUN_NAME" --wait=true >/dev/null
+
+echo "==> verifying fake Codex terminal failure through the real controller"
+CODEX_FAILED_RUN_NAME=e2e-fake-codex-failed-run
+bin/swe run "fake Codex failure smoke test" --name "$CODEX_FAILED_RUN_NAME" --environment "$ENV_NAME" --agent codex --wait=false
+kubectl wait --for=jsonpath='{.status.state}'=Failed run/"$CODEX_FAILED_RUN_NAME" --timeout=3m
+kubectl delete run "$CODEX_FAILED_RUN_NAME" --wait=true >/dev/null
 
 echo "==> verifying idle pause and terminal wake through the control plane"
 PRE_IDLE_POD_UID=$(kubectl get pod "$POD_NAME" -o jsonpath='{.metadata.uid}')

--- a/images/env-base/Dockerfile
+++ b/images/env-base/Dockerfile
@@ -52,6 +52,23 @@ RUN case "$TARGETARCH" in \
 	&& rm "$wrapper" "$archive" amp \
 	&& test "$(/usr/local/bin/amp --version | awk '{print $1}')" = "${AMP_VERSION}"
 
+FROM node:24-bookworm-slim AS codex
+ARG CODEX_VERSION=0.144.6
+ARG TARGETARCH
+RUN case "$TARGETARCH" in \
+		amd64) suffix=linux-x64; triple=x86_64-unknown-linux-musl; integrity='sha512-4E7EnzCg0OnBxCyYnwJ+qnZwWHYe0YScr5ucKWbngE9u4+0XrpWELqq2Kn9jl5GZK8MDjU7PrJwFIwusHOHjuw==' ;; \
+		arm64) suffix=linux-arm64; triple=aarch64-unknown-linux-musl; integrity='sha512-PGiLXMN+2IQRkf7tOLi64dMInjU1pRLbz0Rwfj/yt2Y97SZQqAjFQoi2wmswmqtqMDnfwCPTC1DRXVQkvU6T6Q==' ;; \
+		*) echo "unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; \
+	esac \
+	&& wrapper="$(npm pack "@openai/codex@${CODEX_VERSION}" --silent)" \
+	&& archive="$(npm pack "@openai/codex@${CODEX_VERSION}-${suffix}" --silent)" \
+	&& node -e 'const [file, want] = process.argv.slice(1); const fs = require("fs"), crypto = require("crypto"); const got = "sha512-" + crypto.createHash("sha512").update(fs.readFileSync(file)).digest("base64"); if (got !== want) throw new Error(`integrity mismatch for ${file}`)' "$wrapper" 'sha512-wk+2CWiBNXiJLBoN2D08N9RceWkSBnlgk5g2K1a4CXrP/C0gdlHyRUG7RFzm9y41DCK/7tvCct233JVxyFmznw==' \
+	&& node -e 'const [file, want] = process.argv.slice(1); const fs = require("fs"), crypto = require("crypto"); const got = "sha512-" + crypto.createHash("sha512").update(fs.readFileSync(file)).digest("base64"); if (got !== want) throw new Error(`integrity mismatch for ${file}`)' "$archive" "$integrity" \
+	&& mkdir -p /opt/codex && tar -xzf "$archive" -C /opt/codex --strip-components=3 "package/vendor/$triple" \
+	&& test -x /opt/codex/codex-resources/bwrap \
+	&& test -f /opt/codex/codex-package.json \
+	&& test "$(/opt/codex/bin/codex --version)" = "codex-cli ${CODEX_VERSION}"
+
 # Base image for environments.
 FROM debian:12-slim AS environment
 
@@ -68,9 +85,15 @@ COPY --from=tmux-build /src/tmux /usr/bin/tmux
 COPY --from=claude-code /usr/local/lib/node_modules/@anthropic-ai /usr/local/lib/node_modules/@anthropic-ai
 COPY --from=claude-code /usr/local/bin/claude /usr/local/bin/claude
 COPY --from=amp /usr/local/bin/amp /usr/local/bin/amp
+COPY --from=codex /opt/codex /opt/codex
+RUN ln -s /opt/codex/bin/codex /usr/local/bin/codex
 ENV AMP_SKIP_UPDATE_CHECK=1
 RUN claude --version \
-	&& test "$(amp --version | awk '{print $1}')" = "0.0.1784492094-g5d18e2"
+	&& test "$(amp --version | awk '{print $1}')" = "0.0.1784492094-g5d18e2" \
+	&& test "$(codex --version)" = "codex-cli 0.144.6" \
+	&& test "$(readlink -f "$(command -v codex)")" = /opt/codex/bin/codex \
+	&& test -x /opt/codex/codex-resources/bwrap \
+	&& test -f /opt/codex/codex-package.json
 
 USER swe
 WORKDIR /workspace

--- a/internal/adapters/codex/adapter.go
+++ b/internal/adapters/codex/adapter.go
@@ -1,0 +1,336 @@
+// Package codex implements the OpenAI Codex foreground-process adapter.
+package codex
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
+	"github.com/Chris-Cullins/swe-platform/internal/controllers"
+	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
+)
+
+const (
+	processRole = "agent"
+	pageMax     = 64 * 1024
+)
+
+type Adapter struct {
+	Executable string
+	mu         sync.Mutex
+	cursors    map[cursor]uint64
+	pending    map[cursor]pendingEvent
+}
+type cursor struct {
+	environment, owner, execution string
+	stream                        sandboxdv1.OutputStream
+}
+type pendingEvent struct {
+	event      controllers.AdapterEvent
+	nextOffset uint64
+}
+type outputEvent struct {
+	ExecutionID  string `json:"executionId"`
+	Stream       string `json:"stream"`
+	Offset       uint64 `json:"offset"`
+	NextOffset   uint64 `json:"nextOffset"`
+	GapBytes     uint64 `json:"gapBytes,omitempty"`
+	RetainedFrom uint64 `json:"retainedFrom"`
+	ProducedEnd  uint64 `json:"producedEnd"`
+	EOF          bool   `json:"eof"`
+	Data         []byte `json:"data,omitempty"`
+}
+type terminalEvent struct {
+	Type     string          `json:"type"`
+	ThreadID string          `json:"thread_id"`
+	Usage    json.RawMessage `json:"usage"`
+	Error    struct {
+		Message string `json:"message"`
+	} `json:"error"`
+	Message string `json:"message"`
+}
+
+type outputTruncatedError struct {
+	retainedFrom uint64
+}
+
+func (e *outputTruncatedError) Error() string {
+	return fmt.Sprintf("retained from offset %d", e.retainedFrom)
+}
+
+func (a *Adapter) executable() string {
+	if a.Executable != "" {
+		return a.Executable
+	}
+	return "codex"
+}
+func key(t controllers.AdapterTask) *sandboxdv1.ProcessKey {
+	return &sandboxdv1.ProcessKey{OwnerId: t.ID, Role: processRole}
+}
+func (a *Adapter) spec(t controllers.AdapterTask) *sandboxdv1.ProcessSpec {
+	return &sandboxdv1.ProcessSpec{Argv: []string{a.executable(), "exec", "--json", "--ephemeral", "--ignore-user-config", "--ignore-rules", "--sandbox", "workspace-write", "--color", "never", "--skip-git-repo-check", "--", t.Prompt}, EnvMode: sandboxdv1.EnvironmentMode_ENVIRONMENT_MODE_INHERIT}
+}
+
+func (a *Adapter) EnsureAccepted(ctx context.Context, task controllers.AdapterTask, sandbox controllers.AdapterSandbox, credential *controllers.AdapterCredential) error {
+	if task.Prompt == "-" {
+		return fmt.Errorf("%w: Codex prompt '-' requires managed stdin", controllers.ErrAdapterTaskRejected)
+	}
+	if credential != nil && credential.Type != platformv1alpha1.AgentCredentialTypeAPIKey {
+		return fmt.Errorf("%w: unsupported credential type %q", controllers.ErrAdapterTaskRejected, credential.Type)
+	}
+	client, closeConnection, err := sandbox.DialProcess(ctx)
+	if err != nil {
+		return err
+	}
+	defer closeConnection()
+	if credential == nil {
+		_, err = client.Start(ctx, &sandboxdv1.StartProcessRequest{Key: key(task), Spec: a.spec(task)})
+		return err
+	}
+	apiKey := append([]byte(nil), credential.APIKey...)
+	defer clear(apiKey)
+	_, err = client.StartWithLaunchMaterial(ctx, &sandboxdv1.StartProcessWithLaunchMaterialRequest{Key: key(task), Spec: a.spec(task), LaunchMaterial: &sandboxdv1.LaunchMaterial{SecretEnv: map[string][]byte{"CODEX_API_KEY": apiKey}}})
+	return err
+}
+
+func (a *Adapter) Observe(ctx context.Context, task controllers.AdapterTask, sandbox controllers.AdapterSandbox) (controllers.AdapterObservation, string, error) {
+	client, closeConnection, err := sandbox.DialProcess(ctx)
+	if err != nil {
+		return "", "", err
+	}
+	defer closeConnection()
+	p, err := client.Get(ctx, &sandboxdv1.GetProcessRequest{Key: key(task)})
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return controllers.AdapterObservationFailed, "Codex execution is absent in the current sandbox epoch", nil
+		}
+		return "", "", err
+	}
+	if err = a.forward(ctx, client, task, sandbox, p); err != nil {
+		if errors.Is(err, controllers.ErrAdapterEventRejected) {
+			return controllers.AdapterObservationFailed, "Codex transcript output was permanently rejected", nil
+		}
+		return "", "", err
+	}
+	switch p.State {
+	case sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, sandboxdv1.ProcessState_PROCESS_STATE_STOPPING:
+		return controllers.AdapterObservationRunning, "Codex is running", nil
+	case sandboxdv1.ProcessState_PROCESS_STATE_FAILED:
+		return controllers.AdapterObservationFailed, message("Codex failed to start", p.Error), nil
+	case sandboxdv1.ProcessState_PROCESS_STATE_EXITED:
+		if p.ExitCode == nil {
+			return controllers.AdapterObservationFailed, "Codex exited without an exit code", nil
+		}
+		if p.GetExitCode() != 0 {
+			return controllers.AdapterObservationFailed, fmt.Sprintf("Codex exited with code %d", p.GetExitCode()), nil
+		}
+		out, e := readOutput(ctx, client, key(task), p.ExecutionId)
+		if e != nil {
+			var truncated *outputTruncatedError
+			if errors.As(e, &truncated) {
+				return controllers.AdapterObservationFailed, message("Codex stdout was truncated before terminal validation", truncated.Error()), nil
+			}
+			return "", "", e
+		}
+		thread, detail, ok := terminal(out)
+		if !ok {
+			return controllers.AdapterObservationFailed, message("Codex exited without a coherent completed turn", detail), nil
+		}
+		return controllers.AdapterObservationSucceeded, "Codex completed thread " + thread, nil
+	default:
+		return controllers.AdapterObservationFailed, fmt.Sprintf("Codex returned invalid process state %s", p.State), nil
+	}
+}
+
+func terminal(output []byte) (string, string, bool) {
+	var thread string
+	completed := false
+	terminalSeen := false
+	eventCount := 0
+	lastError := ""
+	for _, line := range bytes.Split(output, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		var e terminalEvent
+		if json.Unmarshal(line, &e) != nil {
+			return thread, "malformed JSONL output", false
+		}
+		if terminalSeen {
+			return thread, "output after completed turn", false
+		}
+		switch e.Type {
+		case "thread.started":
+			if eventCount != 0 || thread != "" {
+				return thread, "duplicate or late thread.started", false
+			}
+			if e.ThreadID == "" {
+				return "", "empty thread.started thread_id", false
+			}
+			thread = e.ThreadID
+		case "turn.completed":
+			if thread == "" {
+				return "", "turn.completed before thread.started", false
+			}
+			terminalSeen = true
+			var usage map[string]json.RawMessage
+			completed = json.Unmarshal(e.Usage, &usage) == nil && usage != nil
+		case "turn.failed":
+			terminalSeen = true
+			return thread, e.Error.Message, false
+		case "error":
+			lastError = e.Message
+		}
+		eventCount++
+	}
+	if thread == "" {
+		return "", "missing thread.started", false
+	}
+	if !completed {
+		if lastError != "" {
+			return thread, lastError, false
+		}
+		return thread, "missing turn.completed usage", false
+	}
+	return thread, "", true
+}
+
+func (a *Adapter) Cancel(ctx context.Context, task controllers.AdapterTask, sandbox controllers.AdapterSandbox) error {
+	client, closeConnection, err := sandbox.DialProcess(ctx)
+	if err != nil {
+		return err
+	}
+	defer closeConnection()
+	p, err := client.Stop(ctx, &sandboxdv1.StopProcessRequest{Key: key(task), Mode: sandboxdv1.StopMode_STOP_MODE_GRACEFUL, GracePeriodMs: 10_000})
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return nil
+		}
+		return err
+	}
+	switch p.State {
+	case sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, sandboxdv1.ProcessState_PROCESS_STATE_STOPPING:
+		return controllers.ErrAdapterCancellationPending
+	case sandboxdv1.ProcessState_PROCESS_STATE_EXITED, sandboxdv1.ProcessState_PROCESS_STATE_FAILED:
+		err = a.forward(ctx, client, task, sandbox, p)
+		if errors.Is(err, controllers.ErrAdapterEventRejected) {
+			return nil
+		}
+		return err
+	default:
+		return fmt.Errorf("Codex cancellation returned invalid process state %s", p.State)
+	}
+}
+
+func (a *Adapter) forward(ctx context.Context, client sandboxdv1.ProcessServiceClient, task controllers.AdapterTask, sandbox controllers.AdapterSandbox, p *sandboxdv1.Process) error {
+	if sandbox.EmitEvent == nil || p.ExecutionId == "" {
+		return nil
+	}
+	for _, stream := range []sandboxdv1.OutputStream{sandboxdv1.OutputStream_OUTPUT_STREAM_STDOUT, sandboxdv1.OutputStream_OUTPUT_STREAM_STDERR} {
+		c := cursor{string(sandbox.EnvironmentUID), task.ID, p.ExecutionId, stream}
+		offset := a.getCursor(c)
+		for {
+			if pending, ok := a.getPending(c); ok {
+				if err := sandbox.EmitEvent(ctx, pending.event); err != nil {
+					return err
+				}
+				offset = pending.nextOffset
+				a.commit(c, offset)
+				continue
+			}
+			r, err := client.ReadOutput(ctx, &sandboxdv1.ReadOutputRequest{Key: key(task), ExecutionId: p.ExecutionId, Stream: stream, Offset: offset, MaxBytes: pageMax})
+			if err != nil {
+				return err
+			}
+			if len(r.Data) == 0 && r.GapBytes == 0 {
+				break
+			}
+			payload, _ := json.Marshal(outputEvent{p.ExecutionId, streamName(stream), r.Offset, r.NextOffset, r.GapBytes, r.RetainedStart, r.ProducedEnd, r.Eof, r.Data})
+			digest := sha256.Sum256(payload)
+			event := controllers.AdapterEvent{Source: "codex", Type: "codex.process-output", IdempotencyKey: fmt.Sprintf("v1:%s:%x", streamName(stream), digest), Data: payload}
+			a.setPending(c, pendingEvent{event, r.NextOffset})
+			if err = sandbox.EmitEvent(ctx, event); err != nil {
+				return err
+			}
+			offset = r.NextOffset
+			a.commit(c, offset)
+			if r.Eof || offset >= r.ProducedEnd {
+				break
+			}
+		}
+	}
+	return nil
+}
+func readOutput(ctx context.Context, client sandboxdv1.ProcessServiceClient, k *sandboxdv1.ProcessKey, execution string) ([]byte, error) {
+	var b bytes.Buffer
+	var offset uint64
+	for {
+		r, e := client.ReadOutput(ctx, &sandboxdv1.ReadOutputRequest{Key: k, ExecutionId: execution, Stream: sandboxdv1.OutputStream_OUTPUT_STREAM_STDOUT, Offset: offset, MaxBytes: pageMax})
+		if e != nil {
+			return nil, e
+		}
+		if r.GapBytes != 0 || r.Offset != offset {
+			return nil, &outputTruncatedError{retainedFrom: r.RetainedStart}
+		}
+		b.Write(r.Data)
+		offset = r.NextOffset
+		if r.Eof || offset >= r.ProducedEnd {
+			return b.Bytes(), nil
+		}
+	}
+}
+func streamName(s sandboxdv1.OutputStream) string {
+	if s == sandboxdv1.OutputStream_OUTPUT_STREAM_STDERR {
+		return "stderr"
+	}
+	return "stdout"
+}
+func message(a, b string) string {
+	if b == "" {
+		return a
+	}
+	if len(b) > 512 {
+		b = b[:512] + "…"
+	}
+	return a + ": " + b
+}
+func (a *Adapter) getCursor(c cursor) uint64 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.cursors == nil {
+		a.cursors = map[cursor]uint64{}
+	}
+	return a.cursors[c]
+}
+func (a *Adapter) getPending(c cursor) (pendingEvent, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	p, ok := a.pending[c]
+	return p, ok
+}
+func (a *Adapter) setPending(c cursor, p pendingEvent) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.pending == nil {
+		a.pending = map[cursor]pendingEvent{}
+	}
+	a.pending[c] = p
+}
+func (a *Adapter) commit(c cursor, o uint64) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.cursors == nil {
+		a.cursors = map[cursor]uint64{}
+	}
+	a.cursors[c] = o
+	delete(a.pending, c)
+}

--- a/internal/adapters/codex/adapter_test.go
+++ b/internal/adapters/codex/adapter_test.go
@@ -1,0 +1,390 @@
+package codex
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/apimachinery/pkg/types"
+
+	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
+	"github.com/Chris-Cullins/swe-platform/internal/controllers"
+	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
+)
+
+type launchClient struct {
+	sandboxdv1.ProcessServiceClient
+	starts        int
+	launches      int
+	key           *sandboxdv1.ProcessKey
+	spec          *sandboxdv1.ProcessSpec
+	material      *sandboxdv1.LaunchMaterial
+	launchRequest *sandboxdv1.StartProcessWithLaunchMaterialRequest
+	launchErr     error
+}
+
+func (f *launchClient) Start(_ context.Context, r *sandboxdv1.StartProcessRequest, _ ...grpc.CallOption) (*sandboxdv1.Process, error) {
+	f.starts++
+	f.key = r.Key
+	f.spec = r.Spec
+	return &sandboxdv1.Process{}, nil
+}
+func (f *launchClient) StartWithLaunchMaterial(_ context.Context, r *sandboxdv1.StartProcessWithLaunchMaterialRequest, _ ...grpc.CallOption) (*sandboxdv1.Process, error) {
+	f.launches++
+	f.key = r.Key
+	f.spec = r.Spec
+	f.launchRequest = r
+	f.material = &sandboxdv1.LaunchMaterial{SecretEnv: map[string][]byte{"CODEX_API_KEY": append([]byte(nil), r.LaunchMaterial.SecretEnv["CODEX_API_KEY"]...)}}
+	if f.launchErr != nil {
+		return nil, f.launchErr
+	}
+	return &sandboxdv1.Process{}, nil
+}
+
+func sandboxFor(c sandboxdv1.ProcessServiceClient, dials *int) controllers.AdapterSandbox {
+	return controllers.AdapterSandbox{EnvironmentUID: "epoch", DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
+		*dials++
+		return c, func() error { return nil }, nil
+	}}
+}
+
+func TestAcceptancePromptAndCredentialSafety(t *testing.T) {
+	dials := 0
+	c := &launchClient{}
+	a := &Adapter{Executable: "fake-codex"}
+	task := controllers.AdapterTask{ID: "run-uid", Prompt: "--leading\nline"}
+	if err := a.EnsureAccepted(context.Background(), task, sandboxFor(c, &dials), nil); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"fake-codex", "exec", "--json", "--ephemeral", "--ignore-user-config", "--ignore-rules", "--sandbox", "workspace-write", "--color", "never", "--skip-git-repo-check", "--", task.Prompt}
+	if !reflect.DeepEqual(c.spec.Argv, want) || c.spec.Env["CODEX_API_KEY"] != "" || c.starts != 1 || c.key.OwnerId != task.ID || c.key.Role != processRole {
+		t.Fatalf("spec/start = %#v/%d", c.spec, c.starts)
+	}
+	credential := &controllers.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: []byte("secret")}
+	if err := a.EnsureAccepted(context.Background(), task, sandboxFor(c, &dials), credential); err != nil {
+		t.Fatal(err)
+	}
+	if c.launches != 1 || string(c.material.SecretEnv["CODEX_API_KEY"]) != "secret" || string(credential.APIKey) != "secret" {
+		t.Fatalf("launch material = %#v", c.material)
+	}
+	if c.launchRequest == nil || !reflect.DeepEqual(c.launchRequest.LaunchMaterial.SecretEnv["CODEX_API_KEY"], make([]byte, len("secret"))) {
+		t.Fatal("adapter did not clear its temporary launch-material copy")
+	}
+	before := dials
+	for _, rejected := range []struct {
+		task controllers.AdapterTask
+		cred *controllers.AdapterCredential
+	}{{task: controllers.AdapterTask{Prompt: "-"}}, {task: task, cred: &controllers.AdapterCredential{Type: "OAuth"}}} {
+		if err := a.EnsureAccepted(context.Background(), rejected.task, sandboxFor(c, &dials), rejected.cred); !errors.Is(err, controllers.ErrAdapterTaskRejected) {
+			t.Fatalf("rejection = %v", err)
+		}
+	}
+	if dials != before {
+		t.Fatalf("rejections dialed: %d -> %d", before, dials)
+	}
+}
+
+func TestLaunchMaterialFailureDoesNotFallbackToAmbientStart(t *testing.T) {
+	dials := 0
+	client := &launchClient{launchErr: status.Error(codes.Unimplemented, "old sandboxd")}
+	err := (&Adapter{}).EnsureAccepted(context.Background(), controllers.AdapterTask{ID: "run", Prompt: "task"}, sandboxFor(client, &dials), &controllers.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: []byte("secret")})
+	if status.Code(err) != codes.Unimplemented || client.starts != 0 || client.launches != 1 {
+		t.Fatalf("EnsureAccepted = %v, starts/launches %d/%d", err, client.starts, client.launches)
+	}
+}
+
+func TestAcceptanceIsDuplicateSafeAndFreshEpoch(t *testing.T) {
+	task := controllers.AdapterTask{ID: "run-uid", Prompt: "task"}
+	adapter := &Adapter{}
+	first := &launchClient{}
+	firstDials := 0
+	for range 2 {
+		if err := adapter.EnsureAccepted(context.Background(), task, sandboxFor(first, &firstDials), nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if first.starts != 2 || firstDials != 2 || first.key.OwnerId != task.ID {
+		t.Fatalf("first epoch starts/dials/key = %d/%d/%#v", first.starts, firstDials, first.key)
+	}
+	second := &launchClient{}
+	secondDials := 0
+	if err := adapter.EnsureAccepted(context.Background(), task, sandboxFor(second, &secondDials), nil); err != nil {
+		t.Fatal(err)
+	}
+	if second.starts != 1 || secondDials != 1 || second.key.OwnerId != task.ID {
+		t.Fatalf("second epoch starts/dials/key = %d/%d/%#v", second.starts, secondDials, second.key)
+	}
+}
+
+func TestTerminalContract(t *testing.T) {
+	tests := []struct {
+		name, output, thread, detail string
+		ok                           bool
+	}{
+		{"success", `{"type":"thread.started","thread_id":"thread-1"}` + "\n" + `{"type":"turn.completed","usage":{"input_tokens":1}}`, "thread-1", "", true},
+		{"missing thread", `{"type":"turn.completed","usage":{}}`, "", "turn.completed before thread.started", false},
+		{"empty thread", `{"type":"thread.started","thread_id":""}` + "\n" + `{"type":"turn.completed","usage":{}}`, "", "empty thread.started thread_id", false},
+		{"missing terminal", `{"type":"thread.started","thread_id":"t"}`, "t", "missing turn.completed usage", false},
+		{"missing usage", `{"type":"thread.started","thread_id":"t"}` + "\n" + `{"type":"turn.completed"}`, "t", "missing turn.completed usage", false},
+		{"scalar usage", `{"type":"thread.started","thread_id":"t"}` + "\n" + `{"type":"turn.completed","usage":"invalid"}`, "t", "missing turn.completed usage", false},
+		{"failed", `{"type":"thread.started","thread_id":"t"}` + "\n" + `{"type":"turn.failed","error":{"message":"denied"}}`, "t", "denied", false},
+		{"error", `{"type":"thread.started","thread_id":"t"}` + "\n" + `{"type":"error","message":"boom"}`, "t", "boom", false},
+		{"recovered error", `{"type":"thread.started","thread_id":"t"}` + "\n" + `{"type":"error","message":"retrying"}` + "\n" + `{"type":"item.completed"}` + "\n" + `{"type":"turn.completed","usage":{}}`, "t", "", true},
+		{"malformed between events", `{"type":"thread.started","thread_id":"t"}` + "\nnope\n" + `{"type":"turn.completed","usage":{}}`, "t", "malformed JSONL output", false},
+		{"later malformed", `{"type":"thread.started","thread_id":"t"}` + "\n" + `{"type":"turn.completed","usage":{}}` + "\nnope", "t", "malformed JSONL output", false},
+		{"later event", `{"type":"thread.started","thread_id":"t"}` + "\n" + `{"type":"turn.completed","usage":{}}` + "\n" + `{"type":"item.completed"}`, "t", "output after completed turn", false},
+		{"duplicate thread", `{"type":"thread.started","thread_id":"t"}` + "\n" + `{"type":"thread.started","thread_id":"other"}`, "t", "duplicate or late thread.started", false},
+		{"valid item", `{"type":"thread.started","thread_id":"t"}` + "\n" + `{"type":"item.completed"}` + "\n" + `{"type":"turn.completed","usage":{}}`, "t", "", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			thread, detail, ok := terminal([]byte(tc.output))
+			if thread != tc.thread || detail != tc.detail || ok != tc.ok {
+				t.Fatalf("terminal = %q, %q, %v", thread, detail, ok)
+			}
+		})
+	}
+}
+
+type fakeProcessClient struct {
+	sandboxdv1.ProcessServiceClient
+	process      *sandboxdv1.Process
+	stdout       []byte
+	stderr       []byte
+	gapBytes     uint64
+	retainedFrom uint64
+	getErr       error
+	stopErr      error
+	stoppedKey   *sandboxdv1.ProcessKey
+	stopMode     sandboxdv1.StopMode
+	readRequests []*sandboxdv1.ReadOutputRequest
+}
+
+func (f *fakeProcessClient) Get(context.Context, *sandboxdv1.GetProcessRequest, ...grpc.CallOption) (*sandboxdv1.Process, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	return f.process, nil
+}
+
+func (f *fakeProcessClient) Stop(_ context.Context, request *sandboxdv1.StopProcessRequest, _ ...grpc.CallOption) (*sandboxdv1.Process, error) {
+	f.stoppedKey, f.stopMode = request.Key, request.Mode
+	if f.stopErr != nil {
+		return nil, f.stopErr
+	}
+	if f.process == nil {
+		return &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED}, nil
+	}
+	return f.process, nil
+}
+
+func (f *fakeProcessClient) ReadOutput(_ context.Context, request *sandboxdv1.ReadOutputRequest, _ ...grpc.CallOption) (*sandboxdv1.ReadOutputResponse, error) {
+	f.readRequests = append(f.readRequests, request)
+	data := f.stdout
+	retainedFrom := f.retainedFrom
+	if request.Stream == sandboxdv1.OutputStream_OUTPUT_STREAM_STDERR {
+		data, retainedFrom = f.stderr, 0
+	}
+	producedEnd := retainedFrom + uint64(len(data))
+	offset := request.Offset
+	var gapBytes uint64
+	if offset < retainedFrom {
+		gapBytes = retainedFrom - offset
+		offset = retainedFrom
+	}
+	if offset > producedEnd {
+		return nil, status.Error(codes.OutOfRange, "offset")
+	}
+	start := offset - retainedFrom
+	end := min(len(data), int(start)+int(request.MaxBytes))
+	return &sandboxdv1.ReadOutputResponse{
+		Data: append([]byte(nil), data[start:end]...), Offset: offset,
+		NextOffset: retainedFrom + uint64(end), GapBytes: gapBytes, RetainedStart: retainedFrom,
+		ProducedEnd: producedEnd, Eof: end == len(data),
+	}, nil
+}
+
+func processSandbox(client sandboxdv1.ProcessServiceClient, epoch string) controllers.AdapterSandbox {
+	return controllers.AdapterSandbox{
+		EnvironmentUID: types.UID(epoch),
+		DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
+			return client, func() error { return nil }, nil
+		},
+	}
+}
+
+func TestObservationOutcomes(t *testing.T) {
+	exit0, exit1 := int32(0), int32(1)
+	success := `{"type":"thread.started","thread_id":"thread-1"}` + "\n" + `{"type":"turn.completed","usage":{"input_tokens":1}}` + "\n"
+	tests := []struct {
+		name    string
+		process *sandboxdv1.Process
+		stdout  string
+		want    controllers.AdapterObservation
+	}{
+		{"running", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "e"}, "", controllers.AdapterObservationRunning},
+		{"stopping", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_STOPPING, ExecutionId: "e"}, "", controllers.AdapterObservationRunning},
+		{"start failure", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_FAILED, ExecutionId: "e", Error: "not found"}, "", controllers.AdapterObservationFailed},
+		{"success", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, success, controllers.AdapterObservationSucceeded},
+		{"missing exit", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e"}, success, controllers.AdapterObservationFailed},
+		{"nonzero", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit1}, success, controllers.AdapterObservationFailed},
+		{"malformed", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, "not-json\n", controllers.AdapterObservationFailed},
+		{"missing thread", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, `{"type":"turn.completed","usage":{}}`, controllers.AdapterObservationFailed},
+		{"missing terminal", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, `{"type":"thread.started","thread_id":"t"}`, controllers.AdapterObservationFailed},
+		{"turn failed", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, `{"type":"thread.started","thread_id":"t"}` + "\n" + `{"type":"turn.failed","error":{"message":"failed"}}`, controllers.AdapterObservationFailed},
+		{"error", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, `{"type":"thread.started","thread_id":"t"}` + "\n" + `{"type":"error","message":"failed"}`, controllers.AdapterObservationFailed},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, processSandbox(&fakeProcessClient{process: test.process, stdout: []byte(test.stdout)}, "epoch"))
+			if err != nil || got != test.want {
+				t.Fatalf("Observe = %q, %v; want %q", got, err, test.want)
+			}
+		})
+	}
+	absent, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, processSandbox(&fakeProcessClient{getErr: status.Error(codes.NotFound, "gone")}, "epoch"))
+	if err != nil || absent != controllers.AdapterObservationFailed {
+		t.Fatalf("absent Observe = %q, %v", absent, err)
+	}
+}
+
+func TestTerminalObservationFailsOnRetainedOutputGap(t *testing.T) {
+	exit0 := int32(0)
+	client := &fakeProcessClient{
+		process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "execution", ExitCode: &exit0},
+		stdout:  []byte(`{"type":"turn.completed","usage":{}}`), retainedFrom: 1024,
+	}
+	got, detail, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, processSandbox(client, "epoch"))
+	if err != nil || got != controllers.AdapterObservationFailed || !strings.Contains(detail, "retained from offset 1024") {
+		t.Fatalf("Observe = %q, %q, %v", got, detail, err)
+	}
+}
+
+func TestCancellationIsRunFencedAndWaitsForTerminalProcess(t *testing.T) {
+	client := &fakeProcessClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_STOPPING, ExecutionId: "execution"}}
+	err := (&Adapter{}).Cancel(context.Background(), controllers.AdapterTask{ID: "run-uid"}, processSandbox(client, "epoch"))
+	if !errors.Is(err, controllers.ErrAdapterCancellationPending) || client.stoppedKey.OwnerId != "run-uid" || client.stoppedKey.Role != processRole || client.stopMode != sandboxdv1.StopMode_STOP_MODE_GRACEFUL {
+		t.Fatalf("Cancel = %v, key %#v, mode %s", err, client.stoppedKey, client.stopMode)
+	}
+	client.process.State = sandboxdv1.ProcessState_PROCESS_STATE_EXITED
+	if err := (&Adapter{}).Cancel(context.Background(), controllers.AdapterTask{ID: "run-uid"}, processSandbox(client, "epoch")); err != nil {
+		t.Fatalf("terminal Cancel = %v", err)
+	}
+}
+
+func TestCancellationTreatsAbsentProcessAsComplete(t *testing.T) {
+	client := &fakeProcessClient{stopErr: status.Error(codes.NotFound, "absent")}
+	if err := (&Adapter{}).Cancel(context.Background(), controllers.AdapterTask{ID: "run-uid"}, processSandbox(client, "epoch")); err != nil {
+		t.Fatalf("Cancel absent process = %v", err)
+	}
+}
+
+func TestOutputIsBoundedGapVisibleAndAdapterOwned(t *testing.T) {
+	client := &fakeProcessClient{
+		process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"},
+		stdout:  []byte("stdout"), stderr: []byte("stderr"), gapBytes: 9, retainedFrom: 9,
+	}
+	var events []controllers.AdapterEvent
+	sandbox := processSandbox(client, "epoch")
+	sandbox.EmitEvent = func(_ context.Context, event controllers.AdapterEvent) error {
+		events = append(events, event)
+		return nil
+	}
+	adapter := &Adapter{}
+	for range 2 {
+		if _, _, err := adapter.Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(events) != 2 || client.readRequests[0].MaxBytes != pageMax {
+		t.Fatalf("events/read requests = %d/%#v", len(events), client.readRequests)
+	}
+	for _, event := range events {
+		if event.Source != "codex" || event.Type != "codex.process-output" || !strings.HasPrefix(event.IdempotencyKey, "v1:") {
+			t.Fatalf("event = %#v", event)
+		}
+	}
+	var output outputEvent
+	if err := json.Unmarshal(events[0].Data, &output); err != nil || output.GapBytes != 9 || output.RetainedFrom != 9 || string(output.Data) != "stdout" {
+		t.Fatalf("stdout output = %#v, %v", output, err)
+	}
+}
+
+func TestTransientOutputFailureRetriesExactEvent(t *testing.T) {
+	client := &fakeProcessClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"}, stdout: []byte("output")}
+	var events []controllers.AdapterEvent
+	sandbox := processSandbox(client, "epoch")
+	sandbox.EmitEvent = func(_ context.Context, event controllers.AdapterEvent) error {
+		events = append(events, event)
+		if len(events) == 1 {
+			return errors.New("retry")
+		}
+		return nil
+	}
+	adapter := &Adapter{}
+	if _, _, err := adapter.Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err == nil {
+		t.Fatal("wanted transient error")
+	}
+	client.stdout = []byte("output appended")
+	if _, _, err := adapter.Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 3 || !reflect.DeepEqual(events[0], events[1]) {
+		t.Fatalf("events = %#v", events)
+	}
+	var appended outputEvent
+	if json.Unmarshal(events[2].Data, &appended) != nil || appended.Offset != 6 || string(appended.Data) != " appended" {
+		t.Fatalf("appended event = %#v", appended)
+	}
+}
+
+func TestPermanentOutputRejectionFailsObserveButNotTerminalCancel(t *testing.T) {
+	exit0 := int32(0)
+	client := &fakeProcessClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"}, stdout: []byte("output")}
+	sandbox := processSandbox(client, "epoch")
+	sandbox.EmitEvent = func(context.Context, controllers.AdapterEvent) error { return controllers.ErrAdapterEventRejected }
+	got, message, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox)
+	if err != nil || got != controllers.AdapterObservationFailed || !strings.Contains(message, "permanently rejected") {
+		t.Fatalf("Observe = %q, %q, %v", got, message, err)
+	}
+	client.process.State, client.process.ExitCode = sandboxdv1.ProcessState_PROCESS_STATE_EXITED, &exit0
+	if err := (&Adapter{}).Cancel(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err != nil {
+		t.Fatalf("Cancel = %v", err)
+	}
+}
+
+func TestEpochAndSnapshotMetadataFenceOutputKeys(t *testing.T) {
+	client := &fakeProcessClient{
+		process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"},
+		stdout:  bytes.Repeat([]byte("x"), pageMax+1),
+	}
+	var first controllers.AdapterEvent
+	firstSandbox := processSandbox(client, "epoch-one")
+	firstSandbox.EmitEvent = func(_ context.Context, event controllers.AdapterEvent) error {
+		first = event
+		return errors.New("uncertain append")
+	}
+	if _, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, firstSandbox); err == nil {
+		t.Fatal("wanted uncertain append error")
+	}
+	client.stdout = append(client.stdout, 'y')
+	var changed controllers.AdapterEvent
+	secondSandbox := processSandbox(client, "epoch-two")
+	secondSandbox.EmitEvent = func(_ context.Context, event controllers.AdapterEvent) error {
+		changed = event
+		return errors.New("stop")
+	}
+	if _, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, secondSandbox); err == nil {
+		t.Fatal("wanted replay stop error")
+	}
+	if first.IdempotencyKey == changed.IdempotencyKey || bytes.Equal(first.Data, changed.Data) {
+		t.Fatalf("keys/payloads did not reflect changed snapshot: %q/%q", first.IdempotencyKey, changed.IdempotencyKey)
+	}
+}


### PR DESCRIPTION
## Summary
- add a Run-UID-fenced Codex 0.144.6 adapter with structured lifecycle mapping
- deliver CODEX_API_KEY only through sandboxd launch material
- pin amd64/arm64 native packages and add fake-controller E2E coverage

## Validation
- make test
- make vet
- bash -n hack/e2e.sh
- independent Oracle review: approved

Closes #62