### PR TITLE
fix: require capacity for Argo kind demo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,8 +118,10 @@ runs both via `make` targets:
   cluster running Argo CD + the Image Updater (`hack/argocd/`,
   `values-argocd.yaml` preset). It syncs the chart from `origin/main` and rolls
   the operator/control plane on new `:latest` digests — only pushed commits
-  take effect. `make argocd-ui` keeps a foreground, loopback-only control-plane
-  Service forward alive across those rollouts. Keep it isolated from `swe-dev`;
+  take effect. The bootstrap requires one node with at least 5 CPUs and 6 GiB
+  allocatable so a warm `tiny` Environment and its replacement remain schedulable
+  with Argo/system workloads. `make argocd-ui` keeps a foreground, loopback-only
+  control-plane Service forward alive across those rollouts. Keep it isolated from `swe-dev`;
   two operators must never reconcile the same custom resources.
 - **Production Helm presets:** `charts/swe-platform/values-{k3s,gke,eks}.yaml`; CI lints
   and renders every preset, verifies all rendered production images use the coordinated

--- a/README.md
+++ b/README.md
@@ -187,7 +187,10 @@ Argo rollout replaces the selected control-plane pod. Override the cluster with
 `KIND_ARGO_CLUSTER` or the local port with `ARGO_UI_PORT`. Stopping the helper also stops
 only its own `kubectl` child. Existing SSE or WebSocket connections still disconnect during
 a rollout and must reconnect, and a control-plane replacement invalidates its process-local
-browser sessions.
+browser sessions. The bootstrap requires one kind node with at least 5 CPUs and 6 GiB
+allocatable so the Argo/system workload and two 1-CPU/2-GiB `tiny` Environments fit while a
+warm member is claimed and replaced. Increase the container runtime's capacity before
+running `make argocd-up`; the script checks this before installing Argo.
 
 Create runs with an explicit template, or reference a `Project` to use its default
 template:

--- a/charts/swe-platform/README.md
+++ b/charts/swe-platform/README.md
@@ -63,7 +63,7 @@ digest-pinned installation overrides.
 | Preset | Assumptions |
 |---|---|
 | `values-kind.yaml` | Local kind development with `:dev` images; explicitly permits insecure HTTP browser sessions. `make kind-up` installs gVisor and snapshot-capable CSI; pass the printed `environmentTemplates[0].spec.runtimeClass=gvisor` override when installing the chart. |
-| `values-argocd.yaml` | Local Argo CD mirror with mutable `:latest` images and an out-of-band bootstrap Secret; explicitly permits insecure HTTP browser sessions. |
+| `values-argocd.yaml` | Local Argo CD mirror with mutable `:latest` images and an out-of-band bootstrap Secret; explicitly permits insecure HTTP browser sessions. `hack/argocd-up.sh` requires one kind node with at least 5 CPUs and 6 GiB allocatable. |
 | `values-k3s.yaml` | A default CSI-backed StorageClass is available. Uses one operator replica and the default OCI runtime because k3s does not ship gVisor. |
 | `values-gke.yaml` | GKE Sandbox is enabled on every node that can host environments. Sets `runtimeClass: gvisor` and runs two operator replicas with leader election. |
 | `values-eks.yaml` | A default EBS CSI StorageClass is available. Runs two operator replicas with leader election. EKS does not provide a standard gVisor RuntimeClass, so environments use the cluster default unless you override `environmentTemplates[].spec.runtimeClass`. |
@@ -82,7 +82,15 @@ lifecycle and backend requirements.
 For local development, use `values-kind.yaml`; it references locally loaded `:dev`
 images and disables leader election. `values-argocd.yaml` is the preset for the
 local Argo CD mirror (`hack/argocd-up.sh`): it tracks the mutable `:latest` images
-published from main and references an out-of-band bootstrap token Secret.
+published from main and references an out-of-band bootstrap token Secret. Its `tiny`
+template requests 1 CPU and 2 GiB per Environment. The configured warm minimum of one
+therefore needs capacity for two Environments while a claimed member and its replacement
+overlap. The bootstrap checks for at least 5 CPUs and 6 GiB allocatable on one node before
+installing Argo, leaving the capacity beyond the Environments' 2 CPUs/4 GiB for Kubernetes,
+Argo CD, the Image Updater, the operator, and the control plane. If local capacity is more
+important than warm starts, explicitly set `environmentTemplates[0].spec.warmPool.min=0`;
+that removes replacement overlap but makes every Run wait for environment provisioning and
+the `env-base` image pull.
 
 ## Control-plane authentication and authorization
 

--- a/charts/swe-platform/values-argocd.yaml
+++ b/charts/swe-platform/values-argocd.yaml
@@ -27,8 +27,10 @@ environmentTemplates:
   - name: small
     spec:
       image: ghcr.io/chris-cullins/swe-platform/env-base:latest
-      # Leave room for the claimed environment and its immediate pool replacement
-      # on kind's single control-plane node.
+      # The Argo bootstrap requires a node with at least 5 CPUs/6 GiB allocatable
+      # so this ready member and its immediate replacement fit during a claim.
+      # Setting min to 0 lowers peak capacity, but every Run then pays environment
+      # provisioning and image-pull cold-start latency.
       size: tiny
       idleTimeout: 15m
       diskSize: 5Gi

--- a/hack/argocd-up.sh
+++ b/hack/argocd-up.sh
@@ -7,13 +7,18 @@
 # two operators must never reconcile the same custom resources, and Argo CD
 # selfHeal would fight manual dev installs.
 #
-# Prerequisites: kind, kubectl. Env overrides: KIND_ARGO_CLUSTER (default
-# swe-argo), ARGOCD_VERSION, IMAGE_UPDATER_VERSION.
+# Prerequisites: kind, kubectl, and a container runtime that gives one kind node
+# at least 5 CPUs and 6 GiB allocatable. Env overrides: KIND_ARGO_CLUSTER
+# (default swe-argo), ARGOCD_VERSION, IMAGE_UPDATER_VERSION.
 set -euo pipefail
 
 CLUSTER="${KIND_ARGO_CLUSTER:-swe-argo}"
 ARGOCD_VERSION="${ARGOCD_VERSION:-v3.4.5}"
 IMAGE_UPDATER_VERSION="${IMAGE_UPDATER_VERSION:-v1.2.2}"
+# Two tiny Environments reserve 2 CPUs/4 GiB during warm-pool replacement; the
+# remainder covers the observed Argo, Kubernetes, and swe-platform workloads.
+MIN_NODE_CPU_MILLICORES=5000
+MIN_NODE_MEMORY_MIB=6144
 ARGOCD_NAMESPACE="argocd"
 APP_NAMESPACE="swe-platform-system"
 BOOTSTRAP_SECRET="swe-platform-bootstrap"
@@ -28,6 +33,35 @@ else
 fi
 
 "${KUBECTL[@]}" cluster-info >/dev/null
+
+capacity_ok=false
+capacity_summary=()
+while IFS='|' read -r node cpu memory; do
+	[[ -n "$node" ]] || continue
+	cpu_millicores="$(awk -v value="$cpu" 'BEGIN {
+		if (value ~ /m$/) { sub(/m$/, "", value); print int(value) }
+		else { print int(value * 1000) }
+	}')"
+	memory_mib="$(awk -v value="$memory" 'BEGIN {
+		if (value ~ /Ki$/) { sub(/Ki$/, "", value); print int(value / 1024) }
+		else if (value ~ /Mi$/) { sub(/Mi$/, "", value); print int(value) }
+		else if (value ~ /Gi$/) { sub(/Gi$/, "", value); print int(value * 1024) }
+		else { print int(value / 1048576) }
+	}')"
+	capacity_summary+=("$node: ${cpu_millicores}m CPU, ${memory_mib}Mi memory allocatable")
+	if (( cpu_millicores >= MIN_NODE_CPU_MILLICORES && memory_mib >= MIN_NODE_MEMORY_MIB )); then
+		capacity_ok=true
+	fi
+done < <("${KUBECTL[@]}" get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"|"}{.status.allocatable.cpu}{"|"}{.status.allocatable.memory}{"\n"}{end}')
+
+if [[ "$capacity_ok" != true ]]; then
+	printf 'kind cluster %q needs one node with at least 5 CPUs and 6 GiB allocatable before installing the Argo demo.\n' "$CLUSTER" >&2
+	printf 'The warm pool intentionally keeps one 1-CPU tiny Environment ready and creates a second during a claim; Argo and system workloads need the remaining capacity.\n' >&2
+	printf 'Increase the CPU/memory available to your container runtime, delete this undersized cluster, and run make argocd-up again.\n' >&2
+	printf 'Observed: %s\n' "${capacity_summary[@]:-no nodes}" >&2
+	exit 1
+fi
+printf '==> capacity check passed: %s\n' "${capacity_summary[@]}"
 
 echo "==> installing Argo CD $ARGOCD_VERSION"
 "${KUBECTL[@]}" create namespace "$ARGOCD_NAMESPACE" --dry-run=client -o yaml | "${KUBECTL[@]}" apply -f -


### PR DESCRIPTION
## Summary
- fail before Argo installation when no kind node has 5 CPUs and 6 GiB allocatable
- preserve the one-member warm pool so claim/replacement overlap remains schedulable
- document the capacity baseline and the optional min=0 cold-start tradeoff

Closes #53

## Validation
- make test
- bash -n hack/argocd-up.sh
- helm lint and helm template for kind, argocd, k3s, gke, and eks presets
- mocked 4-CPU rejection and 5-CPU/6-GiB acceptance paths
- git diff --check