### PR TITLE
Fence terminal activity to the exact execution

### DIFF
--- a/internal/controlplane/terminal.go
+++ b/internal/controlplane/terminal.go
@@ -270,8 +270,24 @@ func (d KubernetesTerminalDialer) heartbeatActivity(ctx context.Context, key typ
 			}
 		case <-timer.C:
 			for {
+				revision, held, err := d.readTerminalPolicy(ctx, key, expectedUID, boundExecution)
+				if err != nil {
+					if errors.Is(err, errTerminalEnvironmentIncarnationChanged) {
+						revoke()
+						return
+					}
+					timer.Reset(retryInterval)
+					break
+				}
+				if held || revision < policyRevision {
+					revoke()
+					return
+				}
+				if revision > policyRevision {
+					policyRevision = revision
+				}
 				environment := platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Namespace: key.Namespace, Name: key.Name}}
-				err := d.markActive(ctx, &environment, expectedUID, policyRevision)
+				err = d.markActive(ctx, &environment, expectedUID, policyRevision)
 				if err == nil {
 					timer.Reset(interval)
 					break

--- a/internal/controlplane/terminal.go
+++ b/internal/controlplane/terminal.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -352,17 +351,11 @@ func (d KubernetesTerminalDialer) readTerminalPolicy(ctx context.Context, key ty
 	}
 	if boundExecution != nil {
 		if execution, bound := boundExecution(); bound {
-			if environment.UID != execution.EnvironmentUID || environment.Status.Lifecycle.Suspended || environment.Status.Lifecycle.Epoch != execution.LifecycleEpoch || environment.Status.PodName != execution.PodName {
-				return 0, false, errTerminalEnvironmentIncarnationChanged
-			}
-			var pod corev1.Pod
-			if err := d.Client.Get(ctx, types.NamespacedName{Namespace: key.Namespace, Name: execution.PodName}, &pod); err != nil {
-				if apierrors.IsNotFound(err) {
-					return 0, false, errTerminalEnvironmentIncarnationChanged
-				}
+			current, err := (sandboxclient.Connector{Reader: d.Client}).TerminalExecutionCurrent(ctx, key.Namespace, key.Name, execution)
+			if err != nil {
 				return 0, false, err
 			}
-			if pod.UID != execution.PodUID {
+			if !current {
 				return 0, false, errTerminalEnvironmentIncarnationChanged
 			}
 		}

--- a/internal/controlplane/terminal.go
+++ b/internal/controlplane/terminal.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -56,9 +57,10 @@ type activeTerminalConnection struct {
 }
 
 type terminalConnectionLease struct {
-	mu     sync.Mutex
-	closer io.Closer
-	closed bool
+	mu        sync.Mutex
+	closer    io.Closer
+	execution sandboxclient.TerminalExecution
+	closed    bool
 }
 
 type closeFunc func() error
@@ -70,16 +72,23 @@ func (c *activeTerminalConnection) Close() error {
 	return c.Closer.Close()
 }
 
-func (l *terminalConnectionLease) attach(closer io.Closer) bool {
+func (l *terminalConnectionLease) attach(closer io.Closer, execution sandboxclient.TerminalExecution) bool {
 	l.mu.Lock()
 	if !l.closed {
 		l.closer = closer
+		l.execution = execution
 		l.mu.Unlock()
 		return true
 	}
 	l.mu.Unlock()
 	_ = closer.Close()
 	return false
+}
+
+func (l *terminalConnectionLease) boundExecution() (sandboxclient.TerminalExecution, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.execution, l.closer != nil && !l.closed
 }
 
 func (l *terminalConnectionLease) Close() error {
@@ -138,7 +147,7 @@ func (d KubernetesTerminalDialer) dialTerminal(ctx context.Context, namespace, n
 		}
 	}()
 	connectionLease := &terminalConnectionLease{}
-	go d.heartbeatActivity(heartbeatContext, types.NamespacedName{Namespace: namespace, Name: name}, expectedUID, policyRevision, heartbeatInterval, association, func() { _ = connectionLease.Close() })
+	go d.heartbeatActivity(heartbeatContext, types.NamespacedName{Namespace: namespace, Name: name}, expectedUID, policyRevision, heartbeatInterval, association, connectionLease.boundExecution, func() { _ = connectionLease.Close() })
 	if err := d.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &environment); err != nil {
 		return nil, nil, nil, fmt.Errorf("refresh environment lifecycle: %w", err)
 	}
@@ -174,7 +183,7 @@ func (d KubernetesTerminalDialer) dialTerminal(ctx context.Context, namespace, n
 	if !platformv1alpha1.IsEnvironmentReady(&environment) {
 		return nil, nil, nil, fmt.Errorf("environment is not ready for its current generation")
 	}
-	terminal, health, closeConnection, err := (sandboxclient.Connector{Reader: d.Client}).DialTerminal(ctx, namespace, name, expectedUID)
+	terminal, health, execution, closeConnection, err := (sandboxclient.Connector{Reader: d.Client}).DialTerminal(ctx, namespace, name, expectedUID)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("connect to sandboxd: %w", err)
 	}
@@ -184,7 +193,7 @@ func (d KubernetesTerminalDialer) dialTerminal(ctx context.Context, namespace, n
 			return nil, nil, nil, err
 		}
 	}
-	if !connectionLease.attach(closeFunc(closeConnection)) {
+	if !connectionLease.attach(closeFunc(closeConnection), execution) {
 		return nil, nil, nil, fmt.Errorf("environment became explicitly held while opening terminal")
 	}
 	closer := &activeTerminalConnection{Closer: connectionLease, cancel: cancelHeartbeat}
@@ -222,7 +231,7 @@ func (d KubernetesTerminalDialer) activityHeartbeatInterval(ctx context.Context,
 	return timeout / 2, nil
 }
 
-func (d KubernetesTerminalDialer) heartbeatActivity(ctx context.Context, key types.NamespacedName, expectedUID types.UID, policyRevision int64, interval time.Duration, association *RunTerminalAssociation, revoke func()) {
+func (d KubernetesTerminalDialer) heartbeatActivity(ctx context.Context, key types.NamespacedName, expectedUID types.UID, policyRevision int64, interval time.Duration, association *RunTerminalAssociation, boundExecution func() (sandboxclient.TerminalExecution, bool), revoke func()) {
 	retryInterval := interval / 4
 	if retryInterval <= 0 || retryInterval > time.Second {
 		retryInterval = time.Second
@@ -245,7 +254,7 @@ func (d KubernetesTerminalDialer) heartbeatActivity(ctx context.Context, key typ
 					continue
 				}
 			}
-			revision, held, err := d.readHoldPolicy(ctx, key, expectedUID)
+			revision, held, err := d.readTerminalPolicy(ctx, key, expectedUID, boundExecution)
 			if err != nil {
 				if errors.Is(err, errTerminalEnvironmentIncarnationChanged) {
 					revoke()
@@ -333,7 +342,7 @@ func (d KubernetesTerminalDialer) holdPolicyPollInterval() time.Duration {
 	return terminalPolicyPollInterval
 }
 
-func (d KubernetesTerminalDialer) readHoldPolicy(ctx context.Context, key types.NamespacedName, expectedUID types.UID) (int64, bool, error) {
+func (d KubernetesTerminalDialer) readTerminalPolicy(ctx context.Context, key types.NamespacedName, expectedUID types.UID, boundExecution func() (sandboxclient.TerminalExecution, bool)) (int64, bool, error) {
 	var environment platformv1alpha1.Environment
 	if err := d.Client.Get(ctx, key, &environment); err != nil {
 		return 0, false, err
@@ -341,12 +350,29 @@ func (d KubernetesTerminalDialer) readHoldPolicy(ctx context.Context, key types.
 	if environment.UID != expectedUID {
 		return 0, false, errTerminalEnvironmentIncarnationChanged
 	}
+	if boundExecution != nil {
+		if execution, bound := boundExecution(); bound {
+			if environment.UID != execution.EnvironmentUID || environment.Status.Lifecycle.Suspended || environment.Status.Lifecycle.Epoch != execution.LifecycleEpoch || environment.Status.PodName != execution.PodName {
+				return 0, false, errTerminalEnvironmentIncarnationChanged
+			}
+			var pod corev1.Pod
+			if err := d.Client.Get(ctx, types.NamespacedName{Namespace: key.Namespace, Name: execution.PodName}, &pod); err != nil {
+				if apierrors.IsNotFound(err) {
+					return 0, false, errTerminalEnvironmentIncarnationChanged
+				}
+				return 0, false, err
+			}
+			if pod.UID != execution.PodUID {
+				return 0, false, errTerminalEnvironmentIncarnationChanged
+			}
+		}
+	}
 	revision := lifecycle.HoldPolicyRevision(&environment)
 	return revision, environment.Spec.Lifecycle.Hold != nil && environment.Spec.Lifecycle.Hold.Enabled, nil
 }
 
 func (d KubernetesTerminalDialer) refreshHoldPolicy(ctx context.Context, key types.NamespacedName, expectedUID types.UID, previousRevision int64) (int64, bool, error) {
-	revision, held, err := d.readHoldPolicy(ctx, key, expectedUID)
+	revision, held, err := d.readTerminalPolicy(ctx, key, expectedUID, nil)
 	if err != nil {
 		return 0, false, err
 	}

--- a/internal/controlplane/terminal_test.go
+++ b/internal/controlplane/terminal_test.go
@@ -36,6 +36,7 @@ import (
 
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
 	"github.com/Chris-Cullins/swe-platform/internal/lifecycle"
+	"github.com/Chris-Cullins/swe-platform/internal/sandboxclient"
 	sandboxdauth "github.com/Chris-Cullins/swe-platform/sandboxd/auth"
 	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
 )
@@ -391,7 +392,7 @@ func TestTerminalHeartbeatRecoversAfterTransientGetFailure(t *testing.T) {
 	dialer := KubernetesTerminalDialer{Client: transient}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 0, 5*time.Millisecond, nil, func() {})
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 0, 5*time.Millisecond, nil, nil, func() {})
 
 	deadline := time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {
@@ -423,7 +424,7 @@ func TestTerminalHeartbeatAdoptsNewerDisabledHoldRevision(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	revoked := atomic.Bool{}
-	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 1, 20*time.Millisecond, nil, func() { revoked.Store(true) })
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 1, 20*time.Millisecond, nil, nil, func() { revoked.Store(true) })
 
 	var updated platformv1alpha1.Environment
 	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(environment), &updated); err != nil {
@@ -457,10 +458,10 @@ func TestTerminalHeartbeatRevokesConnectionWhenHoldEnabled(t *testing.T) {
 	defer cancel()
 	closed := make(chan struct{})
 	lease := &terminalConnectionLease{}
-	if !lease.attach(closeFunc(func() error { close(closed); return nil })) {
+	if !lease.attach(closeFunc(func() error { close(closed); return nil }), sandboxclient.TerminalExecution{}) {
 		t.Fatal("failed to attach test terminal connection")
 	}
-	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 1, time.Hour, nil, func() { _ = lease.Close() })
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 1, time.Hour, nil, nil, func() { _ = lease.Close() })
 
 	var updated platformv1alpha1.Environment
 	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(environment), &updated); err != nil {
@@ -498,7 +499,7 @@ func TestTerminalPolicyPollRetriesTransientFailuresAndRevokesRecoveredHold(t *te
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	closed := make(chan struct{})
-	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 1, time.Hour, nil, func() { close(closed) })
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 1, time.Hour, nil, nil, func() { close(closed) })
 
 	for range 2 {
 		select {
@@ -539,10 +540,10 @@ func TestTerminalHeartbeatRevokesConnectionForReplacementUID(t *testing.T) {
 	defer cancel()
 	closed := make(chan struct{})
 	lease := &terminalConnectionLease{}
-	if !lease.attach(closeFunc(func() error { close(closed); return nil })) {
+	if !lease.attach(closeFunc(func() error { close(closed); return nil }), sandboxclient.TerminalExecution{}) {
 		t.Fatal("failed to attach test terminal connection")
 	}
-	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 0, time.Hour, nil, func() { _ = lease.Close() })
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 0, time.Hour, nil, nil, func() { _ = lease.Close() })
 
 	if err := kubeClient.Delete(context.Background(), environment); err != nil {
 		t.Fatal(err)
@@ -562,6 +563,132 @@ func TestTerminalHeartbeatRevokesConnectionForReplacementUID(t *testing.T) {
 	}
 	if requests := lifecycle.ActivityRequests(&retained); len(requests) != 0 {
 		t.Fatalf("replacement received stale terminal activity: %#v", requests)
+	}
+}
+
+func TestTerminalHeartbeatRevokesConnectionWhenBoundExecutionChanges(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(context.Context, client.Client, *platformv1alpha1.Environment, *corev1.Pod) error
+	}{
+		{name: "suspension", mutate: func(ctx context.Context, kubeClient client.Client, environment *platformv1alpha1.Environment, _ *corev1.Pod) error {
+			var updated platformv1alpha1.Environment
+			if err := kubeClient.Get(ctx, client.ObjectKeyFromObject(environment), &updated); err != nil {
+				return err
+			}
+			updated.Status.Lifecycle.Suspended = true
+			return kubeClient.Status().Update(ctx, &updated)
+		}},
+		{name: "epoch", mutate: func(ctx context.Context, kubeClient client.Client, environment *platformv1alpha1.Environment, _ *corev1.Pod) error {
+			var updated platformv1alpha1.Environment
+			if err := kubeClient.Get(ctx, client.ObjectKeyFromObject(environment), &updated); err != nil {
+				return err
+			}
+			updated.Status.Lifecycle.Epoch++
+			return kubeClient.Status().Update(ctx, &updated)
+		}},
+		{name: "same-name Pod UID replacement", mutate: func(ctx context.Context, kubeClient client.Client, _ *platformv1alpha1.Environment, pod *corev1.Pod) error {
+			if err := kubeClient.Delete(ctx, pod); err != nil {
+				return err
+			}
+			replacement := pod.DeepCopy()
+			replacement.ResourceVersion = ""
+			replacement.UID = "pod-uid-2"
+			return kubeClient.Create(ctx, replacement)
+		}},
+		{name: "Pod NotFound", mutate: func(ctx context.Context, kubeClient client.Client, _ *platformv1alpha1.Environment, pod *corev1.Pod) error {
+			return kubeClient.Delete(ctx, pod)
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			if err := corev1.AddToScheme(scheme); err != nil {
+				t.Fatal(err)
+			}
+			if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+				t.Fatal(err)
+			}
+			environment := &platformv1alpha1.Environment{
+				ObjectMeta: metav1.ObjectMeta{Name: "env-1", Namespace: "project-1", UID: "env-uid", Generation: 1},
+				Status:     platformv1alpha1.EnvironmentStatus{Lifecycle: platformv1alpha1.EnvironmentLifecycleStatus{Epoch: 4}},
+			}
+			applyReadyTerminalStatus(environment, "env-env-1")
+			pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: environment.Status.PodName, Namespace: environment.Namespace, UID: "pod-uid-1"}}
+			baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment, pod).Build()
+			kubeClient := &activityCountingClient{Client: baseClient}
+			dialer := KubernetesTerminalDialer{Client: kubeClient, policyPollInterval: time.Millisecond}
+			lease := &terminalConnectionLease{}
+			closed := make(chan struct{})
+			execution := sandboxclient.TerminalExecution{EnvironmentUID: environment.UID, LifecycleEpoch: 4, PodName: pod.Name, PodUID: pod.UID}
+			if !lease.attach(closeFunc(func() error { close(closed); return nil }), execution) {
+				t.Fatal("failed to bind terminal execution")
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 0, 40*time.Millisecond, nil, lease.boundExecution, func() { _ = lease.Close() })
+
+			if err := test.mutate(context.Background(), baseClient, environment, pod); err != nil {
+				t.Fatal(err)
+			}
+			select {
+			case <-closed:
+			case <-time.After(time.Second):
+				t.Fatal("bound execution change did not revoke terminal")
+			}
+			writes := kubeClient.count()
+			time.Sleep(80 * time.Millisecond)
+			if got := kubeClient.count(); got != writes {
+				t.Fatalf("stale terminal activity continued after replacement: got %d writes, want %d", got, writes)
+			}
+		})
+	}
+}
+
+func TestTerminalExecutionPolicyPollRetriesTransientPodRead(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	environment := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "env-1", Namespace: "project-1", UID: "env-uid", Generation: 1},
+		Status:     platformv1alpha1.EnvironmentStatus{Lifecycle: platformv1alpha1.EnvironmentLifecycleStatus{Epoch: 2}},
+	}
+	applyReadyTerminalStatus(environment, "env-env-1")
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: environment.Status.PodName, Namespace: environment.Namespace, UID: "pod-uid"}}
+	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment, pod).Build()
+	failed := make(chan struct{}, 1)
+	kubeClient := &transientPodGetClient{Client: baseClient, failures: 1, failed: failed}
+	dialer := KubernetesTerminalDialer{Client: kubeClient, policyPollInterval: time.Millisecond}
+	lease := &terminalConnectionLease{}
+	closed := make(chan struct{})
+	execution := sandboxclient.TerminalExecution{EnvironmentUID: environment.UID, LifecycleEpoch: 2, PodName: pod.Name, PodUID: pod.UID}
+	if !lease.attach(closeFunc(func() error { close(closed); return nil }), execution) {
+		t.Fatal("failed to bind terminal execution")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 0, time.Hour, nil, lease.boundExecution, func() { _ = lease.Close() })
+
+	select {
+	case <-failed:
+	case <-time.After(time.Second):
+		t.Fatal("policy poll did not read bound Pod")
+	}
+	select {
+	case <-closed:
+		t.Fatal("transient Pod read revoked terminal")
+	default:
+	}
+	if err := baseClient.Delete(context.Background(), pod); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("policy poll did not revoke after Pod disappeared")
 	}
 }
 
@@ -635,7 +762,7 @@ func TestRunTerminalHeartbeatRevokesAfterAssociationLoss(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	revoked := make(chan struct{})
-	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 0, time.Hour, association, func() { close(revoked) })
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 0, time.Hour, association, nil, func() { close(revoked) })
 
 	var updated platformv1alpha1.Environment
 	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(environment), &updated); err != nil {
@@ -675,6 +802,26 @@ type transientTerminalGetClient struct {
 	getFailures    int
 	updateFailures int
 	failedGets     chan<- struct{}
+}
+
+type transientPodGetClient struct {
+	client.Client
+	mu       sync.Mutex
+	failures int
+	failed   chan<- struct{}
+}
+
+func (c *transientPodGetClient) Get(ctx context.Context, key client.ObjectKey, object client.Object, options ...client.GetOption) error {
+	if _, ok := object.(*corev1.Pod); ok {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		if c.failures > 0 {
+			c.failures--
+			c.failed <- struct{}{}
+			return errors.New("transient Pod API failure")
+		}
+	}
+	return c.Client.Get(ctx, key, object, options...)
 }
 
 func (c *transientTerminalGetClient) Get(ctx context.Context, key client.ObjectKey, object client.Object, options ...client.GetOption) error {

--- a/internal/controlplane/terminal_test.go
+++ b/internal/controlplane/terminal_test.go
@@ -616,7 +616,9 @@ func TestTerminalHeartbeatRevokesConnectionWhenBoundExecutionChanges(t *testing.
 			pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: environment.Status.PodName, Namespace: environment.Namespace, UID: "pod-uid-1"}}
 			baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment, pod).Build()
 			kubeClient := &activityCountingClient{Client: baseClient}
-			dialer := KubernetesTerminalDialer{Client: kubeClient, policyPollInterval: time.Millisecond}
+			// Delay the ordinary policy poll so only the activity timer's
+			// immediate execution check can revoke this stale lease.
+			dialer := KubernetesTerminalDialer{Client: kubeClient, policyPollInterval: time.Hour}
 			lease := &terminalConnectionLease{}
 			closed := make(chan struct{})
 			execution := sandboxclient.TerminalExecution{EnvironmentUID: environment.UID, LifecycleEpoch: 4, PodName: pod.Name, PodUID: pod.UID}
@@ -625,7 +627,7 @@ func TestTerminalHeartbeatRevokesConnectionWhenBoundExecutionChanges(t *testing.
 			}
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 0, 40*time.Millisecond, nil, lease.boundExecution, func() { _ = lease.Close() })
+			go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 0, 10*time.Millisecond, nil, lease.boundExecution, func() { _ = lease.Close() })
 
 			if err := test.mutate(context.Background(), baseClient, environment, pod); err != nil {
 				t.Fatal(err)
@@ -635,10 +637,8 @@ func TestTerminalHeartbeatRevokesConnectionWhenBoundExecutionChanges(t *testing.
 			case <-time.After(time.Second):
 				t.Fatal("bound execution change did not revoke terminal")
 			}
-			writes := kubeClient.count()
-			time.Sleep(80 * time.Millisecond)
-			if got := kubeClient.count(); got != writes {
-				t.Fatalf("stale terminal activity continued after replacement: got %d writes, want %d", got, writes)
+			if writes := kubeClient.count(); writes != 0 {
+				t.Fatalf("stale terminal activity reached replacement execution: got %d writes, want 0", writes)
 			}
 		})
 	}

--- a/internal/sandboxclient/process.go
+++ b/internal/sandboxclient/process.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,9 +32,9 @@ type Connector struct {
 	Reader client.Reader
 }
 
-// TerminalExecution identifies the exact backend execution reached by a
-// terminal connection. PodName locates the backend, while PodUID is its
-// immutable execution fence because Environment Pod names are reused.
+// TerminalExecution is the connector-owned identity of the exact backend
+// execution reached by a terminal connection. Consumers retain it opaquely and
+// ask the Connector whether it is still current.
 type TerminalExecution struct {
 	EnvironmentUID types.UID
 	LifecycleEpoch int64
@@ -74,6 +75,31 @@ func (c Connector) DialTerminal(ctx context.Context, namespace, environment stri
 		return nil, nil, TerminalExecution{}, nil, fmt.Errorf("environment execution changed while resolving terminal endpoint")
 	}
 	return sandboxdv1.NewTerminalServiceClient(conn), sandboxdv1.NewHealthServiceClient(conn), execution, conn.Close, nil
+}
+
+// TerminalExecutionCurrent reports whether execution is still the active
+// backend for its Environment. Backend-specific identity checks stay behind
+// the connector boundary; API read failures remain retryable by the caller.
+func (c Connector) TerminalExecutionCurrent(ctx context.Context, namespace, environment string, execution TerminalExecution) (bool, error) {
+	var currentEnvironment platformv1alpha1.Environment
+	if err := c.Reader.Get(ctx, types.NamespacedName{Namespace: namespace, Name: environment}, &currentEnvironment); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if currentEnvironment.UID != execution.EnvironmentUID || currentEnvironment.Spec.Paused || currentEnvironment.Status.Lifecycle.Suspended ||
+		currentEnvironment.Status.Lifecycle.Epoch != execution.LifecycleEpoch || currentEnvironment.Status.PodName != execution.PodName {
+		return false, nil
+	}
+	var currentPod corev1.Pod
+	if err := c.Reader.Get(ctx, types.NamespacedName{Namespace: namespace, Name: execution.PodName}, &currentPod); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return currentPod.UID == execution.PodUID, nil
 }
 
 // DialProcess resolves the exact Environment UID immediately before dialing

--- a/internal/sandboxclient/process.go
+++ b/internal/sandboxclient/process.go
@@ -31,22 +31,49 @@ type Connector struct {
 	Reader client.Reader
 }
 
+// TerminalExecution identifies the exact backend execution reached by a
+// terminal connection. PodName locates the backend, while PodUID is its
+// immutable execution fence because Environment Pod names are reused.
+type TerminalExecution struct {
+	EnvironmentUID types.UID
+	LifecycleEpoch int64
+	PodName        string
+	PodUID         types.UID
+}
+
 // DialTerminal resolves the current ready Environment incarnation and returns
 // terminal and health clients sharing one authenticated, pod-pinned connection.
-func (c Connector) DialTerminal(ctx context.Context, namespace, environment string, environmentUID types.UID) (sandboxdv1.TerminalServiceClient, sandboxdv1.HealthServiceClient, func() error, error) {
+func (c Connector) DialTerminal(ctx context.Context, namespace, environment string, environmentUID types.UID) (sandboxdv1.TerminalServiceClient, sandboxdv1.HealthServiceClient, TerminalExecution, func() error, error) {
 	env, pod, err := c.resolvePod(ctx, namespace, environment, environmentUID, nil)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, TerminalExecution{}, nil, err
 	}
 	dialOptions, err := DialOptions(pod)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, TerminalExecution{}, nil, err
 	}
 	conn, err := grpc.NewClient(env.Status.Endpoints.Sandboxd, dialOptions...)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, TerminalExecution{}, nil, err
 	}
-	return sandboxdv1.NewTerminalServiceClient(conn), sandboxdv1.NewHealthServiceClient(conn), conn.Close, nil
+	execution := TerminalExecution{
+		EnvironmentUID: env.UID,
+		LifecycleEpoch: env.Status.Lifecycle.Epoch,
+		PodName:        pod.Name,
+		PodUID:         pod.UID,
+	}
+	// Re-read after pinning the endpoint and credentials. A lifecycle transition
+	// or same-name Pod replacement racing the dial must not produce an attachment
+	// whose independent activity heartbeat can outlive that execution.
+	currentEnvironment, currentPod, err := c.resolvePod(ctx, namespace, environment, environmentUID, &execution.LifecycleEpoch)
+	if err != nil || currentEnvironment.Status.PodName != execution.PodName || currentPod.UID != execution.PodUID {
+		_ = conn.Close()
+		if err != nil {
+			return nil, nil, TerminalExecution{}, nil, fmt.Errorf("environment execution changed while resolving terminal endpoint: %w", err)
+		}
+		return nil, nil, TerminalExecution{}, nil, fmt.Errorf("environment execution changed while resolving terminal endpoint")
+	}
+	return sandboxdv1.NewTerminalServiceClient(conn), sandboxdv1.NewHealthServiceClient(conn), execution, conn.Close, nil
 }
 
 // DialProcess resolves the exact Environment UID immediately before dialing

--- a/internal/sandboxclient/process_test.go
+++ b/internal/sandboxclient/process_test.go
@@ -24,6 +24,81 @@ import (
 	sandboxdauth "github.com/Chris-Cullins/swe-platform/sandboxd/auth"
 )
 
+func TestDialTerminalBindsExactExecutionAfterFinalRead(t *testing.T) {
+	const identity = "pod-a.sandboxd.swe.dev"
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	environment := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "environment", Namespace: "ns", UID: "env-uid"},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "default"},
+		Status: platformv1alpha1.EnvironmentStatus{
+			Lifecycle: platformv1alpha1.EnvironmentLifecycleStatus{Epoch: 7},
+			Phase:     platformv1alpha1.EnvironmentPhaseReady,
+			PodName:   "env-environment",
+			Endpoints: platformv1alpha1.EnvironmentEndpoints{Sandboxd: "10.0.0.1:50051"},
+			Conditions: []metav1.Condition{{
+				Type: platformv1alpha1.EnvironmentConditionReady, Status: metav1.ConditionTrue,
+				Reason: "SandboxdReady", Message: "sandboxd is ready",
+			}},
+		},
+	}
+	template := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: environment.Namespace}}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: environment.Status.PodName, Namespace: environment.Namespace, UID: "pod-uid-1",
+			Annotations: map[string]string{
+				sandboxdauth.IdentityAnnotation: identity,
+				sandboxdauth.TrustAnnotation:    string(processTestCertificate(t, identity)),
+				sandboxdauth.TokenAnnotation:    "terminal-token",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: platformv1alpha1.GroupVersion.String(), Kind: "Environment", Name: environment.Name,
+				UID: environment.UID, Controller: processTestPtr(true),
+			}},
+		},
+		Status: corev1.PodStatus{
+			PodIP:      "10.0.0.1",
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+		},
+	}
+	newClient := func() client.Client {
+		return fake.NewClientBuilder().WithScheme(scheme).WithObjects(environment.DeepCopy(), template.DeepCopy(), pod.DeepCopy()).Build()
+	}
+
+	terminal, health, execution, closeConnection, err := (Connector{Reader: newClient()}).DialTerminal(context.Background(), environment.Namespace, environment.Name, environment.UID)
+	if err != nil || terminal == nil || health == nil || closeConnection == nil {
+		t.Fatalf("valid terminal dial: terminal nil=%t, health nil=%t, close nil=%t, error=%v", terminal == nil, health == nil, closeConnection == nil, err)
+	}
+	if execution.EnvironmentUID != environment.UID || execution.LifecycleEpoch != 7 || execution.PodName != pod.Name || execution.PodUID != pod.UID {
+		t.Fatalf("terminal execution = %#v", execution)
+	}
+	if err := closeConnection(); err != nil {
+		t.Fatal(err)
+	}
+
+	epochRace := &environmentChangingReader{Reader: newClient(), mutate: func(current *platformv1alpha1.Environment) {
+		current.Status.Lifecycle.Epoch++
+		current.Status.Lifecycle.Suspended = true
+	}}
+	terminal, health, execution, closeConnection, err = (Connector{Reader: epochRace}).DialTerminal(context.Background(), environment.Namespace, environment.Name, environment.UID)
+	if err == nil || !strings.Contains(err.Error(), "execution changed while resolving terminal endpoint") || epochRace.environmentGets != 2 || terminal != nil || health != nil || closeConnection != nil || execution != (TerminalExecution{}) {
+		t.Fatalf("post-dial lifecycle race: terminal nil=%t, health nil=%t, execution=%#v, close nil=%t, error=%v, Environment reads=%d", terminal == nil, health == nil, execution, closeConnection == nil, err, epochRace.environmentGets)
+	}
+
+	podRace := &podChangingReader{Reader: newClient(), mutate: func(current *corev1.Pod) {
+		current.UID = "pod-uid-2"
+	}}
+	terminal, health, execution, closeConnection, err = (Connector{Reader: podRace}).DialTerminal(context.Background(), environment.Namespace, environment.Name, environment.UID)
+	if err == nil || !strings.Contains(err.Error(), "execution changed while resolving terminal endpoint") || podRace.podGets != 2 || terminal != nil || health != nil || closeConnection != nil || execution != (TerminalExecution{}) {
+		t.Fatalf("post-dial same-name Pod race: terminal nil=%t, health nil=%t, execution=%#v, close nil=%t, error=%v, Pod reads=%d", terminal == nil, health == nil, execution, closeConnection == nil, err, podRace.podGets)
+	}
+}
+
 func TestDialProcessValidatesCurrentEnvironmentPodAndCredentialIncarnation(t *testing.T) {
 	const identity = "pod-a.sandboxd.swe.dev"
 	certificate := processTestCertificate(t, identity)
@@ -154,6 +229,25 @@ type environmentChangingReader struct {
 	client.Reader
 	environmentGets int
 	mutate          func(*platformv1alpha1.Environment)
+}
+
+type podChangingReader struct {
+	client.Reader
+	podGets int
+	mutate  func(*corev1.Pod)
+}
+
+func (r *podChangingReader) Get(ctx context.Context, key client.ObjectKey, object client.Object, options ...client.GetOption) error {
+	if err := r.Reader.Get(ctx, key, object, options...); err != nil {
+		return err
+	}
+	if pod, ok := object.(*corev1.Pod); ok {
+		r.podGets++
+		if r.podGets > 1 {
+			r.mutate(pod)
+		}
+	}
+	return nil
 }
 
 func (r *environmentChangingReader) Get(ctx context.Context, key client.ObjectKey, object client.Object, options ...client.GetOption) error {


### PR DESCRIPTION
Closes #125.

## Summary
- return the exact Environment UID, lifecycle epoch, Pod name, and immutable Pod UID from terminal resolution only after a post-dial identity re-read
- keep the slow-wake heartbeat unarmed until the terminal connection is attached, then bind the connection lease atomically to that execution
- revoke during the existing policy poll on suspension, epoch drift, exact Pod disappearance, or same-name Pod UID replacement while retaining transient API retry behavior

## Validation
- `go test ./internal/controlplane ./internal/sandboxclient`
- `go test -race ./internal/controlplane ./internal/sandboxclient`
- `make test`
- `make vet`
- `make build`

No CRD field, public HTTP API, sandboxd contract, or RBAC change.