### PR TITLE
feat(adapters): add Pi coding agent support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,9 +22,9 @@ browser sessions backed by repeated Kubernetes TokenReview/SAR authorization, an
 Run/Environment resource APIs for the console.
 Remaining gaps are marked `TODO(P0/P1/P2)` in code — most notably secure agent credential
 injection, additional agent adapters, GitHub App–scoped git tokens, and egress/portal
-networking. The `claude-code` (default), `amp`, and `codex` adapters are registered and use sandboxd
-managed processes; Amp's `AMP_API_KEY` delivery remains an unmet prerequisite and adapter
-tests use fake process services; Codex supports process-scoped `CODEX_API_KEY` delivery.
+networking. The `claude-code` (default), `amp`, `codex`, and `pi` adapters are registered and
+use sandboxd managed processes; Amp and Pi credential delivery remain unmet prerequisites and
+adapter tests use fake process services; Codex supports process-scoped `CODEX_API_KEY` delivery.
 
 ## Architecture invariants — do not violate these
 
@@ -129,6 +129,7 @@ runs both via `make` targets:
 - **E2E acceptance:** `./hack/e2e.sh` — full kind + operator + `swe run` pass with the
   env-base image built and loaded locally (no registry credentials needed). It also verifies
   the documented server-side CRD upgrade from the pre-scoped-credentials schema,
+  the Pi adapter through the real Run controller with a credential-free fake executable,
   control-plane TokenReview/SAR scoping, opaque browser session exchange/logout and CSRF,
   the embedded console entry point/SPA fallback/static assets, typed Run
   list/get/create/retry/cancel, Environment get, transcript SSE, terminal attach, and
@@ -140,8 +141,9 @@ runs both via `make` targets:
   its pinned tmux with `images/env-base/tmux-control-output-drain.patch`; keep the
   source checksum and patch synchronized when upgrading tmux. Its `terminal-test`
   target runs the patched-runtime terminal regression during `hack/e2e.sh`. The image
-  also includes version-pinned Claude Code (the default adapter) and Amp CLIs. Amp image
-  installs must retain `AMP_SKIP_UPDATE_CHECK=1` and the pinned npm integrity check.
+  also includes version-pinned Claude Code (the default adapter), Amp, Codex, and Pi CLIs.
+  Amp image installs must retain `AMP_SKIP_UPDATE_CHECK=1`; Amp and Pi installs must retain
+  their pinned npm integrity checks.
 - **Publish images:** pushes to `main` and `v*` tags publish multi-architecture operator
   and env-base images to GHCR via `.github/workflows/publish-images.yaml`.
 

--- a/README.md
+++ b/README.md
@@ -313,10 +313,10 @@ custom Environment images must provide a compatible `pi` executable and Node >=2
 The adapter runs one-shot `pi --mode json` under a Run-UID-keyed sandboxd process. Sessions
 are ephemeral (`--no-session`), `PI_CODING_AGENT_DIR` is isolated at
 `/tmp/swe-platform/pi/<Run UID>`, and project approval/settings plus extension, skill,
-prompt-template, theme, package-resource, and startup-network discovery are disabled. It
+prompt-template, theme, context-file, package-resource, and startup-network discovery are disabled. It
 never continues or resumes a latest/partial session. A zero process exit succeeds only when
-the retained stream contains an `agent_end` event whose final assistant message has
-`stopReason: "stop"`;
+the complete retained stream ends with `agent_settled` after a non-retrying `agent_end`
+whose final assistant message has `stopReason: "stop"`;
 error, abort, unknown, malformed, absent, and non-zero outcomes fail explicitly.
 
 Bounded stdout and stderr chunks are forwarded unchanged as opaque `pi.process-output`

--- a/README.md
+++ b/README.md
@@ -312,7 +312,8 @@ custom Environment images must provide a compatible `pi` executable and Node >=2
 
 The adapter runs one-shot `pi --mode json` under a Run-UID-keyed sandboxd process. Sessions
 are ephemeral (`--no-session`), `PI_CODING_AGENT_DIR` is isolated at
-`/tmp/swe-platform/pi/<Run UID>`, and project approval/settings plus extension, skill,
+the workspace-relative, OS-portable `.swe-platform/pi/<Run UID>`, and project
+approval/settings plus extension, skill,
 prompt-template, theme, context-file, package-resource, and startup-network discovery are disabled. It
 never continues or resumes a latest/partial session. A zero process exit succeeds only when
 the complete retained stream ends with `agent_settled` after a non-retrying `agent_end`

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ with a reviewable diff, branch, or PR.
 > plane's WebSocket terminal endpoint connect to a shared tmux session through `sandboxd`;
 > pause/resume preserves workspace disks and runs repository resume hooks, and idle
 > environments pause automatically before terminal requests wake them. Template warm
-> pools keep unclaimed environments ready for `swe run` to claim. The first agent adapter
-> runs Claude Code through sandboxd's managed-process API. Portal proxying is not built yet.
+> pools keep unclaimed environments ready for `swe run` to claim. Claude Code and Pi agent
+> adapters run through sandboxd's managed-process API. Portal proxying is not built yet.
 > The Helm chart installs the
 > operator, control plane, and CRDs. Values presets
 > cover kind, k3s, GKE with GKE Sandbox, and EKS.
@@ -302,6 +302,34 @@ other credential types are rejected before dialing. The selected agent and same-
 can still read or disclose it; stronger credential isolation and additional credential forms
 remain issue #9 limitations. Acceptance tests use a fake Codex executable and no provider or
 network access.
+
+### Pi adapter
+
+Select Pi with `swe run --agent pi`. The coordinated `env-base` image installs
+`@earendil-works/pi-coding-agent@0.80.10` with its pinned npm integrity and Node 24;
+custom Environment images must provide a compatible `pi` executable and Node >=22.19 on
+`PATH`.
+
+The adapter runs one-shot `pi --mode json` under a Run-UID-keyed sandboxd process. Sessions
+are ephemeral (`--no-session`), `PI_CODING_AGENT_DIR` is isolated at
+`/tmp/swe-platform/pi/<Run UID>`, and project approval/settings plus extension, skill,
+prompt-template, theme, package-resource, and startup-network discovery are disabled. It
+never continues or resumes a latest/partial session. A zero process exit succeeds only when
+the retained stream contains an `agent_end` event whose final assistant message has
+`stopReason: "stop"`;
+error, abort, unknown, malformed, absent, and non-zero outcomes fail explicitly.
+
+Bounded stdout and stderr chunks are forwarded unchanged as opaque `pi.process-output`
+events. The events preserve execution identity, absolute offsets, retained-buffer gaps, and
+content-addressed idempotency keys so retries and fresh sandbox epochs cannot silently splice
+streams.
+
+Pi authentication must already be available through provider environment variables inside
+the Environment. The adapter does not read a shared Pi home or `auth.json`, inject keys, log
+credentials, or include any credential in the image. Secure Run-scoped credential delivery
+remains blocked on issue #9; until it exists, operators must provision authentication at the
+Environment layer and accept that it is not scoped to one adapter process. Never put a
+credential in a Run prompt.
 
 `--name` is the create idempotency key: retry an uncertain request with the same name and
 immutable task arguments. The CLI returns the existing Run only when its intent matches;

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Chris-Cullins/swe-platform/internal/adapters/amp"
 	"github.com/Chris-Cullins/swe-platform/internal/adapters/claudecode"
 	"github.com/Chris-Cullins/swe-platform/internal/adapters/codex"
+	"github.com/Chris-Cullins/swe-platform/internal/adapters/pi"
 	"github.com/Chris-Cullins/swe-platform/internal/controllers"
 	"github.com/Chris-Cullins/swe-platform/internal/transcriptclient"
 )
@@ -134,5 +135,6 @@ func registeredAdapters() map[string]controllers.AdapterLifecycle {
 		"amp":         &amp.Adapter{},
 		"claude-code": &claudecode.Adapter{},
 		"codex":       &codex.Adapter{},
+		"pi":          &pi.Adapter{},
 	}
 }

--- a/cmd/operator/main_test.go
+++ b/cmd/operator/main_test.go
@@ -13,3 +13,9 @@ func TestDefaultClaudeCodeAdapterIsRegistered(t *testing.T) {
 		t.Fatal("codex adapter is not registered")
 	}
 }
+
+func TestPiAdapterIsRegistered(t *testing.T) {
+	if registeredAdapters()["pi"] == nil {
+		t.Fatal("pi adapter is not registered")
+	}
+}

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -171,7 +171,7 @@ chmod 0755 "$FAKE_ENV_CONTEXT/codex"
 cat > "$FAKE_ENV_CONTEXT/pi" <<'EOF'
 #!/bin/sh
 set -eu
-test "$#" -eq 10
+test "$#" -eq 11
 test "$1" = --mode
 test "$2" = json
 test "$3" = --no-session
@@ -180,8 +180,9 @@ test "$5" = --no-extensions
 test "$6" = --no-skills
 test "$7" = --no-prompt-templates
 test "$8" = --no-themes
-test "$9" = --offline
-test "${10}" = '
+test "$9" = --no-context-files
+test "${10}" = --offline
+test "${11}" = '
 --fake-pi-e2e'
 case "${PI_CODING_AGENT_DIR:-}" in
 	/tmp/swe-platform/pi/*) ;;
@@ -193,7 +194,8 @@ test "$run_dir" = "${run_dir#*/}"
 printf '%s\n' '{"type":"agent_start"}'
 printf '%s\n' 'fake Pi diagnostic' >&2
 sleep 5
-printf '%s\n' '{"type":"agent_end","messages":[{"role":"assistant","content":[{"type":"text","text":"fake Pi is working"}],"stopReason":"stop"}]}'
+printf '%s\n' '{"type":"agent_end","messages":[{"role":"assistant","content":[{"type":"text","text":"fake Pi is working"}],"stopReason":"stop"}],"willRetry":false}'
+printf '%s\n' '{"type":"agent_settled"}'
 EOF
 chmod 0755 "$FAKE_ENV_CONTEXT/pi"
 cat > "$FAKE_ENV_CONTEXT/Dockerfile" <<'EOF'

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -185,10 +185,10 @@ test "${10}" = --offline
 test "${11}" = '
 --fake-pi-e2e'
 case "${PI_CODING_AGENT_DIR:-}" in
-	/tmp/swe-platform/pi/*) ;;
+	.swe-platform/pi/*) ;;
 	*) echo 'fake Pi received a shared config directory' >&2; exit 65 ;;
 esac
-run_dir=${PI_CODING_AGENT_DIR#/tmp/swe-platform/pi/}
+run_dir=${PI_CODING_AGENT_DIR#.swe-platform/pi/}
 test -n "$run_dir"
 test "$run_dir" = "${run_dir#*/}"
 printf '%s\n' '{"type":"agent_start"}'

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -168,6 +168,34 @@ sleep 5
 printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":2}}'
 EOF
 chmod 0755 "$FAKE_ENV_CONTEXT/codex"
+cat > "$FAKE_ENV_CONTEXT/pi" <<'EOF'
+#!/bin/sh
+set -eu
+test "$#" -eq 10
+test "$1" = --mode
+test "$2" = json
+test "$3" = --no-session
+test "$4" = --no-approve
+test "$5" = --no-extensions
+test "$6" = --no-skills
+test "$7" = --no-prompt-templates
+test "$8" = --no-themes
+test "$9" = --offline
+test "${10}" = '
+--fake-pi-e2e'
+case "${PI_CODING_AGENT_DIR:-}" in
+	/tmp/swe-platform/pi/*) ;;
+	*) echo 'fake Pi received a shared config directory' >&2; exit 65 ;;
+esac
+run_dir=${PI_CODING_AGENT_DIR#/tmp/swe-platform/pi/}
+test -n "$run_dir"
+test "$run_dir" = "${run_dir#*/}"
+printf '%s\n' '{"type":"agent_start"}'
+printf '%s\n' 'fake Pi diagnostic' >&2
+sleep 5
+printf '%s\n' '{"type":"agent_end","messages":[{"role":"assistant","content":[{"type":"text","text":"fake Pi is working"}],"stopReason":"stop"}]}'
+EOF
+chmod 0755 "$FAKE_ENV_CONTEXT/pi"
 cat > "$FAKE_ENV_CONTEXT/Dockerfile" <<'EOF'
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
@@ -175,6 +203,7 @@ USER root
 COPY claude /usr/local/bin/claude
 COPY amp /usr/local/bin/amp
 COPY codex /usr/local/bin/codex
+COPY pi /usr/local/bin/pi
 USER swe
 EOF
 docker build --build-arg BASE_IMAGE="$ENV_IMAGE" -t "$E2E_ENV_IMAGE" "$FAKE_ENV_CONTEXT" >/dev/null
@@ -369,6 +398,23 @@ for _ in $(seq 1 60); do
 done
 if [[ -z "${REPLACEMENT_NAME:-}" || "$REPLACEMENT_NAME" == "$ENV_NAME" || "${REPLACEMENT_PHASE:-}" != "Ready" ]]; then
 	echo "FAIL: warm pool was not replenished after claim"
+	exit 1
+fi
+
+echo "==> exercising Pi through the real Run controller with a fake executable"
+PI_RUN_NAME=e2e-pi
+bin/swe run --name "$PI_RUN_NAME" --agent pi --environment "$ENV_NAME" --wait=false -- "--fake-pi-e2e"
+kubectl wait --for=jsonpath='{.status.state}'=Running run/"$PI_RUN_NAME" --timeout=2m
+kubectl wait --for=jsonpath='{.status.state}'=Succeeded run/"$PI_RUN_NAME" --timeout=2m
+for _ in $(seq 1 60); do
+	PI_CLAIM_UID=$(kubectl get environment "$ENV_NAME" -o jsonpath='{.status.claimedBy.uid}' 2>/dev/null || true)
+	if [[ -z "$PI_CLAIM_UID" ]]; then
+		break
+	fi
+	sleep 1
+done
+if [[ -n "${PI_CLAIM_UID:-}" ]]; then
+	echo "FAIL: terminal Pi Run did not release its Environment claim"
 	exit 1
 fi
 
@@ -690,6 +736,41 @@ fi
 
 echo "==> rotating the profile without restarting the existing process"
 printf '%s' "$E2E_ROTATED_AGENT_API_KEY" | bin/swe credentials rotate e2e-claude --api-key-stdin
+
+echo "==> verifying fake Pi output through the deployed transcript transport"
+curl --fail --silent --no-buffer --max-time 10 \
+	-H "Authorization: Bearer ${E2E_BOOTSTRAP_TOKEN}" \
+	"http://127.0.0.1:18080/api/v1/namespaces/default/runs/${PI_RUN_NAME}/transcript" \
+	>/tmp/swe-platform-pi-transcript.out &
+PI_STREAM_PID=$!
+for _ in $(seq 1 30); do
+	if grep -Fq '"type":"pi.process-output"' /tmp/swe-platform-pi-transcript.out; then
+		break
+	fi
+	sleep 1
+done
+kill "$PI_STREAM_PID" >/dev/null 2>&1 || true
+wait "$PI_STREAM_PID" >/dev/null 2>&1 || true
+if ! grep -F '"source":"pi"' /tmp/swe-platform-pi-transcript.out | \
+	grep -F '"type":"pi.process-output"' \
+	>/tmp/swe-platform-pi-envelopes.out; then
+	echo "FAIL: deployed transcript transport did not retain the exact Pi source/type envelope"
+	exit 1
+fi
+if ! grep -oE '"data":"[A-Za-z0-9+/=]+"' /tmp/swe-platform-pi-envelopes.out | \
+	sed 's/^"data":"//; s/"$//' | \
+	while IFS= read -r encoded; do printf '%s' "$encoded" | base64 --decode || exit 1; done \
+	>/tmp/swe-platform-pi-output.out; then
+	echo "FAIL: Pi process output was not valid base64 in the deployed transcript transport"
+	exit 1
+fi
+if ! grep -Fq '"type":"agent_end"' /tmp/swe-platform-pi-output.out || \
+	! grep -Fq '"text":"fake Pi is working"' /tmp/swe-platform-pi-output.out || \
+	! grep -Fq 'fake Pi diagnostic' /tmp/swe-platform-pi-output.out; then
+	echo "FAIL: deployed transcript transport did not retain opaque Pi stdout and stderr"
+	cat /tmp/swe-platform-pi-output.out
+	exit 1
+fi
 
 kubectl delete run "$RUN_NAME" --wait=true >/dev/null
 if ! kubectl get environment "$RUN_ENV_NAME" >/dev/null 2>&1; then

--- a/images/env-base/Dockerfile
+++ b/images/env-base/Dockerfile
@@ -75,7 +75,7 @@ ARG PI_CODING_AGENT_INTEGRITY=sha512-aL4apbupCHiVLSXASXvRzH4Q2vmtfrDa+0s909CJuVu
 WORKDIR /tmp/pi
 RUN npm pack "@earendil-works/pi-coding-agent@${PI_CODING_AGENT_VERSION}" --json > pack.json \
 	&& test "$(node -p 'JSON.parse(require("fs").readFileSync("pack.json"))[0].integrity')" = "${PI_CODING_AGENT_INTEGRITY}" \
-	&& npm install -g "./$(node -p 'JSON.parse(require("fs").readFileSync("pack.json"))[0].filename')" \
+	&& npm install -g --ignore-scripts "./$(node -p 'JSON.parse(require("fs").readFileSync("pack.json"))[0].filename')" \
 	&& test "$(pi --version)" = "${PI_CODING_AGENT_VERSION}"
 
 # Base image for environments.

--- a/images/env-base/Dockerfile
+++ b/images/env-base/Dockerfile
@@ -96,8 +96,8 @@ COPY --from=claude-code /usr/local/bin/claude /usr/local/bin/claude
 COPY --from=amp /usr/local/bin/amp /usr/local/bin/amp
 COPY --from=codex /opt/codex /opt/codex
 COPY --from=pi /usr/local/lib/node_modules/@earendil-works /usr/local/lib/node_modules/@earendil-works
-COPY --from=pi /usr/local/bin/pi /usr/local/bin/pi
-RUN ln -s /opt/codex/bin/codex /usr/local/bin/codex
+RUN ln -s /opt/codex/bin/codex /usr/local/bin/codex \
+	&& ln -s ../lib/node_modules/@earendil-works/pi-coding-agent/dist/cli.js /usr/local/bin/pi
 ENV AMP_SKIP_UPDATE_CHECK=1
 RUN claude --version \
 	&& test "$(amp --version | awk '{print $1}')" = "0.0.1784492094-g5d18e2" \

--- a/images/env-base/Dockerfile
+++ b/images/env-base/Dockerfile
@@ -69,8 +69,17 @@ RUN case "$TARGETARCH" in \
 	&& test -f /opt/codex/codex-package.json \
 	&& test "$(/opt/codex/bin/codex --version)" = "codex-cli ${CODEX_VERSION}"
 
+FROM node:24-bookworm-slim AS pi
+ARG PI_CODING_AGENT_VERSION=0.80.10
+ARG PI_CODING_AGENT_INTEGRITY=sha512-aL4apbupCHiVLSXASXvRzH4Q2vmtfrDa+0s909CJuVu/GgGylbDzr7oyF1mPmip5E+VxYYxKWmph4hV04wUcQg==
+WORKDIR /tmp/pi
+RUN npm pack "@earendil-works/pi-coding-agent@${PI_CODING_AGENT_VERSION}" --json > pack.json \
+	&& test "$(node -p 'JSON.parse(require("fs").readFileSync("pack.json"))[0].integrity')" = "${PI_CODING_AGENT_INTEGRITY}" \
+	&& npm install -g "./$(node -p 'JSON.parse(require("fs").readFileSync("pack.json"))[0].filename')" \
+	&& test "$(pi --version)" = "${PI_CODING_AGENT_VERSION}"
+
 # Base image for environments.
-FROM debian:12-slim AS environment
+FROM node:24-bookworm-slim AS environment
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		git ca-certificates curl tmux jq ripgrep \
@@ -86,6 +95,8 @@ COPY --from=claude-code /usr/local/lib/node_modules/@anthropic-ai /usr/local/lib
 COPY --from=claude-code /usr/local/bin/claude /usr/local/bin/claude
 COPY --from=amp /usr/local/bin/amp /usr/local/bin/amp
 COPY --from=codex /opt/codex /opt/codex
+COPY --from=pi /usr/local/lib/node_modules/@earendil-works /usr/local/lib/node_modules/@earendil-works
+COPY --from=pi /usr/local/bin/pi /usr/local/bin/pi
 RUN ln -s /opt/codex/bin/codex /usr/local/bin/codex
 ENV AMP_SKIP_UPDATE_CHECK=1
 RUN claude --version \
@@ -93,7 +104,8 @@ RUN claude --version \
 	&& test "$(codex --version)" = "codex-cli 0.144.6" \
 	&& test "$(readlink -f "$(command -v codex)")" = /opt/codex/bin/codex \
 	&& test -x /opt/codex/codex-resources/bwrap \
-	&& test -f /opt/codex/codex-package.json
+	&& test -f /opt/codex/codex-package.json \
+	&& test "$(pi --version)" = "0.80.10"
 
 USER swe
 WORKDIR /workspace

--- a/internal/adapters/pi/adapter.go
+++ b/internal/adapters/pi/adapter.go
@@ -28,8 +28,9 @@ type assistantMessage struct {
 }
 
 type agentEndEvent struct {
-	Type     string             `json:"type"`
-	Messages []assistantMessage `json:"messages"`
+	Type      string             `json:"type"`
+	Messages  []assistantMessage `json:"messages"`
+	WillRetry *bool              `json:"willRetry"`
 }
 
 // Adapter drives one non-interactive Pi process per Run UID.
@@ -38,6 +39,7 @@ type Adapter struct {
 
 	mu      sync.Mutex
 	cursors map[outputCursor]uint64
+	pending map[outputCursor]pendingEvent
 }
 
 type outputCursor struct {
@@ -57,6 +59,19 @@ type outputEvent struct {
 	ProducedEnd  uint64 `json:"producedEnd"`
 	EOF          bool   `json:"eof"`
 	Data         []byte `json:"data,omitempty"`
+}
+
+type pendingEvent struct {
+	event      controllers.AdapterEvent
+	nextOffset uint64
+}
+
+type outputTruncatedError struct {
+	retainedFrom uint64
+}
+
+func (e *outputTruncatedError) Error() string {
+	return fmt.Sprintf("retained from offset %d", e.retainedFrom)
 }
 
 func (a *Adapter) executable() string {
@@ -81,6 +96,7 @@ func (a *Adapter) processSpec(task controllers.AdapterTask) *sandboxdv1.ProcessS
 			"--no-skills",
 			"--no-prompt-templates",
 			"--no-themes",
+			"--no-context-files",
 			"--offline",
 			// Pi 0.80.10 has no flag terminator. Leading whitespace keeps a
 			// flag-shaped task in the positional-message parser.
@@ -94,7 +110,10 @@ func (a *Adapter) processSpec(task controllers.AdapterTask) *sandboxdv1.ProcessS
 }
 
 // EnsureAccepted duplicate-safely starts (or recovers) the Run-keyed process.
-func (a *Adapter) EnsureAccepted(ctx context.Context, task controllers.AdapterTask, sandbox controllers.AdapterSandbox) error {
+func (a *Adapter) EnsureAccepted(ctx context.Context, task controllers.AdapterTask, sandbox controllers.AdapterSandbox, credential *controllers.AdapterCredential) error {
+	if credential != nil {
+		return fmt.Errorf("%w: Pi credential delivery is not implemented", controllers.ErrAdapterTaskRejected)
+	}
 	client, closeConnection, err := sandbox.DialProcess(ctx)
 	if err != nil {
 		return err
@@ -140,11 +159,15 @@ func (a *Adapter) Observe(ctx context.Context, task controllers.AdapterTask, san
 		}
 		output, err := readRetainedOutput(ctx, client, processKey(task), process.ExecutionId, sandboxdv1.OutputStream_OUTPUT_STREAM_STDOUT)
 		if err != nil {
+			var truncated *outputTruncatedError
+			if errors.As(err, &truncated) {
+				return controllers.AdapterObservationFailed, processMessage("Pi stdout was truncated before terminal validation", truncated.Error()), nil
+			}
 			return "", "", err
 		}
-		message, ok := finalAssistant(output)
+		message, detail, ok := finalAssistant(output)
 		if !ok {
-			return controllers.AdapterObservationFailed, "Pi exited without a valid agent_end assistant message", nil
+			return controllers.AdapterObservationFailed, processMessage("Pi exited without a coherent settled result", detail), nil
 		}
 		switch message.StopReason {
 		case "stop":
@@ -199,6 +222,14 @@ func (a *Adapter) forwardOutput(ctx context.Context, client sandboxdv1.ProcessSe
 		cursor := outputCursor{environment: string(sandbox.EnvironmentUID), owner: task.ID, execution: process.ExecutionId, stream: stream}
 		offset := a.cursor(cursor)
 		for {
+			if pending, ok := a.pendingEvent(cursor); ok {
+				if err := sandbox.EmitEvent(ctx, pending.event); err != nil {
+					return err
+				}
+				offset = pending.nextOffset
+				a.commitPending(cursor, offset)
+				continue
+			}
 			response, err := client.ReadOutput(ctx, &sandboxdv1.ReadOutputRequest{Key: processKey(task), ExecutionId: process.ExecutionId, Stream: stream, Offset: offset, MaxBytes: outputPageMax})
 			if err != nil {
 				return err
@@ -216,11 +247,13 @@ func (a *Adapter) forwardOutput(ctx context.Context, client sandboxdv1.ProcessSe
 			}
 			digest := sha256.Sum256(payload)
 			key := fmt.Sprintf("v1:%s:%x", streamName(stream), digest)
-			if err := sandbox.EmitEvent(ctx, controllers.AdapterEvent{Source: "pi", IdempotencyKey: key, Type: "pi.process-output", Data: payload}); err != nil {
+			event := controllers.AdapterEvent{Source: "pi", IdempotencyKey: key, Type: "pi.process-output", Data: payload}
+			a.setPending(cursor, pendingEvent{event: event, nextOffset: response.NextOffset})
+			if err := sandbox.EmitEvent(ctx, event); err != nil {
 				return err
 			}
 			offset = response.NextOffset
-			a.setCursor(cursor, offset)
+			a.commitPending(cursor, offset)
 			if response.Eof || offset >= response.ProducedEnd {
 				break
 			}
@@ -237,6 +270,9 @@ func readRetainedOutput(ctx context.Context, client sandboxdv1.ProcessServiceCli
 		if err != nil {
 			return nil, err
 		}
+		if response.GapBytes != 0 || response.Offset != offset {
+			return nil, &outputTruncatedError{retainedFrom: response.RetainedStart}
+		}
 		output.Write(response.Data)
 		offset = response.NextOffset
 		if response.Eof || offset >= response.ProducedEnd {
@@ -245,24 +281,46 @@ func readRetainedOutput(ctx context.Context, client sandboxdv1.ProcessServiceCli
 	}
 }
 
-func finalAssistant(output []byte) (assistantMessage, bool) {
+func finalAssistant(output []byte) (assistantMessage, string, bool) {
 	var terminal agentEndEvent
-	found := false
+	settled := false
 	for _, line := range bytes.Split(output, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
 		var candidate agentEndEvent
-		if json.Unmarshal(line, &candidate) == nil && candidate.Type == "agent_end" {
-			terminal, found = candidate, true
+		if json.Unmarshal(line, &candidate) != nil {
+			return assistantMessage{}, "malformed JSONL output", false
+		}
+		if settled {
+			return assistantMessage{}, "output after agent_settled", false
+		}
+		switch candidate.Type {
+		case "agent_end":
+			terminal = candidate
+		case "agent_settled":
+			if terminal.Type == "" {
+				return assistantMessage{}, "agent_settled before agent_end", false
+			}
+			settled = true
 		}
 	}
-	if !found {
-		return assistantMessage{}, false
+	if !settled {
+		return assistantMessage{}, "missing agent_settled", false
+	}
+	if terminal.WillRetry == nil {
+		return assistantMessage{}, "final agent_end is missing willRetry", false
+	}
+	if *terminal.WillRetry {
+		return assistantMessage{}, "final agent_end still indicates a retry", false
 	}
 	for i := len(terminal.Messages) - 1; i >= 0; i-- {
 		if terminal.Messages[i].Role == "assistant" {
-			return terminal.Messages[i], true
+			return terminal.Messages[i], "", true
 		}
 	}
-	return assistantMessage{}, false
+	return assistantMessage{}, "final agent_end has no assistant message", false
 }
 
 func processMessage(summary, detail string) string {
@@ -292,11 +350,28 @@ func (a *Adapter) cursor(key outputCursor) uint64 {
 	return a.cursors[key]
 }
 
-func (a *Adapter) setCursor(key outputCursor, offset uint64) {
+func (a *Adapter) pendingEvent(key outputCursor) (pendingEvent, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	pending, ok := a.pending[key]
+	return pending, ok
+}
+
+func (a *Adapter) setPending(key outputCursor, pending pendingEvent) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.pending == nil {
+		a.pending = make(map[outputCursor]pendingEvent)
+	}
+	a.pending[key] = pending
+}
+
+func (a *Adapter) commitPending(key outputCursor, offset uint64) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if a.cursors == nil {
 		a.cursors = make(map[outputCursor]uint64)
 	}
+	delete(a.pending, key)
 	a.cursors[key] = offset
 }

--- a/internal/adapters/pi/adapter.go
+++ b/internal/adapters/pi/adapter.go
@@ -103,7 +103,9 @@ func (a *Adapter) processSpec(task controllers.AdapterTask) *sandboxdv1.ProcessS
 			"\n" + task.Prompt,
 		},
 		Env: map[string]string{
-			"PI_CODING_AGENT_DIR": "/tmp/swe-platform/pi/" + task.ID,
+			// Process cwd defaults to the backend's workspace. A relative path
+			// remains OS-portable while keeping Pi state private to this Run UID.
+			"PI_CODING_AGENT_DIR": ".swe-platform/pi/" + task.ID,
 		},
 		EnvMode: sandboxdv1.EnvironmentMode_ENVIRONMENT_MODE_INHERIT,
 	}

--- a/internal/adapters/pi/adapter.go
+++ b/internal/adapters/pi/adapter.go
@@ -1,0 +1,302 @@
+// Package pi implements the Pi foreground-process adapter.
+package pi
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/Chris-Cullins/swe-platform/internal/controllers"
+	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
+)
+
+const processRole = "agent"
+
+const outputPageMax = 64 * 1024
+
+type assistantMessage struct {
+	Role         string `json:"role"`
+	StopReason   string `json:"stopReason"`
+	ErrorMessage string `json:"errorMessage"`
+}
+
+type agentEndEvent struct {
+	Type     string             `json:"type"`
+	Messages []assistantMessage `json:"messages"`
+}
+
+// Adapter drives one non-interactive Pi process per Run UID.
+type Adapter struct {
+	Executable string
+
+	mu      sync.Mutex
+	cursors map[outputCursor]uint64
+}
+
+type outputCursor struct {
+	environment string
+	owner       string
+	execution   string
+	stream      sandboxdv1.OutputStream
+}
+
+type outputEvent struct {
+	ExecutionID  string `json:"executionId"`
+	Stream       string `json:"stream"`
+	Offset       uint64 `json:"offset"`
+	NextOffset   uint64 `json:"nextOffset"`
+	GapBytes     uint64 `json:"gapBytes,omitempty"`
+	RetainedFrom uint64 `json:"retainedFrom"`
+	ProducedEnd  uint64 `json:"producedEnd"`
+	EOF          bool   `json:"eof"`
+	Data         []byte `json:"data,omitempty"`
+}
+
+func (a *Adapter) executable() string {
+	if a.Executable != "" {
+		return a.Executable
+	}
+	return "pi"
+}
+
+func processKey(task controllers.AdapterTask) *sandboxdv1.ProcessKey {
+	return &sandboxdv1.ProcessKey{OwnerId: task.ID, Role: processRole}
+}
+
+func (a *Adapter) processSpec(task controllers.AdapterTask) *sandboxdv1.ProcessSpec {
+	return &sandboxdv1.ProcessSpec{
+		Argv: []string{
+			a.executable(),
+			"--mode", "json",
+			"--no-session",
+			"--no-approve",
+			"--no-extensions",
+			"--no-skills",
+			"--no-prompt-templates",
+			"--no-themes",
+			"--offline",
+			// Pi 0.80.10 has no flag terminator. Leading whitespace keeps a
+			// flag-shaped task in the positional-message parser.
+			"\n" + task.Prompt,
+		},
+		Env: map[string]string{
+			"PI_CODING_AGENT_DIR": "/tmp/swe-platform/pi/" + task.ID,
+		},
+		EnvMode: sandboxdv1.EnvironmentMode_ENVIRONMENT_MODE_INHERIT,
+	}
+}
+
+// EnsureAccepted duplicate-safely starts (or recovers) the Run-keyed process.
+func (a *Adapter) EnsureAccepted(ctx context.Context, task controllers.AdapterTask, sandbox controllers.AdapterSandbox) error {
+	client, closeConnection, err := sandbox.DialProcess(ctx)
+	if err != nil {
+		return err
+	}
+	defer closeConnection()
+	_, err = client.Start(ctx, &sandboxdv1.StartProcessRequest{Key: processKey(task), Spec: a.processSpec(task)})
+	return err
+}
+
+// Observe maps Pi's terminal agent_end event and managed process state to the
+// adapter-neutral Run lifecycle.
+func (a *Adapter) Observe(ctx context.Context, task controllers.AdapterTask, sandbox controllers.AdapterSandbox) (controllers.AdapterObservation, string, error) {
+	client, closeConnection, err := sandbox.DialProcess(ctx)
+	if err != nil {
+		return "", "", err
+	}
+	defer closeConnection()
+	process, err := client.Get(ctx, &sandboxdv1.GetProcessRequest{Key: processKey(task)})
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return controllers.AdapterObservationFailed, "Pi execution is absent in the current sandbox epoch", nil
+		}
+		return "", "", err
+	}
+	if err := a.forwardOutput(ctx, client, task, sandbox, process); err != nil {
+		if errors.Is(err, controllers.ErrAdapterEventRejected) {
+			return controllers.AdapterObservationFailed, "Pi transcript output was permanently rejected", nil
+		}
+		return "", "", err
+	}
+
+	switch process.State {
+	case sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, sandboxdv1.ProcessState_PROCESS_STATE_STOPPING:
+		return controllers.AdapterObservationRunning, "Pi is running", nil
+	case sandboxdv1.ProcessState_PROCESS_STATE_FAILED:
+		return controllers.AdapterObservationFailed, processMessage("Pi failed to start", process.Error), nil
+	case sandboxdv1.ProcessState_PROCESS_STATE_EXITED:
+		if process.ExitCode == nil {
+			return controllers.AdapterObservationFailed, "Pi exited without an exit code", nil
+		}
+		if process.GetExitCode() != 0 {
+			return controllers.AdapterObservationFailed, fmt.Sprintf("Pi exited with code %d", process.GetExitCode()), nil
+		}
+		output, err := readRetainedOutput(ctx, client, processKey(task), process.ExecutionId, sandboxdv1.OutputStream_OUTPUT_STREAM_STDOUT)
+		if err != nil {
+			return "", "", err
+		}
+		message, ok := finalAssistant(output)
+		if !ok {
+			return controllers.AdapterObservationFailed, "Pi exited without a valid agent_end assistant message", nil
+		}
+		switch message.StopReason {
+		case "stop":
+			return controllers.AdapterObservationSucceeded, "Pi completed", nil
+		case "error", "aborted":
+			return controllers.AdapterObservationFailed, processMessage("Pi reported "+message.StopReason, message.ErrorMessage), nil
+		default:
+			return controllers.AdapterObservationFailed, fmt.Sprintf("Pi ended with stop reason %q", message.StopReason), nil
+		}
+	default:
+		return controllers.AdapterObservationFailed, fmt.Sprintf("Pi returned invalid process state %s", process.State), nil
+	}
+}
+
+// Cancel idempotently stops only this Run UID's managed process tree.
+func (a *Adapter) Cancel(ctx context.Context, task controllers.AdapterTask, sandbox controllers.AdapterSandbox) error {
+	client, closeConnection, err := sandbox.DialProcess(ctx)
+	if err != nil {
+		return err
+	}
+	defer closeConnection()
+	process, err := client.Stop(ctx, &sandboxdv1.StopProcessRequest{
+		Key:           processKey(task),
+		Mode:          sandboxdv1.StopMode_STOP_MODE_GRACEFUL,
+		GracePeriodMs: 10_000,
+	})
+	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return nil
+		}
+		return err
+	}
+	switch process.State {
+	case sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, sandboxdv1.ProcessState_PROCESS_STATE_STOPPING:
+		return controllers.ErrAdapterCancellationPending
+	case sandboxdv1.ProcessState_PROCESS_STATE_EXITED, sandboxdv1.ProcessState_PROCESS_STATE_FAILED:
+		err := a.forwardOutput(ctx, client, task, sandbox, process)
+		if errors.Is(err, controllers.ErrAdapterEventRejected) {
+			return nil
+		}
+		return err
+	default:
+		return fmt.Errorf("Pi cancellation returned invalid process state %s", process.State)
+	}
+}
+
+func (a *Adapter) forwardOutput(ctx context.Context, client sandboxdv1.ProcessServiceClient, task controllers.AdapterTask, sandbox controllers.AdapterSandbox, process *sandboxdv1.Process) error {
+	if sandbox.EmitEvent == nil || process.ExecutionId == "" {
+		return nil
+	}
+	for _, stream := range []sandboxdv1.OutputStream{sandboxdv1.OutputStream_OUTPUT_STREAM_STDOUT, sandboxdv1.OutputStream_OUTPUT_STREAM_STDERR} {
+		cursor := outputCursor{environment: string(sandbox.EnvironmentUID), owner: task.ID, execution: process.ExecutionId, stream: stream}
+		offset := a.cursor(cursor)
+		for {
+			response, err := client.ReadOutput(ctx, &sandboxdv1.ReadOutputRequest{Key: processKey(task), ExecutionId: process.ExecutionId, Stream: stream, Offset: offset, MaxBytes: outputPageMax})
+			if err != nil {
+				return err
+			}
+			if len(response.Data) == 0 && response.GapBytes == 0 {
+				break
+			}
+			payload, err := json.Marshal(outputEvent{
+				ExecutionID: process.ExecutionId, Stream: streamName(stream), Offset: response.Offset,
+				NextOffset: response.NextOffset, GapBytes: response.GapBytes, RetainedFrom: response.RetainedStart,
+				ProducedEnd: response.ProducedEnd, EOF: response.Eof, Data: response.Data,
+			})
+			if err != nil {
+				return err
+			}
+			digest := sha256.Sum256(payload)
+			key := fmt.Sprintf("v1:%s:%x", streamName(stream), digest)
+			if err := sandbox.EmitEvent(ctx, controllers.AdapterEvent{Source: "pi", IdempotencyKey: key, Type: "pi.process-output", Data: payload}); err != nil {
+				return err
+			}
+			offset = response.NextOffset
+			a.setCursor(cursor, offset)
+			if response.Eof || offset >= response.ProducedEnd {
+				break
+			}
+		}
+	}
+	return nil
+}
+
+func readRetainedOutput(ctx context.Context, client sandboxdv1.ProcessServiceClient, key *sandboxdv1.ProcessKey, executionID string, stream sandboxdv1.OutputStream) ([]byte, error) {
+	var output bytes.Buffer
+	var offset uint64
+	for {
+		response, err := client.ReadOutput(ctx, &sandboxdv1.ReadOutputRequest{Key: key, ExecutionId: executionID, Stream: stream, Offset: offset, MaxBytes: outputPageMax})
+		if err != nil {
+			return nil, err
+		}
+		output.Write(response.Data)
+		offset = response.NextOffset
+		if response.Eof || offset >= response.ProducedEnd {
+			return output.Bytes(), nil
+		}
+	}
+}
+
+func finalAssistant(output []byte) (assistantMessage, bool) {
+	var terminal agentEndEvent
+	found := false
+	for _, line := range bytes.Split(output, []byte("\n")) {
+		var candidate agentEndEvent
+		if json.Unmarshal(line, &candidate) == nil && candidate.Type == "agent_end" {
+			terminal, found = candidate, true
+		}
+	}
+	if !found {
+		return assistantMessage{}, false
+	}
+	for i := len(terminal.Messages) - 1; i >= 0; i-- {
+		if terminal.Messages[i].Role == "assistant" {
+			return terminal.Messages[i], true
+		}
+	}
+	return assistantMessage{}, false
+}
+
+func processMessage(summary, detail string) string {
+	if detail == "" {
+		return summary
+	}
+	const maxDetail = 512
+	if len(detail) > maxDetail {
+		detail = detail[:maxDetail] + "…"
+	}
+	return summary + ": " + detail
+}
+
+func streamName(stream sandboxdv1.OutputStream) string {
+	if stream == sandboxdv1.OutputStream_OUTPUT_STREAM_STDERR {
+		return "stderr"
+	}
+	return "stdout"
+}
+
+func (a *Adapter) cursor(key outputCursor) uint64 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.cursors == nil {
+		a.cursors = make(map[outputCursor]uint64)
+	}
+	return a.cursors[key]
+}
+
+func (a *Adapter) setCursor(key outputCursor, offset uint64) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.cursors == nil {
+		a.cursors = make(map[outputCursor]uint64)
+	}
+	a.cursors[key] = offset
+}

--- a/internal/adapters/pi/adapter_test.go
+++ b/internal/adapters/pi/adapter_test.go
@@ -1,0 +1,353 @@
+package pi
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/Chris-Cullins/swe-platform/internal/controllers"
+	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
+)
+
+type fakeProcessClient struct {
+	process     *sandboxdv1.Process
+	stdout      []byte
+	stderr      []byte
+	stdoutStart uint64
+	stderrStart uint64
+	startCalls  int
+	launches    int
+	startedKey  *sandboxdv1.ProcessKey
+	startedSpec *sandboxdv1.ProcessSpec
+	stoppedKey  *sandboxdv1.ProcessKey
+	stopMode    sandboxdv1.StopMode
+	getErr      error
+	stopErr     error
+}
+
+func (f *fakeProcessClient) Start(_ context.Context, request *sandboxdv1.StartProcessRequest, _ ...grpc.CallOption) (*sandboxdv1.Process, error) {
+	f.startCalls++
+	if f.startedKey == nil {
+		f.launches++
+		f.startedKey, f.startedSpec = request.Key, request.Spec
+	} else if !reflect.DeepEqual(f.startedKey, request.Key) || !reflect.DeepEqual(f.startedSpec, request.Spec) {
+		return nil, status.Error(codes.FailedPrecondition, "conflicting start")
+	}
+	if f.process == nil {
+		f.process = &sandboxdv1.Process{Key: request.Key, Spec: request.Spec, State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution-1"}
+	}
+	return f.process, nil
+}
+
+func (f *fakeProcessClient) Get(context.Context, *sandboxdv1.GetProcessRequest, ...grpc.CallOption) (*sandboxdv1.Process, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	return f.process, nil
+}
+
+func (f *fakeProcessClient) Stop(_ context.Context, request *sandboxdv1.StopProcessRequest, _ ...grpc.CallOption) (*sandboxdv1.Process, error) {
+	f.stoppedKey, f.stopMode = request.Key, request.Mode
+	if f.stopErr != nil {
+		return nil, f.stopErr
+	}
+	if f.process != nil {
+		return f.process, nil
+	}
+	return &sandboxdv1.Process{Key: request.Key, State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED}, nil
+}
+
+func (f *fakeProcessClient) ReadOutput(_ context.Context, request *sandboxdv1.ReadOutputRequest, _ ...grpc.CallOption) (*sandboxdv1.ReadOutputResponse, error) {
+	data := f.stdout
+	bufferStart := f.stdoutStart
+	if request.Stream == sandboxdv1.OutputStream_OUTPUT_STREAM_STDERR {
+		data = f.stderr
+		bufferStart = f.stderrStart
+	}
+	producedEnd := bufferStart + uint64(len(data))
+	offset := request.Offset
+	gap := offset < bufferStart
+	if gap {
+		offset = bufferStart
+	}
+	if offset > producedEnd {
+		return nil, status.Error(codes.OutOfRange, "offset")
+	}
+	startIndex := int(offset - bufferStart)
+	endIndex := min(len(data), startIndex+int(request.MaxBytes))
+	nextOffset := bufferStart + uint64(endIndex)
+	return &sandboxdv1.ReadOutputResponse{
+		Data:          append([]byte(nil), data[startIndex:endIndex]...),
+		Offset:        offset,
+		NextOffset:    nextOffset,
+		ProducedEnd:   producedEnd,
+		Eof:           endIndex == len(data),
+		GapBytes:      offset - request.Offset,
+		RetainedStart: bufferStart,
+	}, nil
+}
+
+func sandboxFor(client sandboxdv1.ProcessServiceClient) controllers.AdapterSandbox {
+	return controllers.AdapterSandbox{
+		EnvironmentName: "environment",
+		EnvironmentUID:  "environment-uid",
+		DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
+			return client, func() error { return nil }, nil
+		},
+	}
+}
+
+func sandboxWithEvents(client sandboxdv1.ProcessServiceClient, events *[]controllers.AdapterEvent) controllers.AdapterSandbox {
+	sandbox := sandboxFor(client)
+	sandbox.EmitEvent = func(_ context.Context, event controllers.AdapterEvent) error {
+		*events = append(*events, event)
+		return nil
+	}
+	return sandbox
+}
+
+func TestAcceptanceIsDuplicateSafeAndEpochFenced(t *testing.T) {
+	task := controllers.AdapterTask{ID: "run-uid", Prompt: "--version"}
+	adapter := &Adapter{Executable: "fake-pi"}
+	firstEpoch := &fakeProcessClient{}
+	for range 2 {
+		if err := adapter.EnsureAccepted(context.Background(), task, sandboxFor(firstEpoch)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if firstEpoch.startCalls != 2 || firstEpoch.launches != 1 {
+		t.Fatalf("start calls/launches = %d/%d, want 2/1", firstEpoch.startCalls, firstEpoch.launches)
+	}
+	if got, want := firstEpoch.startedKey, (&sandboxdv1.ProcessKey{OwnerId: task.ID, Role: "agent"}); !reflect.DeepEqual(got, want) {
+		t.Fatalf("process key = %#v, want %#v", got, want)
+	}
+	wantArgv := []string{
+		"fake-pi", "--mode", "json", "--no-session", "--no-approve",
+		"--no-extensions", "--no-skills", "--no-prompt-templates", "--no-themes",
+		"--offline", "\n" + task.Prompt,
+	}
+	if got := firstEpoch.startedSpec.Argv; !reflect.DeepEqual(got, wantArgv) {
+		t.Fatalf("argv = %#v, want %#v", got, wantArgv)
+	}
+	if firstEpoch.startedSpec.EnvMode != sandboxdv1.EnvironmentMode_ENVIRONMENT_MODE_INHERIT || !reflect.DeepEqual(firstEpoch.startedSpec.Env, map[string]string{
+		"PI_CODING_AGENT_DIR": "/tmp/swe-platform/pi/run-uid",
+	}) {
+		t.Fatalf("environment = %s %#v", firstEpoch.startedSpec.EnvMode, firstEpoch.startedSpec.Env)
+	}
+
+	secondEpoch := &fakeProcessClient{}
+	if err := adapter.EnsureAccepted(context.Background(), task, sandboxFor(secondEpoch)); err != nil {
+		t.Fatal(err)
+	}
+	if secondEpoch.launches != 1 || !reflect.DeepEqual(secondEpoch.startedKey, firstEpoch.startedKey) {
+		t.Fatalf("replacement epoch launch/key = %d/%#v", secondEpoch.launches, secondEpoch.startedKey)
+	}
+}
+
+func TestObservationRequiresNormalAgentEndAndCoherentProcessExit(t *testing.T) {
+	exit0, exit1 := int32(0), int32(1)
+	tests := []struct {
+		name    string
+		process *sandboxdv1.Process
+		stdout  string
+		want    controllers.AdapterObservation
+	}{
+		{name: "running", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "e"}, want: controllers.AdapterObservationRunning},
+		{name: "start failure", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_FAILED, Error: "executable not found", ExecutionId: "e"}, want: controllers.AdapterObservationFailed},
+		{name: "nonzero exit", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit1, ExecutionId: "e"}, want: controllers.AdapterObservationFailed},
+		{name: "success", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"agent_end\",\"messages\":[{\"role\":\"assistant\",\"stopReason\":\"stop\"}]}\n", want: controllers.AdapterObservationSucceeded},
+		{name: "reported error", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"agent_end\",\"messages\":[{\"role\":\"assistant\",\"stopReason\":\"error\",\"errorMessage\":\"provider failed\"}]}\n", want: controllers.AdapterObservationFailed},
+		{name: "reported abort", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"agent_end\",\"messages\":[{\"role\":\"assistant\",\"stopReason\":\"aborted\",\"errorMessage\":\"request aborted\"}]}\n", want: controllers.AdapterObservationFailed},
+		{name: "length stop", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"agent_end\",\"messages\":[{\"role\":\"assistant\",\"stopReason\":\"length\"}]}\n", want: controllers.AdapterObservationFailed},
+		{name: "malformed stream", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "not-json\n", want: controllers.AdapterObservationFailed},
+		{name: "unknown event", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"future_event\"}\n", want: controllers.AdapterObservationFailed},
+		{name: "terminal event without assistant", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"agent_end\",\"messages\":[]}\n", want: controllers.AdapterObservationFailed},
+		{name: "missing exit code", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e"}, want: controllers.AdapterObservationFailed},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := &fakeProcessClient{process: test.process, stdout: []byte(test.stdout)}
+			got, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandboxFor(client))
+			if err != nil || got != test.want {
+				t.Fatalf("Observe() = (%q, %v), want %q", got, err, test.want)
+			}
+		})
+	}
+}
+
+func TestUnavailableAndAbsentExecution(t *testing.T) {
+	dialError := errors.New("sandbox unavailable")
+	sandbox := controllers.AdapterSandbox{DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
+		return nil, nil, dialError
+	}}
+	if err := (&Adapter{}).EnsureAccepted(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); !errors.Is(err, dialError) {
+		t.Fatalf("EnsureAccepted() error = %v", err)
+	}
+	client := &fakeProcessClient{getErr: status.Error(codes.NotFound, "absent")}
+	got, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandboxFor(client))
+	if err != nil || got != controllers.AdapterObservationFailed {
+		t.Fatalf("Observe(absent) = (%q, %v)", got, err)
+	}
+	client.stopErr = status.Error(codes.NotFound, "absent")
+	if err := (&Adapter{}).Cancel(context.Background(), controllers.AdapterTask{ID: "run"}, sandboxFor(client)); err != nil {
+		t.Fatalf("Cancel(absent) error = %v, want success", err)
+	}
+}
+
+func TestCancelStopsOnlyRunOwnedProcessTreeAndWaitsForTerminalState(t *testing.T) {
+	task := controllers.AdapterTask{ID: "run-uid"}
+	client := &fakeProcessClient{}
+	if err := (&Adapter{}).Cancel(context.Background(), task, sandboxFor(client)); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := client.stoppedKey, (&sandboxdv1.ProcessKey{OwnerId: task.ID, Role: "agent"}); !reflect.DeepEqual(got, want) || client.stopMode != sandboxdv1.StopMode_STOP_MODE_GRACEFUL {
+		t.Fatalf("stop = key %#v mode %s", got, client.stopMode)
+	}
+
+	client.process = &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_STOPPING, ExecutionId: "execution"}
+	err := (&Adapter{}).Cancel(context.Background(), task, sandboxFor(client))
+	if !errors.Is(err, controllers.ErrAdapterCancellationPending) {
+		t.Fatalf("Cancel() error = %v, want cancellation pending", err)
+	}
+}
+
+func TestOutputForwardingIsOpaqueGapVisibleAndExecutionScoped(t *testing.T) {
+	task := controllers.AdapterTask{ID: "run-uid"}
+	stdout := []byte("not-json\n{\"type\":\"future_event\"}\n{\"type\":\"agent_end\",\"messages\":[{\"role\":\"assistant\",\"stopReason\":\"error\"}]}\n")
+	stderr := []byte("provider diagnostic\n")
+	client := &fakeProcessClient{
+		process:     &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution-1"},
+		stdout:      stdout,
+		stderr:      stderr,
+		stdoutStart: 7,
+		stderrStart: 3,
+	}
+	var events []controllers.AdapterEvent
+	adapter := &Adapter{}
+	sandbox := sandboxWithEvents(client, &events)
+	if _, _, err := adapter.Observe(context.Background(), task, sandbox); err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("events = %d, want stdout and stderr", len(events))
+	}
+	for i, want := range []struct {
+		stream      string
+		data        []byte
+		bufferStart uint64
+	}{{"stdout", stdout, 7}, {"stderr", stderr, 3}} {
+		event := events[i]
+		if event.Source != "pi" || event.Type != "pi.process-output" || event.IdempotencyKey == "" {
+			t.Fatalf("event = %#v", event)
+		}
+		var payload struct {
+			Stream       string `json:"stream"`
+			Data         string `json:"data"`
+			Offset       uint64 `json:"offset"`
+			GapBytes     uint64 `json:"gapBytes"`
+			RetainedFrom uint64 `json:"retainedFrom"`
+		}
+		if err := json.Unmarshal(event.Data, &payload); err != nil {
+			t.Fatal(err)
+		}
+		decoded, err := base64.StdEncoding.DecodeString(payload.Data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if payload.Stream != want.stream || !reflect.DeepEqual(decoded, want.data) || payload.GapBytes != want.bufferStart || payload.Offset != want.bufferStart || payload.RetainedFrom != want.bufferStart {
+			t.Fatalf("payload = %#v data %q", payload, decoded)
+		}
+	}
+
+	if _, _, err := adapter.Observe(context.Background(), task, sandbox); err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("duplicate observation emitted %d events, want 2 total", len(events))
+	}
+
+	client.process.ExecutionId = "execution-2"
+	client.stdoutStart, client.stderrStart = 0, 0
+	client.stdout, client.stderr = []byte("{\"type\":\"agent_end\",\"messages\":[{\"role\":\"assistant\",\"stopReason\":\"aborted\"}]}\n"), nil
+	if _, _, err := adapter.Observe(context.Background(), task, sandbox); err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("replacement execution did not restart output cursor: %d events", len(events))
+	}
+
+	client.stdout = append(client.stdout, []byte("terminal trailer\n")...)
+	client.process.State = sandboxdv1.ProcessState_PROCESS_STATE_EXITED
+	if err := adapter.Cancel(context.Background(), task, sandbox); err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 4 {
+		t.Fatalf("cancellation did not drain terminal output: %d events", len(events))
+	}
+}
+
+func TestOutputPaginationRetriesTheSameIdempotencyKey(t *testing.T) {
+	transient := errors.New("transcript unavailable")
+	client := &fakeProcessClient{
+		process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"},
+		stdout:  bytes.Repeat([]byte("x"), outputPageMax+1),
+	}
+	var keys []string
+	sandbox := sandboxFor(client)
+	sandbox.EmitEvent = func(_ context.Context, event controllers.AdapterEvent) error {
+		keys = append(keys, event.IdempotencyKey)
+		if len(keys) == 1 {
+			return transient
+		}
+		return nil
+	}
+	adapter := &Adapter{}
+	if _, _, err := adapter.Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); !errors.Is(err, transient) {
+		t.Fatalf("first Observe() error = %v, want transient error", err)
+	}
+	if got, _, err := adapter.Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err != nil || got != controllers.AdapterObservationRunning {
+		t.Fatalf("retry Observe() = (%q, %v)", got, err)
+	}
+	if len(keys) != 3 || keys[0] != keys[1] || keys[1] == keys[2] {
+		t.Fatalf("event keys = %#v, want identical retry followed by a second page", keys)
+	}
+}
+
+func TestPermanentOutputRejectionFailsObservation(t *testing.T) {
+	client := &fakeProcessClient{
+		process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"},
+		stdout:  []byte("output"),
+	}
+	sandbox := sandboxFor(client)
+	sandbox.EmitEvent = func(context.Context, controllers.AdapterEvent) error {
+		return controllers.ErrAdapterEventRejected
+	}
+	got, message, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox)
+	if err != nil || got != controllers.AdapterObservationFailed || !strings.Contains(message, "permanently rejected") {
+		t.Fatalf("Observe() = (%q, %q, %v)", got, message, err)
+	}
+}
+
+func TestTerminalCancellationIgnoresPermanentOutputRejection(t *testing.T) {
+	exitCode := int32(0)
+	client := &fakeProcessClient{
+		process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "execution", ExitCode: &exitCode},
+		stdout:  []byte("output"),
+	}
+	sandbox := sandboxFor(client)
+	sandbox.EmitEvent = func(context.Context, controllers.AdapterEvent) error {
+		return controllers.ErrAdapterEventRejected
+	}
+	if err := (&Adapter{}).Cancel(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err != nil {
+		t.Fatalf("Cancel() error = %v", err)
+	}
+}

--- a/internal/adapters/pi/adapter_test.go
+++ b/internal/adapters/pi/adapter_test.go
@@ -48,6 +48,10 @@ func (f *fakeProcessClient) Start(_ context.Context, request *sandboxdv1.StartPr
 	return f.process, nil
 }
 
+func (f *fakeProcessClient) StartWithLaunchMaterial(context.Context, *sandboxdv1.StartProcessWithLaunchMaterialRequest, ...grpc.CallOption) (*sandboxdv1.Process, error) {
+	return nil, errors.New("unexpected launch material")
+}
+
 func (f *fakeProcessClient) Get(context.Context, *sandboxdv1.GetProcessRequest, ...grpc.CallOption) (*sandboxdv1.Process, error) {
 	if f.getErr != nil {
 		return nil, f.getErr
@@ -120,7 +124,7 @@ func TestAcceptanceIsDuplicateSafeAndEpochFenced(t *testing.T) {
 	adapter := &Adapter{Executable: "fake-pi"}
 	firstEpoch := &fakeProcessClient{}
 	for range 2 {
-		if err := adapter.EnsureAccepted(context.Background(), task, sandboxFor(firstEpoch)); err != nil {
+		if err := adapter.EnsureAccepted(context.Background(), task, sandboxFor(firstEpoch), nil); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -133,7 +137,7 @@ func TestAcceptanceIsDuplicateSafeAndEpochFenced(t *testing.T) {
 	wantArgv := []string{
 		"fake-pi", "--mode", "json", "--no-session", "--no-approve",
 		"--no-extensions", "--no-skills", "--no-prompt-templates", "--no-themes",
-		"--offline", "\n" + task.Prompt,
+		"--no-context-files", "--offline", "\n" + task.Prompt,
 	}
 	if got := firstEpoch.startedSpec.Argv; !reflect.DeepEqual(got, wantArgv) {
 		t.Fatalf("argv = %#v, want %#v", got, wantArgv)
@@ -145,7 +149,7 @@ func TestAcceptanceIsDuplicateSafeAndEpochFenced(t *testing.T) {
 	}
 
 	secondEpoch := &fakeProcessClient{}
-	if err := adapter.EnsureAccepted(context.Background(), task, sandboxFor(secondEpoch)); err != nil {
+	if err := adapter.EnsureAccepted(context.Background(), task, sandboxFor(secondEpoch), nil); err != nil {
 		t.Fatal(err)
 	}
 	if secondEpoch.launches != 1 || !reflect.DeepEqual(secondEpoch.startedKey, firstEpoch.startedKey) {
@@ -153,8 +157,21 @@ func TestAcceptanceIsDuplicateSafeAndEpochFenced(t *testing.T) {
 	}
 }
 
+func TestCredentialIsRejectedBeforeDial(t *testing.T) {
+	dials := 0
+	sandbox := controllers.AdapterSandbox{DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
+		dials++
+		return nil, nil, errors.New("unexpected dial")
+	}}
+	err := (&Adapter{}).EnsureAccepted(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox, &controllers.AdapterCredential{APIKey: []byte("secret")})
+	if !errors.Is(err, controllers.ErrAdapterTaskRejected) || dials != 0 {
+		t.Fatalf("EnsureAccepted() = %v with %d dials", err, dials)
+	}
+}
+
 func TestObservationRequiresNormalAgentEndAndCoherentProcessExit(t *testing.T) {
 	exit0, exit1 := int32(0), int32(1)
+	settled := "\n{\"type\":\"agent_settled\"}\n"
 	tests := []struct {
 		name    string
 		process *sandboxdv1.Process
@@ -164,13 +181,17 @@ func TestObservationRequiresNormalAgentEndAndCoherentProcessExit(t *testing.T) {
 		{name: "running", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "e"}, want: controllers.AdapterObservationRunning},
 		{name: "start failure", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_FAILED, Error: "executable not found", ExecutionId: "e"}, want: controllers.AdapterObservationFailed},
 		{name: "nonzero exit", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit1, ExecutionId: "e"}, want: controllers.AdapterObservationFailed},
-		{name: "success", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"agent_end\",\"messages\":[{\"role\":\"assistant\",\"stopReason\":\"stop\"}]}\n", want: controllers.AdapterObservationSucceeded},
-		{name: "reported error", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"agent_end\",\"messages\":[{\"role\":\"assistant\",\"stopReason\":\"error\",\"errorMessage\":\"provider failed\"}]}\n", want: controllers.AdapterObservationFailed},
-		{name: "reported abort", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"agent_end\",\"messages\":[{\"role\":\"assistant\",\"stopReason\":\"aborted\",\"errorMessage\":\"request aborted\"}]}\n", want: controllers.AdapterObservationFailed},
-		{name: "length stop", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"agent_end\",\"messages\":[{\"role\":\"assistant\",\"stopReason\":\"length\"}]}\n", want: controllers.AdapterObservationFailed},
+		{name: "success", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"agent_end\",\"messages\":[{\"role\":\"assistant\",\"stopReason\":\"stop\"}],\"willRetry\":false}" + settled, want: controllers.AdapterObservationSucceeded},
+		{name: "success after retry", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"agent_end\",\"messages\":[{\"role\":\"assistant\",\"stopReason\":\"error\"}],\"willRetry\":true}\n{\"type\":\"auto_retry_end\"}\n{\"type\":\"agent_end\",\"messages\":[{\"role\":\"assistant\",\"stopReason\":\"stop\"}],\"willRetry\":false}" + settled, want: controllers.AdapterObservationSucceeded},
+		{name: "reported error", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"agent_end\",\"messages\":[{\"role\":\"assistant\",\"stopReason\":\"error\",\"errorMessage\":\"provider failed\"}],\"willRetry\":false}" + settled, want: controllers.AdapterObservationFailed},
+		{name: "reported abort", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"agent_end\",\"messages\":[{\"role\":\"assistant\",\"stopReason\":\"aborted\",\"errorMessage\":\"request aborted\"}],\"willRetry\":false}" + settled, want: controllers.AdapterObservationFailed},
+		{name: "length stop", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"agent_end\",\"messages\":[{\"role\":\"assistant\",\"stopReason\":\"length\"}],\"willRetry\":false}" + settled, want: controllers.AdapterObservationFailed},
 		{name: "malformed stream", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "not-json\n", want: controllers.AdapterObservationFailed},
 		{name: "unknown event", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"future_event\"}\n", want: controllers.AdapterObservationFailed},
-		{name: "terminal event without assistant", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"agent_end\",\"messages\":[]}\n", want: controllers.AdapterObservationFailed},
+		{name: "terminal event without assistant", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"agent_end\",\"messages\":[],\"willRetry\":false}" + settled, want: controllers.AdapterObservationFailed},
+		{name: "missing settlement", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"agent_end\",\"messages\":[{\"role\":\"assistant\",\"stopReason\":\"stop\"}],\"willRetry\":false}\n", want: controllers.AdapterObservationFailed},
+		{name: "output after settlement", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"agent_end\",\"messages\":[{\"role\":\"assistant\",\"stopReason\":\"stop\"}],\"willRetry\":false}" + settled + "{\"type\":\"future_event\"}\n", want: controllers.AdapterObservationFailed},
+		{name: "missing retry marker", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"agent_end\",\"messages\":[{\"role\":\"assistant\",\"stopReason\":\"stop\"}]}" + settled, want: controllers.AdapterObservationFailed},
 		{name: "missing exit code", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e"}, want: controllers.AdapterObservationFailed},
 	}
 	for _, test := range tests {
@@ -189,7 +210,7 @@ func TestUnavailableAndAbsentExecution(t *testing.T) {
 	sandbox := controllers.AdapterSandbox{DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
 		return nil, nil, dialError
 	}}
-	if err := (&Adapter{}).EnsureAccepted(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); !errors.Is(err, dialError) {
+	if err := (&Adapter{}).EnsureAccepted(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox, nil); !errors.Is(err, dialError) {
 		t.Fatalf("EnsureAccepted() error = %v", err)
 	}
 	client := &fakeProcessClient{getErr: status.Error(codes.NotFound, "absent")}
@@ -302,10 +323,13 @@ func TestOutputPaginationRetriesTheSameIdempotencyKey(t *testing.T) {
 		stdout:  bytes.Repeat([]byte("x"), outputPageMax+1),
 	}
 	var keys []string
+	var payloads [][]byte
 	sandbox := sandboxFor(client)
 	sandbox.EmitEvent = func(_ context.Context, event controllers.AdapterEvent) error {
 		keys = append(keys, event.IdempotencyKey)
+		payloads = append(payloads, append([]byte(nil), event.Data...))
 		if len(keys) == 1 {
+			client.stdout = append(client.stdout, []byte("grew-after-uncertain-append")...)
 			return transient
 		}
 		return nil
@@ -317,8 +341,21 @@ func TestOutputPaginationRetriesTheSameIdempotencyKey(t *testing.T) {
 	if got, _, err := adapter.Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err != nil || got != controllers.AdapterObservationRunning {
 		t.Fatalf("retry Observe() = (%q, %v)", got, err)
 	}
-	if len(keys) != 3 || keys[0] != keys[1] || keys[1] == keys[2] {
+	if len(keys) != 3 || keys[0] != keys[1] || !bytes.Equal(payloads[0], payloads[1]) || keys[1] == keys[2] {
 		t.Fatalf("event keys = %#v, want identical retry followed by a second page", keys)
+	}
+}
+
+func TestRetainedOutputGapFailsTerminalValidation(t *testing.T) {
+	exitCode := int32(0)
+	client := &fakeProcessClient{
+		process:     &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "execution", ExitCode: &exitCode},
+		stdoutStart: 7,
+		stdout:      []byte("{\"type\":\"agent_end\",\"messages\":[{\"role\":\"assistant\",\"stopReason\":\"stop\"}],\"willRetry\":false}\n{\"type\":\"agent_settled\"}\n"),
+	}
+	got, message, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandboxFor(client))
+	if err != nil || got != controllers.AdapterObservationFailed || !strings.Contains(message, "truncated") {
+		t.Fatalf("Observe() = (%q, %q, %v)", got, message, err)
 	}
 }
 

--- a/internal/adapters/pi/adapter_test.go
+++ b/internal/adapters/pi/adapter_test.go
@@ -143,7 +143,7 @@ func TestAcceptanceIsDuplicateSafeAndEpochFenced(t *testing.T) {
 		t.Fatalf("argv = %#v, want %#v", got, wantArgv)
 	}
 	if firstEpoch.startedSpec.EnvMode != sandboxdv1.EnvironmentMode_ENVIRONMENT_MODE_INHERIT || !reflect.DeepEqual(firstEpoch.startedSpec.Env, map[string]string{
-		"PI_CODING_AGENT_DIR": "/tmp/swe-platform/pi/run-uid",
+		"PI_CODING_AGENT_DIR": ".swe-platform/pi/run-uid",
 	}) {
 		t.Fatalf("environment = %s %#v", firstEpoch.startedSpec.EnvMode, firstEpoch.startedSpec.Env)
 	}


### PR DESCRIPTION
Closes #63

Supersedes #85 by replaying its contributed implementation onto current `main` with authorship preserved, then addressing integration and review findings.

## Summary

- register a Run-UID-keyed Pi 0.80.10 adapter without changing the default agent
- isolate sessions/config and disable untrusted resource/context discovery
- require coherent `agent_end`/`agent_settled` JSONL plus exit-zero process state
- forward bounded, gap-visible output with exact uncertain-append replay
- integrity-pin Pi in the multi-architecture environment image
- exercise the deployed adapter through a credential-free fake Pi kind flow

## Review

Independent expert re-review: **APPROVE**, no concrete merge blockers.

## Verification

- `go test -race ./internal/adapters/pi ./cmd/operator -count=1`
- `go test ./... -count=1`
- `(cd sandboxd && go test ./... -count=1)`
- `make vet`
- `make build`
- `bash -n hack/e2e.sh`
- `git diff --check origin/main...HEAD`
- pinned npm integrity, `--ignore-scripts` install, and `pi --version` probe

Full multi-architecture image builds and kind acceptance are left to required CI.
