### PR TITLE
fix(controlplane): delete zero-count run-watch admission keys on release

### DIFF
--- a/internal/controlplane/run_watch.go
+++ b/internal/controlplane/run_watch.go
@@ -78,6 +78,12 @@ func (a *watchAdmission) release(namespace, principal string) {
 	a.active--
 	a.namespaces[namespace]--
 	a.principals[principal]--
+	if a.namespaces[namespace] == 0 {
+		delete(a.namespaces, namespace)
+	}
+	if a.principals[principal] == 0 {
+		delete(a.principals, principal)
+	}
 }
 
 func runWatchQuery(r *http.Request) (string, error) {

--- a/internal/controlplane/run_watch_test.go
+++ b/internal/controlplane/run_watch_test.go
@@ -183,3 +183,64 @@ func TestWatchAdmissionBoundsAndReleases(t *testing.T) {
 	}
 	a.release("ns", "principal")
 }
+
+func TestWatchAdmissionDeletesZeroCountKeysOnFinalRelease(t *testing.T) {
+	a := newWatchAdmission()
+	if !a.reserve("ns-a", "principal-x") || !a.reserve("ns-b", "principal-y") {
+		t.Fatal("reservations rejected")
+	}
+	if a.active != 2 || len(a.namespaces) != 2 || len(a.principals) != 2 {
+		t.Fatalf("active/namespaces/principals = %d/%d/%d", a.active, len(a.namespaces), len(a.principals))
+	}
+	a.release("ns-a", "principal-x")
+	if _, ok := a.namespaces["ns-a"]; ok {
+		t.Fatal("ns-a key retained after final release")
+	}
+	if _, ok := a.principals["principal-x"]; ok {
+		t.Fatal("principal-x key retained after final release")
+	}
+	if a.namespaces["ns-b"] != 1 || a.principals["principal-y"] != 1 || a.active != 1 {
+		t.Fatalf("remaining counts = ns-b:%d principal-y:%d active:%d", a.namespaces["ns-b"], a.principals["principal-y"], a.active)
+	}
+	a.release("ns-b", "principal-y")
+	if len(a.namespaces) != 0 || len(a.principals) != 0 || a.active != 0 {
+		t.Fatalf("maps/active after final release = %d/%d/%d", len(a.namespaces), len(a.principals), a.active)
+	}
+}
+
+func TestWatchAdmissionOverlappingReleaseRetainsPositiveCounts(t *testing.T) {
+	a := newWatchAdmission()
+	for _, r := range []struct{ namespace, principal string }{
+		{"ns", "principal-a"},
+		{"ns", "principal-b"},
+		{"ns", "principal-c"},
+	} {
+		if !a.reserve(r.namespace, r.principal) {
+			t.Fatalf("reservation %v rejected", r)
+		}
+	}
+	if a.namespaces["ns"] != 3 || len(a.principals) != 3 || a.active != 3 {
+		t.Fatalf("initial counts = ns:%d principals:%d active:%d", a.namespaces["ns"], len(a.principals), a.active)
+	}
+	a.release("ns", "principal-a")
+	if _, ok := a.principals["principal-a"]; ok {
+		t.Fatal("principal-a key retained after final release")
+	}
+	if a.namespaces["ns"] != 2 {
+		t.Fatalf("ns count = %d, want 2 retained for overlapping watches", a.namespaces["ns"])
+	}
+	if a.principals["principal-b"] != 1 || a.principals["principal-c"] != 1 || a.active != 2 {
+		t.Fatalf("remaining counts = principal-b:%d principal-c:%d active:%d", a.principals["principal-b"], a.principals["principal-c"], a.active)
+	}
+	a.release("ns", "principal-b")
+	if a.namespaces["ns"] != 1 || len(a.principals) != 1 || a.principals["principal-c"] != 1 {
+		t.Fatalf("counts after second release = ns:%d principals:%d principal-c:%d", a.namespaces["ns"], len(a.principals), a.principals["principal-c"])
+	}
+	a.release("ns", "principal-c")
+	if _, ok := a.namespaces["ns"]; ok {
+		t.Fatal("ns key retained after final overlapping release")
+	}
+	if len(a.principals) != 0 || a.active != 0 {
+		t.Fatalf("maps/active after final release = %d/%d", len(a.principals), a.active)
+	}
+}


### PR DESCRIPTION
## Summary

`watchAdmission.release` decremented per-namespace and per-principal counters but never removed keys whose count reached zero. Active admission limits stayed correct, but a long-lived control-plane process retained every historical namespace and principal seen by Run watch streams, causing monotonically growing maps under normal tenant/user churn.

This adds delete-on-zero cleanup in `release` only.

Closes #134.

## Behavior

- When `release` makes a namespace count zero, that key is deleted from `namespaces`.
- When `release` makes a principal count zero, that key is deleted from `principals`.
- All global (`active`/128), per-namespace (16), and per-principal (4) active-watch limits are preserved exactly.
- Positive counters for overlapping active watches are retained until the last release.
- No changes to authentication, authorization, admission token-bucket policy, stream lifetime, wire behavior, CRD/schema, API, or docs directory.

## Validation

- `go test ./internal/controlplane/ -run 'TestWatchAdmission|TestRunWatch' -count=1` — focused tests pass.
- `go test ./internal/controlplane/ -run 'TestWatchAdmission|TestRunWatch' -count=1 -race` — race clean.
- `go test ./internal/controlplane/ -count=1` — full control-plane package green, including existing admission-cap and Run watch tests.
- `go vet ./internal/controlplane/` and `go build ./...` — clean.

## Tests added

- `TestWatchAdmissionDeletesZeroCountKeysOnFinalRelease` — releasing the final watch removes both zero-count namespace and principal keys.
- `TestWatchAdmissionOverlappingReleaseRetainsPositiveCounts` — releasing one of multiple overlapping watches retains the correct positive namespace counter and only deletes the released principal key, until the last release clears all maps.