### PR TITLE
Fence transcript reads by immutable Run UID

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,11 +488,11 @@ The initial tool surface is deliberately finite:
   Run name, and immutable Run UID. The control plane authorizes `create` on Runs and, when an
   exact-intent same-name retry is recovered while that Run still exists, `get` on that exact Run.
 - `read_transcript` requires both the Run name and expected Run UID. It checks that identity
-  before and after every SSE connection is bound, accepts an opaque `after` cursor, and returns
+  on every server-bound SSE request and reconnect, accepts an opaque `after` cursor, and returns
   at most 100 events, 128 KiB of adapter-owned event JSON, and 256 KiB of encoded structured
   output after a wait of at most 10 seconds.
   `dataJSON` is the unmodified JSON text, not a platform transcript schema. This tool requires
-  `get` on the exact Run and `get` on its `transcript` subresource.
+  `get` on the exact Run's `transcript` subresource; it does not add a separate base-Run read.
 
 Interactive `attach` is intentionally not an MCP tool in this slice. The existing endpoint is a
 bidirectional shared terminal with wake and activity side effects, not a bounded request/result
@@ -527,18 +527,19 @@ Run transcripts use the same explicit control-plane URL and bearer credential:
 
 ```sh
 SWE_CONTROL_PLANE_URL=https://swe.example.com \
-SWE_CONTROL_PLANE_TOKEN="$TOKEN" swe logs --run fix-flaky-42
+SWE_CONTROL_PLANE_TOKEN="$TOKEN" swe logs --run fix-flaky-42 --run-uid "$RUN_UID"
 ```
 
-`swe logs --run RUN` selects that exact Run in `--namespace` and emits one NDJSON
+`swe logs --run RUN --run-uid UID` selects that exact immutable Run in `--namespace` and emits one NDJSON
 record per SSE event:
 `{"event":"transcript","id":"<opaque cursor>","data":<server envelope>}`. The
 `data` value remains opaque, adapter-owned JSON; the CLI does not interpret it as a
 shared transcript schema. Retention loss is explicit in records whose `event` is
 `transcript-gap`. Use `--after <opaque cursor>` to resume explicitly. After a
 successfully opened stream drops, the CLI reconnects with the event ID from the last
-complete block successfully emitted. Invalid and expired cursors are reported rather
-than silently skipped.
+complete block successfully emitted and the same expected Run UID. The UID is required
+explicitly so transcript-only RBAC does not gain a hidden base-Run read dependency.
+Invalid and expired cursors are reported rather than silently skipped.
 
 For compatibility, `swe logs <environment>` is not deprecated and still follows the
 current Environment pod's `environment` container using kubeconfig authentication. It

--- a/charts/swe-platform/README.md
+++ b/charts/swe-platform/README.md
@@ -392,10 +392,10 @@ exact namespace, resource name, and subresource on every request:
 This permits producer credentials to be restricted to one Run using an RBAC Role with
 `resourceNames`. The namespace is part of the URL only as a resource selector; it becomes
 authoritative only after RBAC authorizes that exact namespaced identity. Unknown Runs are
-rejected before transcript state is allocated; POST appends additionally require the exact
-`SWE-Run-UID` header so a recreated Run never receives stale events. An already-open stream
-is not continuously reauthorized or closed when its Run is deleted. Transcript event `data`
-remains opaque, adapter-owned JSON.
+rejected before transcript state is allocated; every transcript read and append additionally
+requires the exact `SWE-Run-UID` header so a recreated Run never receives stale events or
+readers. An already-open stream is not continuously reauthorized or closed when its Run is
+deleted. Transcript event `data` remains opaque, adapter-owned JSON.
 
 Service clients send `Authorization: Bearer <token>`. A browser exchanges an explicit,
 non-bootstrap bearer credential with `POST /api/v1/session`. After a successful TokenReview,
@@ -530,8 +530,8 @@ same-name Run replacement returns `409 Conflict`.
 Run and Environment responses omit raw CRDs, managed fields, conditions, transcript storage
 references, sandboxd/terminal endpoints, pod names, image IDs, and secrets. Environment
 `ready` is derived only from the current generation's Ready condition. New REST errors use
-`application/problem+json`; existing transcript SSE and terminal WebSocket wire contracts are
-unchanged.
+`application/problem+json`; transcript event framing and terminal WebSocket wire contracts are
+unchanged. Transcript GET identity now requires the exact Run UID header described below.
 
 ## Transcript API
 
@@ -542,7 +542,7 @@ and clients can consume replay plus live events as an SSE stream:
 kubectl port-forward service/swe-platform-swe-platform-control-plane 8080:80
 TOKEN="$(kubectl create token my-reader -n project-a --audience=swe-platform)"
 RUN_UID="$(kubectl get run run-123 -n project-a -o jsonpath='{.metadata.uid}')"
-curl -N -H "Authorization: Bearer ${TOKEN}" \
+curl -N -H "Authorization: Bearer ${TOKEN}" -H "SWE-Run-UID: ${RUN_UID}" \
   http://127.0.0.1:8080/api/v1/namespaces/project-a/runs/run-123/transcript
 curl -H "Authorization: Bearer ${TOKEN}" -H 'Content-Type: application/json' \
   -H "SWE-Run-UID: ${RUN_UID}" \
@@ -553,12 +553,13 @@ curl -H "Authorization: Bearer ${TOKEN}" -H 'Content-Type: application/json' \
 The platform envelope owns transport metadata only:
 
 - A transcript belongs to the immutable `(namespace, Run UID)` identity, so names reused
-  across namespaces or after Run recreation never collide. POST append requests must carry
-  the exact current Run UID in the `SWE-Run-UID` header; a missing header returns
+  across namespaces or after Run recreation never collide. Every GET stream and POST append
+  must carry the exact current Run UID in the `SWE-Run-UID` header; a missing header returns
   `428 Precondition Required`, a mismatch with the currently resolved Run UID returns
-  `409 Conflict`, and both are rejected before store access so a delete/recreate replacement
-  never receives stale events. GET streaming stays name-addressed and binds once to the
-  current resolved UID; it does not require the header.
+  `409 Conflict`, and an overlong UID returns `400 Bad Request`. Authentication and exact
+  transcript authorization happen before identity validation; identity rejection happens
+  before store access. Readers must retain the same expected UID on every reconnect so a
+  delete/recreate replacement never receives stale events or readers.
 - `source` is a bounded, producer-selected idempotency partition, not authenticated
   provenance. `sourceSequence` is optional producer metadata and does not determine order.
 - `(Run identity, source, idempotencyKey)` identifies one append while that event remains

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -466,8 +466,37 @@ subjects:
   - kind: ServiceAccount
     name: e2e-transcript-producer
     namespace: default
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: e2e-transcript-reader
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: e2e-transcript-reader
+rules:
+  - apiGroups: ["swe.dev"]
+    resources: ["runs/transcript"]
+    resourceNames: ["${RUN_NAME}"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: e2e-transcript-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: e2e-transcript-reader
+subjects:
+  - kind: ServiceAccount
+    name: e2e-transcript-reader
+    namespace: default
 EOF
 PRODUCER_TOKEN=$(kubectl create token e2e-transcript-producer --audience=swe-platform)
+READER_TOKEN=$(kubectl create token e2e-transcript-reader --audience=swe-platform)
 
 echo "==> configuring a console API user"
 cat <<'EOF' | kubectl apply -f -
@@ -738,11 +767,12 @@ if [[ "$ANONYMOUS_STATUS" != "401" ]]; then
 	exit 1
 fi
 curl --fail --silent --no-buffer --max-time 10 \
-	-H "Authorization: Bearer ${E2E_BOOTSTRAP_TOKEN}" \
+	-H "Authorization: Bearer ${READER_TOKEN}" \
+	-H "SWE-Run-UID: ${RUN_UID}" \
 	"http://127.0.0.1:18080/api/v1/namespaces/default/runs/${RUN_NAME}/transcript" > /tmp/swe-platform-transcript.out &
 STREAM_PID=$!
-SWE_CONTROL_PLANE_URL=http://127.0.0.1:18080 SWE_CONTROL_PLANE_TOKEN="$E2E_BOOTSTRAP_TOKEN" \
-	timeout 10 bin/swe logs --run "$RUN_NAME" > /tmp/swe-platform-cli-transcript.out &
+SWE_CONTROL_PLANE_URL=http://127.0.0.1:18080 SWE_CONTROL_PLANE_TOKEN="$READER_TOKEN" \
+	timeout 10 bin/swe logs --run "$RUN_NAME" --run-uid "$RUN_UID" > /tmp/swe-platform-cli-transcript.out &
 CLI_STREAM_PID=$!
 sleep 1
 APPEND_STATUS=$(curl --silent --output /dev/null --write-out '%{http_code}' \
@@ -784,8 +814,32 @@ if [[ "$MISSING_UID_STATUS" != "428" ]]; then
 	echo "FAIL: missing UID producer append status was ${MISSING_UID_STATUS}, expected 428"
 	exit 1
 fi
+MISSING_READ_UID_STATUS=$(curl --silent --output /dev/null --write-out '%{http_code}' \
+	-H "Authorization: Bearer ${E2E_BOOTSTRAP_TOKEN}" \
+	"http://127.0.0.1:18080/api/v1/namespaces/default/runs/${RUN_NAME}/transcript")
+OVERLONG_READ_UID_STATUS=$(curl --silent --output /dev/null --write-out '%{http_code}' \
+	-H "Authorization: Bearer ${E2E_BOOTSTRAP_TOKEN}" \
+	-H "SWE-Run-UID: $(printf 'x%.0s' $(seq 1 129))" \
+	"http://127.0.0.1:18080/api/v1/namespaces/default/runs/${RUN_NAME}/transcript")
+STALE_READ_UID_STATUS=$(curl --silent --output /dev/null --write-out '%{http_code}' \
+	-H "Authorization: Bearer ${E2E_BOOTSTRAP_TOKEN}" \
+	-H 'SWE-Run-UID: stale-uid-not-current' \
+	"http://127.0.0.1:18080/api/v1/namespaces/default/runs/${RUN_NAME}/transcript")
+DENIED_READ_STATUS=$(curl --silent --output /dev/null --write-out '%{http_code}' \
+	-H "Authorization: Bearer ${PRODUCER_TOKEN}" \
+	-H "SWE-Run-UID: $(printf 'x%.0s' $(seq 1 129))" \
+	"http://127.0.0.1:18080/api/v1/namespaces/default/runs/${RUN_NAME}/transcript")
+READER_BASE_RUN_STATUS=$(curl --silent --output /dev/null --write-out '%{http_code}' \
+	-H "Authorization: Bearer ${READER_TOKEN}" \
+	"http://127.0.0.1:18080/api/v1/namespaces/default/runs/${RUN_NAME}")
+if [[ "$MISSING_READ_UID_STATUS" != "428" || "$OVERLONG_READ_UID_STATUS" != "400" || \
+	"$STALE_READ_UID_STATUS" != "409" || "$DENIED_READ_STATUS" != "403" || "$READER_BASE_RUN_STATUS" != "403" ]]; then
+	echo "FAIL: transcript read identity statuses missing=${MISSING_READ_UID_STATUS} overlong=${OVERLONG_READ_UID_STATUS} stale=${STALE_READ_UID_STATUS} denied=${DENIED_READ_STATUS} base-run=${READER_BASE_RUN_STATUS}"
+	exit 1
+fi
 UNKNOWN_STATUS=$(curl --silent --output /dev/null --write-out '%{http_code}' \
 	-H "Authorization: Bearer ${E2E_BOOTSTRAP_TOKEN}" \
+	-H 'SWE-Run-UID: unknown-run-uid' \
 	http://127.0.0.1:18080/api/v1/namespaces/default/runs/unknown-run/transcript)
 if [[ "$UNKNOWN_STATUS" != "404" ]]; then
 	echo "FAIL: unknown Run transcript status was ${UNKNOWN_STATUS}, expected 404"
@@ -825,7 +879,7 @@ echo "==> verifying local authenticated MCP stdio tools"
 		"{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"read_transcript\",\"arguments\":{\"runName\":\"${RUN_NAME}\",\"runUID\":\"${RUN_UID}\",\"maxEvents\":100,\"waitMilliseconds\":1000}}}"
 	sleep 2
 } | \
-	SWE_CONTROL_PLANE_URL=http://127.0.0.1:18080 SWE_CONTROL_PLANE_TOKEN="$E2E_BOOTSTRAP_TOKEN" \
+	SWE_CONTROL_PLANE_URL=http://127.0.0.1:18080 SWE_CONTROL_PLANE_TOKEN="$READER_TOKEN" \
 	timeout 10 bin/swe mcp > /tmp/swe-platform-mcp.out || {
 	echo "FAIL: local MCP stdio process did not complete cleanly"
 	cat /tmp/swe-platform-mcp.out
@@ -837,7 +891,7 @@ if ! grep -F '"id":2' /tmp/swe-platform-mcp.out | grep -Fq '"name":"create_run"'
 	! grep -F '"id":3' /tmp/swe-platform-mcp.out | grep -Fq '"event":"transcript"' || \
 	! grep -F '"id":3' /tmp/swe-platform-mcp.out | grep -Fq '"nextCursor"' || \
 	! grep -F '"id":3' /tmp/swe-platform-mcp.out | grep -Fq 'e2e transcript event' || \
-	grep -Fq "$E2E_BOOTSTRAP_TOKEN" /tmp/swe-platform-mcp.out; then
+	grep -Fq "$READER_TOKEN" /tmp/swe-platform-mcp.out; then
 	echo "FAIL: local MCP stdio server did not list tools and return a UID-fenced transcript batch"
 	cat /tmp/swe-platform-mcp.out
 	exit 1
@@ -981,6 +1035,7 @@ check_sandboxd_process "$POD_NAME" "$RESUME_RUN_UID" "$E2E_ROTATED_AGENT_API_KEY
 set +e
 curl --silent --no-buffer --max-time 2 \
 	-H "Authorization: Bearer ${E2E_BOOTSTRAP_TOKEN}" \
+	-H "SWE-Run-UID: ${RESUME_RUN_UID}" \
 	"http://127.0.0.1:18080/api/v1/namespaces/default/runs/${RESUME_RUN_NAME}/transcript" \
 	> /tmp/swe-platform-resume-transcript.out
 RESUME_TRANSCRIPT_STATUS=$?
@@ -1024,6 +1079,7 @@ check_sandboxd_process "$AMP_POD_NAME" "$AMP_RUN_UID" "$E2E_AMP_API_KEY"
 set +e
 curl --silent --no-buffer --max-time 2 \
 	-H "Authorization: Bearer ${E2E_BOOTSTRAP_TOKEN}" \
+	-H "SWE-Run-UID: ${AMP_RUN_UID}" \
 	"http://127.0.0.1:18080/api/v1/namespaces/default/runs/${AMP_RUN_NAME}/transcript" \
 	> /tmp/swe-platform-amp-transcript.out
 AMP_TRANSCRIPT_STATUS=$?
@@ -1073,8 +1129,9 @@ CODEX_RUN_NAME=e2e-fake-codex-run
 bin/swe run "fake Codex lifecycle smoke test" --name "$CODEX_RUN_NAME" --environment "$ENV_NAME" --agent codex --wait=false
 kubectl wait --for=jsonpath='{.status.state}'=Running run/"$CODEX_RUN_NAME" --timeout=3m
 kubectl wait --for=jsonpath='{.status.state}'=Succeeded run/"$CODEX_RUN_NAME" --timeout=3m
+CODEX_RUN_UID=$(kubectl get run "$CODEX_RUN_NAME" -o jsonpath='{.metadata.uid}')
 set +e
-curl --silent --no-buffer --max-time 2 -H "Authorization: Bearer ${E2E_BOOTSTRAP_TOKEN}" \
+curl --silent --no-buffer --max-time 2 -H "Authorization: Bearer ${E2E_BOOTSTRAP_TOKEN}" -H "SWE-Run-UID: ${CODEX_RUN_UID}" \
 	"http://127.0.0.1:18080/api/v1/namespaces/default/runs/${CODEX_RUN_NAME}/transcript" > /tmp/swe-platform-codex-transcript.out
 CODEX_TRANSCRIPT_STATUS=$?
 set -e
@@ -1095,8 +1152,9 @@ PI_RUN_NAME=e2e-fake-pi-run
 bin/swe run "fake Pi lifecycle smoke test" --name "$PI_RUN_NAME" --environment "$ENV_NAME" --agent pi --wait=false
 kubectl wait --for=jsonpath='{.status.state}'=Running run/"$PI_RUN_NAME" --timeout=3m
 kubectl wait --for=jsonpath='{.status.state}'=Succeeded run/"$PI_RUN_NAME" --timeout=3m
+PI_RUN_UID=$(kubectl get run "$PI_RUN_NAME" -o jsonpath='{.metadata.uid}')
 set +e
-curl --silent --no-buffer --max-time 2 -H "Authorization: Bearer ${E2E_BOOTSTRAP_TOKEN}" \
+curl --silent --no-buffer --max-time 2 -H "Authorization: Bearer ${E2E_BOOTSTRAP_TOKEN}" -H "SWE-Run-UID: ${PI_RUN_UID}" \
 	"http://127.0.0.1:18080/api/v1/namespaces/default/runs/${PI_RUN_NAME}/transcript" > /tmp/swe-platform-pi-transcript.out
 PI_TRANSCRIPT_STATUS=$?
 set -e

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -18,6 +18,7 @@ import (
 func newLogsCommand() *cobra.Command {
 	var (
 		run             string
+		runUID          string
 		controlPlaneURL string
 		token           string
 		cursor          string
@@ -36,12 +37,15 @@ Transcript and transcript-gap data remains adapter-owned JSON.`,
 				if len(args) != 0 {
 					return fmt.Errorf("an environment argument cannot be combined with --run")
 				}
-				return streamRunTranscript(cmd, controlPlaneURL, token, namespace, run, cursor)
+				if runUID == "" {
+					return fmt.Errorf("--run-uid is required with --run")
+				}
+				return streamRunTranscript(cmd, controlPlaneURL, token, namespace, run, runUID, cursor)
 			}
 			if len(args) == 0 {
 				return fmt.Errorf("an environment argument or --run is required")
 			}
-			for _, flag := range []string{"control-plane", "token", "after"} {
+			for _, flag := range []string{"run-uid", "control-plane", "token", "after"} {
 				if cmd.Flags().Changed(flag) {
 					return fmt.Errorf("--%s requires --run", flag)
 				}
@@ -50,6 +54,7 @@ Transcript and transcript-gap data remains adapter-owned JSON.`,
 		},
 	}
 	cmd.Flags().StringVar(&run, "run", "", "Run whose transcript to stream instead of Environment pod logs")
+	cmd.Flags().StringVar(&runUID, "run-uid", "", "Exact immutable Run UID (required with --run)")
 	cmd.Flags().StringVar(&controlPlaneURL, "control-plane", os.Getenv("SWE_CONTROL_PLANE_URL"), "Control-plane base URL (or SWE_CONTROL_PLANE_URL; requires --run)")
 	cmd.Flags().StringVar(&token, "token", os.Getenv("SWE_CONTROL_PLANE_TOKEN"), "Control-plane bearer token (or SWE_CONTROL_PLANE_TOKEN; requires --run)")
 	cmd.Flags().StringVar(&cursor, "after", "", "Opaque transcript cursor to resume after (requires --run)")
@@ -92,13 +97,12 @@ func streamLogs(cmd *cobra.Command, namespace, envName string) error {
 	return err
 }
 
-func streamRunTranscript(cmd *cobra.Command, controlPlaneURL, token, namespace, run, cursor string) error {
+func streamRunTranscript(cmd *cobra.Command, controlPlaneURL, token, namespace, run, runUID, cursor string) error {
 	client, err := controlplaneclient.New(controlPlaneURL, token, nil)
 	if err != nil {
 		return err
 	}
-	endpoint := client.Endpoint("api", "v1", "namespaces", namespace, "runs", run, "transcript")
-	return client.StreamSSE(cmd.Context(), endpoint, cursor, func(event controlplaneclient.SSEEvent) error {
+	return client.StreamRunTranscript(cmd.Context(), namespace, run, runUID, cursor, func(event controlplaneclient.SSEEvent) error {
 		return writeTranscriptOutput(cmd.OutOrStdout(), event)
 	})
 }

--- a/internal/cli/logs_test.go
+++ b/internal/cli/logs_test.go
@@ -18,8 +18,8 @@ func TestStreamRunTranscriptWritesOpaqueNDJSON(t *testing.T) {
 	requests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests++
-		if r.URL.EscapedPath() != "/api/v1/namespaces/team%2Fa/runs/run%20one/transcript" || r.Header.Get("Authorization") != "Bearer reader" {
-			t.Errorf("request path/token = %q/%q", r.URL.EscapedPath(), r.Header.Get("Authorization"))
+		if r.URL.EscapedPath() != "/api/v1/namespaces/team%2Fa/runs/run%20one/transcript" || r.Header.Get("Authorization") != "Bearer reader" || r.Header.Get("SWE-Run-UID") != "uid-one" {
+			t.Errorf("request path/token/UID = %q/%q/%q", r.URL.EscapedPath(), r.Header.Get("Authorization"), r.Header.Get("SWE-Run-UID"))
 		}
 		if requests > 1 {
 			w.WriteHeader(http.StatusNoContent)
@@ -34,7 +34,7 @@ func TestStreamRunTranscriptWritesOpaqueNDJSON(t *testing.T) {
 	command.SetContext(context.Background())
 	var output bytes.Buffer
 	command.SetOut(&output)
-	if err := streamRunTranscript(command, server.URL, "reader", "team/a", "run one", ""); err != nil {
+	if err := streamRunTranscript(command, server.URL, "reader", "team/a", "run one", "uid-one", ""); err != nil {
 		t.Fatal(err)
 	}
 	wantOutput := "{\"event\":\"transcript\",\"id\":\"cursor-1\",\"data\":{\"source\":\"adapter\",\"type\":\"adapter.owned\",\"data\":{\"anything\":true}}}\n" +
@@ -75,6 +75,8 @@ func TestLogsCommandRequiresExactlyOneMode(t *testing.T) {
 	for _, args := range [][]string{
 		{},
 		{"environment", "--run", "run"},
+		{"--run", "run"},
+		{"environment", "--run-uid", "uid"},
 		{"environment", "--control-plane", "https://control.example"},
 		{"environment", "--token", "token"},
 		{"environment", "--after="},

--- a/internal/cli/tui.go
+++ b/internal/cli/tui.go
@@ -719,22 +719,11 @@ func (m *tuiModel) startTranscript(identity runIdentity) tea.Cmd {
 	cursor := m.streamCursor
 	messages := make(chan tea.Msg)
 	m.transcriptMessages = messages
-	endpoint := m.client.Endpoint("api", "v1", "namespaces", identity.namespace, "runs", identity.name, "transcript")
 	stream := func() tea.Msg {
 		defer cancel()
 		defer close(done)
 		defer close(messages)
-		checkIdentity := func(checkCtx context.Context) error {
-			run, err := m.client.GetRun(checkCtx, identity.namespace, identity.name)
-			if err != nil {
-				return fmt.Errorf("verify Run identity before transcript connection: %w", err)
-			}
-			if run.UID != identity.uid {
-				return fmt.Errorf("Run %s was replaced; refreshing transcript identity", safeText(identity.name))
-			}
-			return nil
-		}
-		err := m.client.StreamSSEWithReconnectCheck(ctx, endpoint, cursor, checkIdentity, func(event controlplaneclient.SSEEvent) error {
+		err := m.client.StreamRunTranscript(ctx, identity.namespace, identity.name, identity.uid, cursor, func(event controlplaneclient.SSEEvent) error {
 			select {
 			case messages <- transcriptMsg{identity: identity, generation: generation, event: event}:
 				return nil

--- a/internal/cli/tui_test.go
+++ b/internal/cli/tui_test.go
@@ -313,10 +313,8 @@ func TestTUIAdvertisesTerminalOnlyForExactEnvironmentIncarnation(t *testing.T) {
 func TestTUITranscriptStreamStopsWithContext(t *testing.T) {
 	connected := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !strings.HasSuffix(r.URL.Path, "/transcript") {
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = io.WriteString(w, `{"name":"run-one","uid":"uid-one","createdAt":"2026-07-24T00:00:00Z","intent":{"selector":{"template":"small"},"agent":"future","prompt":"task"},"cancelRequested":false,"state":"Running","usage":{"cpuSeconds":0,"tokensIn":0,"tokensOut":0}}`)
-			return
+		if !strings.HasSuffix(r.URL.Path, "/transcript") || r.Header.Get("SWE-Run-UID") != "uid-one" {
+			t.Errorf("transcript request path/UID = %q/%q", r.URL.Path, r.Header.Get("SWE-Run-UID"))
 		}
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -249,27 +249,22 @@ func (s *Server) handleTranscript(w http.ResponseWriter, r *http.Request, namesp
 		writeAccessError(w, err)
 		return
 	}
+	// Every transcript operation carries the exact expected Run UID so a
+	// delete/recreate replacement never receives stale events or readers.
+	// Authorization is deliberately checked first, then identity validation
+	// happens before the resolver or store is touched.
+	expectedUID := types.UID(strings.TrimSpace(r.Header.Get(RunUIDHeader)))
+	if expectedUID == "" {
+		writeProblem(w, http.StatusPreconditionRequired, "run_uid_required", "Run UID required", "the "+RunUIDHeader+" header is required for transcript requests")
+		return
+	}
+	if len(expectedUID) > 128 {
+		http.Error(w, "run UID exceeds its size limit", http.StatusBadRequest)
+		return
+	}
 	if s.runs == nil {
 		http.Error(w, "run resolver is unavailable", http.StatusServiceUnavailable)
 		return
-	}
-
-	// POST carries the exact expected Run UID so a delete/recreate replacement
-	// never receives stale events. Authorization is checked first (anonymous and
-	// cross-run denials remain 401/403), then the header is validated before the
-	// resolver or store is touched. GET stays name-addressed and binds once to
-	// the current resolved UID; it does not require the header.
-	var expectedUID types.UID
-	if r.Method == http.MethodPost {
-		expectedUID = types.UID(strings.TrimSpace(r.Header.Get(RunUIDHeader)))
-		if expectedUID == "" {
-			writeProblem(w, http.StatusPreconditionRequired, "run_uid_required", "Run UID required", "the "+RunUIDHeader+" header is required to append transcript events")
-			return
-		}
-		if len(expectedUID) > 128 {
-			http.Error(w, "run UID exceeds its size limit", http.StatusBadRequest)
-			return
-		}
 	}
 
 	resolvedUID, err := s.runs.ResolveRun(r.Context(), namespace, run)
@@ -288,18 +283,13 @@ func (s *Server) handleTranscript(w http.ResponseWriter, r *http.Request, namesp
 		return
 	}
 
-	// For POST, build the store identity from the verified header UID (which
-	// equals the current resolved UID) so the race argument is explicit: a
-	// stale producer referencing an old incarnation is rejected before append.
-	uid := resolvedUID
-	if r.Method == http.MethodPost {
-		if expectedUID != resolvedUID {
-			writeTranscriptProblem(w, http.StatusConflict, "run_uid_mismatch", "Run UID mismatch")
-			return
-		}
-		uid = expectedUID
+	if expectedUID != resolvedUID {
+		writeTranscriptProblem(w, http.StatusConflict, "run_uid_mismatch", "Run UID mismatch")
+		return
 	}
-	identity := RunIdentity{Namespace: namespace, UID: uid}
+	// Bind storage to the verified caller expectation, not merely the value
+	// returned by name resolution.
+	identity := RunIdentity{Namespace: namespace, UID: expectedUID}
 
 	switch r.Method {
 	case http.MethodGet:

--- a/internal/controlplane/server_test.go
+++ b/internal/controlplane/server_test.go
@@ -32,6 +32,7 @@ func TestTranscriptReplayAndLiveStream(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	request.Header.Set(RunUIDHeader, "run-1-uid")
 	response, err := http.DefaultClient.Do(request)
 	if err != nil {
 		t.Fatal(err)
@@ -78,6 +79,7 @@ func TestTranscriptStreamSendsHeartbeat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	request.Header.Set(RunUIDHeader, "run-1-uid")
 	response, err := http.DefaultClient.Do(request)
 	if err != nil {
 		t.Fatal(err)
@@ -105,7 +107,12 @@ func TestTranscriptStreamLifecycleUnsubscribes(t *testing.T) {
 	server := httptest.NewServer(api.Handler())
 	defer server.Close()
 
-	response, err := http.Get(server.URL + transcriptURL)
+	request, err := http.NewRequest(http.MethodGet, server.URL+transcriptURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set(RunUIDHeader, "run-1-uid")
+	response, err := http.DefaultClient.Do(request)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,6 +161,7 @@ func TestTranscriptSharedStoreFansOutAcrossServers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	request.Header.Set(RunUIDHeader, "run-1-uid")
 	response, err := http.DefaultClient.Do(request)
 	if err != nil {
 		t.Fatal(err)
@@ -273,6 +281,7 @@ func TestTranscriptReconnectUsesLastEventID(t *testing.T) {
 		t.Fatal(err)
 	}
 	request.Header.Set("Last-Event-ID", first.Event.ID)
+	request.Header.Set(RunUIDHeader, "run-1-uid")
 	response, err := http.DefaultClient.Do(request)
 	if err != nil {
 		t.Fatal(err)
@@ -304,6 +313,26 @@ func TestTranscriptRejectsAnonymousBeforeRunResolutionOrStoreAccess(t *testing.T
 	store := api.store.(*memoryTranscriptStore)
 	if resolver.calls != 0 || len(store.runs) != 0 || len(store.subscribers) != 0 {
 		t.Fatalf("unauthorized request reached backend: resolves=%d runs=%d subscribers=%d", resolver.calls, len(store.runs), len(store.subscribers))
+	}
+}
+
+func TestTranscriptRejectsForbiddenBeforeUIDValidation(t *testing.T) {
+	resolver := &fakeRunResolver{}
+	store := NewMemoryTranscriptStore(MemoryTranscriptStoreOptions{})
+	api := NewServer(nil, ServerOptions{Access: &fakeAccess{err: errForbidden}, Runs: resolver, TranscriptStore: store})
+	for _, method := range []string{http.MethodGet, http.MethodPost} {
+		request := httptest.NewRequest(method, transcriptURL, nil)
+		request.Header.Set("Authorization", "Bearer denied")
+		request.Header.Set(RunUIDHeader, strings.Repeat("x", 129))
+		response := httptest.NewRecorder()
+		api.Handler().ServeHTTP(response, request)
+		if response.Code != http.StatusForbidden {
+			t.Fatalf("%s status = %d, want %d", method, response.Code, http.StatusForbidden)
+		}
+	}
+	memStore := store.(*memoryTranscriptStore)
+	if resolver.calls != 0 || len(memStore.runs) != 0 || len(memStore.subscribers) != 0 {
+		t.Fatalf("forbidden request reached backend: resolves=%d runs=%d subscribers=%d", resolver.calls, len(memStore.runs), len(memStore.subscribers))
 	}
 }
 
@@ -382,36 +411,35 @@ func TestRecreatedRunUsesNewTranscriptIdentity(t *testing.T) {
 	}
 }
 
-func TestTranscriptAppendRequiresRunUID(t *testing.T) {
-	resolver := &fakeRunResolver{}
-	store := NewMemoryTranscriptStore(MemoryTranscriptStoreOptions{})
-	api := NewServer(nil, ServerOptions{Access: &fakeAccess{}, Runs: resolver, TranscriptStore: store})
-
-	request := httptest.NewRequest(http.MethodPost, transcriptURL, strings.NewReader(`{"source":"adapter","idempotencyKey":"event-1","type":"output","data":{}}`))
-	request.Header.Set("Authorization", "Bearer producer")
-	response := httptest.NewRecorder()
-	api.Handler().ServeHTTP(response, request)
-	if response.Code != http.StatusPreconditionRequired {
-		t.Fatalf("missing UID status = %d, want %d", response.Code, http.StatusPreconditionRequired)
-	}
-	if response.Header().Get("Content-Type") != "application/problem+json" {
-		t.Fatalf("Content-Type = %q, want application/problem+json", response.Header().Get("Content-Type"))
-	}
-	memStore := store.(*memoryTranscriptStore)
-	if resolver.calls != 0 || len(memStore.runs) != 0 {
-		t.Fatalf("missing-UID request reached resolver/store: resolves=%d runs=%d", resolver.calls, len(memStore.runs))
-	}
-}
-
-func TestTranscriptAppendRejectsOverlongRunUID(t *testing.T) {
-	api := newTestServer(&fakeAccess{})
-	request := httptest.NewRequest(http.MethodPost, transcriptURL, strings.NewReader(`{"source":"adapter","idempotencyKey":"event-1","type":"output","data":{}}`))
-	request.Header.Set("Authorization", "Bearer producer")
-	request.Header.Set(RunUIDHeader, strings.Repeat("x", 129))
-	response := httptest.NewRecorder()
-	api.Handler().ServeHTTP(response, request)
-	if response.Code != http.StatusBadRequest {
-		t.Fatalf("overlong UID status = %d, want %d", response.Code, http.StatusBadRequest)
+func TestTranscriptRequestsRequireBoundedRunUIDBeforeBackendAccess(t *testing.T) {
+	for _, method := range []string{http.MethodGet, http.MethodPost} {
+		for _, test := range []struct {
+			name   string
+			uid    string
+			status int
+		}{
+			{name: "missing", status: http.StatusPreconditionRequired},
+			{name: "whitespace", uid: "  ", status: http.StatusPreconditionRequired},
+			{name: "overlong", uid: strings.Repeat("x", 129), status: http.StatusBadRequest},
+		} {
+			t.Run(method+"/"+test.name, func(t *testing.T) {
+				resolver := &fakeRunResolver{}
+				store := NewMemoryTranscriptStore(MemoryTranscriptStoreOptions{})
+				api := NewServer(nil, ServerOptions{Access: &fakeAccess{}, Runs: resolver, TranscriptStore: store})
+				request := httptest.NewRequest(method, transcriptURL, strings.NewReader(`{"source":"adapter","idempotencyKey":"event-1","type":"output","data":{}}`))
+				request.Header.Set("Authorization", "Bearer transcript-user")
+				request.Header.Set(RunUIDHeader, test.uid)
+				response := httptest.NewRecorder()
+				api.Handler().ServeHTTP(response, request)
+				if response.Code != test.status {
+					t.Fatalf("status = %d, want %d", response.Code, test.status)
+				}
+				memStore := store.(*memoryTranscriptStore)
+				if resolver.calls != 0 || len(memStore.runs) != 0 || len(memStore.subscribers) != 0 {
+					t.Fatalf("rejected request reached backend: resolves=%d runs=%d subscribers=%d", resolver.calls, len(memStore.runs), len(memStore.subscribers))
+				}
+			})
+		}
 	}
 }
 
@@ -448,6 +476,24 @@ func TestTranscriptAppendRejectsStaleRunUIDAfterReplacement(t *testing.T) {
 	}
 	if _, exists := memStore.runs[newIdentity]; exists {
 		t.Fatalf("stale append allocated store state for the replacement Run: %+v", memStore.runs)
+	}
+}
+
+func TestTranscriptReadRejectsStaleRunUIDAfterReplacementBeforeStoreAccess(t *testing.T) {
+	resolver := &fakeRunResolver{uid: "replacement-uid"}
+	store := NewMemoryTranscriptStore(MemoryTranscriptStoreOptions{})
+	api := NewServer(nil, ServerOptions{Access: &fakeAccess{}, Runs: resolver, TranscriptStore: store})
+	request := httptest.NewRequest(http.MethodGet, transcriptURL, nil)
+	request.Header.Set("Authorization", "Bearer reader")
+	request.Header.Set(RunUIDHeader, "original-uid")
+	response := httptest.NewRecorder()
+	api.Handler().ServeHTTP(response, request)
+	if response.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusConflict)
+	}
+	memStore := store.(*memoryTranscriptStore)
+	if resolver.calls != 1 || len(memStore.runs) != 0 || len(memStore.subscribers) != 0 {
+		t.Fatalf("stale read reached store: resolves=%d runs=%d subscribers=%d", resolver.calls, len(memStore.runs), len(memStore.subscribers))
 	}
 }
 

--- a/internal/controlplaneclient/client_test.go
+++ b/internal/controlplaneclient/client_test.go
@@ -261,6 +261,45 @@ func TestStreamSSEReconnectUsesCommittedLastEventID(t *testing.T) {
 	}
 }
 
+func TestStreamRunTranscriptRetainsExactUIDOnReconnect(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.URL.EscapedPath() != "/api/v1/namespaces/team%2Fa/runs/run%20one/transcript" {
+			t.Errorf("path = %q", r.URL.EscapedPath())
+		}
+		if r.Header.Get("Authorization") != "Bearer reader" || r.Header.Get("SWE-Run-UID") != "exact-uid" {
+			t.Errorf("request %d auth/UID = %q/%q", requests, r.Header.Get("Authorization"), r.Header.Get("SWE-Run-UID"))
+		}
+		switch requests {
+		case 1:
+			if r.URL.Query().Get("after") != "starting cursor" || r.Header.Get("Last-Event-ID") != "" {
+				t.Errorf("initial cursor query/header = %q/%q", r.URL.Query().Get("after"), r.Header.Get("Last-Event-ID"))
+			}
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = io.WriteString(w, "retry: 1\n\nid: committed\nevent: transcript\ndata: {}\n\nid: partial\ndata: {}")
+		case 2:
+			if _, present := r.URL.Query()["after"]; present || r.Header.Get("Last-Event-ID") != "committed" {
+				t.Errorf("reconnect cursor query/header = %q/%q", r.URL.RawQuery, r.Header.Get("Last-Event-ID"))
+			}
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected request %d", requests)
+		}
+	}))
+	defer server.Close()
+	client, err := New(server.URL, "reader", server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.StreamRunTranscript(context.Background(), "team/a", "run one", "exact-uid", "starting cursor", func(SSEEvent) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2", requests)
+	}
+}
+
 func TestStreamSSEReconnectCheckFencesNameBasedIdentity(t *testing.T) {
 	requests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/controlplaneclient/resources.go
+++ b/internal/controlplaneclient/resources.go
@@ -105,7 +105,7 @@ func (c *Client) StreamRunSummaries(ctx context.Context, namespace, resourceVers
 	endpoint := c.Endpoint("api", "v1", "namespaces", namespace, "runs")
 	query := url.Values{"watch": {"true"}, "view": {"summary"}, "resourceVersion": {resourceVersion}}
 	connected := false
-	err := c.streamSSEWithReconnectCheck(ctx, endpoint+"?"+query.Encode(), "", nil, retryInitialRunWatch, func() {
+	err := c.streamSSEWithReconnectCheck(ctx, endpoint+"?"+query.Encode(), "", "", nil, retryInitialRunWatch, func() {
 		connected = true
 		if established != nil {
 			established()

--- a/internal/controlplaneclient/sse.go
+++ b/internal/controlplaneclient/sse.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/Chris-Cullins/swe-platform/internal/controlplane"
 )
 
 const (
@@ -34,17 +36,24 @@ type SSEEvent struct {
 // the first successful connection. The initial cursor is sent as ?after=; a
 // reconnect carries the last completely committed event ID in Last-Event-ID.
 func (c *Client) StreamSSE(ctx context.Context, endpoint, cursor string, handle func(SSEEvent) error) error {
-	return c.streamSSEWithReconnectCheck(ctx, endpoint, cursor, nil, nil, nil, handle)
+	return c.streamSSEWithReconnectCheck(ctx, endpoint, cursor, "", nil, nil, nil, handle)
 }
 
 // StreamSSEWithReconnectCheck is StreamSSE with a check immediately before
 // every connection attempt. Callers can use it to fence a name-based endpoint
 // to an immutable resource identity across reconnects.
 func (c *Client) StreamSSEWithReconnectCheck(ctx context.Context, endpoint, cursor string, check func(context.Context) error, handle func(SSEEvent) error) error {
-	return c.streamSSEWithReconnectCheck(ctx, endpoint, cursor, check, nil, nil, handle)
+	return c.streamSSEWithReconnectCheck(ctx, endpoint, cursor, "", check, nil, nil, handle)
 }
 
-func (c *Client) streamSSEWithReconnectCheck(ctx context.Context, endpoint, cursor string, check func(context.Context) error, retryInitial func(error) bool, established func(), handle func(SSEEvent) error) error {
+// StreamRunTranscript consumes one immutable Run's transcript. The exact Run
+// UID is attached to every physical request, including reconnects.
+func (c *Client) StreamRunTranscript(ctx context.Context, namespace, run, runUID, cursor string, handle func(SSEEvent) error) error {
+	endpoint := c.Endpoint("api", "v1", "namespaces", namespace, "runs", run, "transcript")
+	return c.streamSSEWithReconnectCheck(ctx, endpoint, cursor, runUID, nil, nil, nil, handle)
+}
+
+func (c *Client) streamSSEWithReconnectCheck(ctx context.Context, endpoint, cursor, runUID string, check func(context.Context) error, retryInitial func(error) bool, established func(), handle func(SSEEvent) error) error {
 	connected := false
 	reconnectWait := c.reconnectWait
 	for {
@@ -62,6 +71,9 @@ func (c *Client) streamSSEWithReconnectCheck(ctx context.Context, endpoint, curs
 			return err
 		}
 		request.Header.Set("Accept", "text/event-stream")
+		if runUID != "" {
+			request.Header.Set(controlplane.RunUIDHeader, runUID)
+		}
 		if connected && cursor != "" {
 			request.Header.Set("Last-Event-ID", cursor)
 		}

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -29,9 +29,7 @@ var errBatchComplete = errors.New("transcript batch complete")
 
 type controlPlaneClient interface {
 	CreateRun(context.Context, string, controlplane.CreateRunRequest) (controlplane.Run, error)
-	GetRun(context.Context, string, string) (controlplane.Run, error)
-	Endpoint(...string) string
-	StreamSSEWithReconnectCheck(context.Context, string, string, func(context.Context) error, func(controlplaneclient.SSEEvent) error) error
+	StreamRunTranscript(context.Context, string, string, string, string, func(controlplaneclient.SSEEvent) error) error
 }
 
 // CreateRunInput is the bounded immutable Run intent exposed to MCP clients.
@@ -193,22 +191,10 @@ func readTranscript(ctx context.Context, client controlPlaneClient, namespace st
 		Namespace: namespace, RunName: input.RunName, RunUID: input.RunUID,
 		Events: make([]TranscriptEnvelope, 0, maxEvents), NextCursor: input.After,
 	}
-	checkIdentity := func(checkCtx context.Context) error {
-		run, err := client.GetRun(checkCtx, namespace, input.RunName)
-		if err != nil {
-			return fmt.Errorf("get Run identity: %w", err)
-		}
-		if run.UID != input.RunUID {
-			return fmt.Errorf("Run %s/%s was replaced: expected UID %q, got %q", namespace, input.RunName, input.RunUID, run.UID)
-		}
-		return nil
-	}
-
 	batchCtx, cancel := context.WithTimeout(ctx, wait)
 	defer cancel()
 	dataBytes := 0
-	endpoint := client.Endpoint("api", "v1", "namespaces", namespace, "runs", input.RunName, "transcript")
-	err := client.StreamSSEWithReconnectCheck(batchCtx, endpoint, input.After, checkIdentity, func(event controlplaneclient.SSEEvent) error {
+	err := client.StreamRunTranscript(batchCtx, namespace, input.RunName, input.RunUID, input.After, func(event controlplaneclient.SSEEvent) error {
 		if !json.Valid(event.Data) {
 			return fmt.Errorf("control plane returned non-JSON %q event data", event.Event)
 		}
@@ -240,7 +226,7 @@ func readTranscript(ctx context.Context, client controlPlaneClient, namespace st
 		}
 		if dataBytes+len(event.Data) > maxTranscriptResultData {
 			if len(output.Events) == 0 {
-				return fmt.Errorf("first transcript event exceeds the %d-byte MCP batch bound; use swe logs --run for streaming output", maxTranscriptResultData)
+				return fmt.Errorf("first transcript event exceeds the %d-byte MCP batch bound; use swe logs --run with its exact --run-uid for streaming output", maxTranscriptResultData)
 			}
 			output.LimitReached = true
 			return errBatchComplete

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -18,11 +18,13 @@ type fakeControlPlaneClient struct {
 	createdRequest   controlplane.CreateRunRequest
 	createResult     controlplane.Run
 	createErr        error
-	run              controlplane.Run
-	streamEndpoint   string
+	streamNamespace  string
+	streamRun        string
+	streamRunUID     string
 	streamCursor     string
 	streamEvents     []controlplaneclient.SSEEvent
 	streamCalls      int
+	streamErr        error
 }
 
 func (f *fakeControlPlaneClient) CreateRun(_ context.Context, namespace string, request controlplane.CreateRunRequest) (controlplane.Run, error) {
@@ -30,22 +32,11 @@ func (f *fakeControlPlaneClient) CreateRun(_ context.Context, namespace string, 
 	return f.createResult, f.createErr
 }
 
-func (f *fakeControlPlaneClient) GetRun(context.Context, string, string) (controlplane.Run, error) {
-	return f.run, nil
-}
-
-func (f *fakeControlPlaneClient) Endpoint(segments ...string) string {
-	return "https://control.example/" + strings.Join(segments, "/")
-}
-
-func (f *fakeControlPlaneClient) StreamSSEWithReconnectCheck(ctx context.Context, endpoint, cursor string, check func(context.Context) error, handle func(controlplaneclient.SSEEvent) error) error {
+func (f *fakeControlPlaneClient) StreamRunTranscript(ctx context.Context, namespace, run, runUID, cursor string, handle func(controlplaneclient.SSEEvent) error) error {
 	f.streamCalls++
-	f.streamEndpoint, f.streamCursor = endpoint, cursor
-	if err := check(ctx); err != nil {
-		return err
-	}
-	if err := check(ctx); err != nil {
-		return err
+	f.streamNamespace, f.streamRun, f.streamRunUID, f.streamCursor = namespace, run, runUID, cursor
+	if f.streamErr != nil {
+		return f.streamErr
 	}
 	for _, event := range f.streamEvents {
 		if err := handle(event); err != nil {
@@ -125,7 +116,6 @@ func TestMCPInputSchemasEnforceBoundsBeforeControlPlaneCalls(t *testing.T) {
 
 func TestReadTranscriptReturnsBoundedOpaqueBatchAndCursor(t *testing.T) {
 	fake := &fakeControlPlaneClient{
-		run: controlplane.Run{Name: "task-1", UID: "run-uid"},
 		streamEvents: []controlplaneclient.SSEEvent{
 			{Event: "transcript-gap", Data: []byte(`{"resumeAfter":"gap-cursor"}`)},
 			{Event: "transcript", ID: "cursor-2", HasID: true, Data: []byte(`{"source":"adapter","type":"owned","data":{"value":1}}`)},
@@ -138,8 +128,8 @@ func TestReadTranscriptReturnsBoundedOpaqueBatchAndCursor(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if fake.streamEndpoint != "https://control.example/api/v1/namespaces/team-a/runs/task-1/transcript" || fake.streamCursor != "cursor-1" {
-		t.Fatalf("stream = %q after %q", fake.streamEndpoint, fake.streamCursor)
+	if fake.streamNamespace != "team-a" || fake.streamRun != "task-1" || fake.streamRunUID != "run-uid" || fake.streamCursor != "cursor-1" {
+		t.Fatalf("stream = %q/%q uid %q after %q", fake.streamNamespace, fake.streamRun, fake.streamRunUID, fake.streamCursor)
 	}
 	if len(output.Events) != 2 || !output.LimitReached || output.TimedOut || output.NextCursor != "cursor-2" {
 		t.Fatalf("output = %#v", output)
@@ -151,20 +141,18 @@ func TestReadTranscriptReturnsBoundedOpaqueBatchAndCursor(t *testing.T) {
 
 func TestReadTranscriptRejectsReplacedRunBeforeEvents(t *testing.T) {
 	fake := &fakeControlPlaneClient{
-		run:          controlplane.Run{Name: "task-1", UID: "replacement-uid"},
-		streamEvents: []controlplaneclient.SSEEvent{{Event: "transcript", ID: "cursor", HasID: true, Data: []byte(`{}`)}},
+		streamErr: errors.New("control plane returned 409 Conflict: Run UID mismatch"),
 	}
 	output, err := readTranscript(context.Background(), fake, "team-a", ReadTranscriptInput{
 		RunName: "task-1", RunUID: "original-uid", MaxEvents: 1, WaitMilliseconds: 10,
 	})
-	if err == nil || !strings.Contains(err.Error(), "was replaced") || len(output.Events) != 0 {
+	if err == nil || !strings.Contains(err.Error(), "Run UID mismatch") || len(output.Events) != 0 {
 		t.Fatalf("output/error = %#v/%v", output, err)
 	}
 }
 
 func TestReadTranscriptGapAdvancesSafeCursor(t *testing.T) {
 	fake := &fakeControlPlaneClient{
-		run: controlplane.Run{Name: "task-1", UID: "run-uid"},
 		streamEvents: []controlplaneclient.SSEEvent{
 			{Event: "transcript-gap", ID: "stale-cursor", Data: []byte(`{"resumeAfter":"safe-cursor","earliestSequence":4}`)},
 		},
@@ -182,7 +170,6 @@ func TestReadTranscriptGapAdvancesSafeCursor(t *testing.T) {
 
 func TestReadTranscriptRejectsMalformedGapCursor(t *testing.T) {
 	fake := &fakeControlPlaneClient{
-		run:          controlplane.Run{Name: "task-1", UID: "run-uid"},
 		streamEvents: []controlplaneclient.SSEEvent{{Event: "transcript-gap", Data: []byte(`{"earliestSequence":4}`)}},
 	}
 	_, err := readTranscript(context.Background(), fake, "team-a", ReadTranscriptInput{
@@ -196,7 +183,6 @@ func TestReadTranscriptRejectsMalformedGapCursor(t *testing.T) {
 func TestReadTranscriptDoesNotAdvancePastOmittedGap(t *testing.T) {
 	firstData := []byte(`{"payload":"` + strings.Repeat("x", maxTranscriptResultData-32) + `"}`)
 	fake := &fakeControlPlaneClient{
-		run: controlplane.Run{Name: "task-1", UID: "run-uid"},
 		streamEvents: []controlplaneclient.SSEEvent{
 			{Event: "transcript", ID: "accepted-cursor", HasID: true, Data: firstData},
 			{Event: "transcript-gap", Data: []byte(`{"resumeAfter":"gap-cursor","earliestSequence":4}`)},
@@ -229,7 +215,7 @@ func TestValidateCreateRunRejectsUnboundedOrAmbiguousIntent(t *testing.T) {
 }
 
 func TestReadTranscriptPropagatesCallerCancellation(t *testing.T) {
-	fake := &fakeControlPlaneClient{run: controlplane.Run{Name: "task", UID: "uid"}}
+	fake := &fakeControlPlaneClient{}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	_, err := readTranscript(ctx, fake, "team-a", ReadTranscriptInput{RunName: "task", RunUID: "uid"})

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -26,20 +26,7 @@ function show(path: string, state?: unknown) {
   return { client, ...render(<QueryClientProvider client={client}><MemoryRouter initialEntries={[entry]}><LocationProbe /><App /></MemoryRouter></QueryClientProvider>) }
 }
 
-class TestEventSource {
-  static instances: TestEventSource[] = []
-  static CONNECTING = 0
-  static OPEN = 1
-  static CLOSED = 2
-  readyState = TestEventSource.CONNECTING
-  onopen: (() => void) | null = null
-  onerror: (() => void) | null = null
-  close = vi.fn()
-  constructor(public url: string) { TestEventSource.instances.push(this) }
-  addEventListener() {}
-}
-
-afterEach(() => { TestEventSource.instances = []; vi.useRealTimers(); vi.restoreAllMocks(); vi.unstubAllGlobals() })
+afterEach(() => { vi.useRealTimers(); vi.restoreAllMocks(); vi.unstubAllGlobals() })
 describe('App frozen API integration', () => {
   it('lands on the default namespace Run feed from the root route', async () => {
     const fetch = vi.spyOn(globalThis, 'fetch').mockImplementation(async path => path === '/api/v1/session' ? response({ authenticated: true, username: 'alex' }) : response({ items: [] }))
@@ -179,21 +166,24 @@ describe('App frozen API integration', () => {
   })
 
   it('keeps the transcript stream mounted when cancellation only advances Run generation', async () => {
-    vi.stubGlobal('EventSource', TestEventSource)
     const detail = { ...run, environment: undefined, generation: 1 }
-    vi.spyOn(globalThis, 'fetch').mockImplementation(async path => {
+    const transcriptRequests: RequestInit[] = []
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (path, init = {}) => {
       if (path === '/api/v1/session') return response({ authenticated: true, username: 'alex' })
       if (path === '/api/v1/namespaces/default/runs?limit=200&view=summary') return response({ items: [detail] })
       if (path === '/api/v1/namespaces/default/runs/repair-ui') return response(detail)
+      if (path === '/api/v1/namespaces/default/runs/repair-ui/transcript') {
+        transcriptRequests.push(init)
+        return new Response(new ReadableStream())
+      }
       throw new Error(`Unexpected request: ${path}`)
     })
     const { client } = show('/namespaces/default/runs/repair-ui/transcript')
-    await waitFor(() => expect(TestEventSource.instances).toHaveLength(1))
-    const stream = TestEventSource.instances[0]
+    await waitFor(() => expect(transcriptRequests).toHaveLength(1))
     act(() => client.setQueryData(queryKeys.run('default', 'repair-ui'), { ...detail, generation: 2, cancelRequested: true }))
     await waitFor(() => expect(client.getQueryData<Run>(queryKeys.run('default', 'repair-ui'))?.generation).toBe(2))
-    expect(TestEventSource.instances).toHaveLength(1)
-    expect(stream.close).not.toHaveBeenCalled()
+    expect(transcriptRequests).toHaveLength(1)
+    expect((transcriptRequests[0].signal as AbortSignal).aborted).toBe(false)
   })
 
   it('shows accessible loading and problem error states', async () => {

--- a/ui/src/Transcript.test.tsx
+++ b/ui/src/Transcript.test.tsx
@@ -213,6 +213,20 @@ describe('Transcript', () => {
     }))
   })
 
+  it('retries an initial transport failure with the same exact UID', async () => {
+    let requests = 0
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (path, init = {}) => {
+      requests += 1
+      if (requests === 1) throw new TypeError('network unavailable')
+      return new Events(String(path), init).response()
+    })
+    render(<Transcript namespace="n" run="r" identity="uid-exact" />)
+    await waitFor(() => expect(Events.instances).toHaveLength(1))
+    expect(requests).toBe(2)
+    expect(Events.current.init.headers).toEqual(expect.objectContaining({ 'SWE-Run-UID': 'uid-exact' }))
+    expect(Events.current.init.headers).not.toHaveProperty('Last-Event-ID')
+  })
+
   it('recovers an expired reconnect cursor once without dropping the UID', async () => {
     let requests = 0
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (path, init = {}) => {

--- a/ui/src/Transcript.test.tsx
+++ b/ui/src/Transcript.test.tsx
@@ -19,19 +19,21 @@ vi.mock('./ClaudeTranscript', async importOriginal => {
 class Events {
   static current: Events
   static instances: Events[] = []
-  static CONNECTING = 0
-  static OPEN = 1
-  static CLOSED = 2
-  listeners = new Map<string, EventListener>()
-  readyState = Events.CONNECTING
-  onopen: (() => void) | null = null
-  onerror: (() => void) | null = null
-  close = vi.fn()
-  constructor(public url: string) { Events.current = this; Events.instances.push(this) }
-  addEventListener(type: string, listener: EventListener) { this.listeners.set(type, listener) }
-  emit(type: string, data: string, id = '') { this.listeners.get(type)?.(new MessageEvent(type, { data, lastEventId: id })) }
-  open() { this.readyState = Events.OPEN; this.onopen?.() }
-  async fail(state = Events.CLOSED) { this.readyState = state; await this.onerror?.() }
+  controller!: ReadableStreamDefaultController<Uint8Array>
+  close = vi.fn(() => this.controller.close())
+  constructor(public url: string, public init: RequestInit) {
+    Events.current = this
+    Events.instances.push(this)
+  }
+  response() { return new Response(new ReadableStream({ start: controller => { this.controller = controller } }), { headers: { 'Content-Type': 'text/event-stream' } }) }
+  emit(type: string, data: string, id = '') {
+    this.controller.enqueue(new TextEncoder().encode(`${id ? `id: ${id}\n` : ''}event: ${type}\ndata: ${data}\n\n`))
+  }
+  fail(error = new Error('stream interrupted')) { this.controller.error(error) }
+}
+
+function mockStreams() {
+  return vi.spyOn(globalThis, 'fetch').mockImplementation(async (path, init = {}) => new Events(String(path), init).response())
 }
 
 function processData(records: unknown[]) {
@@ -46,9 +48,10 @@ function processData(records: unknown[]) {
 
 afterEach(() => { Events.instances = []; vi.restoreAllMocks(); vi.unstubAllGlobals() })
 describe('Transcript', () => {
-  it('uses an unchanged encoded EventSource URL, orders events, and deduplicates IDs and sequences', async () => {
-    vi.stubGlobal('EventSource', Events)
-    const view = render(<Transcript namespace="a/b" run="run one" />)
+  it('sends the exact Run UID and SSE headers, orders events, and deduplicates IDs and sequences', async () => {
+    mockStreams()
+    const view = render(<Transcript namespace="a/b" run="run one" identity="uid/Exact Value" />)
+    await waitFor(() => expect(Events.instances).toHaveLength(1))
     act(() => {
       Events.current.emit('transcript', '{"sequence":3,"data":{"opaque":true}}', 'three')
       Events.current.emit('transcript', '{"sequence":1,"data":"first"}', 'one')
@@ -56,17 +59,20 @@ describe('Transcript', () => {
       Events.current.emit('transcript', '{"sequence":1,"data":"duplicate sequence"}', 'other')
     })
     expect(Events.current.url).toBe('/api/v1/namespaces/a%2Fb/runs/run%20one/transcript')
+    expect(Events.current.init).toEqual(expect.objectContaining({ credentials: 'same-origin' }))
+    expect(Events.current.init.headers).toEqual(expect.objectContaining({ Accept: 'text/event-stream', 'SWE-Run-UID': 'uid/Exact Value' }))
     const items = await screen.findAllByRole('listitem')
     expect(items).toHaveLength(2)
     expect(items[0]).toHaveTextContent('Eventfirst')
     expect(items[1]).toHaveTextContent('"opaque": true')
     view.unmount()
-    expect(Events.current.close).toHaveBeenCalledOnce()
+    expect((Events.current.init.signal as AbortSignal).aborted).toBe(true)
   })
 
   it('retains the actual gap payload without requiring an SSE id or sequence', async () => {
-    vi.stubGlobal('EventSource', Events)
-    render(<Transcript namespace="n" run="r" />)
+    mockStreams()
+    render(<Transcript namespace="n" run="r" identity="uid-r" />)
+    await waitFor(() => expect(Events.instances).toHaveLength(1))
     act(() => {
       Events.current.emit('transcript', '{"sequence":2,"data":"before"}', '2')
       Events.current.emit('transcript-gap', '{"resumeAfter":"cursor-9","earliestSequence":4,"latestSequence":8}')
@@ -84,27 +90,31 @@ describe('Transcript', () => {
   })
 
   it('resets stream data when the run or namespace changes', async () => {
-    vi.stubGlobal('EventSource', Events)
-    const view = render(<Transcript namespace="n" run="first" />)
+    mockStreams()
+    const view = render(<Transcript namespace="n" run="first" identity="uid-first" />)
+    await waitFor(() => expect(Events.instances).toHaveLength(1))
     const first = Events.current
     act(() => first.emit('transcript', '{"sequence":1,"data":"old run"}', '1'))
     expect(await screen.findByText('old run')).toBeInTheDocument()
-    view.rerender(<Transcript namespace="n" run="second" />)
-    expect(first.close).toHaveBeenCalledOnce()
+    view.rerender(<Transcript namespace="n" run="second" identity="uid-second" />)
+    expect((first.init.signal as AbortSignal).aborted).toBe(true)
+    await waitFor(() => expect(Events.instances).toHaveLength(2))
     expect(Events.current.url).toContain('/runs/second/transcript')
     expect(screen.queryByText('old run')).not.toBeInTheDocument()
     const second = Events.current
     act(() => second.emit('transcript', '{"sequence":1,"data":"old namespace"}', '2'))
     expect(await screen.findByText('old namespace')).toBeInTheDocument()
-    view.rerender(<Transcript namespace="other" run="second" />)
-    expect(second.close).toHaveBeenCalledOnce()
+    view.rerender(<Transcript namespace="other" run="second" identity="uid-second" />)
+    expect((second.init.signal as AbortSignal).aborted).toBe(true)
+    await waitFor(() => expect(Events.instances).toHaveLength(3))
     expect(Events.current.url).toContain('/namespaces/other/')
     expect(screen.queryByText('old namespace')).not.toBeInTheDocument()
   })
 
   it('safely renders unknown objects, JSON strings, and plain opaque strings', async () => {
-    vi.stubGlobal('EventSource', Events)
-    render(<Transcript namespace="n" run="r" />)
+    mockStreams()
+    render(<Transcript namespace="n" run="r" identity="uid-r" />)
+    await waitFor(() => expect(Events.instances).toHaveLength(1))
     act(() => {
       Events.current.emit('transcript', '{"sequence":1,"source":"new","type":"thing","data":{"x":1}}', '1')
       Events.current.emit('transcript', '{"sequence":2,"data":"hello"}', '2')
@@ -117,8 +127,9 @@ describe('Transcript', () => {
   })
 
   it('renders known Claude records safely and mounts raw transport JSON only when opened', async () => {
-    vi.stubGlobal('EventSource', Events)
-    render(<Transcript namespace="n" run="claude" />)
+    mockStreams()
+    render(<Transcript namespace="n" run="claude" identity="uid-claude" />)
+    await waitFor(() => expect(Events.instances).toHaveLength(1))
     const data = processData([
       { type: 'system', subtype: 'init', session_id: 'session-1', model: 'claude-sonnet' },
       { type: 'assistant', message: { model: 'claude-sonnet', content: [{ type: 'text', text: '<b>safe text</b>' }, { type: 'tool_use', name: 'Read', input: { file_path: 'README.md' } }] } },
@@ -142,8 +153,9 @@ describe('Transcript', () => {
   })
 
   it('coalesces a live replay while visibly bounding history with a client-only assembly reset boundary', async () => {
-    vi.stubGlobal('EventSource', Events)
-    render(<Transcript namespace="n" run="bounded" />)
+    mockStreams()
+    render(<Transcript namespace="n" run="bounded" identity="uid-bounded" />)
+    await waitFor(() => expect(Events.instances).toHaveLength(1))
     reducerCalls.mockClear()
     act(() => {
       for (let sequence = 1; sequence <= MAX_TRANSCRIPT_ITEMS + 2; sequence += 1) {
@@ -158,25 +170,24 @@ describe('Transcript', () => {
     expect(screen.getAllByRole('listitem')).toHaveLength(MAX_TRANSCRIPT_ITEMS + 1)
   })
 
-  it('checks auth then replaces a fatally closed opened source for gap-aware replay', async () => {
-    const fetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ authenticated: true, username: 'alex' })))
-    vi.stubGlobal('EventSource', Events)
-    render(<Transcript namespace="n" run="r" />)
+  it('reconnects with the exact UID and last committed event ID for gap-aware replay', async () => {
+    mockStreams()
+    render(<Transcript namespace="n" run="r" identity="uid-r-EXACT" />)
+    await waitFor(() => expect(Events.instances).toHaveLength(1))
     const stale = Events.current
     act(() => {
-      stale.open()
       stale.emit('transcript', '{"sequence":1,"data":"before disconnect"}', 'cursor-1')
     })
     expect(await screen.findByText('before disconnect')).toBeInTheDocument()
-    await act(async () => stale.fail())
-    expect(fetch).toHaveBeenCalledWith('/api/v1/session', expect.objectContaining({ credentials: 'same-origin' }))
-    expect(stale.close).toHaveBeenCalledOnce()
-    expect(Events.instances).toHaveLength(2)
+    act(() => stale.close())
+    await waitFor(() => expect(Events.instances).toHaveLength(2))
     const fresh = Events.current
     expect(fresh).not.toBe(stale)
     expect(fresh.url).toBe(stale.url)
+    expect(fresh.init.headers).toEqual(expect.objectContaining({
+      Accept: 'text/event-stream', 'SWE-Run-UID': 'uid-r-EXACT', 'Last-Event-ID': 'cursor-1',
+    }))
     act(() => {
-      fresh.open()
       fresh.emit('transcript-gap', '{"resumeAfter":"fresh-cursor","earliestSequence":3,"latestSequence":4}')
       fresh.emit('transcript', '{"sequence":3,"data":"retained replay"}', 'cursor-3')
     })
@@ -188,15 +199,58 @@ describe('Transcript', () => {
     expect(items[2]).toHaveTextContent('Eventretained replay')
   })
 
-  it('leaves CONNECTING errors to native cursor-aware reconnect', async () => {
-    const fetch = vi.spyOn(globalThis, 'fetch')
-    vi.stubGlobal('EventSource', Events)
-    render(<Transcript namespace="n" run="r" />)
-    const stream = Events.current
-    act(() => stream.open())
-    await act(async () => stream.fail(Events.CONNECTING))
-    expect(screen.getByRole('status')).toHaveTextContent('Reconnecting')
-    expect(Events.instances).toHaveLength(1)
-    expect(fetch).not.toHaveBeenCalled()
+  it('reconnects a body-read failure with the same UID and committed cursor', async () => {
+    mockStreams()
+    render(<Transcript namespace="n" run="r" identity="uid-exact" />)
+    await waitFor(() => expect(Events.instances).toHaveLength(1))
+    const interrupted = Events.current
+    act(() => interrupted.emit('transcript', '{"sequence":1,"data":"committed"}', 'cursor-1'))
+    expect(await screen.findByText('committed')).toBeInTheDocument()
+    act(() => interrupted.fail())
+    await waitFor(() => expect(Events.instances).toHaveLength(2))
+    expect(Events.current.init.headers).toEqual(expect.objectContaining({
+      'SWE-Run-UID': 'uid-exact', 'Last-Event-ID': 'cursor-1',
+    }))
   })
+
+  it('recovers an expired reconnect cursor once without dropping the UID', async () => {
+    let requests = 0
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (path, init = {}) => {
+      requests += 1
+      if (requests === 2) return new Response('', { status: 410, statusText: 'Gone' })
+      return new Events(String(path), init).response()
+    })
+    render(<Transcript namespace="n" run="r" identity="uid-exact" />)
+    await waitFor(() => expect(Events.instances).toHaveLength(1))
+    const first = Events.current
+    act(() => {
+      first.emit('transcript', '{"sequence":1,"data":"before retention"}', 'cursor-1')
+      first.close()
+    })
+    await waitFor(() => expect(requests).toBe(3))
+    expect(Events.instances).toHaveLength(2)
+    expect(Events.current.init.headers).toEqual(expect.objectContaining({ 'SWE-Run-UID': 'uid-exact' }))
+    expect(Events.current.init.headers).not.toHaveProperty('Last-Event-ID')
+    act(() => Events.current.emit('transcript-gap', '{"resumeAfter":"fresh","earliestSequence":4}'))
+    expect(await screen.findByText(/History before sequence 4/)).toBeInTheDocument()
+  })
+
+  it('treats a stale Run UID conflict as terminal', async () => {
+    let requests = 0
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (path, init = {}) => {
+      requests += 1
+      if (requests === 2) return new Response('', { status: 409, statusText: 'Conflict' })
+      return new Events(String(path), init).response()
+    })
+    render(<Transcript namespace="n" run="r" identity="stale-uid" />)
+    await waitFor(() => expect(Events.instances).toHaveLength(1))
+    act(() => {
+      Events.current.emit('transcript', '{"sequence":1,"data":"old"}', 'cursor-1')
+      Events.current.close()
+    })
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Conflict'))
+    await new Promise(resolve => setTimeout(resolve, 300))
+    expect(requests).toBe(2)
+  })
+
 })

--- a/ui/src/Transcript.test.tsx
+++ b/ui/src/Transcript.test.tsx
@@ -21,15 +21,17 @@ class Events {
   static instances: Events[] = []
   controller!: ReadableStreamDefaultController<Uint8Array>
   close = vi.fn(() => this.controller.close())
+  cancel = vi.fn()
   constructor(public url: string, public init: RequestInit) {
     Events.current = this
     Events.instances.push(this)
   }
-  response() { return new Response(new ReadableStream({ start: controller => { this.controller = controller } }), { headers: { 'Content-Type': 'text/event-stream' } }) }
+  response() { return new Response(new ReadableStream({ start: controller => { this.controller = controller }, cancel: this.cancel }), { headers: { 'Content-Type': 'text/event-stream' } }) }
   emit(type: string, data: string, id = '') {
     this.controller.enqueue(new TextEncoder().encode(`${id ? `id: ${id}\n` : ''}event: ${type}\ndata: ${data}\n\n`))
   }
   fail(error = new Error('stream interrupted')) { this.controller.error(error) }
+  write(data: Uint8Array) { this.controller.enqueue(data) }
 }
 
 function mockStreams() {
@@ -225,6 +227,17 @@ describe('Transcript', () => {
     expect(requests).toBe(2)
     expect(Events.current.init.headers).toEqual(expect.objectContaining({ 'SWE-Run-UID': 'uid-exact' }))
     expect(Events.current.init.headers).not.toHaveProperty('Last-Event-ID')
+  })
+
+  it('cancels the response reader after a terminal oversized event', async () => {
+    mockStreams()
+    render(<Transcript namespace="n" run="r" identity="uid-exact" />)
+    await waitFor(() => expect(Events.instances).toHaveLength(1))
+    const stream = Events.current
+    act(() => stream.write(new Uint8Array((8 << 20) + 1).fill(120)))
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Transcript event exceeds'))
+    expect(stream.cancel).toHaveBeenCalledOnce()
+    expect(Events.instances).toHaveLength(1)
   })
 
   it('recovers an expired reconnect cursor once without dropping the UID', async () => {

--- a/ui/src/Transcript.test.tsx
+++ b/ui/src/Transcript.test.tsx
@@ -26,7 +26,7 @@ class Events {
     Events.current = this
     Events.instances.push(this)
   }
-  response() { return new Response(new ReadableStream({ start: controller => { this.controller = controller }, cancel: this.cancel }), { headers: { 'Content-Type': 'text/event-stream' } }) }
+  response(status = 200, statusText = '', contentType = 'text/event-stream') { return new Response(new ReadableStream({ start: controller => { this.controller = controller }, cancel: this.cancel }), { status, statusText, headers: { 'Content-Type': contentType } }) }
   emit(type: string, data: string, id = '') {
     this.controller.enqueue(new TextEncoder().encode(`${id ? `id: ${id}\n` : ''}event: ${type}\ndata: ${data}\n\n`))
   }
@@ -238,6 +238,27 @@ describe('Transcript', () => {
     await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Transcript event exceeds'))
     expect(stream.cancel).toHaveBeenCalledOnce()
     expect(Events.instances).toHaveLength(1)
+  })
+
+  it('cancels a retryable error response before reconnecting with the same UID', async () => {
+    let requests = 0
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (path, init = {}) => {
+      requests += 1
+      const stream = new Events(String(path), init)
+      return requests === 1 ? stream.response(503, 'Unavailable') : stream.response()
+    })
+    render(<Transcript namespace="n" run="r" identity="uid-exact" />)
+    await waitFor(() => expect(Events.instances).toHaveLength(2))
+    expect(Events.instances[0].cancel).toHaveBeenCalledOnce()
+    expect(Events.instances[1].init.headers).toEqual(expect.objectContaining({ 'SWE-Run-UID': 'uid-exact' }))
+  })
+
+  it('cancels a terminal wrong-content-type response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (path, init = {}) => new Events(String(path), init).response(200, '', 'application/json'))
+    render(<Transcript namespace="n" run="r" identity="uid-exact" />)
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Expected transcript event stream'))
+    expect(Events.instances).toHaveLength(1)
+    expect(Events.instances[0].cancel).toHaveBeenCalledOnce()
   })
 
   it('recovers an expired reconnect cursor once without dropping the UID', async () => {

--- a/ui/src/Transcript.tsx
+++ b/ui/src/Transcript.tsx
@@ -224,7 +224,7 @@ export function Transcript({ namespace, run, identity }: { namespace: string; ru
           }
         } catch (error) {
           if (disposed || controller.signal.aborted) return
-          if (established && !(error instanceof Error && error.message.startsWith('Transcript event exceeds'))) {
+          if (!(error instanceof Error && error.message.startsWith('Transcript event exceeds'))) {
             setStatus('Reconnecting')
             await reconnectDelay()
             continue

--- a/ui/src/Transcript.tsx
+++ b/ui/src/Transcript.tsx
@@ -184,39 +184,43 @@ export function Transcript({ namespace, run, identity }: { namespace: string; ru
           const reader = response.body.getReader()
           const decoder = new TextDecoder()
           let buffer = ''
-          while (!disposed) {
-            const { value, done } = await reader.read()
-            if (value) buffer += decoder.decode(value, { stream: true })
-            let boundary: { index: number; length: number } | undefined
-            while ((boundary = sseBoundary(buffer)) !== undefined) {
-              if (boundary.index > MAX_SSE_BUFFER) throw new Error(`Transcript event exceeds ${MAX_SSE_BUFFER} bytes`)
-              const block = buffer.slice(0, boundary.index)
-              buffer = buffer.slice(boundary.index + boundary.length)
-              let type = 'message'
-              let id = ''
-              let hasID = false
-              const data: string[] = []
-              for (const line of block.split(/\r\n|\n|\r/)) {
-                if (!line || line.startsWith(':')) continue
-                const colon = line.indexOf(':')
-                const field = colon < 0 ? line : line.slice(0, colon)
-                const fieldValue = colon < 0 ? '' : line.slice(colon + 1).replace(/^ /, '')
-                if (field === 'event') type = fieldValue
-                else if (field === 'id' && !fieldValue.includes('\0')) { id = fieldValue; hasID = true }
-                else if (field === 'data') data.push(fieldValue)
-                else if (field === 'retry' && /^\d+$/.test(fieldValue)) reconnectWait = Math.min(Number(fieldValue), 30_000)
+          try {
+            while (!disposed) {
+              const { value, done } = await reader.read()
+              if (value) buffer += decoder.decode(value, { stream: true })
+              let boundary: { index: number; length: number } | undefined
+              while ((boundary = sseBoundary(buffer)) !== undefined) {
+                if (boundary.index > MAX_SSE_BUFFER) throw new Error(`Transcript event exceeds ${MAX_SSE_BUFFER} bytes`)
+                const block = buffer.slice(0, boundary.index)
+                buffer = buffer.slice(boundary.index + boundary.length)
+                let type = 'message'
+                let id = ''
+                let hasID = false
+                const data: string[] = []
+                for (const line of block.split(/\r\n|\n|\r/)) {
+                  if (!line || line.startsWith(':')) continue
+                  const colon = line.indexOf(':')
+                  const field = colon < 0 ? line : line.slice(0, colon)
+                  const fieldValue = colon < 0 ? '' : line.slice(colon + 1).replace(/^ /, '')
+                  if (field === 'event') type = fieldValue
+                  else if (field === 'id' && !fieldValue.includes('\0')) { id = fieldValue; hasID = true }
+                  else if (field === 'data') data.push(fieldValue)
+                  else if (field === 'retry' && /^\d+$/.test(fieldValue)) reconnectWait = Math.min(Number(fieldValue), 30_000)
+                }
+                if (hasID) lastEventID = id
+                if (!data.length) continue
+                const event = new MessageEvent(type, { data: data.join('\n'), lastEventId: lastEventID })
+                if (type === 'transcript') onTranscript(event)
+                else if (type === 'transcript-gap') onGap(event)
               }
-              if (hasID) lastEventID = id
-              if (!data.length) continue
-              const event = new MessageEvent(type, { data: data.join('\n'), lastEventId: lastEventID })
-              if (type === 'transcript') onTranscript(event)
-              else if (type === 'transcript-gap') onGap(event)
+              if (buffer.length > MAX_SSE_BUFFER) throw new Error(`Transcript event exceeds ${MAX_SSE_BUFFER} bytes`)
+              if (done) {
+                decoder.decode()
+                break
+              }
             }
-            if (buffer.length > MAX_SSE_BUFFER) throw new Error(`Transcript event exceeds ${MAX_SSE_BUFFER} bytes`)
-            if (done) {
-              decoder.decode()
-              break
-            }
+          } finally {
+            await reader.cancel().catch(() => undefined)
           }
           if (!disposed) {
             setStatus('Reconnecting')

--- a/ui/src/Transcript.tsx
+++ b/ui/src/Transcript.tsx
@@ -156,9 +156,16 @@ export function Transcript({ namespace, run, identity }: { namespace: string; ru
       while (!disposed) {
         try {
           const response = await api.transcript(namespace, run, identity, controller.signal, lastEventID || undefined)
-          if (response.status === 401) return
+          const cancelResponse = async () => {
+            if (response.body) await response.body.cancel().catch(() => undefined)
+          }
+          if (response.status === 401) {
+            await cancelResponse()
+            return
+          }
           if (!response.ok || !response.body) {
             if (established && lastEventID && !freshRecoveryUsed && (response.status === 400 || response.status === 410)) {
+              await cancelResponse()
               lastEventID = ''
               freshRecoveryUsed = true
               setStatus('Recovering transcript')
@@ -166,15 +173,18 @@ export function Transcript({ namespace, run, identity }: { namespace: string; ru
               continue
             }
             if (response.status === 408 || response.status === 429 || response.status >= 500) {
+              await cancelResponse()
               setStatus('Reconnecting')
               await reconnectDelay()
               continue
             }
+            await cancelResponse()
             setStatus(response.statusText || `Request failed (${response.status})`)
             return
           }
           const mediaType = response.headers.get('Content-Type')?.split(';', 1)[0].trim().toLowerCase()
           if (mediaType !== 'text/event-stream') {
+            await cancelResponse()
             setStatus(`Expected transcript event stream, got ${mediaType || 'unknown content type'}`)
             return
           }

--- a/ui/src/Transcript.tsx
+++ b/ui/src/Transcript.tsx
@@ -77,24 +77,44 @@ interface TranscriptState {
   claude: ClaudeTranscriptReduction
 }
 
+const MAX_SSE_BUFFER = 8 << 20
+
+function sseBoundary(buffer: string): { index: number; length: number } | undefined {
+  const match = /\r\n\r\n|\n\n|\r\r/.exec(buffer)
+  return match ? { index: match.index, length: match[0].length } : undefined
+}
+
 function emptyTranscriptState(): TranscriptState {
   const timeline: TranscriptRenderItem[] = []
   return { timeline, claude: updateClaudeTranscript(undefined, timeline) }
 }
 
-export function Transcript({ namespace, run, identity }: { namespace: string; run: string; identity?: string }) {
+export function Transcript({ namespace, run, identity }: { namespace: string; run: string; identity: string }) {
   const [status, setStatus] = useState('Connecting')
   const [transcript, setTranscript] = useState<TranscriptState>(emptyTranscriptState)
   useEffect(() => {
     setTranscript(emptyTranscriptState())
     setStatus('Connecting')
-    const url = api.transcriptUrl(namespace, run)
-    let stream: EventSource | undefined
+    const controller = new AbortController()
     let disposed = false
+    let lastEventID = ''
+    let established = false
     let freshRecoveryUsed = false
+    let reconnectWait = 250
     let queuedTimeline: TranscriptRenderItem[] = []
     let frame: number | undefined
     let timer: number | undefined
+    const reconnectDelay = () => new Promise<void>(resolve => {
+      const onAbort = () => {
+        window.clearTimeout(reconnect)
+        resolve()
+      }
+      const reconnect = window.setTimeout(() => {
+        controller.signal.removeEventListener('abort', onAbort)
+        resolve()
+      }, reconnectWait)
+      controller.signal.addEventListener('abort', onAbort, { once: true })
+    })
     const flushTimeline = () => {
       frame = undefined
       timer = undefined
@@ -132,49 +152,94 @@ export function Transcript({ namespace, run, identity }: { namespace: string; ru
       queuedTimeline = appendTimelineItem(queuedTimeline, next)
       scheduleTimelineFlush()
     }
-    const connect = () => {
-      const next = new EventSource(url)
-      stream = next
-      let opened = false
-      next.onopen = () => {
-        if (disposed || stream !== next) return
-        opened = true
-        freshRecoveryUsed = false
-        setStatus('Connected')
-      }
-      next.onerror = async () => {
-        if (disposed || stream !== next) return
-        if (next.readyState === EventSource.CONNECTING) {
-          setStatus('Reconnecting')
-          return
-        }
-        if (next.readyState !== EventSource.CLOSED) return
-        setStatus('Checking session')
+    const connect = async () => {
+      while (!disposed) {
         try {
-          await api.session()
+          const response = await api.transcript(namespace, run, identity, controller.signal, lastEventID || undefined)
+          if (response.status === 401) return
+          if (!response.ok || !response.body) {
+            if (established && lastEventID && !freshRecoveryUsed && (response.status === 400 || response.status === 410)) {
+              lastEventID = ''
+              freshRecoveryUsed = true
+              setStatus('Recovering transcript')
+              await reconnectDelay()
+              continue
+            }
+            if (response.status === 408 || response.status === 429 || response.status >= 500) {
+              setStatus('Reconnecting')
+              await reconnectDelay()
+              continue
+            }
+            setStatus(response.statusText || `Request failed (${response.status})`)
+            return
+          }
+          const mediaType = response.headers.get('Content-Type')?.split(';', 1)[0].trim().toLowerCase()
+          if (mediaType !== 'text/event-stream') {
+            setStatus(`Expected transcript event stream, got ${mediaType || 'unknown content type'}`)
+            return
+          }
+          established = true
+          freshRecoveryUsed = false
+          setStatus('Connected')
+          const reader = response.body.getReader()
+          const decoder = new TextDecoder()
+          let buffer = ''
+          while (!disposed) {
+            const { value, done } = await reader.read()
+            if (value) buffer += decoder.decode(value, { stream: true })
+            let boundary: { index: number; length: number } | undefined
+            while ((boundary = sseBoundary(buffer)) !== undefined) {
+              if (boundary.index > MAX_SSE_BUFFER) throw new Error(`Transcript event exceeds ${MAX_SSE_BUFFER} bytes`)
+              const block = buffer.slice(0, boundary.index)
+              buffer = buffer.slice(boundary.index + boundary.length)
+              let type = 'message'
+              let id = ''
+              let hasID = false
+              const data: string[] = []
+              for (const line of block.split(/\r\n|\n|\r/)) {
+                if (!line || line.startsWith(':')) continue
+                const colon = line.indexOf(':')
+                const field = colon < 0 ? line : line.slice(0, colon)
+                const fieldValue = colon < 0 ? '' : line.slice(colon + 1).replace(/^ /, '')
+                if (field === 'event') type = fieldValue
+                else if (field === 'id' && !fieldValue.includes('\0')) { id = fieldValue; hasID = true }
+                else if (field === 'data') data.push(fieldValue)
+                else if (field === 'retry' && /^\d+$/.test(fieldValue)) reconnectWait = Math.min(Number(fieldValue), 30_000)
+              }
+              if (hasID) lastEventID = id
+              if (!data.length) continue
+              const event = new MessageEvent(type, { data: data.join('\n'), lastEventId: lastEventID })
+              if (type === 'transcript') onTranscript(event)
+              else if (type === 'transcript-gap') onGap(event)
+            }
+            if (buffer.length > MAX_SSE_BUFFER) throw new Error(`Transcript event exceeds ${MAX_SSE_BUFFER} bytes`)
+            if (done) {
+              decoder.decode()
+              break
+            }
+          }
+          if (!disposed) {
+            setStatus('Reconnecting')
+            await reconnectDelay()
+          }
         } catch (error) {
-          if (!disposed && stream === next) setStatus(error instanceof Error ? error.message : 'Disconnected')
+          if (disposed || controller.signal.aborted) return
+          if (established && !(error instanceof Error && error.message.startsWith('Transcript event exceeds'))) {
+            setStatus('Reconnecting')
+            await reconnectDelay()
+            continue
+          }
+          setStatus(error instanceof Error ? error.message : 'Disconnected')
           return
         }
-        if (disposed || stream !== next || next.readyState !== EventSource.CLOSED) return
-        if (!opened || freshRecoveryUsed) {
-          setStatus('Disconnected')
-          return
-        }
-        freshRecoveryUsed = true
-        next.close()
-        setStatus('Recovering transcript')
-        connect()
       }
-      next.addEventListener('transcript', onTranscript)
-      next.addEventListener('transcript-gap', onGap)
     }
-    connect()
+    void connect()
     return () => {
       disposed = true
       if (frame !== undefined) window.cancelAnimationFrame(frame)
       if (timer !== undefined) window.clearTimeout(timer)
-      stream?.close()
+      controller.abort()
     }
   }, [namespace, run, identity])
   const { timeline, claude } = transcript

--- a/ui/src/api.test.ts
+++ b/ui/src/api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { ApiProblem, api, fallbackPollInterval, listAllRuns } from './api'
+import { ApiProblem, api, fallbackPollInterval, listAllRuns, onUnauthorized } from './api'
 import type { Run } from './contracts'
 
 afterEach(() => vi.restoreAllMocks())
@@ -8,6 +8,14 @@ describe('API boundary', () => {
   it('uses bearer authorization only for login and never puts it in the body', async () => { const fetch = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => new Response(JSON.stringify({ authenticated: true }))); await api.login('secret'); const [, init] = fetch.mock.calls[0]; expect((init?.headers as Headers).get('Authorization')).toBe('Bearer secret'); expect(init?.body).toBeUndefined(); await api.session(); expect((fetch.mock.calls[1][1]?.headers as Headers).has('Authorization')).toBe(false) })
   it('sends cancel with an immutable UID fence', async () => { const fetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}')); await api.cancelRun('n', 'r', 'uid'); const [path, init] = fetch.mock.calls[0]; expect(path).toBe('/api/v1/namespaces/n/runs/r/cancel'); expect(init?.method).toBe('POST'); expect(JSON.parse(String(init?.body))).toEqual({ runUID: 'uid' }) })
   it('passes exact Run cancellation through to fetch', async () => { const fetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}')); const controller = new AbortController(); await api.run('n', 'r', controller.signal); expect(fetch).toHaveBeenCalledWith('/api/v1/namespaces/n/runs/r', expect.objectContaining({ signal: controller.signal })) })
+  it('notifies authentication state when a transcript session expires', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 401, statusText: 'Unauthorized' }))
+    const listener = vi.fn()
+    const unsubscribe = onUnauthorized(listener)
+    await api.transcript('n', 'r', 'uid', new AbortController().signal)
+    unsubscribe()
+    expect(listener).toHaveBeenCalledOnce()
+  })
   it('builds optional list pagination with URLSearchParams and validates limit', async () => { const fetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{"items":[]}')); await api.runs('n', { limit: 200, continue: 'a+b' }); expect(fetch.mock.calls[0][0]).toBe('/api/v1/namespaces/n/runs?limit=200&continue=a%2Bb'); expect(() => api.runs('n', { limit: 201 })).toThrow(RangeError) })
   it('safely normalizes malformed errors into a typed problem', async () => { vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('not json', { status: 500, statusText: 'Oops' })); await expect(api.session()).rejects.toEqual(expect.objectContaining({ name: 'ApiProblem', status: 500, message: 'Oops', problem: { type: 'about:blank', title: 'Oops', status: 500 } })); await api.session().catch(error => expect(error).toBeInstanceOf(ApiProblem)) })
   it('follows list continuation cursors and aggregates pages', async () => {

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -86,6 +86,15 @@ export const api = {
   cancelRun: (namespace: string, name: string, runUID: string) => request<Run>(`${base(namespace)}/runs/${encodeURIComponent(name)}/cancel`, { method: 'POST', body: JSON.stringify({ runUID }) }),
   environment: (namespace: string, name: string) => request<Environment>(`${base(namespace)}/environments/${encodeURIComponent(name)}`),
   transcriptUrl: (namespace: string, name: string) => `${base(namespace)}/runs/${encodeURIComponent(name)}/transcript`,
+  transcript: async (namespace: string, name: string, runUID: string, signal: AbortSignal, lastEventID?: string) => {
+    const headers: Record<string, string> = { Accept: 'text/event-stream', 'SWE-Run-UID': runUID }
+    if (lastEventID) headers['Last-Event-ID'] = lastEventID
+    const response = await fetch(`${base(namespace)}/runs/${encodeURIComponent(name)}/transcript`, {
+      headers, credentials: 'same-origin', signal,
+    })
+    if (response.status === 401) notifyUnauthorized()
+    return response
+  },
   terminalPath: (namespace: string, environment: string) => `${base(namespace)}/environments/${encodeURIComponent(environment)}/terminal`,
 }
 


### PR DESCRIPTION
## Summary
- require and verify the exact Run UID after transcript authorization and before Run resolution/store access for GET and POST
- send the same UID on every typed client, CLI, TUI, MCP, and browser SSE reconnect while preserving cursor, gap, and bounded-output semantics
- require explicit `swe logs --run-uid` and prove transcript-only RBAC in acceptance coverage
- update public API/CLI documentation and deterministic identity/reconnect tests

## Validation
- `make test`
- `make vet`
- `make build`
- `bash -n hack/e2e.sh`
- `ui: npm run lint`
- `ui: npm run typecheck`
- `ui: npm test -- --run`
- `ui: npm run build`

Fixes #127