### PR TITLE
feat: stream Run transcripts from swe logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,29 @@ SWE_CONTROL_PLANE_URL=https://swe.example.com \
 SWE_CONTROL_PLANE_TOKEN="$TOKEN" swe attach my-environment
 ```
 
+Run transcripts use the same explicit control-plane URL and bearer credential:
+
+```sh
+SWE_CONTROL_PLANE_URL=https://swe.example.com \
+SWE_CONTROL_PLANE_TOKEN="$TOKEN" swe logs --run fix-flaky-42
+```
+
+`swe logs --run RUN` selects that exact Run in `--namespace` and emits one NDJSON
+record per SSE event:
+`{"event":"transcript","id":"<opaque cursor>","data":<server envelope>}`. The
+`data` value remains opaque, adapter-owned JSON; the CLI does not interpret it as a
+shared transcript schema. Retention loss is explicit in records whose `event` is
+`transcript-gap`. Use `--after <opaque cursor>` to resume explicitly. After a
+successfully opened stream drops, the CLI reconnects with the event ID from the last
+complete block successfully emitted. Invalid and expired cursors are reported rather
+than silently skipped.
+
+For compatibility, `swe logs <environment>` is not deprecated and still follows the
+current Environment pod's `environment` container using kubeconfig authentication. It
+does not read a Run transcript, and the CLI never infers a Run from a reusable
+Environment. The current transcript store is bounded and process-local, so transcript
+mode does not promise durable history or replay across a control-plane restart.
+
 ## Contributing
 
 Too early for code contributions — but design feedback and use-case descriptions are

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -21,6 +21,8 @@ E2E_AGENT_API_KEY='!!SWE-E2E-AGENT-API-KEY-DO-NOT-USE!!'
 E2E_ROTATED_AGENT_API_KEY='!!SWE-E2E-ROTATED-AGENT-API-KEY-DO-NOT-USE!!'
 PORT_FORWARD_PID=""
 SANDBOXD_PORT_FORWARD_PID=""
+STREAM_PID=""
+CLI_STREAM_PID=""
 WEB_TERMINAL_CLIENT=""
 PROJECT_REPO=""
 PROJECT_WORKTREE=""
@@ -28,6 +30,14 @@ FAKE_ENV_CONTEXT=""
 E2E_KUBECONFIG=""
 
 cleanup() {
+	if [[ -n "$STREAM_PID" ]]; then
+		kill "$STREAM_PID" >/dev/null 2>&1 || true
+		wait "$STREAM_PID" >/dev/null 2>&1 || true
+	fi
+	if [[ -n "$CLI_STREAM_PID" ]]; then
+		kill "$CLI_STREAM_PID" >/dev/null 2>&1 || true
+		wait "$CLI_STREAM_PID" >/dev/null 2>&1 || true
+	fi
 	if [[ -n "$PORT_FORWARD_PID" ]]; then
 		kill "$PORT_FORWARD_PID" >/dev/null 2>&1 || true
 		wait "$PORT_FORWARD_PID" >/dev/null 2>&1 || true
@@ -620,6 +630,9 @@ curl --fail --silent --no-buffer --max-time 10 \
 	-H "Authorization: Bearer ${E2E_BOOTSTRAP_TOKEN}" \
 	"http://127.0.0.1:18080/api/v1/namespaces/default/runs/${RUN_NAME}/transcript" > /tmp/swe-platform-transcript.out &
 STREAM_PID=$!
+SWE_CONTROL_PLANE_URL=http://127.0.0.1:18080 SWE_CONTROL_PLANE_TOKEN="$E2E_BOOTSTRAP_TOKEN" \
+	timeout 10 bin/swe logs --run "$RUN_NAME" > /tmp/swe-platform-cli-transcript.out &
+CLI_STREAM_PID=$!
 sleep 1
 APPEND_STATUS=$(curl --silent --output /dev/null --write-out '%{http_code}' \
 	-H "Authorization: Bearer ${PRODUCER_TOKEN}" \
@@ -647,16 +660,27 @@ if [[ "$UNKNOWN_STATUS" != "404" ]]; then
 	exit 1
 fi
 for _ in $(seq 1 30); do
-	if grep -q 'e2e transcript event' /tmp/swe-platform-transcript.out; then
+	if grep -q 'e2e transcript event' /tmp/swe-platform-transcript.out && \
+		grep -q 'e2e transcript event' /tmp/swe-platform-cli-transcript.out; then
 		break
 	fi
 	sleep 1
 done
 kill "$STREAM_PID" >/dev/null 2>&1 || true
 wait "$STREAM_PID" >/dev/null 2>&1 || true
+STREAM_PID=""
+kill "$CLI_STREAM_PID" >/dev/null 2>&1 || true
+wait "$CLI_STREAM_PID" >/dev/null 2>&1 || true
+CLI_STREAM_PID=""
 if ! grep -q 'e2e transcript event' /tmp/swe-platform-transcript.out; then
 	echo "FAIL: transcript event was not received from the SSE stream"
 	cat /tmp/swe-platform-transcript.out
+	exit 1
+fi
+if ! grep -F '"event":"transcript"' /tmp/swe-platform-cli-transcript.out | \
+	grep -Fq 'e2e transcript event'; then
+	echo "FAIL: swe logs --run did not emit the opaque transcript SSE envelope as NDJSON"
+	cat /tmp/swe-platform-cli-transcript.out
 	exit 1
 fi
 if ! grep -F '"source":"claude-code"' /tmp/swe-platform-transcript.out | \

--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -5,15 +5,12 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/http"
-	"net/url"
 	"os"
 	"os/signal"
-	"path"
-	"strings"
 	"syscall"
 	"time"
 
+	"github.com/Chris-Cullins/swe-platform/internal/controlplaneclient"
 	"github.com/gorilla/websocket"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -38,15 +35,12 @@ func newAttachCommand() *cobra.Command {
 }
 
 func attachTerminal(cmd *cobra.Command, controlPlaneURL, token, namespace, envName string) error {
-	endpoint, err := terminalGatewayURL(controlPlaneURL, namespace, envName)
+	client, err := controlplaneclient.New(controlPlaneURL, token, nil)
 	if err != nil {
 		return err
 	}
-	if token == "" {
-		return fmt.Errorf("control-plane token is required (set --token or SWE_CONTROL_PLANE_TOKEN)")
-	}
-	header := http.Header{"Authorization": []string{"Bearer " + token}}
-	connection, response, err := websocket.DefaultDialer.DialContext(cmd.Context(), endpoint, header)
+	endpoint := client.WebSocketEndpoint("api", "v1", "namespaces", namespace, "environments", envName, "terminal")
+	connection, response, err := websocket.DefaultDialer.DialContext(cmd.Context(), endpoint, client.AuthorizationHeader())
 	if err != nil {
 		if response != nil {
 			return fmt.Errorf("connect to environment terminal: control plane returned %s", response.Status)
@@ -58,26 +52,7 @@ func attachTerminal(cmd *cobra.Command, controlPlaneURL, token, namespace, envNa
 }
 
 func terminalGatewayURL(baseURL, namespace, environment string) (string, error) {
-	if baseURL == "" {
-		return "", fmt.Errorf("control-plane URL is required (set --control-plane or SWE_CONTROL_PLANE_URL)")
-	}
-	parsed, err := url.Parse(baseURL)
-	if err != nil {
-		return "", fmt.Errorf("parse control-plane URL: %w", err)
-	}
-	if parsed.Host == "" || parsed.RawQuery != "" || parsed.Fragment != "" {
-		return "", fmt.Errorf("control-plane URL must be an HTTP(S) base URL without a query or fragment")
-	}
-	switch strings.ToLower(parsed.Scheme) {
-	case "http":
-		parsed.Scheme = "ws"
-	case "https":
-		parsed.Scheme = "wss"
-	default:
-		return "", fmt.Errorf("control-plane URL scheme must be http or https")
-	}
-	parsed.Path = path.Join(parsed.Path, "api/v1/namespaces", namespace, "environments", environment, "terminal")
-	return parsed.String(), nil
+	return controlplaneclient.WebSocketEndpoint(baseURL, "api", "v1", "namespaces", namespace, "environments", environment, "terminal")
 }
 
 func bridgeTerminal(ctx context.Context, connection *websocket.Conn, input io.Reader, output io.Writer) error {

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -1,9 +1,12 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 
+	"github.com/Chris-Cullins/swe-platform/internal/controlplaneclient"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,21 +16,47 @@ import (
 )
 
 func newLogsCommand() *cobra.Command {
+	var (
+		run             string
+		controlPlaneURL string
+		token           string
+		cursor          string
+	)
 	cmd := &cobra.Command{
-		Use:   "logs <environment>",
-		Short: "Stream logs from an environment's backing pod",
-		Args:  cobra.ExactArgs(1),
+		Use:   "logs [environment]",
+		Short: "Stream environment pod logs or a Run transcript",
+		Long: `Without --run, stream the backing pod's environment-container logs for
+compatibility. With --run RUN, stream that exact namespaced Run's bounded,
+process-local transcript as NDJSON through the authenticated control plane.
+Transcript and transcript-gap data remains adapter-owned JSON.`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString("namespace")
+			if run != "" {
+				if len(args) != 0 {
+					return fmt.Errorf("an environment argument cannot be combined with --run")
+				}
+				return streamRunTranscript(cmd, controlPlaneURL, token, namespace, run, cursor)
+			}
+			if len(args) == 0 {
+				return fmt.Errorf("an environment argument or --run is required")
+			}
+			for _, flag := range []string{"control-plane", "token", "after"} {
+				if cmd.Flags().Changed(flag) {
+					return fmt.Errorf("--%s requires --run", flag)
+				}
+			}
 			return streamLogs(cmd, namespace, args[0])
 		},
 	}
+	cmd.Flags().StringVar(&run, "run", "", "Run whose transcript to stream instead of Environment pod logs")
+	cmd.Flags().StringVar(&controlPlaneURL, "control-plane", os.Getenv("SWE_CONTROL_PLANE_URL"), "Control-plane base URL (or SWE_CONTROL_PLANE_URL; requires --run)")
+	cmd.Flags().StringVar(&token, "token", os.Getenv("SWE_CONTROL_PLANE_TOKEN"), "Control-plane bearer token (or SWE_CONTROL_PLANE_TOKEN; requires --run)")
+	cmd.Flags().StringVar(&cursor, "after", "", "Opaque transcript cursor to resume after (requires --run)")
 	return cmd
 }
 
 // streamLogs follows the logs of the environment pod.
-// TODO(#57): define a compatible Run-selecting transcript mode before replacing
-// this kubeconfig-authenticated Environment log stream.
 func streamLogs(cmd *cobra.Command, namespace, envName string) error {
 	clients, err := newKubeClients()
 	if err != nil {
@@ -60,5 +89,37 @@ func streamLogs(cmd *cobra.Command, namespace, envName string) error {
 	defer stream.Close()
 
 	_, err = io.Copy(cmd.OutOrStdout(), stream)
+	return err
+}
+
+func streamRunTranscript(cmd *cobra.Command, controlPlaneURL, token, namespace, run, cursor string) error {
+	client, err := controlplaneclient.New(controlPlaneURL, token, nil)
+	if err != nil {
+		return err
+	}
+	endpoint := client.Endpoint("api", "v1", "namespaces", namespace, "runs", run, "transcript")
+	return client.StreamSSE(cmd.Context(), endpoint, cursor, func(event controlplaneclient.SSEEvent) error {
+		return writeTranscriptOutput(cmd.OutOrStdout(), event)
+	})
+}
+
+func writeTranscriptOutput(output io.Writer, event controlplaneclient.SSEEvent) error {
+	if !json.Valid(event.Data) {
+		return fmt.Errorf("control plane returned non-JSON %q event data", event.Event)
+	}
+	eventName, _ := json.Marshal(event.Event)
+	id, _ := json.Marshal(event.ID)
+	record := make([]byte, 0, len(eventName)+len(id)+len(event.Data)+30)
+	record = append(record, `{"event":`...)
+	record = append(record, eventName...)
+	record = append(record, `,"id":`...)
+	record = append(record, id...)
+	record = append(record, `,"data":`...)
+	record = append(record, event.Data...)
+	record = append(record, '}', '\n')
+	n, err := output.Write(record)
+	if err == nil && n != len(record) {
+		err = io.ErrShortWrite
+	}
 	return err
 }

--- a/internal/cli/logs_test.go
+++ b/internal/cli/logs_test.go
@@ -1,0 +1,114 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Chris-Cullins/swe-platform/internal/controlplaneclient"
+	"github.com/spf13/cobra"
+)
+
+func TestStreamRunTranscriptWritesOpaqueNDJSON(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.URL.EscapedPath() != "/api/v1/namespaces/team%2Fa/runs/run%20one/transcript" || r.Header.Get("Authorization") != "Bearer reader" {
+			t.Errorf("request path/token = %q/%q", r.URL.EscapedPath(), r.Header.Get("Authorization"))
+		}
+		if requests > 1 {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "id: cursor-1\nevent: transcript\ndata: {\"source\":\"adapter\",\"type\":\"adapter.owned\",\"data\":{\"anything\":true}}\n\nevent: transcript-gap\ndata: {\"resumeAfter\":\"cursor-0\",\"earliestSequence\":4}\n\n")
+	}))
+	defer server.Close()
+
+	command := &cobra.Command{}
+	command.SetContext(context.Background())
+	var output bytes.Buffer
+	command.SetOut(&output)
+	if err := streamRunTranscript(command, server.URL, "reader", "team/a", "run one", ""); err != nil {
+		t.Fatal(err)
+	}
+	wantOutput := "{\"event\":\"transcript\",\"id\":\"cursor-1\",\"data\":{\"source\":\"adapter\",\"type\":\"adapter.owned\",\"data\":{\"anything\":true}}}\n" +
+		"{\"event\":\"transcript-gap\",\"id\":\"cursor-1\",\"data\":{\"resumeAfter\":\"cursor-0\",\"earliestSequence\":4}}\n"
+	if output.String() != wantOutput {
+		t.Fatalf("NDJSON = %q, want %q", output.String(), wantOutput)
+	}
+
+	decoder := json.NewDecoder(&output)
+	var events []struct {
+		Event string          `json:"event"`
+		ID    string          `json:"id"`
+		Data  json.RawMessage `json:"data"`
+	}
+	for decoder.More() {
+		var event struct {
+			Event string          `json:"event"`
+			ID    string          `json:"id"`
+			Data  json.RawMessage `json:"data"`
+		}
+		if err := decoder.Decode(&event); err != nil {
+			t.Fatal(err)
+		}
+		events = append(events, event)
+	}
+	if len(events) != 2 {
+		t.Fatalf("events = %#v", events)
+	}
+	if events[0].Event != "transcript" || events[0].ID != "cursor-1" || string(events[0].Data) != `{"source":"adapter","type":"adapter.owned","data":{"anything":true}}` {
+		t.Fatalf("transcript event = %#v", events[0])
+	}
+	if events[1].Event != "transcript-gap" || events[1].ID != "cursor-1" || string(events[1].Data) != `{"resumeAfter":"cursor-0","earliestSequence":4}` {
+		t.Fatalf("gap event = %#v", events[1])
+	}
+}
+
+func TestLogsCommandRequiresExactlyOneMode(t *testing.T) {
+	for _, args := range [][]string{
+		{},
+		{"environment", "--run", "run"},
+		{"environment", "--control-plane", "https://control.example"},
+		{"environment", "--token", "token"},
+		{"environment", "--after="},
+	} {
+		command := newLogsCommand()
+		command.SetArgs(args)
+		if err := command.Execute(); err == nil {
+			t.Fatalf("logs %v succeeded", args)
+		}
+	}
+}
+
+type shortWriter struct{}
+
+func (shortWriter) Write(data []byte) (int, error) { return len(data) - 1, nil }
+
+func TestWriteTranscriptOutputRejectsInvalidJSONAndShortWrites(t *testing.T) {
+	event := controlplaneclient.SSEEvent{Event: "transcript", ID: "cursor", Data: []byte(`{"valid":true}`)}
+	if err := writeTranscriptOutput(shortWriter{}, event); !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("short write error = %v", err)
+	}
+	event.Data = []byte(`{"invalid"`)
+	if err := writeTranscriptOutput(io.Discard, event); err == nil {
+		t.Fatal("invalid JSON was emitted")
+	}
+}
+
+func TestLogsControlPlaneEnvironmentDefaultsDoNotSelectRunMode(t *testing.T) {
+	t.Setenv("SWE_CONTROL_PLANE_URL", "https://control.example")
+	t.Setenv("SWE_CONTROL_PLANE_TOKEN", "token")
+	command := newLogsCommand()
+	for _, flag := range []string{"control-plane", "token"} {
+		if command.Flags().Changed(flag) {
+			t.Fatalf("environment default marked --%s as explicitly changed", flag)
+		}
+	}
+}

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -26,6 +26,7 @@ func TestTerminalGatewayURL(t *testing.T) {
 	}{
 		{base: "http://control.example", want: "ws://control.example/api/v1/namespaces/project-a/environments/env-1/terminal"},
 		{base: "https://control.example/platform/", want: "wss://control.example/platform/api/v1/namespaces/project-a/environments/env-1/terminal"},
+		{base: "HTTPS://control.example", want: "wss://control.example/api/v1/namespaces/project-a/environments/env-1/terminal"},
 	}
 	for _, test := range tests {
 		got, err := terminalGatewayURL(test.base, "project-a", "env-1")

--- a/internal/controlplaneclient/client.go
+++ b/internal/controlplaneclient/client.go
@@ -1,0 +1,163 @@
+// Package controlplaneclient provides authenticated control-plane HTTP and SSE primitives.
+package controlplaneclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Client is an explicit bearer-authenticated control-plane client.
+type Client struct {
+	baseURL       *url.URL
+	token         string
+	httpClient    *http.Client
+	reconnectWait time.Duration
+}
+
+// New validates a control-plane base URL and bearer token.
+func New(baseURL, token string, httpClient *http.Client) (*Client, error) {
+	parsed, err := parseBaseURL(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	if token == "" {
+		return nil, fmt.Errorf("control-plane token is required (set --token or SWE_CONTROL_PLANE_TOKEN)")
+	}
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &Client{baseURL: parsed, token: token, httpClient: httpClient, reconnectWait: time.Second}, nil
+}
+
+// Endpoint builds an escaped URL below the configured base path.
+func (c *Client) Endpoint(segments ...string) string {
+	return endpoint(c.baseURL, segments...)
+}
+
+// WebSocketEndpoint builds an escaped WebSocket URL below the configured base path.
+func (c *Client) WebSocketEndpoint(segments ...string) string {
+	parsed := *c.baseURL
+	if parsed.Scheme == "http" {
+		parsed.Scheme = "ws"
+	} else {
+		parsed.Scheme = "wss"
+	}
+	return endpoint(&parsed, segments...)
+}
+
+// WebSocketEndpoint builds an escaped WebSocket URL below an HTTP(S) base URL.
+func WebSocketEndpoint(baseURL string, segments ...string) (string, error) {
+	parsed, err := parseBaseURL(baseURL)
+	if err != nil {
+		return "", err
+	}
+	client := &Client{baseURL: parsed}
+	return client.WebSocketEndpoint(segments...), nil
+}
+
+func parseBaseURL(baseURL string) (*url.URL, error) {
+	if baseURL == "" {
+		return nil, fmt.Errorf("control-plane URL is required (set --control-plane or SWE_CONTROL_PLANE_URL)")
+	}
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse control-plane URL: %w", err)
+	}
+	parsed.Scheme = strings.ToLower(parsed.Scheme)
+	if parsed.Host == "" || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return nil, fmt.Errorf("control-plane URL must be an HTTP(S) base URL without a query or fragment")
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return nil, fmt.Errorf("control-plane URL scheme must be http or https")
+	}
+	return parsed, nil
+}
+
+func endpoint(base *url.URL, segments ...string) string {
+	escaped := make([]string, len(segments))
+	for i, segment := range segments {
+		escaped[i] = url.PathEscape(segment)
+	}
+	return strings.TrimRight(base.String(), "/") + "/" + strings.Join(escaped, "/")
+}
+
+// AuthorizationHeader returns a fresh bearer header suitable for HTTP or WebSocket requests.
+func (c *Client) AuthorizationHeader() http.Header {
+	return http.Header{"Authorization": []string{"Bearer " + c.token}}
+}
+
+// NewRequest creates an authenticated request to endpoint.
+func (c *Client) NewRequest(ctx context.Context, method, endpoint string, body io.Reader) (*http.Request, error) {
+	request, err := http.NewRequestWithContext(ctx, method, endpoint, body)
+	if err != nil {
+		return nil, err
+	}
+	request.Header = c.AuthorizationHeader()
+	return request, nil
+}
+
+// Do sends a request and converts non-2xx responses into ProblemError values.
+func (c *Client) Do(request *http.Request) (*http.Response, error) {
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	if response.StatusCode >= 200 && response.StatusCode < 300 {
+		return response, nil
+	}
+	defer response.Body.Close()
+	body, readErr := io.ReadAll(io.LimitReader(response.Body, 1<<20))
+	problem := Problem{}
+	mediaType, _, _ := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if readErr == nil && mediaType == "application/problem+json" {
+		_ = json.Unmarshal(body, &problem)
+	}
+	problem.Status = response.StatusCode
+	return nil, &ProblemError{Status: response.Status, Problem: problem, Body: bytes.TrimSpace(body), ReadErr: readErr}
+}
+
+// Problem is an RFC problem response. Extra endpoint-specific fields remain in Body.
+type Problem struct {
+	Type   string `json:"type"`
+	Title  string `json:"title"`
+	Status int    `json:"status"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// ProblemError reports a non-successful control-plane HTTP response.
+type ProblemError struct {
+	Status  string
+	Problem Problem
+	Body    []byte
+	ReadErr error
+}
+
+func (e *ProblemError) Error() string {
+	detail := e.Problem.Detail
+	if detail == "" {
+		detail = e.Problem.Title
+	}
+	if detail == "" {
+		detail = string(e.Body)
+	}
+	if detail == "" {
+		detail = "control plane returned " + e.Status
+	} else {
+		detail = fmt.Sprintf("control plane returned %s: %s", e.Status, detail)
+	}
+	if e.ReadErr != nil {
+		return fmt.Sprintf("%s (read response body: %v)", detail, e.ReadErr)
+	}
+	return detail
+}
+
+// Unwrap exposes a response-body read failure without losing the known HTTP status.
+func (e *ProblemError) Unwrap() error { return e.ReadErr }

--- a/internal/controlplaneclient/client.go
+++ b/internal/controlplaneclient/client.go
@@ -121,7 +121,13 @@ func (c *Client) Do(request *http.Request) (*http.Response, error) {
 		_ = json.Unmarshal(body, &problem)
 	}
 	problem.Status = response.StatusCode
-	return nil, &ProblemError{Status: response.Status, Problem: problem, Body: bytes.TrimSpace(body), ReadErr: readErr}
+	return nil, &ProblemError{
+		Status:     response.Status,
+		Problem:    problem,
+		Body:       bytes.TrimSpace(body),
+		ReadErr:    readErr,
+		retryAfter: response.Header.Get("Retry-After"),
+	}
 }
 
 // Problem is an RFC problem response. Extra endpoint-specific fields remain in Body.
@@ -138,6 +144,8 @@ type ProblemError struct {
 	Problem Problem
 	Body    []byte
 	ReadErr error
+	// Retain only the reconnect hint, not arbitrary response headers.
+	retryAfter string
 }
 
 func (e *ProblemError) Error() string {

--- a/internal/controlplaneclient/client_test.go
+++ b/internal/controlplaneclient/client_test.go
@@ -1,0 +1,444 @@
+package controlplaneclient
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestClientBuildsEscapedAuthenticatedRequest(t *testing.T) {
+	var requestURI, authorization string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestURI = r.RequestURI
+		authorization = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client, err := New(server.URL+"/platform/", "reader-token", server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	endpoint := client.Endpoint("api", "v1", "namespaces", "team/a", "runs", "run one", "transcript")
+	request, err := client.NewRequest(context.Background(), http.MethodGet, endpoint, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if requestURI != "/platform/api/v1/namespaces/team%2Fa/runs/run%20one/transcript" {
+		t.Fatalf("request URI = %q", requestURI)
+	}
+	if authorization != "Bearer reader-token" {
+		t.Fatalf("Authorization = %q", authorization)
+	}
+
+	websocketURL, err := WebSocketEndpoint("HTTPS://control.example/platform/", "environments", "env/a", "terminal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if websocketURL != "wss://control.example/platform/environments/env%2Fa/terminal" {
+		t.Fatalf("WebSocket endpoint = %q", websocketURL)
+	}
+}
+
+func TestClientReturnsProblemResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json; charset=utf-8")
+		w.WriteHeader(http.StatusGone)
+		_, _ = io.WriteString(w, `{"type":"https://swe-platform.dev/problems/cursor_expired","title":"transcript cursor expired","status":400,"resumeAfter":"next"}`)
+	}))
+	defer server.Close()
+
+	client, err := New(server.URL, "token", server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	request, _ := client.NewRequest(context.Background(), http.MethodGet, server.URL, nil)
+	_, err = client.Do(request)
+	var problem *ProblemError
+	if !errors.As(err, &problem) {
+		t.Fatalf("Do() error = %v, want ProblemError", err)
+	}
+	if problem.Problem.Status != http.StatusGone || problem.Problem.Title != "transcript cursor expired" || !strings.Contains(string(problem.Body), `"resumeAfter":"next"`) {
+		t.Fatalf("problem = %#v, body = %s", problem.Problem, problem.Body)
+	}
+}
+
+func TestClientClassifiesTruncatedErrorResponseAsProblem(t *testing.T) {
+	readErr := errors.New("truncated problem body")
+	client, err := New("http://control-plane", "token", &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusGone,
+			Status:     "410 Gone",
+			Header:     http.Header{"Content-Type": []string{"application/problem+json"}},
+			Body:       &errorAfterReader{Reader: strings.NewReader(`{"title":"expired"`), err: readErr},
+			Request:    request,
+		}, nil
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request, _ := client.NewRequest(context.Background(), http.MethodGet, client.Endpoint("stream"), nil)
+	_, err = client.Do(request)
+	var problem *ProblemError
+	if !errors.As(err, &problem) || problem.Problem.Status != http.StatusGone || !errors.Is(err, readErr) || string(problem.Body) != `{"title":"expired"` {
+		t.Fatalf("Do() error = %#v", err)
+	}
+}
+
+func TestConsumeSSEFramingAndCursorCommit(t *testing.T) {
+	input := ": comment\r\n" +
+		"id: cursor-1\r\n" +
+		"event: transcript\r\n" +
+		"data: {\"line\":\r\n" +
+		"data: 1}\r\n\r\n" +
+		"id: cursor-2\n\n" +
+		"id:\n\n" +
+		"event: transcript-gap\n" +
+		"data: {}\n\n" +
+		"data: {\"default\":true}\n\n" +
+		"id: uncommitted\n" +
+		"event: transcript\n" +
+		"data: {}"
+	var events []SSEEvent
+	cursor, _, err := consumeSSE(strings.NewReader(input), "initial", func(event SSEEvent) error {
+		events = append(events, event)
+		return nil
+	})
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("consumeSSE() error = %v", err)
+	}
+	if cursor != "" {
+		t.Fatalf("committed cursor = %q, want empty ID reset", cursor)
+	}
+	want := []SSEEvent{
+		{ID: "cursor-1", Event: "transcript", Data: []byte("{\"line\":\n1}")},
+		{ID: "", Event: "transcript-gap", Data: []byte("{}")},
+		{ID: "", Event: "message", Data: []byte("{\"default\":true}")},
+	}
+	if len(events) != len(want) {
+		t.Fatalf("events = %#v", events)
+	}
+	for i := range want {
+		if events[i].ID != want[i].ID || events[i].Event != want[i].Event || string(events[i].Data) != string(want[i].Data) {
+			t.Fatalf("event %d = %#v, want %#v", i, events[i], want[i])
+		}
+	}
+}
+
+func TestConsumeSSEDoesNotCommitIDWhenHandlerFails(t *testing.T) {
+	sentinel := errors.New("output failed")
+	cursor, _, err := consumeSSE(strings.NewReader("id: next\nevent: transcript\ndata: {}\n\n"), "previous", func(SSEEvent) error {
+		return sentinel
+	})
+	if err == nil || !errors.Is(err, sentinel) || cursor != "previous" {
+		t.Fatalf("cursor/error = %q/%v", cursor, err)
+	}
+}
+
+func TestStreamSSEReconnectUsesCommittedLastEventID(t *testing.T) {
+	var mu sync.Mutex
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests++
+		requestNumber := requests
+		mu.Unlock()
+		switch requestNumber {
+		case 1:
+			if r.URL.Query().Get("after") != "starting cursor" || r.Header.Get("Last-Event-ID") != "" {
+				t.Errorf("initial cursor query/header = %q/%q", r.URL.Query().Get("after"), r.Header.Get("Last-Event-ID"))
+			}
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = io.WriteString(w, "retry: 1\n\nid: cursor-1\nevent: transcript\ndata: {}\n\nid: partial\ndata: {}")
+		case 2:
+			if _, present := r.URL.Query()["after"]; present || r.Header.Get("Last-Event-ID") != "cursor-1" {
+				t.Errorf("reconnect query/header = %q/%q", r.URL.RawQuery, r.Header.Get("Last-Event-ID"))
+			}
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected request %d", requestNumber)
+		}
+	}))
+	defer server.Close()
+
+	client, err := New(server.URL, "token", server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	started := time.Now()
+	var events []SSEEvent
+	err = client.StreamSSE(context.Background(), server.URL, "starting cursor", func(event SSEEvent) error {
+		events = append(events, event)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if time.Since(started) > 500*time.Millisecond {
+		t.Fatal("SSE retry hint was not respected")
+	}
+	if len(events) != 1 || events[0].ID != "cursor-1" {
+		t.Fatalf("events = %#v", events)
+	}
+}
+
+func TestStreamSSEEmptyIDResetRemovesInitialCursor(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests == 1 {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = io.WriteString(w, "id:\n\n")
+			return
+		}
+		if r.URL.RawQuery != "" || r.Header.Get("Last-Event-ID") != "" {
+			t.Errorf("reset reconnect query/header = %q/%q", r.URL.RawQuery, r.Header.Get("Last-Event-ID"))
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+	client, _ := New(server.URL, "token", server.Client())
+	client.reconnectWait = time.Millisecond
+	if err := client.StreamSSE(context.Background(), server.URL, "old", func(SSEEvent) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStreamSSESurfacesGaps(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "event: transcript-gap\ndata: {\"resumeAfter\":\"cursor-3\"}\n\n")
+	}))
+	defer server.Close()
+	client, _ := New(server.URL, "token", server.Client())
+	sentinel := errors.New("gap observed")
+	err := client.StreamSSE(context.Background(), server.URL, "", func(event SSEEvent) error {
+		if event.Event != "transcript-gap" || string(event.Data) != `{"resumeAfter":"cursor-3"}` {
+			t.Fatalf("gap = %#v", event)
+		}
+		return sentinel
+	})
+	if err != sentinel {
+		t.Fatalf("StreamSSE() error = %v, want unchanged handler error", err)
+	}
+}
+
+func TestStreamSSEStatusAndProtocolHandling(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      int
+		contentType string
+		body        string
+		wantProblem bool
+		wantNil     bool
+	}{
+		{name: "no content", status: http.StatusNoContent, wantNil: true},
+		{name: "invalid cursor", status: http.StatusBadRequest, contentType: "application/problem+json", body: `{"type":"https://swe-platform.dev/problems/invalid_cursor","title":"invalid transcript cursor","status":400}`, wantProblem: true},
+		{name: "expired cursor", status: http.StatusGone, contentType: "application/problem+json", body: `{"type":"https://swe-platform.dev/problems/cursor_expired","title":"transcript cursor expired","status":410}`, wantProblem: true},
+		{name: "non SSE success", status: http.StatusOK, contentType: "application/json", body: `{}`},
+		{name: "other success", status: http.StatusAccepted, contentType: "text/event-stream"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			requests := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requests++
+				if test.contentType != "" {
+					w.Header().Set("Content-Type", test.contentType)
+				}
+				w.WriteHeader(test.status)
+				_, _ = io.WriteString(w, test.body)
+			}))
+			defer server.Close()
+			client, _ := New(server.URL, "token", server.Client())
+			err := client.StreamSSE(context.Background(), server.URL, "cursor", func(SSEEvent) error { return nil })
+			if test.wantNil && err != nil {
+				t.Fatalf("StreamSSE() error = %v", err)
+			}
+			if !test.wantNil && err == nil {
+				t.Fatal("StreamSSE() succeeded")
+			}
+			var problem *ProblemError
+			if errors.As(err, &problem) != test.wantProblem {
+				t.Fatalf("ProblemError = %t, error = %v", errors.As(err, &problem), err)
+			}
+			if requests != 1 {
+				t.Fatalf("requests = %d, want no retry", requests)
+			}
+		})
+	}
+}
+
+func TestStreamSSEDoesNotRetryInitialTransportFailure(t *testing.T) {
+	sentinel := errors.New("initial dial failed")
+	requests := 0
+	client, err := New("http://control-plane", "token", &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		requests++
+		return nil, sentinel
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = client.StreamSSE(context.Background(), client.Endpoint("stream"), "", func(SSEEvent) error { return nil })
+	if !errors.Is(err, sentinel) || requests != 1 {
+		t.Fatalf("error/requests = %v/%d", err, requests)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) { return f(request) }
+
+type errorAfterReader struct {
+	*strings.Reader
+	err error
+}
+
+func (r *errorAfterReader) Read(buffer []byte) (int, error) {
+	n, err := r.Reader.Read(buffer)
+	if err == io.EOF {
+		return n, r.err
+	}
+	return n, err
+}
+
+func (r *errorAfterReader) Close() error { return nil }
+
+func TestStreamSSEReconnectsAfterBodyReadFailure(t *testing.T) {
+	requests := 0
+	client, err := New("http://control-plane", "token", &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		requests++
+		if requests == 1 {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header:     http.Header{"Content-Type": []string{"text/event-stream; charset=utf-8"}},
+				Body:       &errorAfterReader{Reader: strings.NewReader("id: cursor-1\nevent: transcript\ndata: {}\n\n"), err: io.ErrUnexpectedEOF},
+				Request:    request,
+			}, nil
+		}
+		if request.Header.Get("Last-Event-ID") != "cursor-1" {
+			t.Errorf("Last-Event-ID = %q", request.Header.Get("Last-Event-ID"))
+		}
+		return &http.Response{StatusCode: http.StatusNoContent, Status: "204 No Content", Header: make(http.Header), Body: io.NopCloser(strings.NewReader("")), Request: request}, nil
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.reconnectWait = time.Millisecond
+	if err := client.StreamSSE(context.Background(), client.Endpoint("stream"), "", func(SSEEvent) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d", requests)
+	}
+}
+
+func TestStreamSSEReconnectProblemBodyFailureIsTerminal(t *testing.T) {
+	readErr := errors.New("truncated invalid cursor response")
+	requests := 0
+	client, err := New("http://control-plane", "token", &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		requests++
+		if requests == 1 {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Status:     "200 OK",
+				Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+				Body:       io.NopCloser(strings.NewReader("id: cursor-1\nevent: transcript\ndata: {}\n\n")),
+				Request:    request,
+			}, nil
+		}
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Status:     "400 Bad Request",
+			Header:     http.Header{"Content-Type": []string{"application/problem+json"}},
+			Body:       &errorAfterReader{Reader: strings.NewReader(`{"type":"invalid_cursor"`), err: readErr},
+			Request:    request,
+		}, nil
+	})})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.reconnectWait = time.Millisecond
+	err = client.StreamSSE(context.Background(), client.Endpoint("stream"), "", func(SSEEvent) error { return nil })
+	var problem *ProblemError
+	if !errors.As(err, &problem) || problem.Problem.Status != http.StatusBadRequest || !errors.Is(err, readErr) || requests != 2 {
+		t.Fatalf("error/requests = %#v/%d", err, requests)
+	}
+}
+
+func TestStreamSSEPropagatesHandlerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "event: transcript\ndata: {}\n\n")
+	}))
+	defer server.Close()
+	client, _ := New(server.URL, "token", server.Client())
+	sentinel := io.EOF
+	if err := client.StreamSSE(context.Background(), server.URL, "", func(SSEEvent) error { return sentinel }); err != sentinel {
+		t.Fatalf("StreamSSE() error = %v", err)
+	}
+}
+
+func TestStreamSSECancellationClosesRequest(t *testing.T) {
+	opened := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		close(opened)
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+	client, _ := New(server.URL, "token", server.Client())
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- client.StreamSSE(ctx, server.URL, "", func(SSEEvent) error { return nil }) }()
+	<-opened
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("StreamSSE() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("StreamSSE did not return after cancellation")
+	}
+}
+
+func TestStreamSSECancellationInterruptsRetryWait(t *testing.T) {
+	closed := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "retry: 10000\n\n")
+		close(closed)
+	}))
+	defer server.Close()
+	client, _ := New(server.URL, "token", server.Client())
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- client.StreamSSE(ctx, server.URL, "", func(SSEEvent) error { return nil }) }()
+	<-closed
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("StreamSSE() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("StreamSSE did not cancel during retry wait")
+	}
+}

--- a/internal/controlplaneclient/client_test.go
+++ b/internal/controlplaneclient/client_test.go
@@ -1,7 +1,9 @@
 package controlplaneclient
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -54,6 +56,7 @@ func TestClientBuildsEscapedAuthenticatedRequest(t *testing.T) {
 func TestClientReturnsProblemResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/problem+json; charset=utf-8")
+		w.Header().Set("Retry-After", "7")
 		w.WriteHeader(http.StatusGone)
 		_, _ = io.WriteString(w, `{"type":"https://swe-platform.dev/problems/cursor_expired","title":"transcript cursor expired","status":400,"resumeAfter":"next"}`)
 	}))
@@ -69,7 +72,7 @@ func TestClientReturnsProblemResponse(t *testing.T) {
 	if !errors.As(err, &problem) {
 		t.Fatalf("Do() error = %v, want ProblemError", err)
 	}
-	if problem.Problem.Status != http.StatusGone || problem.Problem.Title != "transcript cursor expired" || !strings.Contains(string(problem.Body), `"resumeAfter":"next"`) {
+	if problem.Problem.Status != http.StatusGone || problem.Problem.Title != "transcript cursor expired" || problem.retryAfter != "7" || !strings.Contains(string(problem.Body), `"resumeAfter":"next"`) {
 		t.Fatalf("problem = %#v, body = %s", problem.Problem, problem.Body)
 	}
 }
@@ -143,6 +146,55 @@ func TestConsumeSSEDoesNotCommitIDWhenHandlerFails(t *testing.T) {
 	})
 	if err == nil || !errors.Is(err, sentinel) || cursor != "previous" {
 		t.Fatalf("cursor/error = %q/%v", cursor, err)
+	}
+}
+
+func TestStreamSSEAcceptsWorstCaseEscapedServerEnvelope(t *testing.T) {
+	text := strings.Repeat("<", 350<<10)
+	requestBody := []byte(`{"type":"output","data":{"text":"` + text + `"}}`)
+	if !json.Valid(requestBody) || len(requestBody) >= 1<<20 {
+		t.Fatalf("request fixture size/validity = %d/%t", len(requestBody), json.Valid(requestBody))
+	}
+	envelope, err := json.Marshal(struct {
+		Data json.RawMessage `json:"data"`
+	}{Data: json.RawMessage(`{"text":"` + text + `"}`)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(envelope) <= 2<<20 || len(envelope) >= maxSSELineSize {
+		t.Fatalf("escaped envelope size = %d, want between old and new limits", len(envelope))
+	}
+	var stream bytes.Buffer
+	stream.WriteString("id: large-cursor\nevent: transcript\ndata: ")
+	stream.Write(envelope)
+	stream.WriteString("\n\n")
+
+	requests := 0
+	dispatches := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests == 1 {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = w.Write(stream.Bytes())
+			return
+		}
+		if r.Header.Get("Last-Event-ID") != "large-cursor" {
+			t.Errorf("Last-Event-ID = %q", r.Header.Get("Last-Event-ID"))
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+	client, _ := New(server.URL, "token", server.Client())
+	client.reconnectWait = time.Millisecond
+	err = client.StreamSSE(context.Background(), server.URL, "", func(event SSEEvent) error {
+		dispatches++
+		if event.ID != "large-cursor" || !bytes.Equal(event.Data, envelope) {
+			t.Fatalf("large event ID/data size = %q/%d", event.ID, len(event.Data))
+		}
+		return nil
+	})
+	if err != nil || dispatches != 1 || requests != 2 {
+		t.Fatalf("error/dispatches/requests = %v/%d/%d", err, dispatches, requests)
 	}
 }
 
@@ -246,6 +298,7 @@ func TestStreamSSEStatusAndProtocolHandling(t *testing.T) {
 		{name: "no content", status: http.StatusNoContent, wantNil: true},
 		{name: "invalid cursor", status: http.StatusBadRequest, contentType: "application/problem+json", body: `{"type":"https://swe-platform.dev/problems/invalid_cursor","title":"invalid transcript cursor","status":400}`, wantProblem: true},
 		{name: "expired cursor", status: http.StatusGone, contentType: "application/problem+json", body: `{"type":"https://swe-platform.dev/problems/cursor_expired","title":"transcript cursor expired","status":410}`, wantProblem: true},
+		{name: "initial unavailable", status: http.StatusServiceUnavailable, contentType: "application/problem+json", body: `{"title":"unavailable","status":503}`, wantProblem: true},
 		{name: "non SSE success", status: http.StatusOK, contentType: "application/json", body: `{}`},
 		{name: "other success", status: http.StatusAccepted, contentType: "text/event-stream"},
 	}
@@ -296,6 +349,26 @@ func TestStreamSSEDoesNotRetryInitialTransportFailure(t *testing.T) {
 	}
 }
 
+func TestRetryableHTTPStatus(t *testing.T) {
+	for _, test := range []struct {
+		status int
+		want   bool
+	}{
+		{http.StatusBadRequest, false},
+		{http.StatusRequestTimeout, true},
+		{http.StatusGone, false},
+		{http.StatusTooManyRequests, true},
+		{499, false},
+		{http.StatusInternalServerError, true},
+		{599, true},
+		{600, false},
+	} {
+		if got := retryableHTTPStatus(test.status); got != test.want {
+			t.Errorf("retryableHTTPStatus(%d) = %t, want %t", test.status, got, test.want)
+		}
+	}
+}
+
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) { return f(request) }
@@ -342,6 +415,70 @@ func TestStreamSSEReconnectsAfterBodyReadFailure(t *testing.T) {
 	}
 	if requests != 2 {
 		t.Fatalf("requests = %d", requests)
+	}
+}
+
+func TestStreamSSERetriesTransientHTTPAfterEstablishment(t *testing.T) {
+	requests := 0
+	dispatches := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests > 1 && r.Header.Get("Last-Event-ID") != "cursor-1" {
+			t.Errorf("request %d Last-Event-ID = %q", requests, r.Header.Get("Last-Event-ID"))
+		}
+		switch requests {
+		case 1:
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = io.WriteString(w, "id: cursor-1\nevent: transcript\ndata: {}\n\n")
+		case 2:
+			w.Header().Set("Content-Type", "application/problem+json")
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = io.WriteString(w, `{"title":"subscriber capacity","status":503}`)
+		case 3:
+			w.WriteHeader(http.StatusBadGateway)
+		case 4:
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected request %d", requests)
+		}
+	}))
+	defer server.Close()
+	client, _ := New(server.URL, "token", server.Client())
+	client.reconnectWait = time.Millisecond
+	err := client.StreamSSE(context.Background(), server.URL, "", func(SSEEvent) error {
+		dispatches++
+		return nil
+	})
+	if err != nil || requests != 4 || dispatches != 1 {
+		t.Fatalf("error/requests/dispatches = %v/%d/%d", err, requests, dispatches)
+	}
+}
+
+func TestStreamSSEReconnectCursorErrorsRemainTerminal(t *testing.T) {
+	for _, status := range []int{http.StatusBadRequest, http.StatusGone} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			requests := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requests++
+				if requests == 1 {
+					w.Header().Set("Content-Type", "text/event-stream")
+					_, _ = io.WriteString(w, "id: cursor-1\nevent: transcript\ndata: {}\n\n")
+					return
+				}
+				w.Header().Set("Content-Type", "application/problem+json")
+				w.WriteHeader(status)
+				_, _ = io.WriteString(w, `{"title":"cursor rejected"}`)
+			}))
+			defer server.Close()
+			client, _ := New(server.URL, "token", server.Client())
+			client.reconnectWait = time.Millisecond
+			err := client.StreamSSE(context.Background(), server.URL, "", func(SSEEvent) error { return nil })
+			var problem *ProblemError
+			if !errors.As(err, &problem) || problem.Problem.Status != status || requests != 2 {
+				t.Fatalf("error/requests = %#v/%d", err, requests)
+			}
+		})
 	}
 }
 
@@ -440,5 +577,35 @@ func TestStreamSSECancellationInterruptsRetryWait(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("StreamSSE did not cancel during retry wait")
+	}
+}
+
+func TestStreamSSECancellationInterruptsHTTPRetryWait(t *testing.T) {
+	retryResponse := make(chan struct{})
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		if requests == 1 {
+			w.Header().Set("Content-Type", "text/event-stream")
+			return
+		}
+		w.Header().Set("Retry-After", "30")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		close(retryResponse)
+	}))
+	defer server.Close()
+	client, _ := New(server.URL, "token", server.Client())
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- client.StreamSSE(ctx, server.URL, "", func(SSEEvent) error { return nil }) }()
+	<-retryResponse
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) || requests != 2 {
+			t.Fatalf("error/requests = %v/%d", err, requests)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("StreamSSE did not cancel during HTTP retry wait")
 	}
 }

--- a/internal/controlplaneclient/sse.go
+++ b/internal/controlplaneclient/sse.go
@@ -1,0 +1,181 @@
+package controlplaneclient
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const maxSSELineSize = 2 << 20
+
+// SSEEvent is one decoded Server-Sent Event. Data remains application-owned.
+type SSEEvent struct {
+	ID    string
+	Event string
+	Data  []byte
+}
+
+// StreamSSE consumes an SSE endpoint and reconnects unexpected closures after
+// the first successful connection. The initial cursor is sent as ?after=; a
+// reconnect carries the last completely committed event ID in Last-Event-ID.
+func (c *Client) StreamSSE(ctx context.Context, endpoint, cursor string, handle func(SSEEvent) error) error {
+	connected := false
+	reconnectWait := c.reconnectWait
+	for {
+		requestEndpoint, err := streamEndpoint(endpoint, cursor, connected)
+		if err != nil {
+			return err
+		}
+		request, err := c.NewRequest(ctx, http.MethodGet, requestEndpoint, nil)
+		if err != nil {
+			return err
+		}
+		request.Header.Set("Accept", "text/event-stream")
+		if connected && cursor != "" {
+			request.Header.Set("Last-Event-ID", cursor)
+		}
+		response, err := c.Do(request)
+		if err != nil {
+			var problem *ProblemError
+			if !connected || ctx.Err() != nil || errors.As(err, &problem) {
+				return err
+			}
+			if err := waitForReconnect(ctx, reconnectWait); err != nil {
+				return err
+			}
+			continue
+		}
+		if response.StatusCode == http.StatusNoContent {
+			response.Body.Close()
+			return nil
+		}
+		mediaType, _, parseErr := mime.ParseMediaType(response.Header.Get("Content-Type"))
+		if parseErr != nil || response.StatusCode != http.StatusOK || mediaType != "text/event-stream" {
+			response.Body.Close()
+			return fmt.Errorf("control plane returned %s with Content-Type %q, want 200 text/event-stream", response.Status, response.Header.Get("Content-Type"))
+		}
+		connected = true
+		streamRetry := time.Duration(-1)
+		cursor, streamRetry, err = consumeSSE(response.Body, cursor, handle)
+		response.Body.Close()
+		if streamRetry >= 0 {
+			reconnectWait = streamRetry
+		}
+		var callback *handlerError
+		if errors.As(err, &callback) {
+			return callback.err
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if err := waitForReconnect(ctx, reconnectWait); err != nil {
+			return err
+		}
+	}
+}
+
+func streamEndpoint(endpoint, cursor string, reconnect bool) (string, error) {
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return "", fmt.Errorf("parse SSE endpoint: %w", err)
+	}
+	query := parsed.Query()
+	query.Del("after")
+	if !reconnect && cursor != "" {
+		query.Set("after", cursor)
+	}
+	parsed.RawQuery = query.Encode()
+	return parsed.String(), nil
+}
+
+func waitForReconnect(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+type handlerError struct{ err error }
+
+func (e *handlerError) Error() string { return e.err.Error() }
+func (e *handlerError) Unwrap() error { return e.err }
+
+func consumeSSE(reader io.Reader, cursor string, handle func(SSEEvent) error) (string, time.Duration, error) {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 4096), maxSSELineSize)
+	var event SSEEvent
+	var data []string
+	var blockID string
+	var hasBlockID bool
+	retry := time.Duration(-1)
+	dispatch := func() error {
+		nextCursor := cursor
+		if hasBlockID {
+			nextCursor = blockID
+		}
+		if len(data) != 0 {
+			event.ID = nextCursor
+			if event.Event == "" {
+				event.Event = "message"
+			}
+			event.Data = []byte(strings.Join(data, "\n"))
+			if err := handle(event); err != nil {
+				return &handlerError{err: err}
+			}
+		}
+		cursor = nextCursor
+		event = SSEEvent{}
+		data = nil
+		blockID = ""
+		hasBlockID = false
+		return nil
+	}
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			if err := dispatch(); err != nil {
+				return cursor, retry, err
+			}
+			continue
+		}
+		if strings.HasPrefix(line, ":") {
+			continue
+		}
+		field, value, _ := strings.Cut(line, ":")
+		value = strings.TrimPrefix(value, " ")
+		switch field {
+		case "id":
+			if !strings.ContainsRune(value, '\x00') {
+				blockID = value
+				hasBlockID = true
+			}
+		case "event":
+			event.Event = value
+		case "data":
+			data = append(data, value)
+		case "retry":
+			milliseconds, err := strconv.ParseUint(value, 10, 31)
+			if err == nil {
+				retry = time.Duration(milliseconds) * time.Millisecond
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return cursor, retry, err
+	}
+	// Only blank-line-terminated blocks commit. An interrupted final block is
+	// replayed from the prior cursor after reconnect.
+	return cursor, retry, io.EOF
+}

--- a/internal/controlplaneclient/sse.go
+++ b/internal/controlplaneclient/sse.go
@@ -14,7 +14,13 @@ import (
 	"time"
 )
 
-const maxSSELineSize = 2 << 20
+const (
+	// The server accepts JSON request bodies up to 1 MiB. json.Marshal may expand
+	// each HTML-sensitive byte to a six-byte Unicode escape in the SSE envelope;
+	// 8 MiB leaves room for that worst case plus transport metadata.
+	maxSSELineSize   = 8 << 20
+	maxReconnectWait = 30 * time.Second
+)
 
 // SSEEvent is one decoded Server-Sent Event. Data remains application-owned.
 type SSEEvent struct {
@@ -45,10 +51,22 @@ func (c *Client) StreamSSE(ctx context.Context, endpoint, cursor string, handle 
 		response, err := c.Do(request)
 		if err != nil {
 			var problem *ProblemError
-			if !connected || ctx.Err() != nil || errors.As(err, &problem) {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if !connected {
 				return err
 			}
-			if err := waitForReconnect(ctx, reconnectWait); err != nil {
+			wait := reconnectWait
+			if errors.As(err, &problem) {
+				if !retryableHTTPStatus(problem.Problem.Status) {
+					return err
+				}
+				if hinted, ok := parseRetryAfter(problem.retryAfter, time.Now()); ok {
+					wait = hinted
+				}
+			}
+			if err := waitForReconnect(ctx, boundedReconnectWait(wait)); err != nil {
 				return err
 			}
 			continue
@@ -76,10 +94,38 @@ func (c *Client) StreamSSE(ctx context.Context, endpoint, cursor string, handle 
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		if err := waitForReconnect(ctx, reconnectWait); err != nil {
+		if err := waitForReconnect(ctx, boundedReconnectWait(reconnectWait)); err != nil {
 			return err
 		}
 	}
+}
+
+func retryableHTTPStatus(status int) bool {
+	return status == http.StatusRequestTimeout || status == http.StatusTooManyRequests || status >= 500 && status <= 599
+}
+
+func parseRetryAfter(value string, now time.Time) (time.Duration, bool) {
+	if seconds, err := strconv.ParseUint(strings.TrimSpace(value), 10, 31); err == nil {
+		return time.Duration(seconds) * time.Second, true
+	}
+	when, err := http.ParseTime(value)
+	if err != nil {
+		return 0, false
+	}
+	if delay := when.Sub(now); delay > 0 {
+		return delay, true
+	}
+	return 0, true
+}
+
+func boundedReconnectWait(delay time.Duration) time.Duration {
+	if delay < 0 {
+		return 0
+	}
+	if delay > maxReconnectWait {
+		return maxReconnectWait
+	}
+	return delay
 }
 
 func streamEndpoint(endpoint, cursor string, reconnect bool) (string, error) {


### PR DESCRIPTION
## Summary

- add an explicit `swe logs --run RUN` mode for authenticated, exact-Run transcript streaming while preserving `swe logs <environment>` as kubeconfig-backed pod logs
- emit opaque transcript and transcript-gap SSE payloads as NDJSON, with explicit cursor resume and complete-block reconnect semantics
- share control-plane URL, bearer auth, RFC problem, and streaming primitives with `swe attach`
- document bounded process-local retention and add CLI-first acceptance coverage

## Validation

- `go test ./internal/controlplaneclient ./internal/cli`
- `go test ./internal/...`
- `go test -race ./internal/controlplaneclient ./internal/cli`
- `go test ./internal/controlplaneclient -count=20`
- `go vet ./internal/controlplaneclient ./internal/cli`
- `make test`
- `make vet`
- `bash -n hack/e2e.sh`
- `git diff --check`
- `go run ./cmd/swe logs --help`

Full kind E2E was not run because this orb has no supported existing kind cluster; the new path is wired into `hack/e2e.sh` for PR CI.

Closes #57