### PR TITLE
Securely deliver Amp API keys to Run-owned processes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,11 +21,11 @@ provides PostgreSQL-backed durable transcript ingestion and database-polled SSE 
 a development-only bounded memory fallback, opaque process-local browser sessions backed by
 repeated Kubernetes TokenReview/SAR authorization, and typed
 Run/Environment resource APIs for the console.
-Remaining gaps are marked `TODO(P0/P1/P2)` in code — most notably secure agent credential
-injection, additional agent adapters, GitHub App–scoped git tokens, and egress/portal
-networking. The `claude-code` (default), `amp`, and `codex` adapters are registered and use sandboxd
-managed processes; Amp's `AMP_API_KEY` delivery remains an unmet prerequisite and adapter
-tests use fake process services; Codex supports process-scoped `CODEX_API_KEY` delivery.
+Remaining gaps are marked `TODO(P0/P1/P2)` in code — most notably additional credential forms,
+additional agent adapters, GitHub App–scoped git tokens, and egress/portal networking. The
+`claude-code` (default), `amp`, and `codex` adapters are registered and use sandboxd managed
+processes. API-key profiles use process-scoped launch material as `ANTHROPIC_API_KEY`,
+`AMP_API_KEY`, or `CODEX_API_KEY`; tests use fake process services and no provider credentials.
 
 ## Architecture invariants — do not violate these
 
@@ -138,7 +138,8 @@ runs both via `make` targets:
   control-plane TokenReview/SAR scoping, opaque browser session exchange/logout and CSRF,
   the embedded console entry point/SPA fallback/static assets, typed Run
   list/get/create/retry/cancel, Environment get, transcript SSE, terminal attach, and
-  process-scoped fake API-key delivery without ambient setup/resume/sandboxd exposure.
+  process-scoped fake Claude and Amp API-key delivery without ambient
+  setup/resume/sandboxd exposure.
   Runs in CI as the `e2e` workflow on relevant PRs and via `workflow_dispatch`.
 - **CRD installation/upgrades:** `make install-crds` uses server-side apply with force-conflicts;
   plain Helm upgrades must apply the chart's `crds/` directory before `helm upgrade`.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ with a reviewable diff, branch, or PR.
 > plane's WebSocket terminal endpoint connect to a shared tmux session through `sandboxd`;
 > pause/resume preserves workspace disks and runs repository resume hooks, and idle
 > environments pause automatically before terminal requests wake them. Template warm
-> pools keep unclaimed environments ready for `swe run` to claim. The first agent adapter
-> runs Claude Code through sandboxd's managed-process API. Portal proxying is not built yet.
+> pools keep unclaimed environments ready for `swe run` to claim. The `claude-code` (default),
+> `amp`, and `codex` adapters run through sandboxd's managed-process API. Portal proxying is not
+> built yet.
 > The Helm chart installs the
 > operator, control plane, and CRDs. Values presets
 > cover kind, k3s, GKE with GKE Sandbox, and EKS.
@@ -308,10 +309,21 @@ append order; an operator restart can replay an overlapping range because output
 process-local, while retrying an uncertain append within one operator process resends the exact
 same event and idempotency key.
 
-`AMP_API_KEY` is currently an unmet runtime prerequisite: secure Amp key delivery is deferred
-to issue #9. The platform does not mount user Amp configuration, add ambient credentials, or
-accept a credential profile for this adapter. Consequently the stock image cannot run Amp
-against its service without separately solving that prerequisite; tests use a fake executable.
+For non-interactive environments, the pinned public Amp CLI follows the official
+[Amp authentication contract](https://ampcode.com/manual#non-interactive-environments): an
+API-key profile selected with `--credential-profile` is delivered as `AMP_API_KEY` only through
+sandboxd launch material to the Run-owned Amp process. Credentialless Runs retain the plain
+managed-process path. The platform does not persist Amp login files, mount user configuration,
+or place the key in the public process specification, setup/resume hooks, sandboxd environment,
+or ordinary executions. Rotation does not restart or compare an existing process; acceptance in
+a fresh sandbox epoch reads and materializes the current key.
+
+The selected Amp process and its descendants can read or explicitly output the key. Profiles
+are namespace-shared: anyone authorized to create Runs there can initially select a profile,
+and same-UID peers are not strongly isolated. Transcript redaction is not guaranteed.
+Subscription/OAuth login persistence, refresh/writeback, leases, and stronger per-user or
+same-user isolation remain unsupported issue #9 work. Never put the key in a Run prompt,
+Project configuration, image, or chart values.
 Abrupt cancellation stops only the Run-owned local process tree, but Amp's public contract does
 not guarantee that remote/server-backed thread work has also stopped.
 

--- a/charts/swe-platform/README.md
+++ b/charts/swe-platform/README.md
@@ -1,10 +1,20 @@
 # swe-platform Helm chart
 
 The bundled environment image provides the default `claude-code` adapter and the explicitly
-selected `amp` adapter (`swe run --agent amp ...`). Amp's `AMP_API_KEY` is not injected by the
-chart or operator yet; secure runtime delivery remains deferred to issue #9. Do not place Amp
-credentials in chart values, Project configuration, or a custom image. The image only pins the
-public Amp CLI and disables its update check.
+selected `amp` adapter (`swe run --agent amp ...`). In accordance with the official
+[Amp non-interactive authentication contract](https://ampcode.com/manual#non-interactive-environments),
+an API-key profile selected for an Amp Run is delivered as `AMP_API_KEY` only to its Run-owned
+managed process through sandboxd launch material. It is not injected by chart values or into the
+operator, sandboxd, setup/resume hooks, ordinary processes, public process specification, or
+workspace by the platform. The image pins the public Amp CLI and disables its update check.
+
+Do not place Amp credentials in chart values, Project configuration, prompts, or custom-image
+ambient environment variables. Profiles are shared within their namespace, the selected agent
+and descendants can read or explicitly output the key, same-UID peers are not strongly isolated,
+and transcript redaction is not guaranteed. A newly created keyed process receives the
+then-current key; duplicate acceptance in the same sandbox epoch ignores rotated launch material,
+while a fresh epoch recreates the process with the current key. Subscription/OAuth login
+persistence, refresh/writeback, leases, and stronger per-user isolation remain unsupported.
 
 The image also bundles the explicitly selected `codex` adapter and pinned Codex CLI. Codex API
 key profiles use sandboxd's process-scoped launch-material path as `CODEX_API_KEY`; never put the
@@ -280,7 +290,8 @@ When the control plane is enabled, the chart projects a rotating `swe-platform`-
 service-account token into the operator and grants that identity `update` on
 `runs/transcript`. The operator uses it only to forward opaque adapter events to the
 control-plane Service. This platform transport credential is separate from agent provider
-credentials, which are never added by the chart or adapter.
+credentials, which the chart never adds to ambient component or Environment state; supported
+API-key adapters deliver them only as write-only process launch material.
 
 For initial self-hosted setup, an optional static bootstrap token provides all control-plane
 API permissions. Create it out of band and reference it during installation:

--- a/hack/e2e-process-check/main.go
+++ b/hack/e2e-process-check/main.go
@@ -75,7 +75,7 @@ func run() error {
 	ordinary, err := client.Start(ctx, &sandboxdv1.StartProcessRequest{
 		Key: &sandboxdv1.ProcessKey{OwnerId: "e2e-ordinary-" + os.Args[5], Role: "credential-check"},
 		Spec: &sandboxdv1.ProcessSpec{
-			Argv: []string{"sh", "-c", `if [ -n "${ANTHROPIC_API_KEY+x}" ]; then exit 86; fi; printf ordinary-process-credential-absent`},
+			Argv: []string{"sh", "-c", `if [ -n "${ANTHROPIC_API_KEY+x}" ] || [ -n "${AMP_API_KEY+x}" ]; then exit 86; fi; printf ordinary-process-credential-absent`},
 		},
 	})
 	if err != nil {
@@ -133,8 +133,10 @@ func checkPublicProcess(process *sandboxdv1.Process, forbidden []byte) error {
 		return fmt.Errorf("public Process contains launch material")
 	}
 	if spec := process.GetSpec(); spec != nil {
-		if _, exposed := spec.Env["ANTHROPIC_API_KEY"]; exposed {
-			return fmt.Errorf("public ProcessSpec contains secret environment name")
+		for _, name := range []string{"ANTHROPIC_API_KEY", "AMP_API_KEY"} {
+			if _, exposed := spec.Env[name]; exposed {
+				return fmt.Errorf("public ProcessSpec contains secret environment name")
+			}
 		}
 		for _, value := range spec.Env {
 			if bytes.Contains([]byte(value), forbidden) {

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -19,6 +19,7 @@ OPERATOR_IMAGE="ghcr.io/chris-cullins/swe-platform/operator:dev"
 CONTROL_PLANE_IMAGE="ghcr.io/chris-cullins/swe-platform/control-plane:dev"
 E2E_AGENT_API_KEY='!!SWE-E2E-AGENT-API-KEY-DO-NOT-USE!!'
 E2E_ROTATED_AGENT_API_KEY='!!SWE-E2E-ROTATED-AGENT-API-KEY-DO-NOT-USE!!'
+E2E_AMP_API_KEY='!!SWE-E2E-AMP-API-KEY-DO-NOT-USE!!'
 PORT_FORWARD_PID=""
 SANDBOXD_PORT_FORWARD_PID=""
 STREAM_PID=""
@@ -69,7 +70,8 @@ cleanup() {
 trap cleanup EXIT
 
 contains_e2e_key() {
-	grep -aFq -- "$E2E_AGENT_API_KEY" "$1" || grep -aFq -- "$E2E_ROTATED_AGENT_API_KEY" "$1"
+	grep -aFq -- "$E2E_AGENT_API_KEY" "$1" || grep -aFq -- "$E2E_ROTATED_AGENT_API_KEY" "$1" || \
+		grep -aFq -- "$E2E_AMP_API_KEY" "$1"
 }
 
 check_sandboxd_process() {
@@ -140,11 +142,19 @@ cat > "$FAKE_ENV_CONTEXT/amp" <<'EOF'
 #!/bin/sh
 set -eu
 test "$#" -eq 4
-test "$1" = '--execute=fake Amp lifecycle smoke test'
 test "$2" = '--stream-json'
 test "$3" = '--no-ide'
 test "$4" = '--no-notifications'
-test -z "${AMP_API_KEY+x}"
+case "$1" in
+	'--execute=fake Amp lifecycle smoke test')
+		test "${AMP_API_KEY:-}" = '!!SWE-E2E-AMP-API-KEY-DO-NOT-USE!!'
+		printf '%s\n' amp-credential-present
+		;;
+	'--execute=fake Amp credentialless lifecycle smoke test')
+		test -z "${AMP_API_KEY+x}"
+		;;
+	*) exit 45 ;;
+esac
 printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"fake-amp-stdout-marker"}]}}'
 printf '%s\n' 'fake-amp-stderr-marker' >&2
 sleep 5
@@ -255,11 +265,11 @@ git -C "$PROJECT_WORKTREE" config user.name "swe e2e"
 git -C "$PROJECT_WORKTREE" config user.email "swe-e2e@example.invalid"
 mkdir -p "$PROJECT_WORKTREE/.agents"
 cat > "$PROJECT_WORKTREE/.agents/setup" <<'EOF'
-if [ -n "${ANTHROPIC_API_KEY+x}" ]; then exit 43; fi
+if [ -n "${ANTHROPIC_API_KEY+x}" ] || [ -n "${AMP_API_KEY+x}" ]; then exit 43; fi
 printf '%s\n' credential-absent >> setup-result
 EOF
 cat > "$PROJECT_WORKTREE/.agents/resume" <<'EOF'
-if [ -n "${ANTHROPIC_API_KEY+x}" ]; then exit 44; fi
+if [ -n "${ANTHROPIC_API_KEY+x}" ] || [ -n "${AMP_API_KEY+x}" ]; then exit 44; fi
 printf '%s\n' credential-absent >> resume-result
 EOF
 git -C "$PROJECT_WORKTREE" add .agents/setup .agents/resume
@@ -857,12 +867,21 @@ if contains_e2e_key /tmp/swe-platform-resumed-workspace.tar; then
 fi
 kubectl delete run "$RESUME_RUN_NAME" --wait=true >/dev/null
 
-echo "==> verifying fake Amp real Run lifecycle without credentials or network"
+echo "==> verifying credentialed fake Amp process scope without network"
 AMP_RUN_NAME=e2e-fake-amp-run
+printf '%s' "$E2E_AMP_API_KEY" | bin/swe credentials create e2e-amp --agent amp --api-key-stdin
 bin/swe run "fake Amp lifecycle smoke test" --name "$AMP_RUN_NAME" --environment "$ENV_NAME" \
-	--agent amp --wait=false
+	--agent amp --credential-profile e2e-amp --wait=false
 kubectl wait --for=jsonpath='{.status.state}'=Running run/"$AMP_RUN_NAME" --timeout=3m
 kubectl wait --for=jsonpath='{.status.state}'=Succeeded run/"$AMP_RUN_NAME" --timeout=3m
+AMP_RUN_UID=$(kubectl get run "$AMP_RUN_NAME" -o jsonpath='{.metadata.uid}')
+AMP_POD_NAME=$(kubectl get environment "$ENV_NAME" -o jsonpath='{.status.podName}')
+if ! kubectl exec "$AMP_POD_NAME" -- sh -c \
+	'test -z "${AMP_API_KEY+x}" && ! tr "\000" "\n" < /proc/1/environ | grep -q "^AMP_API_KEY="'; then
+	echo "FAIL: AMP_API_KEY was not confined to the selected fake Amp process"
+	exit 1
+fi
+check_sandboxd_process "$AMP_POD_NAME" "$AMP_RUN_UID" "$E2E_AMP_API_KEY"
 set +e
 curl --silent --no-buffer --max-time 2 \
 	-H "Authorization: Bearer ${E2E_BOOTSTRAP_TOKEN}" \
@@ -880,12 +899,35 @@ grep -F '"source":"amp"' /tmp/swe-platform-amp-transcript.out | \
 	while IFS= read -r encoded; do printf '%s' "$encoded" | base64 --decode || exit 1; done \
 	> /tmp/swe-platform-amp-process-output.out
 if ! grep -Fq 'fake-amp-stdout-marker' /tmp/swe-platform-amp-process-output.out || \
-	! grep -Fq 'fake-amp-stderr-marker' /tmp/swe-platform-amp-process-output.out; then
+	! grep -Fq 'fake-amp-stderr-marker' /tmp/swe-platform-amp-process-output.out || \
+	! grep -Fq 'amp-credential-present' /tmp/swe-platform-amp-process-output.out; then
 	echo "FAIL: Amp transcript did not retain both output stream markers"
 	cat /tmp/swe-platform-amp-process-output.out
 	exit 1
 fi
+kubectl get run "$AMP_RUN_NAME" -o yaml > /tmp/swe-platform-amp-run.yaml
+kubectl logs -l app.kubernetes.io/component=control-plane --all-containers --prefix --tail=-1 > /tmp/swe-platform-amp-control-plane.log
+kubectl logs -l app.kubernetes.io/component=operator --all-containers --prefix --tail=-1 > /tmp/swe-platform-amp-operator.log
+kubectl logs "$AMP_POD_NAME" -c environment --tail=-1 > /tmp/swe-platform-amp-environment.log
+kubectl exec "$AMP_POD_NAME" -- tar -C /workspace -cf - . > /tmp/swe-platform-amp-workspace.tar
+for artifact in /tmp/swe-platform-amp-transcript.out /tmp/swe-platform-amp-process-output.out \
+	/tmp/swe-platform-amp-run.yaml /tmp/swe-platform-amp-control-plane.log \
+	/tmp/swe-platform-amp-operator.log /tmp/swe-platform-amp-environment.log \
+	/tmp/swe-platform-amp-workspace.tar; do
+	if contains_e2e_key "$artifact"; then
+		echo "FAIL: Amp API key leaked through $artifact"
+		exit 1
+	fi
+done
 kubectl delete run "$AMP_RUN_NAME" --wait=true >/dev/null
+
+echo "==> verifying credentialless fake Amp retains the plain managed-process path"
+AMP_CREDENTIALLESS_RUN_NAME=e2e-fake-amp-credentialless-run
+bin/swe run "fake Amp credentialless lifecycle smoke test" --name "$AMP_CREDENTIALLESS_RUN_NAME" \
+	--environment "$ENV_NAME" --agent amp --wait=false
+kubectl wait --for=jsonpath='{.status.state}'=Running run/"$AMP_CREDENTIALLESS_RUN_NAME" --timeout=3m
+kubectl wait --for=jsonpath='{.status.state}'=Succeeded run/"$AMP_CREDENTIALLESS_RUN_NAME" --timeout=3m
+kubectl delete run "$AMP_CREDENTIALLESS_RUN_NAME" --wait=true >/dev/null
 
 echo "==> verifying fake Codex real Run lifecycle without credentials or network"
 CODEX_RUN_NAME=e2e-fake-codex-run

--- a/internal/adapters/amp/adapter.go
+++ b/internal/adapters/amp/adapter.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
 	"github.com/Chris-Cullins/swe-platform/internal/controllers"
 	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
 )
@@ -81,15 +82,24 @@ func (a *Adapter) spec(task controllers.AdapterTask) *sandboxdv1.ProcessSpec {
 
 // EnsureAccepted duplicate-safely starts (or recovers) the Run-keyed process.
 func (a *Adapter) EnsureAccepted(ctx context.Context, task controllers.AdapterTask, sandbox controllers.AdapterSandbox, credential *controllers.AdapterCredential) error {
-	if credential != nil {
-		return fmt.Errorf("%w: Amp credential delivery is not implemented; AMP_API_KEY is a runtime prerequisite", controllers.ErrAdapterTaskRejected)
+	if credential != nil && credential.Type != platformv1alpha1.AgentCredentialTypeAPIKey {
+		return fmt.Errorf("%w: unsupported credential type %q", controllers.ErrAdapterTaskRejected, credential.Type)
 	}
 	client, closeConnection, err := sandbox.DialProcess(ctx)
 	if err != nil {
 		return err
 	}
 	defer closeConnection()
-	_, err = client.Start(ctx, &sandboxdv1.StartProcessRequest{Key: key(task), Spec: a.spec(task)})
+	if credential == nil {
+		_, err = client.Start(ctx, &sandboxdv1.StartProcessRequest{Key: key(task), Spec: a.spec(task)})
+		return err
+	}
+	apiKey := append([]byte(nil), credential.APIKey...)
+	defer clear(apiKey)
+	_, err = client.StartWithLaunchMaterial(ctx, &sandboxdv1.StartProcessWithLaunchMaterialRequest{
+		Key: key(task), Spec: a.spec(task),
+		LaunchMaterial: &sandboxdv1.LaunchMaterial{SecretEnv: map[string][]byte{"AMP_API_KEY": apiKey}},
+	})
 	return err
 }
 

--- a/internal/adapters/amp/adapter_test.go
+++ b/internal/adapters/amp/adapter_test.go
@@ -13,23 +13,30 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
 	"github.com/Chris-Cullins/swe-platform/internal/controllers"
 	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
 )
 
 type fakeClient struct {
-	process      *sandboxdv1.Process
-	stdout       []byte
-	stderr       []byte
-	gapBytes     uint64
-	retainedFrom uint64
-	getErr       error
-	starts       int
-	launches     int
-	startedKey   *sandboxdv1.ProcessKey
-	startedSpec  *sandboxdv1.ProcessSpec
-	stoppedKey   *sandboxdv1.ProcessKey
-	readRequests []*sandboxdv1.ReadOutputRequest
+	process         *sandboxdv1.Process
+	stdout          []byte
+	stderr          []byte
+	gapBytes        uint64
+	retainedFrom    uint64
+	getErr          error
+	starts          int
+	launchCalls     int
+	launches        int
+	startedKey      *sandboxdv1.ProcessKey
+	startedSpec     *sandboxdv1.ProcessSpec
+	launchValue     []byte
+	submittedValue  []byte
+	launchRequest   *sandboxdv1.StartProcessWithLaunchMaterialRequest
+	beforeLaunchErr error
+	afterLaunchErr  error
+	stoppedKey      *sandboxdv1.ProcessKey
+	readRequests    []*sandboxdv1.ReadOutputRequest
 }
 
 func (f *fakeClient) Start(_ context.Context, request *sandboxdv1.StartProcessRequest, _ ...grpc.CallOption) (*sandboxdv1.Process, error) {
@@ -46,8 +53,27 @@ func (f *fakeClient) Start(_ context.Context, request *sandboxdv1.StartProcessRe
 	return f.process, nil
 }
 
-func (f *fakeClient) StartWithLaunchMaterial(context.Context, *sandboxdv1.StartProcessWithLaunchMaterialRequest, ...grpc.CallOption) (*sandboxdv1.Process, error) {
-	return nil, errors.New("unexpected launch material")
+func (f *fakeClient) StartWithLaunchMaterial(_ context.Context, request *sandboxdv1.StartProcessWithLaunchMaterialRequest, _ ...grpc.CallOption) (*sandboxdv1.Process, error) {
+	f.launchCalls++
+	f.launchRequest = request
+	f.submittedValue = append([]byte(nil), request.LaunchMaterial.SecretEnv["AMP_API_KEY"]...)
+	if f.beforeLaunchErr != nil {
+		return nil, f.beforeLaunchErr
+	}
+	if f.startedKey == nil {
+		f.launches++
+		f.startedKey, f.startedSpec = request.Key, request.Spec
+		f.launchValue = append([]byte(nil), request.LaunchMaterial.SecretEnv["AMP_API_KEY"]...)
+	} else if !reflect.DeepEqual(f.startedKey, request.Key) || !reflect.DeepEqual(f.startedSpec, request.Spec) {
+		return nil, status.Error(codes.FailedPrecondition, "conflicting start")
+	}
+	if f.process == nil {
+		f.process = &sandboxdv1.Process{Key: request.Key, Spec: request.Spec, State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"}
+	}
+	if f.afterLaunchErr != nil {
+		return nil, f.afterLaunchErr
+	}
+	return f.process, nil
 }
 func (f *fakeClient) Get(context.Context, *sandboxdv1.GetProcessRequest, ...grpc.CallOption) (*sandboxdv1.Process, error) {
 	if f.getErr != nil {
@@ -125,15 +151,85 @@ func TestAcceptanceIsDuplicateSafePromptSafeAndFreshEpoch(t *testing.T) {
 	}
 }
 
-func TestCredentialIsRejectedWithoutDial(t *testing.T) {
+func TestAPIKeyUsesLaunchMaterialOnlyAndClearsTemporaryCopy(t *testing.T) {
+	client := &fakeClient{}
+	key := []byte("!!AMP-API-KEY-FIXTURE!!")
+	credential := &controllers.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: key}
+	if err := (&Adapter{}).EnsureAccepted(context.Background(), controllers.AdapterTask{ID: "run", Prompt: "task"}, testSandbox(client), credential); err != nil {
+		t.Fatal(err)
+	}
+	if client.launchCalls != 1 || client.starts != 0 || string(client.launchValue) != string(key) || string(credential.APIKey) != string(key) {
+		t.Fatalf("launch/plain calls = %d/%d", client.launchCalls, client.starts)
+	}
+	if client.launchRequest == nil || !reflect.DeepEqual(client.launchRequest.LaunchMaterial.SecretEnv["AMP_API_KEY"], make([]byte, len(key))) {
+		t.Fatal("adapter did not clear its temporary launch-material copy")
+	}
+	if client.launchRequest.Spec == nil {
+		t.Fatal("launch request is missing its public process spec")
+	}
+	if _, exposed := client.launchRequest.Spec.Env["AMP_API_KEY"]; exposed {
+		t.Fatalf("public process spec contains credential material: %#v", client.launchRequest.Spec)
+	}
+}
+
+func TestUnsupportedCredentialTypeFailsBeforeDial(t *testing.T) {
 	dials := 0
 	sandbox := controllers.AdapterSandbox{DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
 		dials++
 		return nil, nil, nil
 	}}
-	err := (&Adapter{}).EnsureAccepted(context.Background(), controllers.AdapterTask{}, sandbox, &controllers.AdapterCredential{APIKey: []byte("secret")})
+	err := (&Adapter{}).EnsureAccepted(context.Background(), controllers.AdapterTask{}, sandbox, &controllers.AdapterCredential{Type: "OAuth", APIKey: []byte("!!UNUSED-KEY-FIXTURE!!")})
 	if !errors.Is(err, controllers.ErrAdapterTaskRejected) || dials != 0 {
 		t.Fatalf("error/dials = %v/%d", err, dials)
+	}
+}
+
+func TestLaunchMaterialFailureDoesNotFallbackOrExposeKey(t *testing.T) {
+	key := []byte("!!AMP-FAILURE-KEY-FIXTURE!!")
+	client := &fakeClient{beforeLaunchErr: status.Error(codes.Unimplemented, "old sandboxd")}
+	err := (&Adapter{}).EnsureAccepted(context.Background(), controllers.AdapterTask{ID: "run", Prompt: "task"}, testSandbox(client), &controllers.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: key})
+	if status.Code(err) != codes.Unimplemented || client.starts != 0 || client.launchCalls != 1 || client.launches != 0 || strings.Contains(err.Error(), string(key)) {
+		t.Fatalf("error/start/calls/launches = %v/%d/%d/%d", err, client.starts, client.launchCalls, client.launches)
+	}
+}
+
+func TestKeyedAcceptancePreservesDuplicateRotationAndFreshEpochSemantics(t *testing.T) {
+	task := controllers.AdapterTask{ID: "run-uid", Prompt: "task"}
+	adapter := &Adapter{}
+	first := &fakeClient{}
+	for _, value := range []string{"first-key", "rotated-key"} {
+		credential := &controllers.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: []byte(value)}
+		if err := adapter.EnsureAccepted(context.Background(), task, testSandbox(first), credential); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if first.launchCalls != 2 || first.launches != 1 || string(first.launchValue) != "first-key" || string(first.submittedValue) != "rotated-key" || first.startedKey.OwnerId != task.ID {
+		t.Fatalf("duplicate calls/launches/launched/submitted/key = %d/%d/%q/%q/%#v", first.launchCalls, first.launches, first.launchValue, first.submittedValue, first.startedKey)
+	}
+	second := &fakeClient{}
+	credential := &controllers.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: []byte("current-key")}
+	if err := adapter.EnsureAccepted(context.Background(), task, testSandbox(second), credential); err != nil {
+		t.Fatal(err)
+	}
+	if second.launches != 1 || string(second.launchValue) != "current-key" || second.startedKey.OwnerId != task.ID {
+		t.Fatalf("fresh epoch launch/value/key = %d/%q/%#v", second.launches, second.launchValue, second.startedKey)
+	}
+}
+
+func TestUncertainKeyedStartRetryDoesNotUsePlainStart(t *testing.T) {
+	client := &fakeClient{afterLaunchErr: status.Error(codes.Unavailable, "response lost")}
+	credential := &controllers.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: []byte("first-key")}
+	task := controllers.AdapterTask{ID: "run", Prompt: "task"}
+	if err := (&Adapter{}).EnsureAccepted(context.Background(), task, testSandbox(client), credential); status.Code(err) != codes.Unavailable {
+		t.Fatalf("first start error = %v", err)
+	}
+	client.afterLaunchErr = nil
+	credential.APIKey = []byte("rotated-key")
+	if err := (&Adapter{}).EnsureAccepted(context.Background(), task, testSandbox(client), credential); err != nil {
+		t.Fatal(err)
+	}
+	if client.launchCalls != 2 || client.launches != 1 || client.starts != 0 || string(client.launchValue) != "first-key" || string(client.submittedValue) != "rotated-key" {
+		t.Fatalf("calls/launches/plain/launched/submitted = %d/%d/%d/%q/%q", client.launchCalls, client.launches, client.starts, client.launchValue, client.submittedValue)
 	}
 }
 


### PR DESCRIPTION
## Summary
- deliver selected Amp API-key profiles only as write-only `AMP_API_KEY` launch material to the Run-UID-keyed managed process
- preserve credentialless starts and same-epoch duplicate/rotation semantics while failing closed for unsupported credentials and old sandboxd implementations
- extend focused race coverage, fake Kind acceptance, leakage checks, and operator/chart documentation

## Verification
- `go test -race ./internal/adapters/amp ./internal/adapters/codex ./internal/adapters/claudecode`
- `go test -race ./internal/adapters/amp ./internal/controllers ./internal/sandboxclient`
- `(cd sandboxd && go test -race ./internal/server -run 'TestStartWithLaunchMaterial|TestProcess')`
- `make test`
- `make vet`
- `make build`
- `bash -n hack/e2e.sh`
- Helm lint for default, kind, Argo CD, k3s, GKE, and EKS presets
- `make check-chart-crds`
- `git diff --check`

Full Kind acceptance was not run locally because Docker and kind are unavailable in the orb; GitHub CI provides that coverage.

Closes #103
