### PR TITLE
fix(adapters): reject terminal success when retained stdout has gaps

### DIFF
--- a/internal/adapters/amp/adapter.go
+++ b/internal/adapters/amp/adapter.go
@@ -137,6 +137,10 @@ func (a *Adapter) Observe(ctx context.Context, task controllers.AdapterTask, san
 		}
 		output, err := readOutput(ctx, client, key(task), process.ExecutionId)
 		if err != nil {
+			var truncated *outputTruncatedError
+			if errors.As(err, &truncated) {
+				return controllers.AdapterObservationFailed, message("Amp stdout was truncated before terminal validation", truncated.Error()), nil
+			}
 			return "", "", err
 		}
 		result, ok := finalResult(output)
@@ -235,12 +239,23 @@ func readOutput(ctx context.Context, client sandboxdv1.ProcessServiceClient, pro
 		if err != nil {
 			return nil, err
 		}
+		if response.GapBytes != 0 || response.Offset != offset {
+			return nil, &outputTruncatedError{retainedFrom: response.RetainedStart}
+		}
 		output.Write(response.Data)
 		offset = response.NextOffset
 		if response.Eof || offset >= response.ProducedEnd {
 			return output.Bytes(), nil
 		}
 	}
+}
+
+type outputTruncatedError struct {
+	retainedFrom uint64
+}
+
+func (e *outputTruncatedError) Error() string {
+	return fmt.Sprintf("retained from offset %d", e.retainedFrom)
 }
 
 func finalResult(output []byte) (resultEvent, bool) {

--- a/internal/adapters/amp/adapter_test.go
+++ b/internal/adapters/amp/adapter_test.go
@@ -22,7 +22,6 @@ type fakeClient struct {
 	process         *sandboxdv1.Process
 	stdout          []byte
 	stderr          []byte
-	gapBytes        uint64
 	retainedFrom    uint64
 	getErr          error
 	starts          int
@@ -90,24 +89,26 @@ func (f *fakeClient) Stop(_ context.Context, request *sandboxdv1.StopProcessRequ
 }
 func (f *fakeClient) ReadOutput(_ context.Context, request *sandboxdv1.ReadOutputRequest, _ ...grpc.CallOption) (*sandboxdv1.ReadOutputResponse, error) {
 	f.readRequests = append(f.readRequests, request)
-	data := f.stdout
+	data, retainedFrom := f.stdout, f.retainedFrom
 	if request.Stream == sandboxdv1.OutputStream_OUTPUT_STREAM_STDERR {
-		data = f.stderr
+		data, retainedFrom = f.stderr, 0
 	}
-	gapBytes, retainedFrom := f.gapBytes, f.retainedFrom
-	if request.Stream == sandboxdv1.OutputStream_OUTPUT_STREAM_STDERR {
-		gapBytes, retainedFrom = 0, 0
+	producedEnd := retainedFrom + uint64(len(data))
+	offset := request.Offset
+	var gapBytes uint64
+	if offset < retainedFrom {
+		gapBytes, offset = retainedFrom-offset, retainedFrom
 	}
-	start := request.Offset
-	if start > uint64(len(data)) {
+	if offset > producedEnd {
 		return nil, status.Error(codes.OutOfRange, "offset")
 	}
+	start := offset - retainedFrom
 	end := min(len(data), int(start)+int(request.MaxBytes))
-	return &sandboxdv1.ReadOutputResponse{Data: append([]byte(nil), data[start:end]...), Offset: start, NextOffset: uint64(end), GapBytes: gapBytes, RetainedStart: retainedFrom, ProducedEnd: uint64(len(data)), Eof: end == len(data)}, nil
+	return &sandboxdv1.ReadOutputResponse{Data: append([]byte(nil), data[start:end]...), Offset: offset, NextOffset: retainedFrom + uint64(end), GapBytes: gapBytes, RetainedStart: retainedFrom, ProducedEnd: producedEnd, Eof: end == len(data)}, nil
 }
 
 func TestOutputIncludesGapMetadata(t *testing.T) {
-	client := &fakeClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"}, stdout: []byte("kept"), gapBytes: 9, retainedFrom: 9}
+	client := &fakeClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"}, stdout: []byte("kept"), retainedFrom: 9}
 	var event controllers.AdapterEvent
 	sandbox := testSandbox(client)
 	sandbox.EmitEvent = func(_ context.Context, got controllers.AdapterEvent) error { event = got; return nil }
@@ -124,6 +125,22 @@ func testSandbox(client sandboxdv1.ProcessServiceClient) controllers.AdapterSand
 	return controllers.AdapterSandbox{EnvironmentUID: "epoch", DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
 		return client, func() error { return nil }, nil
 	}}
+}
+
+func TestTerminalValidationFailsOnRetainedOutputGap(t *testing.T) {
+	exit0 := int32(0)
+	// sandboxd dropped the first 1024 bytes of stdout before the requested
+	// offset; the retained tail still contains a valid-looking success event,
+	// but the transport-reported gap makes the terminal result untrustworthy.
+	client := &fakeClient{
+		process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "execution", ExitCode: &exit0},
+		stdout:  []byte(`{"type":"result","subtype":"success","is_error":false,"result":"done"}` + "\n"),
+		retainedFrom: 1024,
+	}
+	got, detail, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, testSandbox(client))
+	if err != nil || got != controllers.AdapterObservationFailed || !strings.Contains(detail, "truncated before terminal validation") || !strings.Contains(detail, "retained from offset 1024") {
+		t.Fatalf("Observe = %q, %q, %v", got, detail, err)
+	}
 }
 
 func TestAcceptanceIsDuplicateSafePromptSafeAndFreshEpoch(t *testing.T) {

--- a/internal/adapters/claudecode/adapter.go
+++ b/internal/adapters/claudecode/adapter.go
@@ -143,6 +143,10 @@ func (a *Adapter) Observe(ctx context.Context, task controllers.AdapterTask, san
 		}
 		output, err := readRetainedOutput(ctx, client, processKey(task), process.ExecutionId, sandboxdv1.OutputStream_OUTPUT_STREAM_STDOUT)
 		if err != nil {
+			var truncated *outputTruncatedError
+			if errors.As(err, &truncated) {
+				return controllers.AdapterObservationFailed, processMessage("Claude Code stdout was truncated before terminal validation", truncated.Error()), nil
+			}
 			return "", "", err
 		}
 		result, ok := finalResult(output)
@@ -236,12 +240,23 @@ func readRetainedOutput(ctx context.Context, client sandboxdv1.ProcessServiceCli
 		if err != nil {
 			return nil, err
 		}
+		if response.GapBytes != 0 || response.Offset != offset {
+			return nil, &outputTruncatedError{retainedFrom: response.RetainedStart}
+		}
 		output.Write(response.Data)
 		offset = response.NextOffset
 		if response.Eof || offset >= response.ProducedEnd {
 			return output.Bytes(), nil
 		}
 	}
+}
+
+type outputTruncatedError struct {
+	retainedFrom uint64
+}
+
+func (e *outputTruncatedError) Error() string {
+	return fmt.Sprintf("retained from offset %d", e.retainedFrom)
 }
 
 func finalResult(output []byte) (resultEvent, bool) {

--- a/internal/adapters/claudecode/adapter_test.go
+++ b/internal/adapters/claudecode/adapter_test.go
@@ -20,6 +20,7 @@ type fakeProcessClient struct {
 	process       *sandboxdv1.Process
 	stdout        []byte
 	stderr        []byte
+	retainedFrom  uint64
 	startCalls    int
 	launches      int
 	startedKey    *sandboxdv1.ProcessKey
@@ -78,17 +79,22 @@ func (f *fakeProcessClient) Stop(_ context.Context, request *sandboxdv1.StopProc
 
 func (f *fakeProcessClient) ReadOutput(_ context.Context, request *sandboxdv1.ReadOutputRequest, _ ...grpc.CallOption) (*sandboxdv1.ReadOutputResponse, error) {
 	f.readRequests = append(f.readRequests, request)
-	data := f.stdout
+	data, retainedFrom := f.stdout, f.retainedFrom
 	if request.Stream == sandboxdv1.OutputStream_OUTPUT_STREAM_STDERR {
-		data = f.stderr
+		data, retainedFrom = f.stderr, 0
 	}
+	producedEnd := retainedFrom + uint64(len(data))
 	offset := request.Offset
-	if offset > uint64(len(data)) {
+	var gapBytes uint64
+	if offset < retainedFrom {
+		gapBytes, offset = retainedFrom-offset, retainedFrom
+	}
+	if offset > producedEnd {
 		return nil, status.Error(codes.OutOfRange, "offset")
 	}
-	end := min(len(data), int(offset)+int(request.MaxBytes))
-	chunk := append([]byte(nil), data[offset:end]...)
-	return &sandboxdv1.ReadOutputResponse{Data: chunk, Offset: offset, NextOffset: uint64(end), ProducedEnd: uint64(len(data)), Eof: end == len(data)}, nil
+	start := offset - retainedFrom
+	end := min(len(data), int(start)+int(request.MaxBytes))
+	return &sandboxdv1.ReadOutputResponse{Data: append([]byte(nil), data[start:end]...), Offset: offset, NextOffset: retainedFrom + uint64(end), GapBytes: gapBytes, RetainedStart: retainedFrom, ProducedEnd: producedEnd, Eof: end == len(data)}, nil
 }
 
 func sandboxFor(client sandboxdv1.ProcessServiceClient) controllers.AdapterSandbox {
@@ -319,6 +325,22 @@ func TestPermanentOutputRejectionFailsObservation(t *testing.T) {
 	got, message, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox)
 	if err != nil || got != controllers.AdapterObservationFailed || !strings.Contains(message, "permanently rejected") {
 		t.Fatalf("Observe() = (%q, %q, %v)", got, message, err)
+	}
+}
+
+func TestTerminalValidationFailsOnRetainedOutputGap(t *testing.T) {
+	exit0 := int32(0)
+	// sandboxd dropped the first 512 bytes of stdout before the requested
+	// offset; the retained tail still contains a valid-looking success event,
+	// but the transport-reported gap makes the terminal result untrustworthy.
+	client := &fakeProcessClient{
+		process:      &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "execution"},
+		stdout:       []byte(`{"type":"result","subtype":"success","is_error":false,"result":"done"}` + "\n"),
+		retainedFrom: 512,
+	}
+	got, detail, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandboxFor(client))
+	if err != nil || got != controllers.AdapterObservationFailed || !strings.Contains(detail, "truncated before terminal validation") || !strings.Contains(detail, "retained from offset 512") {
+		t.Fatalf("Observe() = (%q, %q, %v)", got, detail, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #128.

Codex and Pi already reject a terminal-success decision when sandboxd reports that stdout retention dropped bytes before the requested offset. Amp and Claude Code did not: their terminal-validation readers appended `ReadOutputResponse.Data` while ignoring `GapBytes` and a shifted `Offset`, so a retained final result event after retention loss could drive an authoritative `Succeeded` observation from incomplete protocol history.

This PR matches the existing Codex/Pi pattern in both adapters without changing output-forwarding gap envelopes or adapter-owned parsing semantics for gap-free malformed text.

## Behavior

- In the Amp `readOutput` and Claude Code `readRetainedOutput` terminal-validation stdout loops, detect `GapBytes != 0` or `response.Offset != requestedOffset` and return a permanent `outputTruncatedError`.
- At the `Observe` call site, map that error to a truthful `AdapterObservationFailed` with a bounded message (`... stdout was truncated before terminal validation; retained from offset N`), not `Succeeded` and not an endless transient retry.
- Each adapter keeps its own local `outputTruncatedError` type — no shared transcript schema, CRD, sandboxd API, or architecture change.

## Acceptance criteria (#128)

- [x] Amp cannot report success when terminal-validation stdout has a retention gap or shifted offset.
- [x] Claude Code cannot report success under the same conditions.
- [x] Both return a truthful bounded failure message consistent with Codex/Pi behavior.
- [x] No-gap success/error parsing and output-forwarding gap envelopes remain unchanged.
- [x] Tests simulate actual `ReadOutputResponse.GapBytes`/`Offset` shifts (not merely malformed retained text) and cover both adapters.
- [x] No shared transcript schema, CRD, sandboxd API, or architecture change is introduced.

## Validation

- `go test ./internal/adapters/...` — all four adapter packages pass.
- `go test ./...` (root module) and `go test ./...` (sandboxd module) — pass.
- `go vet ./internal/adapters/...` and `go build ./...` — clean.
- New tests `TestTerminalValidationFailsOnRetainedOutputGap` (amp + claudecode) exercise real gap metadata/offset shifts and fail without the production fix.