### PR TITLE
fix(terminal): bound transport handshake and writes

### DIFF
--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -48,6 +48,8 @@ type Server struct {
 	heartbeat             time.Duration
 	streams               context.Context
 	watchAdmission        *watchAdmission
+	terminalOpenTimeout   time.Duration
+	terminalWriteTimeout  time.Duration
 }
 
 // RunResolver verifies that a namespaced Run exists before transcript state is used.
@@ -115,6 +117,8 @@ func NewServer(log *slog.Logger, options ServerOptions) *Server {
 		heartbeat:             heartbeat,
 		streams:               streams,
 		watchAdmission:        processWatchAdmission,
+		terminalOpenTimeout:   terminalHandshakeTimeout,
+		terminalWriteTimeout:  terminalStreamingWriteTimeout,
 	}
 }
 

--- a/internal/controlplane/terminal.go
+++ b/internal/controlplane/terminal.go
@@ -24,11 +24,12 @@ import (
 )
 
 const (
-	wakeTimeout                = 2 * time.Minute
-	wakePollInterval           = 250 * time.Millisecond
-	terminalPolicyPollInterval = 5 * time.Second
-	terminalHealthTimeout      = 5 * time.Second
-	terminalHandshakeTimeout   = 5 * time.Second
+	wakeTimeout                   = 2 * time.Minute
+	wakePollInterval              = 250 * time.Millisecond
+	terminalPolicyPollInterval    = 5 * time.Second
+	terminalHealthTimeout         = 5 * time.Second
+	terminalHandshakeTimeout      = 5 * time.Second
+	terminalStreamingWriteTimeout = 15 * time.Second
 )
 
 var errTerminalEnvironmentIncarnationChanged = errors.New("environment incarnation changed")
@@ -534,7 +535,7 @@ func (s *Server) serveTerminal(w http.ResponseWriter, r *http.Request, namespace
 	stopCloseOnCancel := context.AfterFunc(r.Context(), func() { _ = connection.Close() })
 	defer stopCloseOnCancel()
 	connection.SetReadLimit(1 << 20)
-	if err := bridgeWebTerminal(r.Context(), connection, terminal); err != nil {
+	if err := bridgeWebTerminalWithTimeouts(r.Context(), connection, terminal, s.terminalOpenTimeout, s.terminalWriteTimeout); err != nil {
 		if r.Context().Err() == nil {
 			s.log.Debug("web terminal closed", "namespace", namespace, "environment", environment, "error", err)
 		}
@@ -566,6 +567,10 @@ func (s *Server) checkWebSocketOrigin(r *http.Request) bool {
 }
 
 func bridgeWebTerminal(ctx context.Context, connection *websocket.Conn, client sandboxdv1.TerminalServiceClient) error {
+	return bridgeWebTerminalWithTimeouts(ctx, connection, client, terminalHandshakeTimeout, terminalStreamingWriteTimeout)
+}
+
+func bridgeWebTerminalWithTimeouts(ctx context.Context, connection *websocket.Conn, client sandboxdv1.TerminalServiceClient, openTimeout, writeTimeout time.Duration) error {
 	streamContext, cancel := context.WithCancelCause(ctx)
 	defer cancel(nil)
 	stream, err := client.Terminal(streamContext)
@@ -573,6 +578,9 @@ func bridgeWebTerminal(ctx context.Context, connection *websocket.Conn, client s
 		return fmt.Errorf("open sandboxd terminal: %w", err)
 	}
 
+	if err := connection.SetReadDeadline(time.Now().Add(openTimeout)); err != nil {
+		return fmt.Errorf("set terminal open deadline: %w", err)
+	}
 	messageType, payload, err := connection.ReadMessage()
 	if err != nil {
 		if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
@@ -583,6 +591,9 @@ func bridgeWebTerminal(ctx context.Context, connection *websocket.Conn, client s
 	control, err := decodeTerminalControl(messageType, payload, "open")
 	if err != nil {
 		return err
+	}
+	if err := connection.SetReadDeadline(time.Time{}); err != nil {
+		return fmt.Errorf("clear terminal open deadline: %w", err)
 	}
 	if err := stream.Send(&sandboxdv1.TerminalMessage{Kind: &sandboxdv1.TerminalMessage_Open{
 		Open: &sandboxdv1.TerminalOpen{Cols: control.Cols, Rows: control.Rows},
@@ -634,8 +645,14 @@ func bridgeWebTerminal(ctx context.Context, connection *websocket.Conn, client s
 			}
 			return fmt.Errorf("sandboxd terminal: %w", err)
 		}
+		if err := connection.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {
+			return fmt.Errorf("set terminal output deadline: %w", err)
+		}
 		if err := connection.WriteMessage(websocket.BinaryMessage, message.GetData()); err != nil {
 			return fmt.Errorf("write terminal output: %w", err)
+		}
+		if err := connection.SetWriteDeadline(time.Time{}); err != nil {
+			return fmt.Errorf("clear terminal output deadline: %w", err)
 		}
 	}
 }

--- a/internal/controlplane/terminal_test.go
+++ b/internal/controlplane/terminal_test.go
@@ -194,8 +194,121 @@ func TestWebTerminalClosesWhileWaitingForOpenWhenContextCanceled(t *testing.T) {
 	}
 }
 
+func TestWebTerminalOpenTimeoutReleasesStreamAndBackend(t *testing.T) {
+	backend := &terminalLivenessServer{started: make(chan struct{}), stopped: make(chan struct{})}
+	backendConnection := newTerminalTestConnection(t, backend)
+	backendClosed := make(chan struct{})
+	dialer := &terminalTestDialer{client: sandboxdv1.NewTerminalServiceClient(backendConnection), closer: closeFunc(func() error {
+		close(backendClosed)
+		return nil
+	})}
+	controlPlane := NewServer(nil, ServerOptions{Access: &fakeAccess{}, TerminalDialer: dialer})
+	controlPlane.terminalOpenTimeout = 20 * time.Millisecond
+	server := httptest.NewServer(controlPlane.Handler())
+	t.Cleanup(server.Close)
+
+	websocketURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/v1/namespaces/project-1/environments/env-1/terminal"
+	connection, _, err := websocket.DefaultDialer.Dial(websocketURL, http.Header{"Authorization": []string{"Bearer reader"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = connection.Close() })
+	select {
+	case <-backend.started:
+	case <-time.After(time.Second):
+		t.Fatal("sandboxd terminal stream did not open")
+	}
+	select {
+	case <-backendClosed:
+	case <-time.After(time.Second):
+		t.Fatal("terminal backend was not released after open timeout")
+	}
+	select {
+	case <-backend.stopped:
+	case <-time.After(time.Second):
+		t.Fatal("sandboxd terminal stream was not canceled after open timeout")
+	}
+}
+
+func TestWebTerminalValidOpenClearsReadDeadline(t *testing.T) {
+	backend := &terminalIdleServer{opened: make(chan struct{})}
+	backendConnection := newTerminalTestConnection(t, backend)
+	dialer := &terminalTestDialer{client: sandboxdv1.NewTerminalServiceClient(backendConnection)}
+	controlPlane := NewServer(nil, ServerOptions{Access: &fakeAccess{}, TerminalDialer: dialer})
+	controlPlane.terminalOpenTimeout = 100 * time.Millisecond
+	server := httptest.NewServer(controlPlane.Handler())
+	t.Cleanup(server.Close)
+
+	websocketURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/v1/namespaces/project-1/environments/env-1/terminal"
+	connection, _, err := websocket.DefaultDialer.Dial(websocketURL, http.Header{"Authorization": []string{"Bearer reader"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = connection.Close() })
+	if err := connection.WriteJSON(terminalControl{Type: "open", Cols: 80, Rows: 24}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-backend.opened:
+	case <-time.After(time.Second):
+		t.Fatal("sandboxd did not receive terminal open")
+	}
+	time.Sleep(2 * controlPlane.terminalOpenTimeout)
+	if err := connection.WriteMessage(websocket.BinaryMessage, []byte("after idle")); err != nil {
+		t.Fatalf("terminal input after post-open idle: %v", err)
+	}
+	messageType, payload, err := connection.ReadMessage()
+	if err != nil {
+		t.Fatalf("terminal output after post-open idle: %v", err)
+	}
+	if messageType != websocket.BinaryMessage || string(payload) != "after idle" {
+		t.Fatalf("terminal output = (%d, %q), want binary echo", messageType, payload)
+	}
+}
+
+func TestWebTerminalStalledOutputWriteIsBounded(t *testing.T) {
+	backend := &terminalLivenessServer{started: make(chan struct{}), stopped: make(chan struct{}), output: make([]byte, 1<<20)}
+	backendConnection := newTerminalTestConnection(t, backend)
+	backendClosed := make(chan struct{})
+	dialer := &terminalTestDialer{client: sandboxdv1.NewTerminalServiceClient(backendConnection), closer: closeFunc(func() error {
+		close(backendClosed)
+		return nil
+	})}
+	controlPlane := NewServer(nil, ServerOptions{Access: &fakeAccess{}, TerminalDialer: dialer})
+	controlPlane.terminalWriteTimeout = 20 * time.Millisecond
+	server := httptest.NewServer(controlPlane.Handler())
+	t.Cleanup(server.Close)
+
+	websocketURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/v1/namespaces/project-1/environments/env-1/terminal"
+	connection, _, err := websocket.DefaultDialer.Dial(websocketURL, http.Header{"Authorization": []string{"Bearer reader"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = connection.Close() })
+	tcp, ok := connection.UnderlyingConn().(*net.TCPConn)
+	if !ok {
+		t.Fatalf("websocket connection type = %T, want *net.TCPConn", connection.UnderlyingConn())
+	}
+	if err := tcp.SetReadBuffer(1024); err != nil {
+		t.Fatal(err)
+	}
+	if err := connection.WriteJSON(terminalControl{Type: "open", Cols: 80, Rows: 24}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-backendClosed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("terminal backend remained held by stalled output write")
+	}
+	select {
+	case <-backend.stopped:
+	case <-time.After(time.Second):
+		t.Fatal("sandboxd terminal stream remained held by stalled output write")
+	}
+}
+
 func TestTerminalHandshakeTimeoutBoundsPostHijackWrite(t *testing.T) {
-	if terminalUpgrader.HandshakeTimeout != terminalHandshakeTimeout || terminalHandshakeTimeout >= shutdownTimeoutForTest {
+	if terminalUpgrader.HandshakeTimeout != terminalHandshakeTimeout || terminalHandshakeTimeout != 5*time.Second || terminalHandshakeTimeout >= shutdownTimeoutForTest || terminalStreamingWriteTimeout != 15*time.Second {
 		t.Fatalf("terminal handshake timeout = %v, want positive and below shutdown budget", terminalUpgrader.HandshakeTimeout)
 	}
 	upgrader := terminalUpgrader
@@ -1389,6 +1502,72 @@ type terminalTestServer struct {
 	open          *sandboxdv1.TerminalOpen
 	resize        *sandboxdv1.TerminalResize
 	input         []byte
+}
+
+func newTerminalTestConnection(t *testing.T, backend sandboxdv1.TerminalServiceServer) *grpc.ClientConn {
+	t.Helper()
+	listener := bufconn.Listen(8 << 20)
+	grpcServer := grpc.NewServer()
+	sandboxdv1.RegisterTerminalServiceServer(grpcServer, backend)
+	go func() { _ = grpcServer.Serve(listener) }()
+	t.Cleanup(grpcServer.Stop)
+	connection, err := grpc.NewClient("passthrough:///bufconn", grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+		return listener.Dial()
+	}), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = connection.Close() })
+	return connection
+}
+
+type terminalLivenessServer struct {
+	sandboxdv1.UnimplementedTerminalServiceServer
+	started chan struct{}
+	stopped chan struct{}
+	output  []byte
+}
+
+func (s *terminalLivenessServer) Terminal(stream sandboxdv1.TerminalService_TerminalServer) error {
+	close(s.started)
+	defer close(s.stopped)
+	if len(s.output) == 0 {
+		<-stream.Context().Done()
+		return stream.Context().Err()
+	}
+	message, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+	if message.GetOpen() == nil {
+		return errors.New("missing terminal open")
+	}
+	for {
+		if err := stream.Send(&sandboxdv1.TerminalMessage{Kind: &sandboxdv1.TerminalMessage_Data{Data: s.output}}); err != nil {
+			return err
+		}
+	}
+}
+
+type terminalIdleServer struct {
+	sandboxdv1.UnimplementedTerminalServiceServer
+	opened chan struct{}
+}
+
+func (s *terminalIdleServer) Terminal(stream sandboxdv1.TerminalService_TerminalServer) error {
+	message, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+	if message.GetOpen() == nil {
+		return errors.New("missing terminal open")
+	}
+	close(s.opened)
+	message, err = stream.Recv()
+	if err != nil {
+		return err
+	}
+	return stream.Send(&sandboxdv1.TerminalMessage{Kind: &sandboxdv1.TerminalMessage_Data{Data: message.GetData()}})
 }
 
 func (s *terminalTestServer) Check(context.Context, *sandboxdv1.HealthCheckRequest) (*sandboxdv1.HealthCheckResponse, error) {


### PR DESCRIPTION
## Summary
- bound the required post-upgrade terminal open frame with the existing 5-second handshake duration
- clear the read deadline after a valid open and bound each terminal output write to 15 seconds
- verify no-open and stalled-reader teardown while preserving post-open idle, normal close, and context cancellation

## Validation
- `go test ./internal/controlplane ./internal/sandboxclient -count=1`
- `go test -race ./internal/controlplane -run 'Test(WebTerminal|BridgeWebTerminal|TerminalHandshake)' -count=1`
- focused transport-liveness tests repeated 20 times
- `make test`
- `make vet`
- `make build`

Fixes #133