### PR TITLE
Require immutable Run UID for cancellation

### DIFF
--- a/charts/swe-platform/README.md
+++ b/charts/swe-platform/README.md
@@ -522,7 +522,10 @@ when the caller is separately authorized to get that exact Run and its immutable
 matches; otherwise the API returns a conflict without exposing it. Clients select either an
 existing Environment or a Project/Template allocation intent. Only the Run is created—the
 Run controller exclusively allocates or claims Environments. Cancellation monotonically sets
-`spec.cancel` and retries bounded Kubernetes update conflicts.
+`spec.cancel` and retries bounded Kubernetes update conflicts. Every cancellation body must
+include the expected immutable Run UID, for example `{"runUID":"<uid from the Run response>"}`.
+Missing or empty UIDs fail before resource resolution, and a UID that no longer matches a
+same-name Run replacement returns `409 Conflict`.
 
 Run and Environment responses omit raw CRDs, managed fields, conditions, transcript storage
 references, sandboxd/terminal endpoints, pod names, image IDs, and secrets. Environment

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -706,10 +706,12 @@ API_CREATE_STATUS=$(curl --silent --output /tmp/swe-platform-api-run.json --writ
 API_RETRY_STATUS=$(curl --silent --output /dev/null --write-out '%{http_code}' \
 	--cookie "$COOKIE_JAR" -H 'Origin: http://127.0.0.1:18080' -H 'Content-Type: application/json' \
 	-d "$API_RUN_BODY" http://127.0.0.1:18080/api/v1/namespaces/default/runs)
+API_RUN_UID=$(python3 -c 'import json; print(json.load(open("/tmp/swe-platform-api-run.json"))["uid"])')
 CSRF_STATUS=$(curl --silent --output /dev/null --write-out '%{http_code}' \
 	--cookie "$COOKIE_JAR" -X POST http://127.0.0.1:18080/api/v1/namespaces/default/runs/e2e-api-run/cancel)
 API_CANCEL_STATUS=$(curl --silent --output /dev/null --write-out '%{http_code}' \
-	--cookie "$COOKIE_JAR" -X POST -H 'Origin: http://127.0.0.1:18080' \
+	--cookie "$COOKIE_JAR" -X POST -H 'Origin: http://127.0.0.1:18080' -H 'Content-Type: application/json' \
+	-d "{\"runUID\":\"${API_RUN_UID}\"}" \
 	http://127.0.0.1:18080/api/v1/namespaces/default/runs/e2e-api-run/cancel)
 if [[ "$API_CREATE_STATUS" != "201" || "$API_RETRY_STATUS" != "200" || "$CSRF_STATUS" != "403" || "$API_CANCEL_STATUS" != "200" ]]; then
 	echo "FAIL: typed mutation API statuses create=${API_CREATE_STATUS} retry=${API_RETRY_STATUS} csrf=${CSRF_STATUS} cancel=${API_CANCEL_STATUS}"

--- a/internal/controlplane/api_contract.go
+++ b/internal/controlplane/api_contract.go
@@ -121,10 +121,9 @@ type RunWatchRelist struct {
 	Reason string `json:"reason"`
 }
 
-// CancelRunRequest optionally fences cancellation to one immutable Run.
-// An empty request remains supported for existing browser clients.
+// CancelRunRequest fences cancellation to one immutable Run.
 type CancelRunRequest struct {
-	RunUID string `json:"runUID,omitempty"`
+	RunUID string `json:"runUID"`
 }
 
 // RunTerminalAssociation is the exact server-validated Run-to-Environment

--- a/internal/controlplane/api_contract_test.go
+++ b/internal/controlplane/api_contract_test.go
@@ -87,9 +87,12 @@ func TestAPIContractFixturesAreCanonicalHandlerAndMapperOutput(t *testing.T) {
 			cancelled := run.DeepCopy()
 			cancelled.Spec.Cancel = true
 			resources := &fakeResources{cancel: runDTO(cancelled)}
-			request := httptest.NewRequest(http.MethodPost, "https://console.test/api/v1/namespaces/default/runs/fix-flaky-42/cancel", nil)
+			request := httptest.NewRequest(http.MethodPost, "https://console.test/api/v1/namespaces/default/runs/fix-flaky-42/cancel", bytes.NewReader(readCanonicalFixture(t, "cancel-run-request.json", nil)))
 			request.Header.Set("Authorization", "Bearer fixture")
 			NewServer(nil, ServerOptions{Access: &recordingAccess{}, Resources: resources}).Handler().ServeHTTP(w, request)
+			if resources.cancelUID != string(run.UID) {
+				t.Fatalf("cancel UID = %q, want %q", resources.cancelUID, run.UID)
+			}
 		}},
 		{name: "environment handler and mapper", fixture: "environment.json", status: http.StatusOK, contentType: "application/json", write: func(w http.ResponseWriter) {
 			resources := &fakeResources{environment: environmentDTO(environment)}
@@ -122,6 +125,20 @@ func TestCreateRunContractFixturePassesStrictRequestValidation(t *testing.T) {
 	request := httptest.NewRequest(http.MethodPost, "/api/v1/namespaces/default/runs", bytes.NewReader(fixture))
 	response := httptest.NewRecorder()
 	got, err := decodeCreateRun(response, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, expected) {
+		t.Fatalf("decoded request = %#v, want %#v", got, expected)
+	}
+}
+
+func TestCancelRunContractFixturePassesStrictRequestValidation(t *testing.T) {
+	var expected CancelRunRequest
+	fixture := readCanonicalFixture(t, "cancel-run-request.json", &expected)
+	request := httptest.NewRequest(http.MethodPost, "/api/v1/namespaces/default/runs/fix-flaky-42/cancel", bytes.NewReader(fixture))
+	response := httptest.NewRecorder()
+	got, err := decodeCancelRun(response, request)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/controlplane/resource_handlers.go
+++ b/internal/controlplane/resource_handlers.go
@@ -138,6 +138,10 @@ func (s *Server) handleCancelRun(w http.ResponseWriter, r *http.Request, namespa
 	}
 	request, err := decodeCancelRun(w, r)
 	if err != nil {
+		if errors.Is(err, errRunUIDRequired) {
+			writeProblem(w, http.StatusPreconditionRequired, "run-uid-required", "Run UID required", "runUID is required to cancel the exact Run")
+			return
+		}
 		writeProblem(w, http.StatusBadRequest, "invalid-request", "Invalid request", err.Error())
 		return
 	}
@@ -269,7 +273,7 @@ func decodeCancelRun(w http.ResponseWriter, r *http.Request) (CancelRunRequest, 
 	var request CancelRunRequest
 	if err := decoder.Decode(&request); err != nil {
 		if errors.Is(err, io.EOF) {
-			return request, nil
+			return request, errRunUIDRequired
 		}
 		var tooLarge *http.MaxBytesError
 		if errors.As(err, &tooLarge) {
@@ -280,8 +284,11 @@ func decodeCancelRun(w http.ResponseWriter, r *http.Request) (CancelRunRequest, 
 	if err := decoder.Decode(&struct{}{}); err != io.EOF {
 		return request, fmt.Errorf("request body must contain exactly one JSON object")
 	}
-	if len(request.RunUID) > 128 {
-		return request, fmt.Errorf("runUID must not exceed 128 bytes")
+	if request.RunUID == "" {
+		return request, errRunUIDRequired
+	}
+	if len(request.RunUID) > maxRunUIDLength {
+		return request, errRunUIDTooLong
 	}
 	return request, nil
 }

--- a/internal/controlplane/resource_handlers_test.go
+++ b/internal/controlplane/resource_handlers_test.go
@@ -206,14 +206,32 @@ func TestCreateCollisionAuthorizationAndIntent(t *testing.T) {
 	}
 }
 
-func TestCancelBodyResponseAndDelegation(t *testing.T) {
+func TestCancelRequiresBoundedUIDBeforeResourceResolution(t *testing.T) {
 	f := &fakeResources{cancel: Run{Name: "r", CancelRequested: true}}
 	s := NewServer(nil, ServerOptions{Access: &recordingAccess{}, Resources: f})
-	if w := resourceRequest(s, "POST", "/api/v1/namespaces/ns/runs/r/cancel", "x", ""); w.Code != 400 || len(f.calls) != 0 {
-		t.Fatalf("nonempty=%d calls=%v", w.Code, f.calls)
+	for _, test := range []struct {
+		name, body string
+		status     int
+		typeSuffix string
+	}{
+		{name: "missing", body: "", status: http.StatusPreconditionRequired, typeSuffix: "/run-uid-required"},
+		{name: "empty object", body: `{}`, status: http.StatusPreconditionRequired, typeSuffix: "/run-uid-required"},
+		{name: "empty UID", body: `{"runUID":""}`, status: http.StatusPreconditionRequired, typeSuffix: "/run-uid-required"},
+		{name: "malformed", body: "x", status: http.StatusBadRequest, typeSuffix: "/invalid-request"},
+		{name: "unknown field", body: `{"runUID":"uid","other":true}`, status: http.StatusBadRequest, typeSuffix: "/invalid-request"},
+		{name: "overlong UID", body: `{"runUID":"` + strings.Repeat("u", maxRunUIDLength+1) + `"}`, status: http.StatusBadRequest, typeSuffix: "/invalid-request"},
+		{name: "overlong body", body: `{"runUID":"uid"}` + strings.Repeat(" ", maxCancelRunBody), status: http.StatusBadRequest, typeSuffix: "/invalid-request"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			w := resourceRequest(s, "POST", "/api/v1/namespaces/ns/runs/r/cancel", test.body, "")
+			if w.Code != test.status || !strings.Contains(w.Body.String(), test.typeSuffix) || len(f.calls) != 0 {
+				t.Fatalf("response=%d %s calls=%v", w.Code, w.Body.String(), f.calls)
+			}
+		})
 	}
+
 	for range 2 {
-		w := resourceRequest(s, "POST", "/api/v1/namespaces/ns/runs/r/cancel", "", "")
+		w := resourceRequest(s, "POST", "/api/v1/namespaces/ns/runs/r/cancel", `{"runUID":"uid-1"}`, "")
 		if w.Code != 200 || !strings.Contains(w.Body.String(), `"cancelRequested":true`) {
 			t.Fatalf("response=%d %s", w.Code, w.Body.String())
 		}
@@ -221,9 +239,12 @@ func TestCancelBodyResponseAndDelegation(t *testing.T) {
 	if strings.Join(f.calls, ",") != "cancel,cancel" {
 		t.Fatalf("calls=%v", f.calls)
 	}
+	if f.cancelUID != "uid-1" {
+		t.Fatalf("cancel UID = %q", f.cancelUID)
+	}
 }
 
-func TestCancelTypedUIDConflictAndEmptyBodyCompatibility(t *testing.T) {
+func TestCancelUIDConflict(t *testing.T) {
 	f := &fakeResources{cancel: Run{Name: "r", CancelRequested: true}}
 	s := NewServer(nil, ServerOptions{Access: &recordingAccess{}, Resources: f})
 	w := resourceRequest(s, "POST", "/api/v1/namespaces/ns/runs/r/cancel", `{"runUID":"uid-1"}`, "")
@@ -235,10 +256,24 @@ func TestCancelTypedUIDConflictAndEmptyBodyCompatibility(t *testing.T) {
 	if w.Code != http.StatusConflict || !strings.Contains(w.Body.String(), `/run-uid-conflict"`) {
 		t.Fatalf("conflict = %d %s", w.Code, w.Body.String())
 	}
-	f.cancelErr = nil
-	w = resourceRequest(s, "POST", "/api/v1/namespaces/ns/runs/r/cancel", "", "")
-	if w.Code != http.StatusOK || f.cancelUID != "" {
-		t.Fatalf("empty cancel = %d, UID %q", w.Code, f.cancelUID)
+}
+
+func TestCancelChecksAuthorizationAndOriginBeforeUIDPrecondition(t *testing.T) {
+	f := &fakeResources{}
+	denied := &recordingAccess{err: errForbidden}
+	w := resourceRequest(NewServer(nil, ServerOptions{Access: denied, Resources: f}), "POST", "/api/v1/namespaces/ns/runs/r/cancel", "", "https://api.test")
+	if w.Code != http.StatusForbidden || len(denied.calls) != 1 || len(f.calls) != 0 {
+		t.Fatalf("denied response/access/resources = %d/%v/%v", w.Code, denied.calls, f.calls)
+	}
+
+	request := httptest.NewRequest(http.MethodPost, "https://api.test/api/v1/namespaces/ns/runs/r/cancel", nil)
+	request.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "session"})
+	request.Header.Set("Origin", "https://other.test")
+	response := httptest.NewRecorder()
+	access := &recordingAccess{}
+	NewServer(nil, ServerOptions{Access: access, Resources: f}).Handler().ServeHTTP(response, request)
+	if response.Code != http.StatusForbidden || len(access.calls) != 1 || len(f.calls) != 0 {
+		t.Fatalf("origin response/access/resources = %d/%v/%v", response.Code, access.calls, f.calls)
 	}
 }
 

--- a/internal/controlplane/resource_service.go
+++ b/internal/controlplane/resource_service.go
@@ -17,6 +17,8 @@ import (
 
 var (
 	errRunIntentConflict      = errors.New("run already exists with different immutable intent")
+	errRunUIDRequired         = errors.New("expected Run UID is required")
+	errRunUIDTooLong          = errors.New("expected Run UID exceeds 128 bytes")
 	errRunUIDConflict         = errors.New("run UID does not match the current Run")
 	errRunTerminalAssociation = errors.New("run is not associated with the exact environment")
 )
@@ -24,6 +26,7 @@ var (
 const (
 	runPromptPreviewRunes = 160
 	runAgentSummaryRunes  = 128
+	maxRunUIDLength       = 128
 )
 
 // ResourceService is the Kubernetes-independent resource API used by HTTP
@@ -148,13 +151,19 @@ func desiredRunSpec(request CreateRunRequest) platformv1alpha1.RunSpec {
 }
 
 func (s *KubernetesResourceService) CancelRun(ctx context.Context, namespace, name, expectedUID string) (Run, error) {
+	if expectedUID == "" {
+		return Run{}, errRunUIDRequired
+	}
+	if len(expectedUID) > maxRunUIDLength {
+		return Run{}, errRunUIDTooLong
+	}
 	key := types.NamespacedName{Namespace: namespace, Name: name}
 	for attempt := 0; attempt < 5; attempt++ {
 		var run platformv1alpha1.Run
 		if err := s.Client.Get(ctx, key, &run); err != nil {
 			return Run{}, err
 		}
-		if expectedUID != "" && string(run.UID) != expectedUID {
+		if string(run.UID) != expectedUID {
 			return Run{}, errRunUIDConflict
 		}
 		if run.Spec.Cancel {

--- a/internal/controlplane/resource_service_test.go
+++ b/internal/controlplane/resource_service_test.go
@@ -116,7 +116,7 @@ func TestResourceServiceCreateCollisionComparesFullRunSpec(t *testing.T) {
 
 func TestResourceServiceCancelIdempotentRetriesAndErrors(t *testing.T) {
 	scheme := resourceScheme(t)
-	run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns"}}
+	run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid"}}
 	base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(run).Build()
 	updates := 0
 	c := interceptor.NewClient(base, interceptor.Funcs{Update: func(ctx context.Context, underlying client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
@@ -127,11 +127,11 @@ func TestResourceServiceCancelIdempotentRetriesAndErrors(t *testing.T) {
 		return underlying.Update(ctx, obj, opts...)
 	}})
 	service := &KubernetesResourceService{Client: c}
-	got, err := service.CancelRun(context.Background(), "ns", "r", "")
+	got, err := service.CancelRun(context.Background(), "ns", "r", "run-uid")
 	if err != nil || !got.CancelRequested || updates != 3 {
 		t.Fatalf("run = %#v, updates = %d, err = %v", got, updates, err)
 	}
-	if _, err := service.CancelRun(context.Background(), "ns", "r", ""); err != nil || updates != 3 {
+	if _, err := service.CancelRun(context.Background(), "ns", "r", "run-uid"); err != nil || updates != 3 {
 		t.Fatalf("idempotent updates = %d, err = %v", updates, err)
 	}
 
@@ -143,7 +143,7 @@ func TestResourceServiceCancelIdempotentRetriesAndErrors(t *testing.T) {
 			return final
 		},
 	})
-	_, err = (&KubernetesResourceService{Client: alwaysConflict}).CancelRun(context.Background(), "ns", "r", "")
+	_, err = (&KubernetesResourceService{Client: alwaysConflict}).CancelRun(context.Background(), "ns", "r", "run-uid")
 	if err != final || attempts != 5 {
 		t.Fatalf("final error = %v, attempts = %d", err, attempts)
 	}
@@ -158,6 +158,25 @@ func TestResourceServiceCancelRunFencesEveryRetryByUID(t *testing.T) {
 	newRun := func(uid types.UID, cancel bool) *platformv1alpha1.Run {
 		return &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: uid}, Spec: platformv1alpha1.RunSpec{Cancel: cancel}}
 	}
+
+	t.Run("missing and overlong UIDs fail before lookup", func(t *testing.T) {
+		gets := 0
+		base := fake.NewClientBuilder().WithScheme(scheme).WithObjects(newRun("current", false)).Build()
+		wrapped := interceptor.NewClient(base, interceptor.Funcs{Get: func(context.Context, client.WithWatch, client.ObjectKey, client.Object, ...client.GetOption) error {
+			gets++
+			return nil
+		}})
+		service := &KubernetesResourceService{Client: wrapped}
+		if _, err := service.CancelRun(context.Background(), "ns", "r", ""); !errors.Is(err, errRunUIDRequired) {
+			t.Fatalf("missing UID error = %v", err)
+		}
+		if _, err := service.CancelRun(context.Background(), "ns", "r", strings.Repeat("u", maxRunUIDLength+1)); !errors.Is(err, errRunUIDTooLong) {
+			t.Fatalf("overlong UID error = %v", err)
+		}
+		if gets != 0 {
+			t.Fatalf("invalid preconditions performed %d lookups", gets)
+		}
+	})
 
 	t.Run("wrong UID conflicts without mutation", func(t *testing.T) {
 		updates := 0

--- a/internal/controlplane/testdata/contracts/cancel-run-request.json
+++ b/internal/controlplane/testdata/contracts/cancel-run-request.json
@@ -1,0 +1,1 @@
+{"runUID":"eb7e3ff7-8117-4caf-912d-167b70eaee21"}

--- a/internal/controlplaneclient/resources.go
+++ b/internal/controlplaneclient/resources.go
@@ -186,10 +186,7 @@ func (c *Client) CreateRun(ctx context.Context, namespace string, value controlp
 // CancelRun requests idempotent cancellation of an exact namespaced Run.
 func (c *Client) CancelRun(ctx context.Context, namespace, name, expectedUID string) (controlplane.Run, error) {
 	var run controlplane.Run
-	var body any
-	if expectedUID != "" {
-		body = controlplane.CancelRunRequest{RunUID: expectedUID}
-	}
+	body := controlplane.CancelRunRequest{RunUID: expectedUID}
 	err := c.sendJSON(ctx, http.MethodPost, c.Endpoint("api", "v1", "namespaces", namespace, "runs", name, "cancel"), body, &run)
 	return run, err
 }

--- a/internal/controlplaneclient/resources_test.go
+++ b/internal/controlplaneclient/resources_test.go
@@ -86,6 +86,27 @@ func TestResourceClientUsesAuthenticatedTypedEndpoints(t *testing.T) {
 	}
 }
 
+func TestResourceClientAlwaysSendsCancelUIDPrecondition(t *testing.T) {
+	var body []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		body, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusPreconditionRequired)
+		_, _ = io.WriteString(w, `{"title":"Run UID required","status":428}`)
+	}))
+	defer server.Close()
+	client, _ := New(server.URL, "token", server.Client())
+	_, err := client.CancelRun(context.Background(), "ns", "run", "")
+	var problem *ProblemError
+	if !errors.As(err, &problem) || string(body) != `{"runUID":""}` {
+		t.Fatalf("error/body = %#v/%s", err, body)
+	}
+}
+
 func TestResourceClientSurfacesAPIStatusesWithoutCredentialDisclosure(t *testing.T) {
 	statuses := []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusConflict, http.StatusServiceUnavailable}
 	for _, status := range statuses {


### PR DESCRIPTION
## Summary
- require a non-empty, bounded immutable Run UID for every HTTP cancellation
- enforce the same precondition before resource-service lookup and recheck it on every conflict retry
- update the typed client, contract fixture, docs, and e2e request to send the UID fence

## Ordering and errors
- exact-name authorization remains first
- cookie mutation-origin enforcement remains second
- missing/empty UID returns 428 before resource resolution
- malformed/unknown/overlong requests remain 400
- stale UID remains 409 without mutating a replacement

## Validation
- `go test ./internal/controlplane ./internal/controlplaneclient ./internal/cli`
- `make test`
- `make vet`
- `make build`
- `npm run lint`
- `npm run typecheck`
- `npm test -- --run` (69 tests)
- `npm run build`
- `bash -n hack/e2e.sh`
- `git diff --check`

Closes #121