### PR TITLE
Fence terminal attaches by immutable identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,20 +424,40 @@ values on existing resources fail with an `UnsupportedBackend` Ready-condition r
 before the operator creates a Pod or PVC. CRD admission rejects unsupported values for
 new Environments and templates.
 
-The authenticated control plane exposes a browser terminal at
-`GET /api/v1/namespaces/{namespace}/environments/{name}/terminal`. The WebSocket client
-first sends `{"type":"open","cols":80,"rows":24}`, then uses binary frames for terminal
-input and output. Send `{"type":"resize","cols":120,"rows":40}` to resize the shared
-terminal. Kubernetes TokenReview authenticates bearer credentials and SubjectAccessReview
-authorizes the exact namespaced environment; the namespace is never accepted from a query
-parameter. See the [Helm chart documentation](charts/swe-platform/README.md#control-plane-authentication-and-authorization)
+The authenticated control plane exposes a direct terminal at
+`GET /api/v1/namespaces/{namespace}/environments/{name}/terminal`; native clients must send
+the expected immutable Environment identity in `SWE-Environment-UID`. The browser console
+uses the Run-scoped route
+`GET /api/v1/namespaces/{namespace}/runs/{run}/terminal/{runUID}/{environmentUID}` instead.
+Each UID is a separately percent-encoded path segment. These UIDs are non-secret identity
+preconditions and can appear in browser devtools, proxy access logs, and tracing; bearer
+credentials and session identifiers must never be placed in the URL. The existing native
+Run route, `/runs/{run}/terminal`, remains available with `SWE-Run-UID` and
+`SWE-Environment-UID` headers.
+
+All terminal WebSocket clients first send `{"type":"open","cols":80,"rows":24}`, then use
+binary frames for terminal input and output. Send `{"type":"resize","cols":120,"rows":40}`
+to resize the shared terminal. Kubernetes TokenReview authenticates bearer credentials and
+SubjectAccessReview authorizes exact namespaced resources; the namespace is never accepted
+from a query parameter. The browser route authorizes the exact Run before decoding or
+validating bounded UIDs, resolves its exact current Environment association, authorizes that
+Environment's terminal subresource, and only then applies origin/upgrade checks and the
+existing repeatedly fenced terminal dial. See the
+[Helm chart documentation](charts/swe-platform/README.md#control-plane-authentication-and-authorization)
 for credentials, browser sessions, RBAC, and self-hosted bootstrap setup.
-The CLI uses this gateway rather than Kubernetes pod discovery or port forwarding:
+The CLI uses this gateway rather than Kubernetes pod discovery or port forwarding. Direct
+attach deliberately requires an explicit UID and does not perform a hidden base-Environment
+GET, so a credential restricted to `environments/terminal` remains sufficient:
 
 ```sh
+ENV_UID="$(kubectl get environment my-environment -o jsonpath='{.metadata.uid}')"
 SWE_CONTROL_PLANE_URL=https://swe.example.com \
-SWE_CONTROL_PLANE_TOKEN="$TOKEN" swe attach my-environment
+SWE_CONTROL_PLANE_TOKEN="$TOKEN" swe attach my-environment --environment-uid "$ENV_UID"
 ```
+
+Name-only direct clients now fail with a terminal-identity error rather than selecting a
+same-name replacement. A stale UID is rejected before terminal activity, wake, readiness,
+backend resolution, or WebSocket upgrade.
 
 ### Terminal operations console
 
@@ -460,7 +480,9 @@ attached terminal and restores the dashboard. Run details show normalized status
 wall-time timestamps (started/finished), and usage, Environment readiness/pause state, and a
 bounded raw transcript view. Transcript source, type,
 payload, and retention gaps are displayed generically; adapter-owned payloads are not parsed as
-a common event schema.
+a common event schema. Both native and browser consoles show terminal navigation only when the
+Run API returns `terminalAvailable` with an exact `environment.uid`; reconnects and component
+remounts retain that same Run and Environment identity and never follow same-name replacements.
 
 For a non-interactive authentication/connectivity check (including CI), use `swe tui --check`.
 It validates namespaced Run-list access without starting a terminal UI or printing credentials.

--- a/charts/swe-platform/README.md
+++ b/charts/swe-platform/README.md
@@ -387,7 +387,8 @@ exact namespace, resource name, and subresource on every request:
 | Read an Environment | `get` on `environments` with the requested Environment `resourceName` |
 | Read a transcript | `get` on `runs/transcript` with the requested Run `resourceName` |
 | Append a transcript event | `update` on `runs/transcript` with the requested Run `resourceName` |
-| Open a terminal | `get` on `environments/terminal` with the requested Environment `resourceName` |
+| Open a direct Environment terminal | `get` on `environments/terminal` with the requested Environment `resourceName` |
+| Open a Run terminal | `get` on the requested base `runs` `resourceName`, then `get` on the resolved `environments/terminal` `resourceName` |
 
 This permits producer credentials to be restricted to one Run using an RBAC Role with
 `resourceNames`. The namespace is part of the URL only as a resource selector; it becomes
@@ -422,6 +423,26 @@ plane then requires single-valued `X-Forwarded-Host` and `X-Forwarded-Proto` hea
 the proxy must overwrite (not append or pass through) both. Non-browser WebSocket clients
 without `Origin` are allowed only with an explicit bearer credential. Tokens are never
 accepted in query parameters.
+
+Direct Environment WebSockets use
+`/api/v1/namespaces/{namespace}/environments/{name}/terminal` and require the exact bounded
+Environment UID in `SWE-Environment-UID`. This keeps terminal-subresource-only RBAC viable:
+`swe attach ENVIRONMENT --environment-uid UID` never performs a base-Environment read.
+The native Run terminal route `/runs/{run}/terminal` retains its bounded `SWE-Run-UID` and
+`SWE-Environment-UID` headers. Browsers, which cannot set those headers in the WebSocket
+constructor, use `/runs/{run}/terminal/{runUID}/{environmentUID}` with each UID encoded as one
+path segment. UIDs are non-secret identity preconditions whose URL/log/devtools visibility is
+intentional; credentials and tickets are never accepted there.
+
+For the browser route, authentication and exact base-Run authorization precede UID decoding,
+bounds, and staleness checks. The server then resolves the exact current Run/Environment
+association, authorizes the exact Environment terminal, checks WebSocket origin and upgrade,
+and enters the same repeatedly association-, hold-, revision-, execution-, and backend-fenced
+dial path used by native Run clients. Direct stale/missing identities and stale, released, or
+reassigned Run associations fail before activity, wake, readiness polling, connector/backend
+resolution, health checks, or upgrade. The Run DTO exposes `environment.uid` and
+`terminalAvailable` only for an exact current association; browser terminal navigation must be
+absent otherwise and must retain both identities on remount.
 
 When the control plane is enabled, the chart projects a rotating `swe-platform`-audience
 service-account token into the operator and grants that identity `update` on

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -25,6 +25,7 @@ SANDBOXD_PORT_FORWARD_PID=""
 STREAM_PID=""
 CLI_STREAM_PID=""
 WEB_TERMINAL_CLIENT=""
+WEB_TERMINAL_SOURCE=""
 PROJECT_REPO=""
 PROJECT_WORKTREE=""
 FAKE_ENV_CONTEXT=""
@@ -49,6 +50,9 @@ cleanup() {
 	fi
 	if [[ -n "$WEB_TERMINAL_CLIENT" ]]; then
 		rm -f "$WEB_TERMINAL_CLIENT"
+	fi
+	if [[ -n "$WEB_TERMINAL_SOURCE" ]]; then
+		rm -f "$WEB_TERMINAL_SOURCE"
 	fi
 	if [[ -n "$PROJECT_REPO" ]]; then
 		rm -rf "$PROJECT_REPO"
@@ -134,7 +138,20 @@ fi
 printf '%s\n' credential-present >> /workspace/agent-credential-marker
 printf '%s\n' '{"type":"system","subtype":"init","session_id":"fake-e2e"}'
 printf '%s\n' '{"type":"assistant","session_id":"fake-e2e","message":{"id":"msg-fake-e2e","type":"message","role":"assistant","model":"claude-e2e","content":[{"type":"text","text":"fake Claude Code is working"},{"type":"tool_use","id":"tool-fake-e2e","name":"Read","input":{"file_path":"README.md"}}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":2}},"parent_tool_use_id":null}'
-sleep 5
+WAIT_FOR_BROWSER=false
+for arg in "$@"; do
+	if [ "$arg" = 'resume credential smoke test' ]; then WAIT_FOR_BROWSER=true; fi
+done
+if [ "$WAIT_FOR_BROWSER" = true ]; then
+	attempt=0
+	while [ "$attempt" -lt 60 ]; do
+		if [ -f /workspace/browser-terminal-opened ]; then break; fi
+		attempt=$((attempt + 1))
+		sleep 1
+	done
+else
+	sleep 5
+fi
 printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"result":"fake Claude Code completed"}'
 EOF
 chmod 0755 "$FAKE_ENV_CONTEXT/claude"
@@ -404,6 +421,7 @@ if [[ -n "${CLAIM_UID:-}" ]]; then
 fi
 kubectl wait --for=jsonpath='{.status.phase}'=Ready environment/"$RUN_ENV_NAME" --timeout=3m
 ENV_NAME=$RUN_ENV_NAME
+ENV_UID=$(kubectl get environment "$ENV_NAME" -o jsonpath='{.metadata.uid}')
 for _ in $(seq 1 60); do
 	REPLACEMENT_NAME=$(kubectl get environments -l swe.dev/warm-pool=small -o jsonpath='{range .items[*]}{.metadata.name}{end}' 2>/dev/null || true)
 	REPLACEMENT_PHASE=$(kubectl get environments -l swe.dev/warm-pool=small -o jsonpath='{range .items[*]}{.status.phase}{end}' 2>/dev/null || true)
@@ -494,9 +512,38 @@ subjects:
   - kind: ServiceAccount
     name: e2e-transcript-reader
     namespace: default
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: e2e-terminal
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: e2e-terminal
+rules:
+  - apiGroups: ["swe.dev"]
+    resources: ["environments/terminal"]
+    resourceNames: ["${ENV_NAME}"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: e2e-terminal
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: e2e-terminal
+subjects:
+  - kind: ServiceAccount
+    name: e2e-terminal
+    namespace: default
 EOF
 PRODUCER_TOKEN=$(kubectl create token e2e-transcript-producer --audience=swe-platform)
 READER_TOKEN=$(kubectl create token e2e-transcript-reader --audience=swe-platform)
+TERMINAL_TOKEN=$(kubectl create token e2e-terminal --audience=swe-platform)
 
 echo "==> configuring a console API user"
 cat <<'EOF' | kubectl apply -f -
@@ -515,6 +562,9 @@ rules:
     verbs: ["create", "get", "list", "update", "watch"]
   - apiGroups: ["swe.dev"]
     resources: ["environments"]
+    verbs: ["get"]
+  - apiGroups: ["swe.dev"]
+    resources: ["environments/terminal"]
     verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -581,6 +631,83 @@ for _ in $(seq 1 30); do
 	fi
 	sleep 1
 done
+
+WEB_TERMINAL_SOURCE="$(mktemp /tmp/swe-browser-terminal-XXXXXX.go)"
+WEB_TERMINAL_CLIENT="${WEB_TERMINAL_SOURCE%.go}"
+cat > "$WEB_TERMINAL_SOURCE" <<'EOF'
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func main() {
+	if len(os.Args) != 6 {
+		panic("usage: browser-terminal BASE_URL TOKEN PATH COMMAND MARKER")
+	}
+	base, token, path, command, marker := os.Args[1], os.Args[2], os.Args[3], os.Args[4], os.Args[5]
+	request, err := http.NewRequest(http.MethodPost, base+"/api/v1/session", nil)
+	if err != nil {
+		panic(err)
+	}
+	request.Header.Set("Authorization", "Bearer "+token)
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		panic(err)
+	}
+	_, _ = io.Copy(io.Discard, response.Body)
+	_ = response.Body.Close()
+	if response.StatusCode != http.StatusOK || len(response.Cookies()) == 0 {
+		panic(fmt.Sprintf("session exchange returned %s", response.Status))
+	}
+	parsed, err := url.Parse(base)
+	if err != nil {
+		panic(err)
+	}
+	parsed.Scheme = "ws"
+	parsed.Path = path
+	header := http.Header{"Origin": []string{base}}
+	for _, cookie := range response.Cookies() {
+		header.Add("Cookie", cookie.Name+"="+cookie.Value)
+	}
+	connection, dialResponse, err := websocket.DefaultDialer.Dial(parsed.String(), header)
+	if err != nil {
+		if dialResponse != nil {
+			panic(fmt.Sprintf("terminal handshake returned %s", dialResponse.Status))
+		}
+		panic(err)
+	}
+	defer connection.Close()
+	if err := connection.WriteJSON(map[string]any{"type": "open", "cols": 80, "rows": 24}); err != nil {
+		panic(err)
+	}
+	if err := connection.WriteMessage(websocket.BinaryMessage, []byte(command)); err != nil {
+		panic(err)
+	}
+	_ = connection.SetReadDeadline(time.Now().Add(30 * time.Second))
+	var output strings.Builder
+	for !strings.Contains(output.String(), marker) {
+		messageType, payload, err := connection.ReadMessage()
+		if err != nil {
+			panic(err)
+		}
+		if messageType == websocket.BinaryMessage {
+			output.Write(payload)
+		}
+	}
+}
+EOF
+go build -o "$WEB_TERMINAL_CLIENT" "$WEB_TERMINAL_SOURCE"
+rm -f "$WEB_TERMINAL_SOURCE"
+WEB_TERMINAL_SOURCE=""
 
 echo "==> verifying terminal console authenticated client path"
 SWE_CONTROL_PLANE_URL=http://127.0.0.1:18080 SWE_CONTROL_PLANE_TOKEN="$CONSOLE_TOKEN" \
@@ -935,9 +1062,20 @@ if ! kubectl get environment "$RUN_ENV_NAME" >/dev/null 2>&1; then
 fi
 
 echo "==> verifying shared terminal through swe attach"
+MISSING_TERMINAL_UID_STATUS=$(curl --silent --output /dev/null --write-out '%{http_code}' \
+	-H "Authorization: Bearer ${TERMINAL_TOKEN}" \
+	"http://127.0.0.1:18080/api/v1/namespaces/default/environments/${ENV_NAME}/terminal")
+UNAUTHORIZED_TERMINAL_STATUS=$(curl --silent --output /dev/null --write-out '%{http_code}' \
+	-H "Authorization: Bearer ${READER_TOKEN}" \
+	-H 'SWE-Environment-UID: stale-environment-uid' \
+	"http://127.0.0.1:18080/api/v1/namespaces/default/environments/${ENV_NAME}/terminal")
+if [[ "$MISSING_TERMINAL_UID_STATUS" != "400" || "$UNAUTHORIZED_TERMINAL_STATUS" != "403" ]]; then
+	echo "FAIL: direct terminal auth/identity ordering statuses missing=${MISSING_TERMINAL_UID_STATUS} unauthorized=${UNAUTHORIZED_TERMINAL_STATUS}"
+	exit 1
+fi
 printf 'printf terminal-e2e-ok; if [ -n "${ANTHROPIC_API_KEY+x}" ]; then printf credential-present; else printf credential-absent; fi; exit\n' | \
-	SWE_CONTROL_PLANE_URL=http://127.0.0.1:18080 SWE_CONTROL_PLANE_TOKEN="$E2E_BOOTSTRAP_TOKEN" \
-	bin/swe attach "$ENV_NAME" > /tmp/swe-platform-terminal.out
+	SWE_CONTROL_PLANE_URL=http://127.0.0.1:18080 SWE_CONTROL_PLANE_TOKEN="$TERMINAL_TOKEN" \
+	bin/swe attach "$ENV_NAME" --environment-uid "$ENV_UID" > /tmp/swe-platform-terminal.out
 if ! grep -q 'terminal-e2e-ok' /tmp/swe-platform-terminal.out; then
 	echo "FAIL: terminal output was not received through swe attach"
 	cat /tmp/swe-platform-terminal.out
@@ -1024,8 +1162,38 @@ RESUME_RUN_NAME=e2e-resume-credential-run
 bin/swe run "resume credential smoke test" --name "$RESUME_RUN_NAME" --environment "$ENV_NAME" \
 	--credential-profile e2e-claude --wait=false
 kubectl wait --for=jsonpath='{.status.state}'=Running run/"$RESUME_RUN_NAME" --timeout=3m
-kubectl wait --for=jsonpath='{.status.state}'=Succeeded run/"$RESUME_RUN_NAME" --timeout=3m
 RESUME_RUN_UID=$(kubectl get run "$RESUME_RUN_NAME" -o jsonpath='{.metadata.uid}')
+RESUME_ENV_UID=$(kubectl get run "$RESUME_RUN_NAME" -o jsonpath='{.status.environmentRef.uid}')
+RUN_TERMINAL_PATH="/api/v1/namespaces/default/runs/${RESUME_RUN_NAME}/terminal/${RESUME_RUN_UID}/${RESUME_ENV_UID}"
+echo "==> verifying exact browser Run terminal through a same-origin session"
+"$WEB_TERMINAL_CLIENT" http://127.0.0.1:18080 "$CONSOLE_TOKEN" "$RUN_TERMINAL_PATH" \
+	$'touch /workspace/browser-terminal-opened; printf browser-run-terminal-e2e-ok; exit\n' browser-run-terminal-e2e-ok
+STALE_RUN_ENVIRONMENT_STATUS=$(curl --silent --output /dev/null --write-out '%{http_code}' \
+	-H "Authorization: Bearer ${CONSOLE_TOKEN}" \
+	"http://127.0.0.1:18080/api/v1/namespaces/default/runs/${RESUME_RUN_NAME}/terminal/${RESUME_RUN_UID}/stale-environment-uid")
+if [[ "$STALE_RUN_ENVIRONMENT_STATUS" != "409" ]]; then
+	echo "FAIL: browser Run terminal stale Environment status was ${STALE_RUN_ENVIRONMENT_STATUS}, expected 409"
+	exit 1
+fi
+kubectl wait --for=jsonpath='{.status.state}'=Succeeded run/"$RESUME_RUN_NAME" --timeout=3m
+for _ in $(seq 1 60); do
+	RELEASED_CLAIM_UID=$(kubectl get environment "$ENV_NAME" -o jsonpath='{.status.claimedBy.uid}' 2>/dev/null || true)
+	if [[ -z "$RELEASED_CLAIM_UID" || "$RELEASED_CLAIM_UID" != "$RESUME_RUN_UID" ]]; then
+		break
+	fi
+	sleep 1
+done
+if [[ "${RELEASED_CLAIM_UID:-}" == "$RESUME_RUN_UID" ]]; then
+	echo "FAIL: completed Run retained its Environment claim"
+	exit 1
+fi
+RELEASED_RUN_TERMINAL_STATUS=$(curl --silent --output /dev/null --write-out '%{http_code}' \
+	-H "Authorization: Bearer ${CONSOLE_TOKEN}" \
+	"http://127.0.0.1:18080/api/v1/namespaces/default/runs/${RESUME_RUN_NAME}/terminal/${RESUME_RUN_UID}/${RESUME_ENV_UID}")
+if [[ "$RELEASED_RUN_TERMINAL_STATUS" != "409" ]]; then
+	echo "FAIL: released browser Run terminal status was ${RELEASED_RUN_TERMINAL_STATUS}, expected 409"
+	exit 1
+fi
 if ! kubectl exec "$POD_NAME" -- sh -c \
 	'test "$(wc -l < /workspace/agent-credential-marker)" -eq 2 && test -z "${ANTHROPIC_API_KEY+x}" && ! tr "\000" "\n" < /proc/1/environ | grep -q "^ANTHROPIC_API_KEY="'; then
 	echo "FAIL: fresh agent launch did not receive the rotated profile in isolation"
@@ -1059,7 +1227,6 @@ if contains_e2e_key /tmp/swe-platform-resumed-workspace.tar; then
 	echo "FAIL: resumed workspace contains an agent API key"
 	exit 1
 fi
-kubectl delete run "$RESUME_RUN_NAME" --wait=true >/dev/null
 
 echo "==> verifying credentialed fake Amp process scope without network"
 AMP_RUN_NAME=e2e-fake-amp-run
@@ -1067,6 +1234,14 @@ printf '%s' "$E2E_AMP_API_KEY" | bin/swe credentials create e2e-amp --agent amp 
 bin/swe run "fake Amp lifecycle smoke test" --name "$AMP_RUN_NAME" --environment "$ENV_NAME" \
 	--agent amp --credential-profile e2e-amp --wait=false
 kubectl wait --for=jsonpath='{.status.state}'=Running run/"$AMP_RUN_NAME" --timeout=3m
+REASSIGNED_RUN_TERMINAL_STATUS=$(curl --silent --output /dev/null --write-out '%{http_code}' \
+	-H "Authorization: Bearer ${CONSOLE_TOKEN}" \
+	"http://127.0.0.1:18080/api/v1/namespaces/default/runs/${RESUME_RUN_NAME}/terminal/${RESUME_RUN_UID}/${RESUME_ENV_UID}")
+if [[ "$REASSIGNED_RUN_TERMINAL_STATUS" != "409" ]]; then
+	echo "FAIL: reassigned browser Run terminal status was ${REASSIGNED_RUN_TERMINAL_STATUS}, expected 409"
+	exit 1
+fi
+kubectl delete run "$RESUME_RUN_NAME" --wait=true >/dev/null
 kubectl wait --for=jsonpath='{.status.state}'=Succeeded run/"$AMP_RUN_NAME" --timeout=3m
 AMP_RUN_UID=$(kubectl get run "$AMP_RUN_NAME" -o jsonpath='{.metadata.uid}')
 AMP_POD_NAME=$(kubectl get environment "$ENV_NAME" -o jsonpath='{.status.podName}')
@@ -1183,8 +1358,8 @@ if [[ "${PHASE:-}" != "Paused" ]] || kubectl get pod "$POD_NAME" >/dev/null 2>&1
 	exit 1
 fi
 printf 'printf web-terminal-e2e-ok; exit\n' | \
-	SWE_CONTROL_PLANE_URL=http://127.0.0.1:18080 SWE_CONTROL_PLANE_TOKEN="$E2E_BOOTSTRAP_TOKEN" \
-	bin/swe attach "$ENV_NAME" > /tmp/swe-platform-web-terminal.out
+	SWE_CONTROL_PLANE_URL=http://127.0.0.1:18080 SWE_CONTROL_PLANE_TOKEN="$TERMINAL_TOKEN" \
+	bin/swe attach "$ENV_NAME" --environment-uid "$ENV_UID" > /tmp/swe-platform-web-terminal.out
 if ! grep -q 'web-terminal-e2e-ok' /tmp/swe-platform-web-terminal.out; then
 	echo "FAIL: terminal output was not received through the control-plane websocket"
 	cat /tmp/swe-platform-web-terminal.out
@@ -1204,6 +1379,32 @@ if [[ "$POST_WAKE_POD_UID" == "$PRE_IDLE_POD_UID" ]]; then
 	exit 1
 fi
 
+echo "==> verifying direct attach rejects a same-name Environment replacement without side effects"
+kubectl patch environmenttemplate small --type=merge -p '{"spec":{"idleTimeout":"15m"}}' >/dev/null
+kubectl delete environment "$ENV_NAME" --wait=true >/dev/null
+cat <<EOF | kubectl apply -f -
+apiVersion: swe.dev/v1alpha1
+kind: Environment
+metadata:
+  name: ${ENV_NAME}
+spec:
+  projectRef: e2e
+  templateRef: small
+EOF
+kubectl wait --for=jsonpath='{.status.phase}'=Ready environment/"$ENV_NAME" --timeout=3m
+REPLACEMENT_ENV_UID=$(kubectl get environment "$ENV_NAME" -o jsonpath='{.metadata.uid}')
+REPLACEMENT_LIFECYCLE_BEFORE=$(kubectl get environment "$ENV_NAME" -o jsonpath='{.spec.lifecycle}')
+STALE_REPLACEMENT_STATUS=$(curl --silent --output /dev/null --write-out '%{http_code}' \
+	-H "Authorization: Bearer ${TERMINAL_TOKEN}" \
+	-H "SWE-Environment-UID: ${ENV_UID}" \
+	-H 'Connection: Upgrade' -H 'Upgrade: websocket' \
+	"http://127.0.0.1:18080/api/v1/namespaces/default/environments/${ENV_NAME}/terminal")
+REPLACEMENT_LIFECYCLE_AFTER=$(kubectl get environment "$ENV_NAME" -o jsonpath='{.spec.lifecycle}')
+if [[ "$REPLACEMENT_ENV_UID" == "$ENV_UID" || "$STALE_REPLACEMENT_STATUS" != "409" || "$REPLACEMENT_LIFECYCLE_AFTER" != "$REPLACEMENT_LIFECYCLE_BEFORE" ]]; then
+	echo "FAIL: replacement terminal fence uid=${REPLACEMENT_ENV_UID} status=${STALE_REPLACEMENT_STATUS} lifecycle-before=${REPLACEMENT_LIFECYCLE_BEFORE} lifecycle-after=${REPLACEMENT_LIFECYCLE_AFTER}"
+	exit 1
+fi
+POD_NAME=$(kubectl get environment "$ENV_NAME" -o jsonpath='{.status.podName}')
 POD_PHASE=$(kubectl get pod "$POD_NAME" -o jsonpath='{.status.phase}')
 if [[ "$POD_PHASE" != "Running" ]]; then
 	echo "FAIL: pod ${POD_NAME} is ${POD_PHASE}, expected Running"

--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -23,6 +23,7 @@ import (
 func newAttachCommand() *cobra.Command {
 	var controlPlaneURL string
 	var token string
+	var environmentUID string
 	cmd := &cobra.Command{
 		Use:   "attach <environment>",
 		Short: "Attach a terminal to an environment through the control plane",
@@ -30,28 +31,36 @@ func newAttachCommand() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString("namespace")
-			return attachTerminal(cmd, controlPlaneURL, token, namespace, args[0])
+			return attachTerminal(cmd, controlPlaneURL, token, namespace, args[0], environmentUID)
 		},
 	}
 	cmd.Flags().StringVar(&controlPlaneURL, "control-plane", os.Getenv("SWE_CONTROL_PLANE_URL"), "Control-plane base URL (or SWE_CONTROL_PLANE_URL)")
 	cmd.Flags().StringVar(&token, "token", os.Getenv("SWE_CONTROL_PLANE_TOKEN"), "Control-plane bearer token (or SWE_CONTROL_PLANE_TOKEN)")
+	cmd.Flags().StringVar(&environmentUID, "environment-uid", "", "Exact immutable Environment UID")
+	_ = cmd.MarkFlagRequired("environment-uid")
 	return cmd
 }
 
-func attachTerminal(cmd *cobra.Command, controlPlaneURL, token, namespace, envName string) error {
+func attachTerminal(cmd *cobra.Command, controlPlaneURL, token, namespace, envName, environmentUID string) error {
 	client, err := controlplaneclient.New(controlPlaneURL, token, nil)
 	if err != nil {
 		return err
 	}
-	return attachTerminalWithClient(cmd.Context(), client, namespace, envName, cmd.InOrStdin(), cmd.OutOrStdout())
+	return attachTerminalWithClient(cmd.Context(), client, namespace, envName, environmentUID, cmd.InOrStdin(), cmd.OutOrStdout())
 }
 
-func attachTerminalWithClient(ctx context.Context, client *controlplaneclient.Client, namespace, environment string, input io.Reader, output io.Writer) error {
+func attachTerminalWithClient(ctx context.Context, client *controlplaneclient.Client, namespace, environment, environmentUID string, input io.Reader, output io.Writer) error {
 	if err := validateTerminalInput(input); err != nil {
 		return err
 	}
+	environmentUID = strings.TrimSpace(environmentUID)
+	if environmentUID == "" || len(environmentUID) > 128 {
+		return fmt.Errorf("--environment-uid must be a non-empty UID of at most 128 bytes")
+	}
 	endpoint := client.WebSocketEndpoint("api", "v1", "namespaces", namespace, "environments", environment, "terminal")
-	return dialAndBridgeTerminal(ctx, endpoint, client.AuthorizationHeader(), input, output)
+	header := client.AuthorizationHeader()
+	header.Set(controlplane.EnvironmentUIDHeader, environmentUID)
+	return dialAndBridgeTerminal(ctx, endpoint, header, input, output)
 }
 
 func attachRunTerminalWithClient(ctx context.Context, client *controlplaneclient.Client, namespace, runName, runUID, environmentUID string, input io.Reader, output io.Writer) error {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -51,7 +51,8 @@ func TestTerminalGatewayURL(t *testing.T) {
 func TestAttachTerminalUsesAuthenticatedGateway(t *testing.T) {
 	serverErrors := make(chan error, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/v1/namespaces/project-a/environments/env-1/terminal" || r.Header.Get("Authorization") != "Bearer terminal-token" {
+		if r.URL.Path != "/api/v1/namespaces/project-a/environments/env-1/terminal" || r.Header.Get("Authorization") != "Bearer terminal-token" ||
+			r.Header.Get(controlplane.EnvironmentUIDHeader) != "env-uid" {
 			serverErrors <- errors.New("gateway request did not carry the environment identity and bearer token")
 			http.Error(w, "bad request", http.StatusBadRequest)
 			return
@@ -84,7 +85,7 @@ func TestAttachTerminalUsesAuthenticatedGateway(t *testing.T) {
 	command.SetIn(strings.NewReader("echo hello\n"))
 	var output bytes.Buffer
 	command.SetOut(&output)
-	if err := attachTerminal(command, server.URL, "terminal-token", "project-a", "env-1"); err != nil {
+	if err := attachTerminal(command, server.URL, "terminal-token", "project-a", "env-1", "env-uid"); err != nil {
 		t.Fatalf("attachTerminal() error = %v", err)
 	}
 	if err := <-serverErrors; err != nil {
@@ -92,6 +93,30 @@ func TestAttachTerminalUsesAuthenticatedGateway(t *testing.T) {
 	}
 	if output.String() != "terminal output" {
 		t.Fatalf("terminal output = %q", output.String())
+	}
+}
+
+func TestAttachCommandRequiresExplicitEnvironmentUID(t *testing.T) {
+	command := NewRootCommand()
+	command.SetArgs([]string{"attach", "env-1", "--control-plane", "https://control.example", "--token", "token"})
+	command.SetOut(io.Discard)
+	command.SetErr(io.Discard)
+	err := command.Execute()
+	if err == nil || !strings.Contains(err.Error(), `required flag(s) "environment-uid" not set`) {
+		t.Fatalf("missing --environment-uid error = %v", err)
+	}
+}
+
+func TestAttachTerminalRejectsInvalidEnvironmentUIDBeforeDial(t *testing.T) {
+	client, err := controlplaneclient.New("https://control.example", "token", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, uid := range []string{"", " ", strings.Repeat("x", 129)} {
+		err := attachTerminalWithClient(context.Background(), client, "default", "env-1", uid, strings.NewReader(""), io.Discard)
+		if err == nil || !strings.Contains(err.Error(), "--environment-uid") {
+			t.Fatalf("UID %q error = %v", uid, err)
+		}
 	}
 }
 
@@ -150,7 +175,7 @@ func TestAttachTerminalReturnsWhenContextIsCancelled(t *testing.T) {
 	command.SetContext(ctx)
 	command.SetIn(strings.NewReader(""))
 	done := make(chan error, 1)
-	go func() { done <- attachTerminal(command, server.URL, "terminal-token", "default", "env-1") }()
+	go func() { done <- attachTerminal(command, server.URL, "terminal-token", "default", "env-1", "env-uid") }()
 	<-opened
 	cancel()
 	select {
@@ -191,7 +216,7 @@ func TestAttachTerminalDetachStopsInputAtControlBracket(t *testing.T) {
 	command.SetContext(context.Background())
 	command.SetIn(strings.NewReader("before\x1dafter"))
 	command.SetOut(io.Discard)
-	if err := attachTerminal(command, server.URL, "terminal-token", "default", "env-1"); err != nil {
+	if err := attachTerminal(command, server.URL, "terminal-token", "default", "env-1", "env-uid"); err != nil {
 		t.Fatal(err)
 	}
 	if err := <-serverResult; err != nil {
@@ -214,7 +239,7 @@ func TestAttachTerminalRejectsUnjoinableInputReader(t *testing.T) {
 	command.SetContext(context.Background())
 	command.SetIn(panicBlockingReader{})
 	command.SetOut(io.Discard)
-	err := attachTerminal(command, server.URL, "terminal-token", "default", "env-1")
+	err := attachTerminal(command, server.URL, "terminal-token", "default", "env-1", "env-uid")
 	if err == nil || !strings.Contains(err.Error(), "standard input or a finite in-memory reader") {
 		t.Fatalf("error = %v", err)
 	}

--- a/internal/controlplane/resource_handlers_test.go
+++ b/internal/controlplane/resource_handlers_test.go
@@ -14,13 +14,17 @@ import (
 )
 
 type recordingAccess struct {
-	calls   []ResourceAccess
-	err     error
-	denyGet bool
+	calls                   []ResourceAccess
+	err                     error
+	denyGet                 bool
+	denyEnvironmentTerminal bool
 }
 
 func (a *recordingAccess) Authorize(_ *http.Request, x ResourceAccess, _ bool) error {
 	a.calls = append(a.calls, x)
+	if a.denyEnvironmentTerminal && x.Resource == "environments" && x.Subresource == "terminal" {
+		return errForbidden
+	}
 	if a.denyGet && x.Verb == "get" {
 		return errForbidden
 	}
@@ -312,6 +316,97 @@ func TestRunTerminalRouteRequiresExactIdentityAndPreservesEnvironmentSAR(t *test
 	}
 	if !reflect.DeepEqual(access.calls, want) {
 		t.Fatalf("authorization calls = %#v, want %#v", access.calls, want)
+	}
+}
+
+func TestBrowserRunTerminalRouteDecodesExactIdentityAndPreservesEnvironmentSAR(t *testing.T) {
+	access := &recordingAccess{}
+	resources := &fakeResources{terminalAssociation: RunTerminalAssociation{RunName: "run", RunUID: "run/uid", EnvironmentName: "env", EnvironmentUID: "env/uid"}}
+	server := NewServer(nil, ServerOptions{Access: access, Resources: resources, TerminalDialer: &terminalTestDialer{}})
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/ns/runs/run/terminal/run%2Fuid/env%2Fuid", nil)
+	request.Header.Set("Authorization", "Bearer x")
+	response := httptest.NewRecorder()
+	server.Handler().ServeHTTP(response, request)
+	if response.Code != http.StatusBadRequest || resources.terminalRunUID != "run/uid" || resources.terminalEnvironmentUID != "env/uid" {
+		t.Fatalf("response/identity = %d/%q/%q", response.Code, resources.terminalRunUID, resources.terminalEnvironmentUID)
+	}
+	want := []ResourceAccess{
+		{Namespace: "ns", Verb: "get", Resource: "runs", Name: "run"},
+		{Namespace: "ns", Verb: "get", Resource: "environments", Subresource: "terminal", Name: "env"},
+	}
+	if !reflect.DeepEqual(access.calls, want) {
+		t.Fatalf("authorization calls = %#v, want %#v", access.calls, want)
+	}
+}
+
+func TestBrowserRunTerminalAuthorizesRunBeforeIdentityValidation(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		access *recordingAccess
+		path   string
+		want   int
+	}{
+		{name: "unauthorized empty identity", access: &recordingAccess{err: errForbidden}, path: "/api/v1/namespaces/ns/runs/run/terminal/%20/%20", want: http.StatusForbidden},
+		{name: "authorized overlong identity", access: &recordingAccess{}, path: "/api/v1/namespaces/ns/runs/run/terminal/" + strings.Repeat("r", 129) + "/env-uid", want: http.StatusBadRequest},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			resources := &fakeResources{}
+			dialer := &terminalTestDialer{}
+			request := httptest.NewRequest(http.MethodGet, test.path, nil)
+			request.Header.Set("Authorization", "Bearer x")
+			response := httptest.NewRecorder()
+			NewServer(nil, ServerOptions{Access: test.access, Resources: resources, TerminalDialer: dialer}).Handler().ServeHTTP(response, request)
+			if response.Code != test.want || len(test.access.calls) != 1 || resources.terminalRunUID != "" || dialer.calls != 0 {
+				t.Fatalf("response/access/identity/dials = %d/%v/%q/%d", response.Code, test.access.calls, resources.terminalRunUID, dialer.calls)
+			}
+		})
+	}
+}
+
+func TestBrowserRunTerminalChecksAssociationAndEnvironmentAuthorizationBeforeOrigin(t *testing.T) {
+	access := &recordingAccess{}
+	resources := &fakeResources{terminalAssociation: RunTerminalAssociation{RunName: "run", RunUID: "run-uid", EnvironmentName: "env", EnvironmentUID: "env-uid"}}
+	dialer := &terminalTestDialer{}
+	request := httptest.NewRequest(http.MethodGet, "https://api.test/api/v1/namespaces/ns/runs/run/terminal/run-uid/env-uid", nil)
+	request.Header.Set("Origin", "https://other.test")
+	request.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "session"})
+	setWebSocketUpgrade(request)
+	request.Header.Del("Authorization")
+	response := httptest.NewRecorder()
+	NewServer(nil, ServerOptions{Access: access, Resources: resources, TerminalDialer: dialer}).Handler().ServeHTTP(response, request)
+	want := []ResourceAccess{
+		{Namespace: "ns", Verb: "get", Resource: "runs", Name: "run"},
+		{Namespace: "ns", Verb: "get", Resource: "environments", Subresource: "terminal", Name: "env"},
+	}
+	if response.Code != http.StatusForbidden || !reflect.DeepEqual(access.calls, want) || resources.terminalRunUID != "run-uid" || dialer.calls != 0 {
+		t.Fatalf("response/access/identity/dials = %d/%v/%q/%d", response.Code, access.calls, resources.terminalRunUID, dialer.calls)
+	}
+}
+
+func TestBrowserRunTerminalPreservesAssociationConflictFromRepeatedDialFence(t *testing.T) {
+	for _, dialErr := range []error{errRunUIDConflict, errRunTerminalAssociation} {
+		access := &recordingAccess{}
+		resources := &fakeResources{terminalAssociation: RunTerminalAssociation{RunName: "run", RunUID: "run-uid", EnvironmentName: "env", EnvironmentUID: "env-uid"}}
+		dialer := &terminalTestDialer{err: dialErr}
+		request := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/ns/runs/run/terminal/run-uid/env-uid", nil)
+		setWebSocketUpgrade(request)
+		response := httptest.NewRecorder()
+		NewServer(nil, ServerOptions{Access: access, Resources: resources, TerminalDialer: dialer}).Handler().ServeHTTP(response, request)
+		if response.Code != http.StatusConflict || !strings.Contains(response.Body.String(), "/run-terminal-association-conflict") || dialer.calls != 1 {
+			t.Fatalf("dial error %v response/dials = %d/%s/%d", dialErr, response.Code, response.Body.String(), dialer.calls)
+		}
+	}
+}
+
+func TestBrowserRunTerminalAuthorizesEnvironmentBeforeGatewayAvailability(t *testing.T) {
+	access := &recordingAccess{denyEnvironmentTerminal: true}
+	resources := &fakeResources{terminalAssociation: RunTerminalAssociation{RunName: "run", RunUID: "run-uid", EnvironmentName: "env", EnvironmentUID: "env-uid"}}
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/ns/runs/run/terminal/run-uid/env-uid", nil)
+	setWebSocketUpgrade(request)
+	response := httptest.NewRecorder()
+	NewServer(nil, ServerOptions{Access: access, Resources: resources}).Handler().ServeHTTP(response, request)
+	if response.Code != http.StatusForbidden || len(access.calls) != 2 || resources.terminalRunUID != "run-uid" {
+		t.Fatalf("response/access/identity = %d/%v/%q", response.Code, access.calls, resources.terminalRunUID)
 	}
 }
 

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -10,6 +10,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -156,6 +157,14 @@ func (s *Server) Handler() http.Handler {
 }
 
 func (s *Server) handleNamespacedAPI(w http.ResponseWriter, r *http.Request) {
+	if namespace, run, runUID, environmentUID, ok := browserRunTerminalPath(r.URL.EscapedPath()); ok {
+		if r.Method == http.MethodGet {
+			s.handleBrowserRunTerminal(w, r, namespace, run, runUID, environmentUID)
+		} else {
+			writeResourceMethodError(w, "GET")
+		}
+		return
+	}
 	namespace, resource, name, subresource, ok := namespacedResource(r.URL.Path)
 	if !ok {
 		http.NotFound(w, r)
@@ -202,6 +211,29 @@ func (s *Server) handleNamespacedAPI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	http.NotFound(w, r)
+}
+
+// browserRunTerminalPath keeps each immutable UID in one percent-encoded path
+// segment. It returns the UID segments undecoded so Run authorization can happen
+// before malformed identity is distinguished from stale identity.
+func browserRunTerminalPath(path string) (namespace, run, runUID, environmentUID string, ok bool) {
+	remainder := strings.TrimPrefix(path, namespacedPathPrefix)
+	if remainder == path {
+		return "", "", "", "", false
+	}
+	parts := strings.Split(remainder, "/")
+	if len(parts) != 6 || parts[1] != "runs" || parts[3] != "terminal" {
+		return "", "", "", "", false
+	}
+	decodedNamespace, err := url.PathUnescape(parts[0])
+	if err != nil || decodedNamespace == "" {
+		return "", "", "", "", false
+	}
+	decodedRun, err := url.PathUnescape(parts[2])
+	if err != nil || decodedRun == "" {
+		return "", "", "", "", false
+	}
+	return decodedNamespace, decodedRun, parts[4], parts[5], true
 }
 
 func writeResourceMethodError(w http.ResponseWriter, allow string) {

--- a/internal/controlplane/terminal.go
+++ b/internal/controlplane/terminal.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -30,6 +31,7 @@ const (
 	terminalHealthTimeout         = 5 * time.Second
 	terminalHandshakeTimeout      = 5 * time.Second
 	terminalStreamingWriteTimeout = 15 * time.Second
+	maxTerminalUIDLength          = 128
 )
 
 var errTerminalEnvironmentIncarnationChanged = errors.New("environment incarnation changed")
@@ -41,7 +43,7 @@ const (
 
 // TerminalDialer resolves an Environment and connects to its sandboxd API.
 type TerminalDialer interface {
-	DialTerminal(context.Context, string, string) (sandboxdv1.TerminalServiceClient, sandboxdv1.HealthServiceClient, io.Closer, error)
+	DialTerminal(context.Context, string, string, string) (sandboxdv1.TerminalServiceClient, sandboxdv1.HealthServiceClient, io.Closer, error)
 	DialRunTerminal(context.Context, string, RunTerminalAssociation) (sandboxdv1.TerminalServiceClient, sandboxdv1.HealthServiceClient, io.Closer, error)
 }
 
@@ -109,20 +111,23 @@ func (l *terminalConnectionLease) Close() error {
 // DialTerminal records terminal activity, wakes a paused environment, and then
 // requests an authenticated sandboxd connection through the environment
 // connector. Backend transport details stay out of terminal feature code.
-func (d KubernetesTerminalDialer) DialTerminal(ctx context.Context, namespace, name string) (sandboxdv1.TerminalServiceClient, sandboxdv1.HealthServiceClient, io.Closer, error) {
-	return d.dialTerminal(ctx, namespace, name, nil)
+func (d KubernetesTerminalDialer) DialTerminal(ctx context.Context, namespace, name, expectedUID string) (sandboxdv1.TerminalServiceClient, sandboxdv1.HealthServiceClient, io.Closer, error) {
+	return d.dialTerminal(ctx, namespace, name, expectedUID, nil)
 }
 
 func (d KubernetesTerminalDialer) DialRunTerminal(ctx context.Context, namespace string, association RunTerminalAssociation) (sandboxdv1.TerminalServiceClient, sandboxdv1.HealthServiceClient, io.Closer, error) {
-	return d.dialTerminal(ctx, namespace, association.EnvironmentName, &association)
+	return d.dialTerminal(ctx, namespace, association.EnvironmentName, association.EnvironmentUID, &association)
 }
 
-func (d KubernetesTerminalDialer) dialTerminal(ctx context.Context, namespace, name string, association *RunTerminalAssociation) (sandboxdv1.TerminalServiceClient, sandboxdv1.HealthServiceClient, io.Closer, error) {
+func (d KubernetesTerminalDialer) dialTerminal(ctx context.Context, namespace, name, expectedUID string, association *RunTerminalAssociation) (sandboxdv1.TerminalServiceClient, sandboxdv1.HealthServiceClient, io.Closer, error) {
 	var environment platformv1alpha1.Environment
 	if err := d.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &environment); err != nil {
 		return nil, nil, nil, fmt.Errorf("get environment: %w", err)
 	}
-	expectedUID := environment.UID
+	if string(environment.UID) != expectedUID {
+		return nil, nil, nil, errTerminalEnvironmentIncarnationChanged
+	}
+	expectedEnvironmentUID := environment.UID
 	if association != nil {
 		if err := d.validateRunTerminalAssociation(ctx, namespace, association, &environment); err != nil {
 			return nil, nil, nil, err
@@ -132,7 +137,7 @@ func (d KubernetesTerminalDialer) dialTerminal(ctx context.Context, namespace, n
 	if err := terminalAccessPolicyError(&environment); err != nil {
 		return nil, nil, nil, err
 	}
-	if err := d.markActive(ctx, &environment, expectedUID, policyRevision); err != nil {
+	if err := d.markActive(ctx, &environment, expectedEnvironmentUID, policyRevision); err != nil {
 		return nil, nil, nil, err
 	}
 	heartbeatInterval, err := d.activityHeartbeatInterval(ctx, &environment)
@@ -147,11 +152,11 @@ func (d KubernetesTerminalDialer) dialTerminal(ctx context.Context, namespace, n
 		}
 	}()
 	connectionLease := &terminalConnectionLease{}
-	go d.heartbeatActivity(heartbeatContext, types.NamespacedName{Namespace: namespace, Name: name}, expectedUID, policyRevision, heartbeatInterval, association, connectionLease.boundExecution, func() { _ = connectionLease.Close() })
+	go d.heartbeatActivity(heartbeatContext, types.NamespacedName{Namespace: namespace, Name: name}, expectedEnvironmentUID, policyRevision, heartbeatInterval, association, connectionLease.boundExecution, func() { _ = connectionLease.Close() })
 	if err := d.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &environment); err != nil {
 		return nil, nil, nil, fmt.Errorf("refresh environment lifecycle: %w", err)
 	}
-	if environment.UID != expectedUID {
+	if environment.UID != expectedEnvironmentUID {
 		return nil, nil, nil, errTerminalEnvironmentIncarnationChanged
 	}
 	if association != nil {
@@ -164,26 +169,26 @@ func (d KubernetesTerminalDialer) dialTerminal(ctx context.Context, namespace, n
 	}
 	if environment.Status.Lifecycle.Suspended {
 		requestID := fmt.Sprintf("terminal/wake/%d", time.Now().UnixNano())
-		if err := lifecycle.RequestWake(ctx, d.Client, types.NamespacedName{Namespace: namespace, Name: name}, expectedUID, policyRevision, requestID); err != nil {
+		if err := lifecycle.RequestWake(ctx, d.Client, types.NamespacedName{Namespace: namespace, Name: name}, expectedEnvironmentUID, policyRevision, requestID); err != nil {
 			return nil, nil, nil, fmt.Errorf("wake environment: %w", err)
 		}
-		if err := d.waitUntilReady(ctx, namespace, name, expectedUID, &environment); err != nil {
+		if err := d.waitUntilReady(ctx, namespace, name, expectedEnvironmentUID, &environment); err != nil {
 			return nil, nil, nil, err
 		}
-		if err := d.markActive(ctx, &environment, expectedUID, policyRevision); err != nil {
+		if err := d.markActive(ctx, &environment, expectedEnvironmentUID, policyRevision); err != nil {
 			return nil, nil, nil, err
 		}
 	}
 	// Wake intents advance generation, while activity metadata does not. Do not
 	// resolve sandboxd against a stale Ready observation after a wake or a
 	// concurrent lifecycle change.
-	if err := d.waitUntilReady(ctx, namespace, name, expectedUID, &environment); err != nil {
+	if err := d.waitUntilReady(ctx, namespace, name, expectedEnvironmentUID, &environment); err != nil {
 		return nil, nil, nil, err
 	}
 	if !platformv1alpha1.IsEnvironmentReady(&environment) {
 		return nil, nil, nil, fmt.Errorf("environment is not ready for its current generation")
 	}
-	terminal, health, execution, closeConnection, err := (sandboxclient.Connector{Reader: d.Client}).DialTerminal(ctx, namespace, name, expectedUID)
+	terminal, health, execution, closeConnection, err := (sandboxclient.Connector{Reader: d.Client}).DialTerminal(ctx, namespace, name, expectedEnvironmentUID)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("connect to sandboxd: %w", err)
 	}
@@ -453,12 +458,25 @@ func (s *Server) handleTerminal(w http.ResponseWriter, r *http.Request, namespac
 		writeAccessError(w, err)
 		return
 	}
+	expectedEnvironmentUID := strings.TrimSpace(r.Header.Get(EnvironmentUIDHeader))
+	if expectedEnvironmentUID == "" || len(expectedEnvironmentUID) > maxTerminalUIDLength {
+		writeProblem(w, http.StatusBadRequest, "terminal-identity-required", "Terminal identity required", "an exact Environment UID is required")
+		return
+	}
 	s.serveTerminal(w, r, namespace, environment, func(ctx context.Context) (sandboxdv1.TerminalServiceClient, sandboxdv1.HealthServiceClient, io.Closer, error) {
-		return s.terminalDialer.DialTerminal(ctx, namespace, environment)
+		return s.terminalDialer.DialTerminal(ctx, namespace, environment, expectedEnvironmentUID)
 	})
 }
 
 func (s *Server) handleRunTerminal(w http.ResponseWriter, r *http.Request, namespace, runName string) {
+	s.handleRunTerminalWithIdentity(w, r, namespace, runName, r.Header.Get(RunUIDHeader), r.Header.Get(EnvironmentUIDHeader), false)
+}
+
+func (s *Server) handleBrowserRunTerminal(w http.ResponseWriter, r *http.Request, namespace, runName, encodedRunUID, encodedEnvironmentUID string) {
+	s.handleRunTerminalWithIdentity(w, r, namespace, runName, encodedRunUID, encodedEnvironmentUID, true)
+}
+
+func (s *Server) handleRunTerminalWithIdentity(w http.ResponseWriter, r *http.Request, namespace, runName, runUID, environmentUID string, encoded bool) {
 	if s.access == nil {
 		writeAccessError(w, errUnauthenticated)
 		return
@@ -467,20 +485,31 @@ func (s *Server) handleRunTerminal(w http.ResponseWriter, r *http.Request, names
 		writeAccessError(w, err)
 		return
 	}
-	expectedRunUID := strings.TrimSpace(r.Header.Get(RunUIDHeader))
-	expectedEnvironmentUID := strings.TrimSpace(r.Header.Get(EnvironmentUIDHeader))
-	if expectedRunUID == "" || expectedEnvironmentUID == "" || len(expectedRunUID) > 128 || len(expectedEnvironmentUID) > 128 {
+	if encoded {
+		var err error
+		runUID, err = url.PathUnescape(runUID)
+		if err == nil {
+			environmentUID, err = url.PathUnescape(environmentUID)
+		}
+		if err != nil {
+			writeProblem(w, http.StatusBadRequest, "terminal-identity-required", "Terminal identity required", "exact Run and Environment UIDs must be valid encoded path segments")
+			return
+		}
+	}
+	expectedRunUID := strings.TrimSpace(runUID)
+	expectedEnvironmentUID := strings.TrimSpace(environmentUID)
+	if expectedRunUID == "" || expectedEnvironmentUID == "" || len(expectedRunUID) > maxTerminalUIDLength || len(expectedEnvironmentUID) > maxTerminalUIDLength {
 		writeProblem(w, http.StatusBadRequest, "terminal-identity-required", "Terminal identity required", "exact Run and Environment UIDs are required")
 		return
 	}
-	if s.resources == nil || s.terminalDialer == nil {
+	if s.resources == nil {
 		writeProblem(w, http.StatusServiceUnavailable, "terminal-gateway-unavailable", "Terminal gateway unavailable", "Run terminal resources are not configured")
 		return
 	}
 	association, err := s.resources.ResolveRunTerminal(r.Context(), namespace, runName, expectedRunUID, expectedEnvironmentUID)
 	if err != nil {
 		if errors.Is(err, errRunUIDConflict) || errors.Is(err, errRunTerminalAssociation) {
-			writeProblem(w, http.StatusConflict, "run-terminal-association-conflict", "Run terminal association changed", "the exact Run no longer owns or claims the exact Environment")
+			writeRunTerminalAssociationConflict(w)
 			return
 		}
 		s.writeResourceError(w, "resolve Run terminal", namespace, runName, err)
@@ -516,6 +545,14 @@ func (s *Server) serveTerminal(w http.ResponseWriter, r *http.Request, namespace
 
 	terminal, health, closer, err := dial(r.Context())
 	if err != nil {
+		if errors.Is(err, errRunUIDConflict) || errors.Is(err, errRunTerminalAssociation) {
+			writeRunTerminalAssociationConflict(w)
+			return
+		}
+		if errors.Is(err, errTerminalEnvironmentIncarnationChanged) {
+			writeProblem(w, http.StatusConflict, "environment-terminal-identity-conflict", "Environment terminal identity changed", "the exact Environment no longer exists")
+			return
+		}
 		s.log.Warn("resolve terminal backend", "namespace", namespace, "environment", environment, "error", err)
 		http.Error(w, "environment terminal is unavailable", http.StatusBadGateway)
 		return
@@ -542,6 +579,10 @@ func (s *Server) serveTerminal(w http.ResponseWriter, r *http.Request, namespace
 		return
 	}
 	_ = connection.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""), time.Now().Add(time.Second))
+}
+
+func writeRunTerminalAssociationConflict(w http.ResponseWriter) {
+	writeProblem(w, http.StatusConflict, "run-terminal-association-conflict", "Run terminal association changed", "the exact Run no longer owns or claims the exact Environment")
 }
 
 func checkTerminalHealth(ctx context.Context, health sandboxdv1.HealthServiceClient, timeout time.Duration) error {

--- a/internal/controlplane/terminal_test.go
+++ b/internal/controlplane/terminal_test.go
@@ -65,7 +65,7 @@ func TestWebTerminalBridgesSandboxd(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	websocketURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/v1/namespaces/project-1/environments/env-1/terminal"
-	header := http.Header{"Authorization": []string{"Bearer reader"}}
+	header := http.Header{"Authorization": []string{"Bearer reader"}, EnvironmentUIDHeader: []string{"env-uid"}}
 	websocketConnection, _, err := websocket.DefaultDialer.Dial(websocketURL, header)
 	if err != nil {
 		t.Fatal(err)
@@ -175,7 +175,7 @@ func TestWebTerminalClosesWhileWaitingForOpenWhenContextCanceled(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	websocketURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/v1/namespaces/project-1/environments/env-1/terminal"
-	connection, _, err := websocket.DefaultDialer.Dial(websocketURL, http.Header{"Authorization": []string{"Bearer reader"}})
+	connection, _, err := websocket.DefaultDialer.Dial(websocketURL, http.Header{"Authorization": []string{"Bearer reader"}, EnvironmentUIDHeader: []string{"env-uid"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -208,7 +208,7 @@ func TestWebTerminalOpenTimeoutReleasesStreamAndBackend(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	websocketURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/v1/namespaces/project-1/environments/env-1/terminal"
-	connection, _, err := websocket.DefaultDialer.Dial(websocketURL, http.Header{"Authorization": []string{"Bearer reader"}})
+	connection, _, err := websocket.DefaultDialer.Dial(websocketURL, http.Header{"Authorization": []string{"Bearer reader"}, EnvironmentUIDHeader: []string{"env-uid"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -240,7 +240,7 @@ func TestWebTerminalValidOpenClearsReadDeadline(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	websocketURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/v1/namespaces/project-1/environments/env-1/terminal"
-	connection, _, err := websocket.DefaultDialer.Dial(websocketURL, http.Header{"Authorization": []string{"Bearer reader"}})
+	connection, _, err := websocket.DefaultDialer.Dial(websocketURL, http.Header{"Authorization": []string{"Bearer reader"}, EnvironmentUIDHeader: []string{"env-uid"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -280,7 +280,7 @@ func TestWebTerminalStalledOutputWriteIsBounded(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	websocketURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/v1/namespaces/project-1/environments/env-1/terminal"
-	connection, _, err := websocket.DefaultDialer.Dial(websocketURL, http.Header{"Authorization": []string{"Bearer reader"}})
+	connection, _, err := websocket.DefaultDialer.Dial(websocketURL, http.Header{"Authorization": []string{"Bearer reader"}, EnvironmentUIDHeader: []string{"env-uid"}})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -354,6 +354,7 @@ func (w *hijackResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 func TestWebTerminalRequiresDialer(t *testing.T) {
 	request := httptest.NewRequest("GET", "/api/v1/namespaces/project-1/environments/env-1/terminal", nil)
 	setWebSocketUpgrade(request)
+	request.Header.Set(EnvironmentUIDHeader, "env-uid")
 	response := httptest.NewRecorder()
 	NewServer(nil, ServerOptions{Access: &fakeAccess{}}).Handler().ServeHTTP(response, request)
 	if response.Code != 503 {
@@ -383,7 +384,7 @@ func TestWebTerminalChecksSandboxdHealthBeforeUpgrade(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	websocketURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/v1/namespaces/project-1/environments/env-1/terminal"
-	connection, response, err := websocket.DefaultDialer.Dial(websocketURL, http.Header{"Authorization": []string{"Bearer reader"}})
+	connection, response, err := websocket.DefaultDialer.Dial(websocketURL, http.Header{"Authorization": []string{"Bearer reader"}, EnvironmentUIDHeader: []string{"env-uid"}})
 	if connection != nil {
 		_ = connection.Close()
 	}
@@ -453,6 +454,31 @@ func TestKubernetesTerminalDialerDoesNotMarkReplacementEnvironmentActive(t *test
 	}
 }
 
+func TestKubernetesTerminalDialerRejectsStaleExpectedUIDBeforeLifecycleSideEffects(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	environment := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "env-1", Namespace: "project-1", UID: "new-uid"},
+		Status: platformv1alpha1.EnvironmentStatus{Lifecycle: platformv1alpha1.EnvironmentLifecycleStatus{
+			Suspended: true, SuspensionReason: platformv1alpha1.EnvironmentSuspensionReasonIdle,
+		}},
+	}
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment).Build()
+	dialer := KubernetesTerminalDialer{Client: kubeClient}
+	if _, _, _, err := dialer.DialTerminal(context.Background(), environment.Namespace, environment.Name, "old-uid"); !errors.Is(err, errTerminalEnvironmentIncarnationChanged) {
+		t.Fatalf("DialTerminal() error = %v, want incarnation conflict", err)
+	}
+	var retained platformv1alpha1.Environment
+	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(environment), &retained); err != nil {
+		t.Fatal(err)
+	}
+	if retained.Spec.Lifecycle.Wake != nil || len(lifecycle.ActivityRequests(&retained)) != 0 {
+		t.Fatalf("stale direct terminal wrote lifecycle traffic: %#v", retained.Spec.Lifecycle)
+	}
+}
+
 func TestKubernetesTerminalDialerRejectsNonIdleSuspension(t *testing.T) {
 	for _, test := range []struct {
 		name   string
@@ -479,7 +505,7 @@ func TestKubernetesTerminalDialerRejectsNonIdleSuspension(t *testing.T) {
 			kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment).Build()
 			dialer := KubernetesTerminalDialer{Client: kubeClient}
 
-			if _, _, _, err := dialer.DialTerminal(context.Background(), environment.Namespace, environment.Name); err == nil {
+			if _, _, _, err := dialer.DialTerminal(context.Background(), environment.Namespace, environment.Name, string(environment.UID)); err == nil {
 				t.Fatal("DialTerminal() unexpectedly succeeded")
 			}
 			var retained platformv1alpha1.Environment
@@ -1000,7 +1026,7 @@ func TestKubernetesTerminalDialerActivityPreservesReadyGeneration(t *testing.T) 
 	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment, template, pod).Build()
 	dialer := KubernetesTerminalDialer{Client: kubeClient}
 
-	_, _, closer, err := dialer.DialTerminal(context.Background(), environment.Namespace, environment.Name)
+	_, _, closer, err := dialer.DialTerminal(context.Background(), environment.Namespace, environment.Name, string(environment.UID))
 	if err != nil {
 		t.Fatalf("DialTerminal() error = %v", err)
 	}
@@ -1056,7 +1082,7 @@ func TestKubernetesTerminalDialerUsesRecreatedPodCredentialsAfterWake(t *testing
 	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment, template, newPod).Build()
 	dialer := KubernetesTerminalDialer{Client: wakeReadyClient{Client: baseClient, podName: newPod.Name}}
 
-	_, _, closer, err := dialer.DialTerminal(context.Background(), environment.Namespace, environment.Name)
+	_, _, closer, err := dialer.DialTerminal(context.Background(), environment.Namespace, environment.Name, string(environment.UID))
 	if err != nil {
 		t.Fatalf("DialTerminal() error = %v; wake did not use the recreated pod credential bundle", err)
 	}
@@ -1108,7 +1134,7 @@ func TestTerminalHeartbeatProtectsSlowWakeBeforeConnection(t *testing.T) {
 	wakeClient := &heartbeatWakeReadyClient{activityCountingClient: activityClient, podName: pod.Name, minimumActivityWrites: 3}
 	dialer := KubernetesTerminalDialer{Client: wakeClient}
 
-	_, _, closer, err := dialer.DialTerminal(context.Background(), environment.Namespace, environment.Name)
+	_, _, closer, err := dialer.DialTerminal(context.Background(), environment.Namespace, environment.Name, string(environment.UID))
 	if err != nil {
 		t.Fatalf("DialTerminal() error = %v", err)
 	}
@@ -1159,7 +1185,7 @@ func TestTerminalHeartbeatCancelsWhenWakeOrDialFails(t *testing.T) {
 			}
 			dialer := KubernetesTerminalDialer{Client: kubeClient}
 
-			if _, _, _, err := dialer.DialTerminal(context.Background(), environment.Namespace, environment.Name); err == nil {
+			if _, _, _, err := dialer.DialTerminal(context.Background(), environment.Namespace, environment.Name, string(environment.UID)); err == nil {
 				t.Fatalf("DialTerminal() succeeded during %s failure", test.name)
 			}
 			writesAfterFailure := waitForActivityWritesToQuiesce(t, activityClient, 60*time.Millisecond)
@@ -1353,6 +1379,31 @@ func TestWebTerminalAuthorizesBeforeDial(t *testing.T) {
 	}
 }
 
+func TestWebTerminalRequiresBoundedIdentityAfterAuthorization(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		access *fakeAccess
+		uid    string
+		want   int
+	}{
+		{name: "unauthorized missing", access: &fakeAccess{err: errForbidden}, want: http.StatusForbidden},
+		{name: "authorized missing", access: &fakeAccess{}, want: http.StatusBadRequest},
+		{name: "authorized overlong", access: &fakeAccess{}, uid: strings.Repeat("x", maxTerminalUIDLength+1), want: http.StatusBadRequest},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dialer := &terminalTestDialer{}
+			request := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/project-a/environments/shared/terminal", nil)
+			request.Header.Set("Authorization", "Bearer reader")
+			request.Header.Set(EnvironmentUIDHeader, test.uid)
+			response := httptest.NewRecorder()
+			NewServer(nil, ServerOptions{Access: test.access, TerminalDialer: dialer}).Handler().ServeHTTP(response, request)
+			if response.Code != test.want || dialer.calls != 0 {
+				t.Fatalf("response/dials = %d/%d, want %d/0", response.Code, dialer.calls, test.want)
+			}
+		})
+	}
+}
+
 func TestWebTerminalSameNamedEnvironmentCannotCrossNamespace(t *testing.T) {
 	dialer := &terminalTestDialer{}
 	access := &fakeAccess{allow: func(resource ResourceAccess) bool { return resource.Namespace == "project-a" }}
@@ -1407,6 +1458,7 @@ func TestWebTerminalRejectsCookieWithoutOriginAndCrossOriginBeforeDial(t *testin
 		handler := NewServer(nil, ServerOptions{Access: &fakeAccess{}, TerminalDialer: dialer}).Handler()
 		request := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/project-a/environments/env-1/terminal", nil)
 		setWebSocketUpgrade(request)
+		request.Header.Set(EnvironmentUIDHeader, "env-uid")
 		request.Header.Del("Authorization")
 		request.Header.Set("Origin", origin)
 		request.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "reader-session"})
@@ -1455,7 +1507,7 @@ func TestKubernetesTerminalDialerRejectsPodOwnedByAnotherEnvironmentIncarnation(
 	template := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "project-1"}}
 	dialer := KubernetesTerminalDialer{Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment, pod, template).Build()}
 
-	_, _, _, err := dialer.DialTerminal(context.Background(), "project-1", "env-1")
+	_, _, _, err := dialer.DialTerminal(context.Background(), "project-1", "env-1", string(environment.UID))
 	if err == nil || !strings.Contains(err.Error(), "not owned by the current environment") {
 		t.Fatalf("DialTerminal() error = %v, want stale pod rejection", err)
 	}
@@ -1468,17 +1520,21 @@ type terminalTestDialer struct {
 	client      sandboxdv1.TerminalServiceClient
 	health      sandboxdv1.HealthServiceClient
 	closer      io.Closer
+	err         error
 	namespace   string
 	environment string
 	calls       int
 }
 
-func (d *terminalTestDialer) DialTerminal(_ context.Context, namespace, environment string) (sandboxdv1.TerminalServiceClient, sandboxdv1.HealthServiceClient, io.Closer, error) {
+func (d *terminalTestDialer) DialTerminal(_ context.Context, namespace, environment, _ string) (sandboxdv1.TerminalServiceClient, sandboxdv1.HealthServiceClient, io.Closer, error) {
 	d.mu.Lock()
 	d.calls++
 	d.namespace = namespace
 	d.environment = environment
 	d.mu.Unlock()
+	if d.err != nil {
+		return nil, nil, nil, d.err
+	}
 	health := d.health
 	if health == nil {
 		health = terminalTestHealthClient{}
@@ -1491,7 +1547,7 @@ func (d *terminalTestDialer) DialTerminal(_ context.Context, namespace, environm
 }
 
 func (d *terminalTestDialer) DialRunTerminal(ctx context.Context, namespace string, association RunTerminalAssociation) (sandboxdv1.TerminalServiceClient, sandboxdv1.HealthServiceClient, io.Closer, error) {
-	return d.DialTerminal(ctx, namespace, association.EnvironmentName)
+	return d.DialTerminal(ctx, namespace, association.EnvironmentName, association.EnvironmentUID)
 }
 
 type terminalTestServer struct {

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -10,7 +10,7 @@ import type { Environment, Run } from './contracts'
 const run: Run = {
   name: 'repair-ui', uid: 'run-uid', generation: 1, createdAt: '2026-07-19T12:00:00Z',
   intent: { selector: { project: 'platform', template: 'small' }, agent: 'amp', prompt: 'Repair UI', credentialProfile: 'amp-production' },
-  cancelRequested: false, state: 'Running', startedAt: '2026-07-19T12:01:00Z', environment: { name: 'repair-env', ownership: 'Owned' }, branch: 'agent/repair',
+  cancelRequested: false, state: 'Running', startedAt: '2026-07-19T12:01:00Z', environment: { name: 'repair-env', uid: 'env-uid', ownership: 'Owned' }, terminalAvailable: true, branch: 'agent/repair',
   usage: { cpuSeconds: 12.5, tokensIn: 101, tokensOut: 202 },
 }
 const environment: Environment = { name: 'repair-env', uid: 'env-uid', createdAt: '2026-07-19T12:00:01Z', project: 'platform', template: 'small', backend: 'pod', paused: false, phase: 'Running', ready: true }
@@ -257,6 +257,17 @@ describe('App frozen API integration', () => {
     expect(screen.getByText('2026-07-19T12:01:00Z')).toBeInTheDocument()
     expect(screen.getByText('Owned')).toBeInTheDocument()
     expect(screen.queryByRole('link', { name: /changes/i })).not.toBeInTheDocument()
+  })
+
+  it('hides and revokes terminal navigation when the exact association is unavailable', async () => {
+    const released = { ...run, terminalAvailable: false, environment: { name: 'repair-env', ownership: 'Owned' as const } }
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async path => {
+      if (path === '/api/v1/session') return response({ authenticated: true, username: 'alex' })
+      return response(released)
+    })
+    show('/namespaces/default/runs/repair-ui/terminal')
+    expect(await screen.findByText('Terminal unavailable for this Run identity.')).toHaveAttribute('role', 'status')
+    expect(screen.queryByRole('link', { name: 'Terminal' })).not.toBeInTheDocument()
   })
 
   it('clears login token after an error and never accesses browser storage', async () => {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -207,7 +207,7 @@ function Detail() {
   if (query.isPending) return <main><Busy label="Loading run" /></main>
   if (query.error) return <main><Failure error={query.error} /></main>
   return <main><div className="title"><div><Link to={`/namespaces/${encodeURIComponent(namespace)}/runs`}>← Runs</Link><h1>{run}</h1></div><span className="pill">{query.data.state}</span></div>
-    <nav aria-label="Run sections"><NavLink to="overview">Overview</NavLink><NavLink to="transcript">Transcript</NavLink>{query.data.environment && <NavLink to="terminal">Terminal</NavLink>}</nav>
+    <nav aria-label="Run sections"><NavLink to="overview">Overview</NavLink><NavLink to="transcript">Transcript</NavLink>{query.data.terminalAvailable && query.data.environment?.uid && <NavLink to="terminal">Terminal</NavLink>}</nav>
     <Outlet context={query.data} />
   </main>
 }
@@ -246,7 +246,7 @@ function Overview() {
 }
 
 function TranscriptRoute() { const run = useOutletRun(); const { namespace = '' } = useParams(); return <Transcript key={`${namespace}/${run.name}/${run.uid}`} namespace={namespace} run={run.name} identity={run.uid} /> }
-function TerminalRoute() { const run = useOutletRun(); const { namespace = '' } = useParams(); return run.environment ? <Suspense fallback={<Busy label="Loading terminal" />}><Terminal namespace={namespace} environment={run.environment.name} /></Suspense> : <p role="status">No environment allocated.</p> }
+function TerminalRoute() { const run = useOutletRun(); const { namespace = '' } = useParams(); return run.terminalAvailable && run.environment?.uid ? <Suspense fallback={<Busy label="Loading terminal" />}><Terminal key={`${namespace}/${run.name}/${run.uid}/${run.environment.uid}`} namespace={namespace} run={run.name} runUID={run.uid} environment={run.environment.name} environmentUID={run.environment.uid} /></Suspense> : <p role="status">Terminal unavailable for this Run identity.</p> }
 
 export function App() {
   return <Routes>

--- a/ui/src/Terminal.test.tsx
+++ b/ui/src/Terminal.test.tsx
@@ -32,9 +32,9 @@ describe('Terminal', () => {
   it('opens, resizes, handles binary traffic, and cleans up', async () => {
     vi.stubGlobal('WebSocket', Socket)
     vi.stubGlobal('ResizeObserver', Observer)
-    const view = render(<Terminal namespace="team/a" environment="env one" />)
+    const view = render(<Terminal namespace="team/a" run="run one" runUID="run/uid" environment="env one" environmentUID="env/uid" />)
     expect(screen.getByRole('application', { name: 'Terminal for env one' })).toBeInTheDocument()
-    expect(Socket.current.url).toContain('/namespaces/team%2Fa/environments/env%20one/terminal')
+    expect(Socket.current.url).toContain('/namespaces/team%2Fa/runs/run%20one/terminal/run%2Fuid/env%2Fuid')
     act(() => Socket.current.onopen?.())
     expect(JSON.parse(Socket.current.send.mock.calls[0][0])).toEqual({ type: 'open', cols: 80, rows: 24 })
     act(() => { mocks.input?.('abc'); Observer.current.callback() })
@@ -52,5 +52,16 @@ describe('Terminal', () => {
     expect(mocks.disposeInput).toHaveBeenCalledOnce()
     expect(mocks.disposeFit).toHaveBeenCalledOnce()
     expect(mocks.disposeTerminal).toHaveBeenCalledOnce()
+  })
+
+  it('remounts on exact identity replacement without retaining the old socket', () => {
+    vi.stubGlobal('WebSocket', Socket)
+    vi.stubGlobal('ResizeObserver', Observer)
+    const view = render(<Terminal namespace="team" run="run" runUID="run-old" environment="env" environmentUID="env-old" />)
+    const oldSocket = Socket.current
+    view.rerender(<Terminal namespace="team" run="run" runUID="run-new" environment="env" environmentUID="env-new" />)
+    expect(oldSocket.close).toHaveBeenCalledOnce()
+    expect(Socket.current).not.toBe(oldSocket)
+    expect(Socket.current.url).toContain('/runs/run/terminal/run-new/env-new')
   })
 })

--- a/ui/src/Terminal.tsx
+++ b/ui/src/Terminal.tsx
@@ -4,7 +4,7 @@ import { FitAddon } from '@xterm/addon-fit'
 import '@xterm/xterm/css/xterm.css'
 import { api } from './api'
 
-export default function Terminal({ namespace, environment }: { namespace: string; environment: string }) {
+export default function Terminal({ namespace, run, runUID, environment, environmentUID }: { namespace: string; run: string; runUID: string; environment: string; environmentUID: string }) {
   const host = useRef<HTMLDivElement>(null)
   const [status, setStatus] = useState('Connecting')
 
@@ -16,7 +16,7 @@ export default function Terminal({ namespace, environment }: { namespace: string
     terminal.open(host.current)
 
     const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
-    const socket = new WebSocket(`${protocol}//${location.host}${api.terminalPath(namespace, environment)}`)
+    const socket = new WebSocket(`${protocol}//${location.host}${api.terminalPath(namespace, run, runUID, environmentUID)}`)
     socket.binaryType = 'arraybuffer'
     let opened = false
     let disposed = false
@@ -61,7 +61,7 @@ export default function Terminal({ namespace, environment }: { namespace: string
       fit.dispose()
       terminal.dispose()
     }
-  }, [namespace, environment])
+  }, [namespace, run, runUID, environment, environmentUID])
 
   return <section>
     <p role="status" aria-live="polite">Terminal: {status}</p>

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -95,7 +95,7 @@ export const api = {
     if (response.status === 401) notifyUnauthorized()
     return response
   },
-  terminalPath: (namespace: string, environment: string) => `${base(namespace)}/environments/${encodeURIComponent(environment)}/terminal`,
+  terminalPath: (namespace: string, run: string, runUID: string, environmentUID: string) => `${base(namespace)}/runs/${encodeURIComponent(run)}/terminal/${encodeURIComponent(runUID)}/${encodeURIComponent(environmentUID)}`,
 }
 
 export async function listAllRuns(namespace: string): Promise<RunList> {

--- a/ui/src/contracts.ts
+++ b/ui/src/contracts.ts
@@ -41,8 +41,10 @@ export interface Run {
   finishedAt?: string
   environment?: {
     name: string
+    uid?: string
     ownership: 'Owned' | 'Claimed'
   }
+  terminalAvailable?: boolean
   branch?: string
   usage: {
     cpuSeconds: number


### PR DESCRIPTION
Closes #132.

## Summary

- retain the native header-based Run terminal endpoint and add the approved browser route `/api/v1/namespaces/{namespace}/runs/{run}/terminal/{runUID}/{environmentUID}`, with each non-secret UID carried as one percent-encoded path segment
- preserve disclosure-safe ordering: exact Run authorization, bounded identity decoding/validation, exact association resolution, exact Environment terminal authorization, origin/upgrade checks, then the existing repeatedly fenced connector-owned dial
- require direct `swe attach` callers to provide `--environment-uid`; authorize the terminal subresource before rejecting missing, overlong, or stale `SWE-Environment-UID` values and before lifecycle/backend side effects
- align the browser TypeScript Run contract with `environment.uid` and `terminalAvailable`, hide unavailable navigation, and remount sockets on exact Run/Environment identity changes
- document the additive browser API and direct CLI compatibility break, and extend kind acceptance for terminal-only RBAC, browser sessions, released/reassigned/stale identities, replacement fencing, and no lifecycle writes on stale direct identity

No CRD/schema or private architecture document changes are included (`docs/` is absent).

## Validation

- `go test -race ./internal/controlplane ./internal/cli`
- `make test`
- `make vet`
- `make build`
- `cd ui && npm run lint`
- `cd ui && npm run typecheck`
- `cd ui && npm test -- --run` (78 tests)
- `cd ui && npm run build`
- `bash -n hack/e2e.sh`
- `git diff --check`

The full kind E2E was updated but not run locally; CI owns the fresh-cluster acceptance environment.
