### PR TITLE
fix(cli): fence Environment hold retries by immutable UID

### DIFF
--- a/internal/cli/environment.go
+++ b/internal/cli/environment.go
@@ -10,6 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
+	"github.com/Chris-Cullins/swe-platform/internal/lifecycle"
 )
 
 func newEnvironmentCommand() *cobra.Command {
@@ -49,10 +50,20 @@ func newEnvironmentHoldCommand(enabled bool) *cobra.Command {
 
 func setEnvironmentHold(ctx context.Context, kube client.Client, key types.NamespacedName, enabled bool) (int64, error) {
 	revision := int64(0)
+	var pinnedUID types.UID
+	pinned := false
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		var environment platformv1alpha1.Environment
 		if err := kube.Get(ctx, key, &environment); err != nil {
 			return err
+		}
+		// Pin the immutable UID on the first successful read so a conflict
+		// retry cannot patch a same-name replacement incarnation.
+		if !pinned {
+			pinnedUID = environment.UID
+			pinned = true
+		} else if environment.UID != pinnedUID {
+			return lifecycle.ErrEnvironmentIncarnationChanged
 		}
 		if environment.Spec.Paused {
 			return fmt.Errorf("environment has a legacy pause awaiting controller migration")

--- a/internal/cli/environment_test.go
+++ b/internal/cli/environment_test.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
+	"github.com/Chris-Cullins/swe-platform/internal/lifecycle"
 )
 
 func TestSetEnvironmentHoldUsesMonotonicIdempotentPolicy(t *testing.T) {
@@ -95,6 +96,61 @@ func TestSetEnvironmentHoldRetriesConflictAndPreservesConcurrentLifecycleIntents
 		current.Spec.Lifecycle.Wake == nil || current.Spec.Lifecycle.Wake.ID != "wake-1" ||
 		current.Spec.Lifecycle.Suspend == nil || current.Spec.Lifecycle.Suspend.ID != "suspend-concurrent" {
 		t.Fatalf("concurrent lifecycle intent was lost: %#v", current.Spec.Lifecycle)
+	}
+}
+
+func TestSetEnvironmentHoldRejectsSameNameReplacementIncarnation(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	environment := &platformv1alpha1.Environment{}
+	environment.Name = "shared"
+	environment.Namespace = "ns"
+	environment.UID = "env-uid-old"
+	base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(environment).Build()
+	key := types.NamespacedName{Namespace: environment.Namespace, Name: environment.Name}
+	patches := 0
+	kube := interceptor.NewClient(base, interceptor.Funcs{Patch: func(ctx context.Context, underlying client.WithWatch, object client.Object, patch client.Patch, options ...client.PatchOption) error {
+		patches++
+		if patches == 1 {
+			// Between the first read and the retry, the original incarnation is
+			// deleted and a same-name replacement is created with a new UID.
+			var original platformv1alpha1.Environment
+			if err := underlying.Get(ctx, key, &original); err != nil {
+				return err
+			}
+			if err := underlying.Delete(ctx, &original); err != nil {
+				return err
+			}
+			replacement := &platformv1alpha1.Environment{}
+			replacement.Name = environment.Name
+			replacement.Namespace = environment.Namespace
+			replacement.UID = "env-uid-new"
+			if err := underlying.Create(ctx, replacement); err != nil {
+				return err
+			}
+			return apierrors.NewConflict(schema.GroupResource{Group: platformv1alpha1.GroupVersion.Group, Resource: "environments"}, object.GetName(), errors.New("simulated hold conflict"))
+		}
+		return underlying.Patch(ctx, object, patch, options...)
+	}})
+
+	revision, err := setEnvironmentHold(context.Background(), kube, key, true)
+	if err == nil || revision != 0 {
+		t.Fatalf("replacement incarnation = revision %d, error %v; want failure", revision, err)
+	}
+	if !errors.Is(err, lifecycle.ErrEnvironmentIncarnationChanged) {
+		t.Fatalf("error = %v; want incarnation-changed error", err)
+	}
+	if patches != 1 {
+		t.Fatalf("replacement incarnation patched %d times; want 1 (no retry patch)", patches)
+	}
+	var current platformv1alpha1.Environment
+	if err := base.Get(context.Background(), key, &current); err != nil {
+		t.Fatal(err)
+	}
+	if current.UID != "env-uid-new" || current.Spec.Lifecycle.Hold != nil {
+		t.Fatalf("replacement incarnation was mutated: uid=%q spec=%#v", current.UID, current.Spec.Lifecycle)
 	}
 }
 


### PR DESCRIPTION
## Summary

`setEnvironmentHold` (the `swe environment hold|release` command) re-GETs the Environment by namespace/name on every `RetryOnConflict` attempt without pinning the UID. If the original incarnation is deleted and a same-name replacement is created between retries, the user's hold/release intent can be applied to the replacement object (#123).

## Failure sequence

1. The command reads `ns/shared` with UID `old`.
2. Its optimistic-lock Patch conflicts.
3. Before retry, `old` is deleted and `ns/shared` is recreated with UID `new`.
4. The retry reads `new` and applies the stale hold/release intent to it.

## Change

Pin the immutable UID returned by the first successful read and reject any conflict retry that observes a different UID by returning the existing `lifecycle.ErrEnvironmentIncarnationChanged` sentinel. Because that error is not a conflict, `RetryOnConflict` stops immediately and the replacement receives no hold-policy mutation. Concurrent updates to the same UID still retry and merge lifecycle intents unchanged — the retry/merge path is preserved.

This reuses the established UID-fencing pattern from `internal/lifecycle/intent.go` (`patchIntent`) and the `lifecycle.ErrEnvironmentIncarnationChanged` sentinel already consumed by `internal/controlplane/terminal.go`. No new public API, CRD change, or abstraction is introduced.

## Behavior

- Hold/release conflict retries remain pinned to the first Environment UID.
- A same-name replacement causes a clear incarnation-changed error and receives no hold-policy mutation.
- Concurrent updates to the same UID still retry and preserve wake/suspend lifecycle intents.

## Validation

- `go test ./internal/cli/...` — focused tests pass, including the new `TestSetEnvironmentHoldRejectsSameNameReplacementIncarnation` and the existing same-UID conflict regression `TestSetEnvironmentHoldRetriesConflictAndPreservesConcurrentLifecycleIntents`.
- `go test ./internal/lifecycle/...` — passes (sentinel reused).
- `go vet ./internal/cli/...` — clean.
- `go build ./...` — clean.
- `make check-chart-crds` — no CRD diff.

Closes #123
