### PR TITLE
Reject unsupported project egress allowlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ with a reviewable diff, branch, or PR.
 
 ## Why
 
-- **Real isolation** — agents execute untrusted, model-generated code. Environments run
-  under gVisor/Kata by default, behind default-deny egress with per-project allowlists.
+- **Real isolation** — agents execute untrusted, model-generated code. Environments support
+  hardened containers, sandboxd authentication, restricted sandboxd ingress, and optional
+  RuntimeClasses such as gVisor. Default-deny egress is not implemented yet.
 - **Pause economics** — idle environments are paused (pod deleted, disk retained) and
   woken on demand. An agent waiting on its children costs ~$0.
 - **Agent-agnostic** — existing agents plug in via adapters; the platform never depends
@@ -39,7 +40,7 @@ with a reviewable diff, branch, or PR.
 | **Environment** | One ephemeral machine an agent works in (pod + volume + network policy) |
 | **Run** | One agent task executing in an environment |
 | **Project** | One or more git repos + config: setup hooks, size, changes workflow |
-| **Template** | Environment class: image, size, runtime, egress rules, warm pool |
+| **Template** | Environment class: image, size, runtime, warm pool |
 | **Inbox** | Addressable message queue per run — how agents talk to each other |
 | **Portal** | Authenticated URL exposing a dev server inside an environment |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,6 +50,12 @@ enforcement. Environment pods do not receive a Kubernetes service-account token 
 NetworkPolicies are additive, destination-node traffic may be exempt, and Kubernetes API
 port-forwarding is governed by `pods/portforward` RBAC rather than this policy.
 
+Default-deny egress and the per-project egress proxy are not implemented. The
+`Project.spec.egressAllowlist` field is reserved for that future contract; the operator rejects
+non-empty values and fences any existing Environment execution rather than running with an
+unenforced allowlist. Empty or omitted allowlists do not restrict environment egress, which is
+subject to the cluster's network configuration.
+
 ### Credential lifecycle
 
 1. **Bootstrap:** before creating a pod, the operator generates a new certificate, private key,

--- a/api/v1alpha1/project_types.go
+++ b/api/v1alpha1/project_types.go
@@ -29,8 +29,9 @@ type ProjectSpec struct {
 	// +optional
 	ChangesWorkflow ChangesWorkflow `json:"changesWorkflow,omitempty"`
 
-	// EgressAllowlist lists hosts environments for this project may reach.
-	// Everything else is denied by the egress proxy.
+	// EgressAllowlist is reserved for future per-project egress enforcement.
+	// Non-empty values are currently unsupported and cause referenced Environments
+	// to fail validation until the egress proxy is implemented.
 	// +optional
 	// +listType=set
 	EgressAllowlist []string `json:"egressAllowlist,omitempty"`

--- a/charts/swe-platform/README.md
+++ b/charts/swe-platform/README.md
@@ -176,6 +176,10 @@ Kubernetes NetworkPolicy for this defense in depth; TLS identity and capability 
 remain mandatory regardless. See [the security model](../../SECURITY.md) for credential
 lifecycle and backend requirements.
 
+The chart does not install default-deny egress or an egress allowlist proxy. Project
+`egressAllowlist` values are reserved and rejected when non-empty; empty or omitted values leave
+egress subject to the cluster's network configuration.
+
 For local development, use `values-kind.yaml`; it references locally loaded `:dev`
 images and disables leader election. `values-argocd.yaml` is the preset for the
 local Argo CD mirror (`hack/argocd-up.sh`): it tracks the mutable `:latest` images

--- a/charts/swe-platform/crds/swe.dev_projects.yaml
+++ b/charts/swe-platform/crds/swe.dev_projects.yaml
@@ -50,8 +50,9 @@ spec:
                 type: string
               egressAllowlist:
                 description: |-
-                  EgressAllowlist lists hosts environments for this project may reach.
-                  Everything else is denied by the egress proxy.
+                  EgressAllowlist is reserved for future per-project egress enforcement.
+                  Non-empty values are currently unsupported and cause referenced Environments
+                  to fail validation until the egress proxy is implemented.
                 items:
                   type: string
                 type: array

--- a/config/crd/bases/swe.dev_projects.yaml
+++ b/config/crd/bases/swe.dev_projects.yaml
@@ -50,8 +50,9 @@ spec:
                 type: string
               egressAllowlist:
                 description: |-
-                  EgressAllowlist lists hosts environments for this project may reach.
-                  Everything else is denied by the egress proxy.
+                  EgressAllowlist is reserved for future per-project egress enforcement.
+                  Non-empty values are currently unsupported and cause referenced Environments
+                  to fail validation until the egress proxy is implemented.
                 items:
                   type: string
                 type: array

--- a/internal/controllers/environment_controller.go
+++ b/internal/controllers/environment_controller.go
@@ -204,7 +204,7 @@ func (r *EnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 	project, projectErr := r.resolveEnvironmentProject(ctx, &env)
 	if project != nil && len(project.Spec.EgressAllowlist) != 0 {
-		return r.reconcileUnsupportedEgressAllowlist(ctx, &env, project)
+		return r.reconcileInvalidProjectConfiguration(ctx, &env, unsupportedEgressAllowlistMessage(project.Name))
 	}
 	// Fencing must not depend on a still-readable template or successful setup.
 	// Cancellation/finalization can therefore stop an execution domain even after
@@ -217,6 +217,10 @@ func (r *EnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return result, nil
 	}
 	if projectErr != nil {
+		var terminal *terminalEnvironmentError
+		if stderrors.As(projectErr, &terminal) {
+			return r.reconcileInvalidProjectConfiguration(ctx, &env, projectErr.Error())
+		}
 		return ctrl.Result{}, r.fail(ctx, &env, projectErr)
 	}
 	if err := validateEnvironmentProject(project); err != nil {
@@ -545,13 +549,12 @@ func (r *EnvironmentReconciler) now() time.Time {
 	return time.Now()
 }
 
-// reconcileUnsupportedEgressAllowlist withdraws the published connection
-// before fencing an execution domain that cannot enforce its Project's egress
-// policy. The workspace and ingress policy are retained, and credentials are
-// revoked only after the exact Environment-owned Pod is gone.
-func (r *EnvironmentReconciler) reconcileUnsupportedEgressAllowlist(ctx context.Context, env *platformv1alpha1.Environment, project *platformv1alpha1.Project) (ctrl.Result, error) {
+// reconcileInvalidProjectConfiguration withdraws the published connection
+// before fencing an execution domain whose Project configuration cannot be
+// safely established. The workspace and ingress policy are retained, and
+// credentials are revoked only after the exact Environment-owned Pod is gone.
+func (r *EnvironmentReconciler) reconcileInvalidProjectConfiguration(ctx context.Context, env *platformv1alpha1.Environment, message string) (ctrl.Result, error) {
 	hadPublishedConnection := env.Status.PodName != "" || env.Status.Endpoints.Sandboxd != "" || platformv1alpha1.IsEnvironmentReady(env)
-	message := unsupportedEgressAllowlistMessage(project.Name)
 	if err := r.setEnvironmentStatus(ctx, env, platformv1alpha1.EnvironmentPhaseFailed, "", "", "InvalidConfiguration", message); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -563,7 +566,7 @@ func (r *EnvironmentReconciler) reconcileUnsupportedEgressAllowlist(ctx context.
 	if err := r.Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: envPodName(env)}, &pod); err == nil {
 		if exactControllerOwner(&pod, platformv1alpha1.GroupVersion.String(), "Environment", env.Name, env.UID) {
 			if err := r.deleteObservedChild(ctx, &pod); err != nil && !errors.IsNotFound(err) {
-				return ctrl.Result{}, fmt.Errorf("delete pod for unsupported egress allowlist: %w", err)
+				return ctrl.Result{}, fmt.Errorf("delete pod for invalid Project configuration: %w", err)
 			}
 			return ctrl.Result{Requeue: true}, nil
 		}
@@ -577,7 +580,7 @@ func (r *EnvironmentReconciler) reconcileUnsupportedEgressAllowlist(ctx context.
 			return ctrl.Result{}, nil
 		}
 		if err := r.deleteObservedChild(ctx, &credentials); err != nil && !errors.IsNotFound(err) {
-			return ctrl.Result{}, fmt.Errorf("revoke credentials for unsupported egress allowlist: %w", err)
+			return ctrl.Result{}, fmt.Errorf("revoke credentials for invalid Project configuration: %w", err)
 		}
 		return ctrl.Result{Requeue: true}, nil
 	} else if !errors.IsNotFound(err) {

--- a/internal/controllers/environment_controller.go
+++ b/internal/controllers/environment_controller.go
@@ -202,15 +202,25 @@ func (r *EnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if changed {
 		return ctrl.Result{Requeue: true}, nil
 	}
+	project, projectErr := r.resolveEnvironmentProject(ctx, &env)
+	if project != nil && len(project.Spec.EgressAllowlist) != 0 {
+		return r.reconcileUnsupportedEgressAllowlist(ctx, &env, project)
+	}
 	// Fencing must not depend on a still-readable template or successful setup.
-	// Cancellation/finalization can therefore stop an execution domain even
-	// after its template was deleted or provisioning became permanently broken.
+	// Cancellation/finalization can therefore stop an execution domain even after
+	// its template or Project was deleted or provisioning became permanently broken.
 	if env.Status.Lifecycle.Suspended {
 		result, err := r.reconcilePaused(ctx, &env)
 		if err != nil {
 			return ctrl.Result{}, r.fail(ctx, &env, fmt.Errorf("pause environment: %w", err))
 		}
 		return result, nil
+	}
+	if projectErr != nil {
+		return ctrl.Result{}, r.fail(ctx, &env, projectErr)
+	}
+	if err := validateEnvironmentProject(project); err != nil {
+		return ctrl.Result{}, r.fail(ctx, &env, err)
 	}
 	if result, handled, err := r.reconcilePendingPodRecovery(ctx, &env); handled || err != nil {
 		return result, err
@@ -252,7 +262,7 @@ func (r *EnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{Requeue: true}, r.setPhase(ctx, &env, platformv1alpha1.EnvironmentPhaseResuming, "", "")
 	}
 
-	pod, err := r.ensurePod(ctx, &env, &tmpl)
+	pod, err := r.ensurePodForProject(ctx, &env, &tmpl, project)
 	if stderrors.Is(err, errPodReplacing) {
 		return ctrl.Result{Requeue: true}, nil
 	}
@@ -535,6 +545,47 @@ func (r *EnvironmentReconciler) now() time.Time {
 	return time.Now()
 }
 
+// reconcileUnsupportedEgressAllowlist withdraws the published connection
+// before fencing an execution domain that cannot enforce its Project's egress
+// policy. The workspace and ingress policy are retained, and credentials are
+// revoked only after the exact Environment-owned Pod is gone.
+func (r *EnvironmentReconciler) reconcileUnsupportedEgressAllowlist(ctx context.Context, env *platformv1alpha1.Environment, project *platformv1alpha1.Project) (ctrl.Result, error) {
+	hadPublishedConnection := env.Status.PodName != "" || env.Status.Endpoints.Sandboxd != "" || platformv1alpha1.IsEnvironmentReady(env)
+	message := unsupportedEgressAllowlistMessage(project.Name)
+	if err := r.setEnvironmentStatus(ctx, env, platformv1alpha1.EnvironmentPhaseFailed, "", "", "InvalidConfiguration", message); err != nil {
+		return ctrl.Result{}, err
+	}
+	if hadPublishedConnection {
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	var pod corev1.Pod
+	if err := r.Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: envPodName(env)}, &pod); err == nil {
+		if exactControllerOwner(&pod, platformv1alpha1.GroupVersion.String(), "Environment", env.Name, env.UID) {
+			if err := r.deleteObservedChild(ctx, &pod); err != nil && !errors.IsNotFound(err) {
+				return ctrl.Result{}, fmt.Errorf("delete pod for unsupported egress allowlist: %w", err)
+			}
+			return ctrl.Result{Requeue: true}, nil
+		}
+	} else if !errors.IsNotFound(err) {
+		return ctrl.Result{}, err
+	}
+
+	var credentials corev1.Secret
+	if err := r.Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: envCredentialName(env)}, &credentials); err == nil {
+		if !exactControllerOwner(&credentials, platformv1alpha1.GroupVersion.String(), "Environment", env.Name, env.UID) {
+			return ctrl.Result{}, nil
+		}
+		if err := r.deleteObservedChild(ctx, &credentials); err != nil && !errors.IsNotFound(err) {
+			return ctrl.Result{}, fmt.Errorf("revoke credentials for unsupported egress allowlist: %w", err)
+		}
+		return ctrl.Result{Requeue: true}, nil
+	} else if !errors.IsNotFound(err) {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
 // reconcileUnsupportedBackend withdraws the published connection identity
 // before stopping any legacy pod admitted under an older CRD. It retains the
 // workspace PVC and removes credentials only after the pod is gone.
@@ -797,8 +848,50 @@ func envImagePullPolicy(image string) corev1.PullPolicy {
 	return corev1.PullAlways
 }
 
-// ensurePod returns the backing pod, creating it if necessary.
+// ensurePod resolves the optional Project and returns the backing pod, creating
+// it if necessary. Reconcile resolves the Project earlier so validation happens
+// before any child resource is created.
 func (r *EnvironmentReconciler) ensurePod(ctx context.Context, env *platformv1alpha1.Environment, tmpl *platformv1alpha1.EnvironmentTemplate) (*corev1.Pod, error) {
+	project, err := r.resolveEnvironmentProject(ctx, env)
+	if err != nil {
+		return nil, err
+	}
+	if project != nil && len(project.Spec.EgressAllowlist) != 0 {
+		return nil, terminalEnvironment(stderrors.New(unsupportedEgressAllowlistMessage(project.Name)))
+	}
+	if err := validateEnvironmentProject(project); err != nil {
+		return nil, err
+	}
+	return r.ensurePodForProject(ctx, env, tmpl, project)
+}
+
+func (r *EnvironmentReconciler) resolveEnvironmentProject(ctx context.Context, env *platformv1alpha1.Environment) (*platformv1alpha1.Project, error) {
+	if env.Spec.ProjectRef == "" {
+		return nil, nil
+	}
+	var project platformv1alpha1.Project
+	if err := r.Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: env.Spec.ProjectRef}, &project); err != nil {
+		wrapped := fmt.Errorf("get project %q: %w", env.Spec.ProjectRef, err)
+		if errors.IsNotFound(err) {
+			wrapped = terminalEnvironment(wrapped)
+		}
+		return nil, wrapped
+	}
+	return &project, nil
+}
+
+func validateEnvironmentProject(project *platformv1alpha1.Project) error {
+	if project != nil && len(project.Spec.Repositories) != 1 {
+		return terminalEnvironment(fmt.Errorf("project %q must have exactly one repository, got %d", project.Name, len(project.Spec.Repositories)))
+	}
+	return nil
+}
+
+func unsupportedEgressAllowlistMessage(projectName string) string {
+	return fmt.Sprintf("project %q has a non-empty egressAllowlist, which is unsupported until GitHub issue #68 is implemented", projectName)
+}
+
+func (r *EnvironmentReconciler) ensurePodForProject(ctx context.Context, env *platformv1alpha1.Environment, tmpl *platformv1alpha1.EnvironmentTemplate, project *platformv1alpha1.Project) (*corev1.Pod, error) {
 	podName := envPodName(env)
 	var pod corev1.Pod
 	err := r.Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: podName}, &pod)
@@ -975,18 +1068,7 @@ func (r *EnvironmentReconciler) ensurePod(ctx context.Context, env *platformv1al
 	if tmpl.Spec.RuntimeClass != "" {
 		pod.Spec.RuntimeClassName = &tmpl.Spec.RuntimeClass
 	}
-	if env.Spec.ProjectRef != "" {
-		var project platformv1alpha1.Project
-		if err := r.Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: env.Spec.ProjectRef}, &project); err != nil {
-			wrapped := fmt.Errorf("get project %q: %w", env.Spec.ProjectRef, err)
-			if errors.IsNotFound(err) {
-				wrapped = terminalEnvironment(wrapped)
-			}
-			return nil, wrapped
-		}
-		if len(project.Spec.Repositories) != 1 {
-			return nil, terminalEnvironment(fmt.Errorf("project %q must have exactly one repository, got %d", env.Spec.ProjectRef, len(project.Spec.Repositories)))
-		}
+	if project != nil {
 		repository := project.Spec.Repositories[0]
 		projectEnv := []corev1.EnvVar{
 			{Name: "SWE_REPOSITORY", Value: repository},

--- a/internal/controllers/environment_controller_test.go
+++ b/internal/controllers/environment_controller_test.go
@@ -1593,6 +1593,299 @@ func TestProjectRepositoryValidationIsTerminal(t *testing.T) {
 	}
 }
 
+func TestReconcileRejectsUnsupportedEgressAllowlistBeforeCreatingChildren(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := networkingv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	project := &platformv1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "project", Namespace: "default"},
+		Spec: platformv1alpha1.ProjectSpec{
+			Repositories:    []string{"https://github.com/example/repo"},
+			EgressAllowlist: []string{"github.com"},
+		},
+	}
+	env := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "environment-uid", Generation: 1, Finalizers: []string{environmentFinalizer}},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small", ProjectRef: project.Name},
+	}
+	template := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: "default"}}
+	reconciler := &EnvironmentReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env, project, template).Build(), Scheme: scheme,
+	}
+
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(env)})
+	if err != nil || result != (ctrl.Result{}) {
+		t.Fatalf("Reconcile() = (%#v, %v), want stable terminal result", result, err)
+	}
+	var failed platformv1alpha1.Environment
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(env), &failed); err != nil {
+		t.Fatal(err)
+	}
+	condition := apimeta.FindStatusCondition(failed.Status.Conditions, platformv1alpha1.EnvironmentConditionReady)
+	if failed.Status.Phase != platformv1alpha1.EnvironmentPhaseFailed || condition == nil || condition.Reason != "InvalidConfiguration" ||
+		condition.Message != `project "project" has a non-empty egressAllowlist, which is unsupported until GitHub issue #68 is implemented` {
+		t.Fatalf("unsupported allowlist status = phase %q, condition %#v", failed.Status.Phase, condition)
+	}
+	var pods corev1.PodList
+	var pvcs corev1.PersistentVolumeClaimList
+	var secrets corev1.SecretList
+	var policies networkingv1.NetworkPolicyList
+	for _, list := range []client.ObjectList{&pods, &pvcs, &secrets, &policies} {
+		if err := reconciler.List(context.Background(), list, client.InNamespace(env.Namespace)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(pods.Items) != 0 || len(pvcs.Items) != 0 || len(secrets.Items) != 0 || len(policies.Items) != 0 {
+		t.Fatalf("unsupported allowlist created children: %d Pods, %d PVCs, %d Secrets, %d NetworkPolicies", len(pods.Items), len(pvcs.Items), len(secrets.Items), len(policies.Items))
+	}
+}
+
+func TestUnsupportedEgressAllowlistFencesExactOwnedExecutionAndRetainsWorkspace(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := networkingv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	project := &platformv1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "project", Namespace: "default"},
+		Spec:       platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/example/repo"}, EgressAllowlist: []string{"github.com"}},
+	}
+	env := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "environment-uid", Generation: 2, Finalizers: []string{environmentFinalizer}},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small", ProjectRef: project.Name},
+		Status: platformv1alpha1.EnvironmentStatus{
+			ObservedGeneration: 2, Phase: platformv1alpha1.EnvironmentPhaseReady, PodName: "env-test",
+			Endpoints:  platformv1alpha1.EnvironmentEndpoints{Sandboxd: "10.0.0.1:50051"},
+			Conditions: []metav1.Condition{{Type: platformv1alpha1.EnvironmentConditionReady, Status: metav1.ConditionTrue, ObservedGeneration: 2, Reason: "SandboxdReady"}},
+		},
+	}
+	controller := true
+	owner := metav1.OwnerReference{APIVersion: platformv1alpha1.GroupVersion.String(), Kind: "Environment", Name: env.Name, UID: env.UID, Controller: &controller}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: envPodName(env), Namespace: env.Namespace, UID: "pod-uid", OwnerReferences: []metav1.OwnerReference{owner}}}
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: envCredentialName(env), Namespace: env.Namespace, UID: "secret-uid", OwnerReferences: []metav1.OwnerReference{owner}}}
+	pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: envPVCName(env), Namespace: env.Namespace, UID: "pvc-uid", OwnerReferences: []metav1.OwnerReference{owner}}}
+	policy := &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: envNetworkPolicyName(env), Namespace: env.Namespace, UID: "policy-uid", OwnerReferences: []metav1.OwnerReference{owner}}}
+	template := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: "default"}}
+	reconciler := &EnvironmentReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env, project, template, pod, secret, pvc, policy).Build(), Scheme: scheme,
+	}
+	request := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(env)}
+
+	if result, err := reconciler.Reconcile(context.Background(), request); err != nil || !result.Requeue {
+		t.Fatalf("withdraw readiness = (%#v, %v)", result, err)
+	}
+	var failed platformv1alpha1.Environment
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(env), &failed); err != nil {
+		t.Fatal(err)
+	}
+	ready := apimeta.FindStatusCondition(failed.Status.Conditions, platformv1alpha1.EnvironmentConditionReady)
+	if failed.Status.Phase != platformv1alpha1.EnvironmentPhaseFailed || failed.Status.PodName != "" || failed.Status.Endpoints.Sandboxd != "" || ready == nil || ready.Reason != "InvalidConfiguration" {
+		t.Fatalf("readiness was not withdrawn: %#v", failed.Status)
+	}
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(pod), &corev1.Pod{}); err != nil {
+		t.Fatal("pod was deleted before readiness withdrawal")
+	}
+	if result, err := reconciler.Reconcile(context.Background(), request); err != nil || !result.Requeue {
+		t.Fatalf("delete pod = (%#v, %v)", result, err)
+	}
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(pod), &corev1.Pod{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("owned pod still exists: %v", err)
+	}
+	if result, err := reconciler.Reconcile(context.Background(), request); err != nil || !result.Requeue {
+		t.Fatalf("revoke credentials = (%#v, %v)", result, err)
+	}
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(secret), &corev1.Secret{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("owned credentials still exist: %v", err)
+	}
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(pvc), &corev1.PersistentVolumeClaim{}); err != nil {
+		t.Fatal("workspace PVC was not retained")
+	}
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(policy), &networkingv1.NetworkPolicy{}); err != nil {
+		t.Fatal("ingress NetworkPolicy was not retained")
+	}
+	if result, err := reconciler.Reconcile(context.Background(), request); err != nil || result != (ctrl.Result{}) {
+		t.Fatalf("stable failed reconcile = (%#v, %v)", result, err)
+	}
+}
+
+func TestUnsupportedEgressAllowlistDoesNotDeleteForeignSameNameChildren(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	project := &platformv1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "project", Namespace: "default"},
+		Spec:       platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/example/repo"}, EgressAllowlist: []string{"github.com"}},
+	}
+	env := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "current-environment", Generation: 1, Finalizers: []string{environmentFinalizer}},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small", ProjectRef: project.Name},
+	}
+	controller := true
+	oldOwner := metav1.OwnerReference{APIVersion: platformv1alpha1.GroupVersion.String(), Kind: "Environment", Name: env.Name, UID: "old-environment", Controller: &controller}
+	foreignPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: envPodName(env), Namespace: env.Namespace, UID: "foreign-pod", OwnerReferences: []metav1.OwnerReference{oldOwner}}}
+	foreignSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: envCredentialName(env), Namespace: env.Namespace, UID: "foreign-secret", OwnerReferences: []metav1.OwnerReference{oldOwner}}}
+	reconciler := &EnvironmentReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env, project, foreignPod, foreignSecret).Build(), Scheme: scheme,
+	}
+
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(env)})
+	if err != nil || result != (ctrl.Result{}) {
+		t.Fatalf("Reconcile() = (%#v, %v), want stable terminal result", result, err)
+	}
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(foreignPod), &corev1.Pod{}); err != nil {
+		t.Fatal("foreign same-name Pod was deleted")
+	}
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(foreignSecret), &corev1.Secret{}); err != nil {
+		t.Fatal("foreign same-name Secret was deleted")
+	}
+}
+
+func TestUnsupportedEgressAllowlistRevokesOwnedSecretBehindForeignPod(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	project := &platformv1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "project", Namespace: "default"},
+		Spec:       platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/example/repo"}, EgressAllowlist: []string{"github.com"}},
+	}
+	env := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "current-environment", Generation: 1, Finalizers: []string{environmentFinalizer}},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small", ProjectRef: project.Name},
+	}
+	controller := true
+	oldOwner := metav1.OwnerReference{APIVersion: platformv1alpha1.GroupVersion.String(), Kind: "Environment", Name: env.Name, UID: "old-environment", Controller: &controller}
+	currentOwner := oldOwner
+	currentOwner.UID = env.UID
+	foreignPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: envPodName(env), Namespace: env.Namespace, UID: "foreign-pod", OwnerReferences: []metav1.OwnerReference{oldOwner}}}
+	ownedSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: envCredentialName(env), Namespace: env.Namespace, UID: "owned-secret", OwnerReferences: []metav1.OwnerReference{currentOwner}}}
+	reconciler := &EnvironmentReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env, project, foreignPod, ownedSecret).Build(), Scheme: scheme,
+	}
+
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(env)})
+	if err != nil || !result.Requeue {
+		t.Fatalf("Reconcile() = (%#v, %v), want credential revocation requeue", result, err)
+	}
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(foreignPod), &corev1.Pod{}); err != nil {
+		t.Fatal("foreign same-name Pod was deleted")
+	}
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(ownedSecret), &corev1.Secret{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("exact-owned Secret still exists: %v", err)
+	}
+}
+
+func TestUnsupportedEgressAllowlistRetainsForeignSecretAfterFencingOwnedPod(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	project := &platformv1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "project", Namespace: "default"},
+		Spec:       platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/example/repo"}, EgressAllowlist: []string{"github.com"}},
+	}
+	env := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "current-environment", Generation: 1, Finalizers: []string{environmentFinalizer}},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small", ProjectRef: project.Name},
+	}
+	controller := true
+	currentOwner := metav1.OwnerReference{APIVersion: platformv1alpha1.GroupVersion.String(), Kind: "Environment", Name: env.Name, UID: env.UID, Controller: &controller}
+	oldOwner := currentOwner
+	oldOwner.UID = "old-environment"
+	ownedPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: envPodName(env), Namespace: env.Namespace, UID: "owned-pod", OwnerReferences: []metav1.OwnerReference{currentOwner}}}
+	foreignSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: envCredentialName(env), Namespace: env.Namespace, UID: "foreign-secret", OwnerReferences: []metav1.OwnerReference{oldOwner}}}
+	reconciler := &EnvironmentReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env, project, ownedPod, foreignSecret).Build(), Scheme: scheme,
+	}
+	request := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(env)}
+
+	if result, err := reconciler.Reconcile(context.Background(), request); err != nil || !result.Requeue {
+		t.Fatalf("fence Pod = (%#v, %v)", result, err)
+	}
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(ownedPod), &corev1.Pod{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("exact-owned Pod still exists: %v", err)
+	}
+	if result, err := reconciler.Reconcile(context.Background(), request); err != nil || result != (ctrl.Result{}) {
+		t.Fatalf("foreign Secret reconcile = (%#v, %v), want stable result", result, err)
+	}
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(foreignSecret), &corev1.Secret{}); err != nil {
+		t.Fatal("foreign same-name Secret was deleted")
+	}
+}
+
+func TestUnsupportedEgressAllowlistRecoversAfterProjectIsCleared(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := networkingv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	project := &platformv1alpha1.Project{
+		ObjectMeta: metav1.ObjectMeta{Name: "project", Namespace: "default"},
+		Spec:       platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/example/repo"}, EgressAllowlist: []string{"github.com"}},
+	}
+	env := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "environment-uid", Generation: 1, Finalizers: []string{environmentFinalizer}},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small", ProjectRef: project.Name},
+	}
+	template := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: "default"}, Spec: platformv1alpha1.EnvironmentTemplateSpec{Image: "example/environment:dev", Size: "small"}}
+	reconciler := &EnvironmentReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env, project, template).Build(), Scheme: scheme,
+	}
+	request := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(env)}
+	if _, err := reconciler.Reconcile(context.Background(), request); err != nil {
+		t.Fatal(err)
+	}
+	var updatedProject platformv1alpha1.Project
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(project), &updatedProject); err != nil {
+		t.Fatal(err)
+	}
+	updatedProject.Spec.EgressAllowlist = nil
+	if err := reconciler.Update(context.Background(), &updatedProject); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reconciler.Reconcile(context.Background(), request); err != nil {
+		t.Fatalf("Reconcile() after clearing allowlist: %v", err)
+	}
+	var pod corev1.Pod
+	if err := reconciler.Get(context.Background(), types.NamespacedName{Namespace: env.Namespace, Name: envPodName(env)}, &pod); err != nil {
+		t.Fatalf("ordinary provisioning did not recover: %v", err)
+	}
+	var recovering platformv1alpha1.Environment
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(env), &recovering); err != nil {
+		t.Fatal(err)
+	}
+	if recovering.Status.Phase == platformv1alpha1.EnvironmentPhaseFailed {
+		t.Fatalf("Environment remained failed after allowlist was cleared: %#v", recovering.Status)
+	}
+}
+
 func TestReconcileRejectsUnsupportedEffectiveBackendBeforeCreatingChildren(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/internal/controllers/environment_controller_test.go
+++ b/internal/controllers/environment_controller_test.go
@@ -1886,6 +1886,54 @@ func TestUnsupportedEgressAllowlistRecoversAfterProjectIsCleared(t *testing.T) {
 	}
 }
 
+func TestMissingReferencedProjectFencesExistingExecution(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	env := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "environment-uid", Generation: 2, Finalizers: []string{environmentFinalizer}},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small", ProjectRef: "deleted-project"},
+		Status: platformv1alpha1.EnvironmentStatus{
+			ObservedGeneration: 2, Phase: platformv1alpha1.EnvironmentPhaseReady, PodName: "env-test",
+			Endpoints:  platformv1alpha1.EnvironmentEndpoints{Sandboxd: "10.0.0.1:50051"},
+			Conditions: []metav1.Condition{{Type: platformv1alpha1.EnvironmentConditionReady, Status: metav1.ConditionTrue, ObservedGeneration: 2, Reason: "SandboxdReady"}},
+		},
+	}
+	controller := true
+	owner := metav1.OwnerReference{APIVersion: platformv1alpha1.GroupVersion.String(), Kind: "Environment", Name: env.Name, UID: env.UID, Controller: &controller}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: envPodName(env), Namespace: env.Namespace, UID: "pod-uid", OwnerReferences: []metav1.OwnerReference{owner}}}
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: envCredentialName(env), Namespace: env.Namespace, UID: "secret-uid", OwnerReferences: []metav1.OwnerReference{owner}}}
+	reconciler := &EnvironmentReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env, pod, secret).Build(), Scheme: scheme,
+	}
+	request := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(env)}
+
+	for step := 0; step < 3; step++ {
+		result, err := reconciler.Reconcile(context.Background(), request)
+		if err != nil || !result.Requeue {
+			t.Fatalf("fencing step %d = (%#v, %v)", step+1, result, err)
+		}
+	}
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(pod), &corev1.Pod{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("owned Pod still exists: %v", err)
+	}
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(secret), &corev1.Secret{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("owned Secret still exists: %v", err)
+	}
+	var failed platformv1alpha1.Environment
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(env), &failed); err != nil {
+		t.Fatal(err)
+	}
+	ready := apimeta.FindStatusCondition(failed.Status.Conditions, platformv1alpha1.EnvironmentConditionReady)
+	if failed.Status.Phase != platformv1alpha1.EnvironmentPhaseFailed || ready == nil || ready.Reason != "InvalidConfiguration" || !strings.Contains(ready.Message, `get project "deleted-project"`) {
+		t.Fatalf("missing Project status = %#v", failed.Status)
+	}
+}
+
 func TestReconcileRejectsUnsupportedEffectiveBackendBeforeCreatingChildren(t *testing.T) {
 	tests := []struct {
 		name            string


### PR DESCRIPTION
## Summary

- reject referenced Projects with non-empty `spec.egressAllowlist` before Environment child creation
- withdraw readiness and fence only the exact Environment-owned Pod, then revoke exact-owned sandboxd credentials while retaining the workspace PVC
- preserve foreign same-name objects and resume ordinary reconciliation after the allowlist is cleared
- correct API, README, chart, and security documentation to describe egress allowlists as reserved and unsupported

This is a focused partial security fix related to #10 and #68; it does not implement egress enforcement.

## Validation

- `go test -race ./internal/controllers -run 'EgressAllowlist|ReferenceWatchMappers|ProjectRepositoryValidation|ReconcilePaused'`
- `make test`
- `make vet`
- `make generate manifests`
- `make check-chart-crds`
- Helm lint and render for default, kind, argocd, k3s, gke, and eks values
- `bash -n hack/e2e.sh`
- `git diff --check`

## E2E scope

No `hack/e2e.sh` scenario was added. The fail-closed behavior depends on exact owner UID combinations, ordered Pod/Secret deletion, no-child side effects, and recovery after a Project watch event; focused fake-client controller tests cover these deterministically without adding a costly cluster lifecycle path for behavior already exercised at the reconciliation boundary.
