### PR TITLE
docs(transcripts): document unbounded storage and add monitoring queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,7 +506,13 @@ current Environment pod's `environment` container using kubeconfig authenticatio
 does not read a Run transcript, and the CLI never infers a Run from a reusable
 Environment. Production transcript durability and replay across control-plane restarts
 require the chart's PostgreSQL configuration. The default, kind, and Argo development
-presets retain bounded process-local storage and cannot promise restart replay.
+presets retain bounded process-local storage and cannot promise restart replay. Per-Run event
+and byte limits bound each Run's retained window, but total transcript storage is not bounded
+across Run churn: deleting a Run does not reclaim its UID-fenced transcript rows, and
+retention/garbage-collection policy is tracked in
+[#101](https://github.com/Chris-Cullins/swe-platform/issues/101). See the
+[chart README](charts/swe-platform/README.md#durable-transcript-storage) for operator monitoring
+guidance and the manual retention procedure until automatic cleanup ships.
 
 ## Contributing
 

--- a/charts/swe-platform/README.md
+++ b/charts/swe-platform/README.md
@@ -243,8 +243,30 @@ does not yet reclaim its UID-fenced transcript rows automatically, because compl
 and Project-offboarding retention policy depends on the lifecycle decisions tracked in
 [#101](https://github.com/Chris-Cullins/swe-platform/issues/101) and #11. Until that work ships,
 operators must monitor and provision the dedicated transcript database for accumulated history.
-Manual deletion should be exceptional: take a backup and target the exact namespace and immutable
-Run UID so a same-name replacement Run's transcript cannot be removed.
+Total retained storage across all Runs can be checked directly against the per-Run accounting
+columns the append path maintains:
+
+```sql
+SELECT count(*) AS runs,
+       coalesce(sum(retained_events), 0) AS retained_events,
+       coalesce(sum(retained_bytes), 0) AS retained_bytes
+FROM transcript_runs;
+```
+
+or grouped by namespace:
+
+```sql
+SELECT namespace, count(*) AS runs,
+       coalesce(sum(retained_events), 0) AS retained_events,
+       coalesce(sum(retained_bytes), 0) AS retained_bytes
+FROM transcript_runs
+GROUP BY namespace
+ORDER BY coalesce(sum(retained_bytes), 0) DESC;
+```
+
+These queries are read-only and report retained history only; they do not advise when or whether
+to delete. Manual deletion should be exceptional: take a backup and target the exact namespace and
+immutable Run UID so a same-name replacement Run's transcript cannot be removed.
 
 ## Control-plane authentication and authorization
 


### PR DESCRIPTION
## What

Documentation-only slice for #101 (transcript retention and lifecycle garbage collection).

The chart README already stated that per-Run event/byte limits do not bound total
PostgreSQL transcript storage across Run churn and that deleting a Run does not reclaim
its UID-fenced transcript rows. This PR makes that limitation fully actionable and
publicly visible without prescribing any unresolved deletion policy.

## Changes

- **`charts/swe-platform/README.md`** — add concrete, read-only monitoring SQL queries
  against the per-Run accounting columns (`transcript_runs.retained_events`,
  `transcript_runs.retained_bytes`) — one total, one grouped by namespace — so the
  existing "operators must monitor" guidance is actionable. The queries are explicitly
  marked read-only and non-prescriptive.
- **`README.md`** — cross-reference the unbounded-growth limitation from the primary
  public doc (which previously only noted that production persistence requires
  PostgreSQL), pointing to the chart README and #101.

## Why this is safe to land now

- States only current, verified behavior: there is no Run-deletion transcript purge
  path, and per-Run eviction on append is the only reclamation today.
- Does **not** prescribe retention periods, deletion triggers, or Project-offboarding
  semantics — those remain open in #101 / #11.
- No code, schema, CRD, chart template, or values changes.

## Verification

- `helm lint charts/swe-platform` passes.
- Markdown code fences balanced in both files.
- Query columns verified against `internal/controlplane/migrations/001_transcripts.sql`.

Refs #101