### PR TITLE
feat: keep Argo console port-forward alive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,8 +118,9 @@ runs both via `make` targets:
   cluster running Argo CD + the Image Updater (`hack/argocd/`,
   `values-argocd.yaml` preset). It syncs the chart from `origin/main` and rolls
   the operator/control plane on new `:latest` digests — only pushed commits
-  take effect. Keep it isolated from `swe-dev`; two operators must never
-  reconcile the same custom resources.
+  take effect. `make argocd-ui` keeps a foreground, loopback-only control-plane
+  Service forward alive across those rollouts. Keep it isolated from `swe-dev`;
+  two operators must never reconcile the same custom resources.
 - **Production Helm presets:** `charts/swe-platform/values-{k3s,gke,eks}.yaml`; CI lints
   and renders every preset, verifies all rendered production images use the coordinated
   chart `appVersion`, and rejects `latest`/`dev`. Provider assumptions are documented in

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ check-build-output: ## Verify all built binaries land in bin/
 test: ## Run unit tests in both modules
 	go test ./...
 	cd sandboxd && go test ./...
+	./hack/argocd-port-forward_test.sh
 
 .PHONY: vet
 vet: ## Run go vet in both modules
@@ -124,6 +125,10 @@ kind-down: ## Delete the kind dev cluster
 .PHONY: argocd-up
 argocd-up: ## Create the Argo CD cluster tracking origin/main
 	./hack/argocd-up.sh
+
+.PHONY: argocd-ui
+argocd-ui: ## Keep the Argo mirror console reachable across rollouts
+	./hack/argocd-port-forward.sh
 
 .PHONY: argocd-down
 argocd-down: ## Delete the Argo CD cluster

--- a/README.md
+++ b/README.md
@@ -180,6 +180,15 @@ upgrade CRDs from a chart's `crds/` directory, so apply CRD changes separately w
 `kubectl --context "kind-${KIND_CLUSTER:-swe-dev}" apply --server-side --force-conflicts -f
 config/crd/bases`.
 
+For the separate Argo mirror created by `make argocd-up`, run `make argocd-ui` in a
+foreground terminal and open `http://127.0.0.1:18080/`. The helper explicitly targets
+`kind-swe-argo`, binds only to loopback, and reconnects the Service port-forward after an
+Argo rollout replaces the selected control-plane pod. Override the cluster with
+`KIND_ARGO_CLUSTER` or the local port with `ARGO_UI_PORT`. Stopping the helper also stops
+only its own `kubectl` child. Existing SSE or WebSocket connections still disconnect during
+a rollout and must reconnect, and a control-plane replacement invalidates its process-local
+browser sessions.
+
 Create runs with an explicit template, or reference a `Project` to use its default
 template:
 

--- a/charts/swe-platform/README.md
+++ b/charts/swe-platform/README.md
@@ -203,6 +203,13 @@ open `http://127.0.0.1:8080/`:
 kubectl port-forward service/swe-platform-swe-platform-control-plane 8080:80
 ```
 
+For the Argo kind mirror, use `make argocd-ui` instead and open
+`http://127.0.0.1:18080/`. That foreground helper targets the `kind-swe-argo` context and
+restarts its loopback-only Service forward when a rollout replaces the selected pod. Set
+`KIND_ARGO_CLUSTER` or `ARGO_UI_PORT` to override its cluster or local port. A reconnect
+restores the URL and all control-plane routes, but cannot preserve an open SSE/WebSocket TCP
+connection or a process-local browser session across control-plane replacement.
+
 The kind preset permits HTTP browser sessions for this local flow. Production browser sessions
 still require HTTPS. To build the embedded binary outside the image build, run `make ui-build`
 followed by `make build-control-plane-production`; ordinary Go builds intentionally omit the UI

--- a/hack/argocd-port-forward.sh
+++ b/hack/argocd-port-forward.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Keep the Argo mirror's control-plane Service reachable across pod rollouts.
+set -euo pipefail
+
+CLUSTER="${KIND_ARGO_CLUSTER:-swe-argo}"
+LOCAL_PORT="${ARGO_UI_PORT:-18080}"
+CONTEXT="kind-$CLUSTER"
+NAMESPACE="swe-platform-system"
+SERVICE="swe-platform-swe-platform-control-plane"
+LOCK_ROOT="${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}"
+LOCK_KEY="${CONTEXT//[^a-zA-Z0-9_.-]/_}-$LOCAL_PORT"
+LOCK_DIR="$LOCK_ROOT/swe-platform-argocd-port-forward-$LOCK_KEY.lock"
+child_pid=""
+lock_owned=false
+stopping=false
+
+case "$LOCAL_PORT" in
+	''|*[!0-9]*)
+		echo "ARGO_UI_PORT must be a numeric TCP port" >&2
+		exit 2
+		;;
+esac
+if ((LOCAL_PORT < 1 || LOCAL_PORT > 65535)); then
+	echo "ARGO_UI_PORT must be between 1 and 65535" >&2
+	exit 2
+fi
+command -v kubectl >/dev/null 2>&1 || { echo "kubectl is required" >&2; exit 1; }
+
+cleanup() {
+	if [[ -n "$child_pid" ]]; then
+		kill "$child_pid" 2>/dev/null || true
+		wait "$child_pid" 2>/dev/null || true
+		child_pid=""
+	fi
+	if [[ "$lock_owned" == true ]]; then
+		rm -f "$LOCK_DIR/pid"
+		rmdir "$LOCK_DIR" 2>/dev/null || true
+		lock_owned=false
+	fi
+}
+
+request_stop() {
+	stopping=true
+	if [[ -n "$child_pid" ]]; then
+		kill "$child_pid" 2>/dev/null || true
+	fi
+}
+
+acquire_lock() {
+	if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+		local existing_pid=""
+		if [[ -r "$LOCK_DIR/pid" ]]; then
+			read -r existing_pid <"$LOCK_DIR/pid" || true
+		fi
+		echo "an Argo console port-forward helper lock already exists for $CONTEXT on port $LOCAL_PORT${existing_pid:+ (pid $existing_pid)}" >&2
+		echo "if no helper is running, remove the stale lock: $LOCK_DIR" >&2
+		exit 1
+	fi
+	printf '%s\n' "$$" >"$LOCK_DIR/pid"
+	lock_owned=true
+}
+
+trap request_stop INT TERM
+trap cleanup EXIT
+acquire_lock
+
+echo "==> console URL: http://127.0.0.1:$LOCAL_PORT/"
+echo "==> forwarding $CONTEXT/$NAMESPACE/service/$SERVICE (Ctrl-C to stop)"
+
+while [[ "$stopping" == false ]]; do
+	kubectl --context "$CONTEXT" --namespace "$NAMESPACE" port-forward \
+		--address 127.0.0.1 "service/$SERVICE" "$LOCAL_PORT:80" &
+	child_pid=$!
+	if [[ "$stopping" == true ]]; then
+		break
+	fi
+
+	set +e
+	wait "$child_pid"
+	status=$?
+	set -e
+	child_pid=""
+	if [[ "$stopping" == true ]]; then
+		break
+	fi
+
+	echo "==> port-forward exited with status $status; retrying in 1 second" >&2
+	sleep 1 || true
+done
+
+echo "==> stopped Argo console port-forward"

--- a/hack/argocd-port-forward_test.sh
+++ b/hack/argocd-port-forward_test.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HELPER="$ROOT/hack/argocd-port-forward.sh"
+TEST_ROOT="$(mktemp -d)"
+helper_pid=""
+
+cleanup() {
+	if [[ -n "$helper_pid" ]] && kill -0 "$helper_pid" 2>/dev/null; then
+		kill -TERM "$helper_pid" 2>/dev/null || true
+		wait "$helper_pid" 2>/dev/null || true
+	fi
+	rm -rf "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+	echo "FAIL: $*" >&2
+	exit 1
+}
+
+wait_for() {
+	local description="$1"
+	shift
+	for _ in {1..100}; do
+		if "$@"; then
+			return 0
+		fi
+		sleep 0.05
+	done
+	fail "timed out waiting for $description"
+}
+
+mkdir -p "$TEST_ROOT/bin" "$TEST_ROOT/runtime"
+cat >"$TEST_ROOT/bin/kubectl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >>"$FAKE_KUBECTL_LOG"
+count=0
+if [[ -r "$FAKE_COUNT_FILE" ]]; then
+	read -r count <"$FAKE_COUNT_FILE"
+fi
+count=$((count + 1))
+printf '%s\n' "$count" >"$FAKE_COUNT_FILE"
+if [[ "${FAKE_EXIT_FIRST:-false}" == true && "$count" -eq 1 ]]; then
+	exit 42
+fi
+
+printf '%s\n' "$$" >"$FAKE_CHILD_PID_FILE"
+trap 'printf "%s\n" "$$" >"$FAKE_TERM_FILE"; exit 0' INT TERM
+while true; do
+	sleep 1
+done
+EOF
+chmod +x "$TEST_ROOT/bin/kubectl"
+
+export PATH="$TEST_ROOT/bin:$PATH"
+export TMPDIR="$TEST_ROOT/runtime"
+export FAKE_KUBECTL_LOG="$TEST_ROOT/kubectl.log"
+export FAKE_COUNT_FILE="$TEST_ROOT/count"
+export FAKE_CHILD_PID_FILE="$TEST_ROOT/child.pid"
+export FAKE_TERM_FILE="$TEST_ROOT/terminated.pid"
+export FAKE_EXIT_FIRST=true
+
+"$HELPER" >"$TEST_ROOT/helper.log" 2>&1 &
+helper_pid=$!
+
+wait_for "port-forward retry" test -s "$FAKE_CHILD_PID_FILE"
+[[ "$(cat "$FAKE_COUNT_FILE")" -ge 2 ]] || fail "kubectl was not restarted after its first exit"
+expected="--context kind-swe-argo --namespace swe-platform-system port-forward --address 127.0.0.1 service/swe-platform-swe-platform-control-plane 18080:80"
+grep -Fx -- "$expected" "$FAKE_KUBECTL_LOG" >/dev/null || fail "kubectl did not receive the scoped context, namespace, address, Service, and port"
+
+if "$HELPER" >"$TEST_ROOT/duplicate.log" 2>&1; then
+	fail "a duplicate helper unexpectedly started"
+fi
+grep -F "lock already exists" "$TEST_ROOT/duplicate.log" >/dev/null || fail "duplicate helper failure was not explained"
+
+child_pid="$(cat "$FAKE_CHILD_PID_FILE")"
+kill -TERM "$helper_pid"
+wait "$helper_pid"
+helper_pid=""
+wait_for "kubectl child signal cleanup" test -s "$FAKE_TERM_FILE"
+[[ "$(cat "$FAKE_TERM_FILE")" == "$child_pid" ]] || fail "the helper did not terminate its own kubectl child"
+
+rm -f "$FAKE_CHILD_PID_FILE" "$FAKE_TERM_FILE"
+export FAKE_EXIT_FIRST=false
+"$HELPER" >"$TEST_ROOT/reacquired.log" 2>&1 &
+helper_pid=$!
+wait_for "helper lock reacquisition" test -s "$FAKE_CHILD_PID_FILE"
+child_pid="$(cat "$FAKE_CHILD_PID_FILE")"
+kill -TERM "$helper_pid"
+wait "$helper_pid"
+helper_pid=""
+wait_for "reacquired kubectl child signal cleanup" test -s "$FAKE_TERM_FILE"
+[[ "$(cat "$FAKE_TERM_FILE")" == "$child_pid" ]] || fail "the reacquired helper did not terminate its own kubectl child"
+
+if ARGO_UI_PORT=not-a-port "$HELPER" >"$TEST_ROOT/invalid.log" 2>&1; then
+	fail "an invalid local port was accepted"
+fi
+
+echo "argocd port-forward helper tests passed"

--- a/hack/argocd-up.sh
+++ b/hack/argocd-up.sh
@@ -78,7 +78,7 @@ Argo CD UI:
   password: \$(${KUBECTL[*]} -n $ARGOCD_NAMESPACE get secret argocd-initial-admin-secret -o jsonpath='{.data.password}' | base64 -d)
 
 Drive it with the swe CLI:
-  ${KUBECTL[*]} -n $APP_NAMESPACE port-forward svc/swe-platform-swe-platform-control-plane 18080:80
+  KIND_ARGO_CLUSTER=$CLUSTER make argocd-ui
   export SWE_CONTROL_PLANE_URL=http://127.0.0.1:18080
   export SWE_CONTROL_PLANE_TOKEN=\$(${KUBECTL[*]} -n $APP_NAMESPACE get secret $BOOTSTRAP_SECRET -o jsonpath='{.data.token}' | base64 -d)
   bin/swe run "fix the flaky tests" -t small


### PR DESCRIPTION
Closes #51

## Summary

- add `make argocd-ui`, a foreground loopback-only helper scoped to `kind-swe-argo`
- reconnect the existing control-plane Service forward after pod replacement while preventing duplicate helpers
- clean up only the helper's own `kubectl` child on shutdown
- cover default scoping, retry, duplicate locking, lock reacquisition, signal cleanup, and invalid ports with fake-`kubectl` tests
- document rollout effects on SSE, WebSocket, and process-local browser sessions

## Verification

- `make test`
- `bash -n hack/argocd-port-forward.sh hack/argocd-port-forward_test.sh hack/argocd-up.sh`
- `git diff --check`
- independent review: approved after fixing atomic lock ownership and child-spawn signal races

## Environment limitation

A real `swe-argo` rollout acceptance check could not run in this orb because `kind` and `kubectl` are unavailable; the fake-`kubectl` lifecycle test exercises the reconnect path deterministically.
