### PR TITLE
docs: add tracked architecture source

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,10 @@ Guidance for coding agents working in this repository.
 ephemeral, isolated Kubernetes environments. Read `README.md` first for the product
 shape and core concepts.
 
-**Detailed design docs live in `docs/` (`ARCHITECTURE.md`, `TODO.md`) — that folder is
-gitignored and local-only.** If `docs/` is present, read it before doing anything
-architectural. If it's missing, ask the maintainer instead of guessing at design intent.
+[`ARCHITECTURE.md`](ARCHITECTURE.md) is the canonical tracked architecture source. Read it
+before architectural work and keep implemented behavior, approved future contracts, and
+open work clearly separated. Do not guess at design intent that is not recorded there or in
+an approved maintainer decision.
 
 ## Current state
 
@@ -24,10 +25,11 @@ Run/Environment resource APIs for the console.
 The CLI also provides a local stdio `swe mcp` server with bounded `create_run` and
 UID-fenced `read_transcript` tools that act through the caller's existing explicit
 control-plane bearer credential; interactive terminal attach is intentionally not an MCP tool.
-Remaining gaps are marked `TODO(P0/P1/P2)` in code — most notably additional credential forms,
-additional agent adapters, GitHub App–scoped git tokens, and egress/portal networking. The
-`claude-code` (default), `amp`, `codex`, and `pi` adapters are registered and use sandboxd managed
-processes. API-key profiles use process-scoped launch material as `ANTHROPIC_API_KEY`,
+Remaining gaps are tracked in `ARCHITECTURE.md`, code comments, and linked issues — most notably
+additional credential forms, additional agent adapters, GitHub App–scoped git tokens, and
+egress/portal networking. The `claude-code` (default), `amp`, `codex`, and `pi` adapters are
+registered and use sandboxd managed processes. API-key profiles use process-scoped launch
+material as `ANTHROPIC_API_KEY`,
 `AMP_API_KEY`, or `CODEX_API_KEY`; tests use fake process services and no provider credentials.
 Pi deliberately supports no credential profiles or credential injection.
 
@@ -39,13 +41,14 @@ Pi deliberately supports no credential profiles or credential injection.
    internals; integrations go through the adapter interface.
 3. **Pause = disk + transcript.** Delete the pod, retain the PVC, resume onto a fresh
    pod. No CRIU/process checkpointing.
-4. **CRDs are the source of truth for infrastructure state.** Postgres (when it lands)
-   is only for transcripts/events, not desired/observed state.
+4. **CRDs are the source of truth for infrastructure state.** PostgreSQL is only for
+   transcripts/events, not desired/observed infrastructure state.
 5. **gVisor RuntimeClass by default** wherever it's possible; isolation is a feature.
-6. **Namespace-per-project tenancy.** `Project.spec.repositories` is a list from day
-   one even though v1 executes single-repo.
-7. **Inter-agent messaging is a platform primitive** (inbox + wake + notify). Transcript
-   formats stay adapter-owned; don't build a shared transcript schema.
+6. **Namespace-per-project tenancy is the approved target.** Do not build an alternate
+   tenancy boundary; current gaps and the approved claim model are in `ARCHITECTURE.md`.
+   `Project.spec.repositories` is a list from day one even though v1 executes single-repo.
+7. **Inter-agent messaging is a future platform primitive** (inbox + wake + notify).
+   Transcript formats stay adapter-owned; don't build a shared transcript schema.
 8. **Environment backends are pluggable** (`pod` / `kubevirt` / `external-runner`) and
    `sandboxd` must stay OS-portable: no Linux-only assumptions in its API; abstract
    terminal (tmux vs ConPTY), paths, and exec.
@@ -57,11 +60,11 @@ Pi deliberately supports no credential profiles or credential injection.
   `internal/controllers/`, `cmd/{operator,swe}`. Shared fenced Environment intent
   publication and validation belongs in `internal/lifecycle/`; controllers remain
   the sole owners of observed lifecycle transitions. `sandboxd/` is a **separate Go
-  module** with its own `go.mod`: keep its dependencies minimal (gRPC + protobuf
-  only) so it stays portable and the environment base image stays small.
+  module** with its own `go.mod`: keep its dependencies minimal so it stays portable and
+  the environment base image stays small.
   Generated protobuf code lives in `sandboxd/gen/` and is committed.
-- **APIs:** CRDs are `v1alpha1`; breaking changes are acceptable pre-1.0, but migrate
-  the CRD sketch in `docs/ARCHITECTURE.md` when you change fields.
+- **APIs:** CRDs are `v1alpha1`; breaking changes are acceptable pre-1.0, but update
+  the current CRD sketch in root [`ARCHITECTURE.md`](ARCHITECTURE.md) when fields change.
 - **CLI-first:** every user-facing feature needs a CLI path before any UI work.
 - **Minimal changes:** match existing style; don't refactor beyond the task.
 
@@ -72,8 +75,8 @@ When a change touches one side of a row, update the other side **in the same
 commit**:
 
 - **CRD field changes** → `make generate manifests` (deepcopy + CRDs + RBAC; CI
-  diffs `charts/swe-platform/crds`) and migrate the CRD sketch in
-  `docs/ARCHITECTURE.md`.
+  diffs `charts/swe-platform/crds`) and update the current CRD sketch in root
+  [`ARCHITECTURE.md`](ARCHITECTURE.md).
 - **Chart values/template changes** → review every `values-*.yaml` preset —
   `kind` uses locally loaded `:dev`, `argocd` tracks `:latest` for the Argo
   mirror, `k3s`/`gke`/`eks` stay immutable on the chart `appVersion` — plus the
@@ -166,5 +169,5 @@ commit.**
 
 ## Safety
 
-- Never commit secrets, tokens, or the `docs/` folder (gitignored — leave it that way).
+- Never commit secrets or tokens.
 - Don't create git commits/pushes unless the maintainer explicitly asks.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,8 +63,10 @@ Pi deliberately supports no credential profiles or credential injection.
   module** with its own `go.mod`: keep its dependencies minimal so it stays portable and
   the environment base image stays small.
   Generated protobuf code lives in `sandboxd/gen/` and is committed.
-- **APIs:** CRDs are `v1alpha1`; breaking changes are acceptable pre-1.0, but update
-  the current CRD sketch in root [`ARCHITECTURE.md`](ARCHITECTURE.md) when fields change.
+- **APIs:** CRDs are `v1alpha1`; breaking changes are acceptable pre-1.0. Whenever CRD
+  fields or contracts change, update the relevant current resource table and
+  ownership/reference documentation in root [`ARCHITECTURE.md`](ARCHITECTURE.md) in the
+  same commit.
 - **CLI-first:** every user-facing feature needs a CLI path before any UI work.
 - **Minimal changes:** match existing style; don't refactor beyond the task.
 
@@ -74,9 +76,9 @@ Several files must move in lockstep, and CI only enforces some of the pairings.
 When a change touches one side of a row, update the other side **in the same
 commit**:
 
-- **CRD field changes** → `make generate manifests` (deepcopy + CRDs + RBAC; CI
-  diffs `charts/swe-platform/crds`) and update the current CRD sketch in root
-  [`ARCHITECTURE.md`](ARCHITECTURE.md).
+- **CRD field or contract changes** → `make generate manifests` (deepcopy + CRDs + RBAC;
+  CI diffs `charts/swe-platform/crds`) and update the relevant current resource table and
+  ownership/reference documentation in root [`ARCHITECTURE.md`](ARCHITECTURE.md).
 - **Chart values/template changes** → review every `values-*.yaml` preset —
   `kind` uses locally loaded `:dev`, `argocd` tracks `:latest` for the Argo
   mirror, `k3s`/`gke`/`eks` stay immutable on the chart `appVersion` — plus the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,9 +1,11 @@
 # swe-platform architecture
 
-This is the canonical, tracked architecture source for `swe-platform`. It records the
-implemented system and the contracts already approved for its next stages. Code and
-generated CRDs remain authoritative for runtime behavior; a CRD field change must update
-the current resource sketch below in the same commit.
+This root document is the canonical, tracked architecture source for `swe-platform`. It
+supersedes the private, gitignored `docs/ARCHITECTURE.md` referenced by earlier decisions; do
+not recreate that path. This document records the implemented system and the contracts already
+approved for its next stages. Code and generated CRDs remain authoritative for runtime
+behavior. Whenever CRD fields or contracts change, update the relevant entries in the current
+resource table and ownership/reference documentation below in the same commit.
 
 ## Implemented today
 
@@ -26,7 +28,7 @@ CLI / TUI / local MCP / browser console
           agent processes + sandboxd
                     ^
                     | authenticated TLS gRPC
-                    +---- control plane and adapters
+                    +---- control plane and operator-hosted adapters
 ```
 
 - **CRDs and controllers.** Kubernetes `swe.dev/v1alpha1` resources hold durable

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,378 @@
+# swe-platform architecture
+
+This is the canonical, tracked architecture source for `swe-platform`. It records the
+implemented system and the contracts already approved for its next stages. Code and
+generated CRDs remain authoritative for runtime behavior; a CRD field change must update
+the current resource sketch below in the same commit.
+
+## Implemented today
+
+### System topology
+
+```text
+CLI / TUI / local MCP / browser console
+                    |
+                    | HTTP, SSE, WebSocket
+                    v
+             control plane -------- PostgreSQL transcripts
+                    |                    (or bounded dev memory)
+                    | Kubernetes API
+                    v
+       CRDs <---- operator/controllers
+                    |
+                    | Pod backend
+                    v
+        Environment pod + workspace PVC
+          agent processes + sandboxd
+                    ^
+                    | authenticated TLS gRPC
+                    +---- control plane and adapters
+```
+
+- **CRDs and controllers.** Kubernetes `swe.dev/v1alpha1` resources hold durable
+  infrastructure and task intent. Controllers allocate or claim Environments for Runs,
+  reconcile Environment pods and volumes, maintain warm pools, reap idle Environments, and
+  drive adapter lifecycle.
+- **Control plane.** A singleton HTTP service exposes typed Run and Environment operations,
+  Run watches, transcript ingestion/SSE, browser sessions, the embedded operations console,
+  and terminal WebSockets. It acts through Kubernetes APIs and the sandboxd connector; it
+  does not exec into Environment pods.
+- **Clients.** `swe run`, `logs`, `attach`, `tui`, and the bounded local stdio MCP server use
+  the control-plane or Kubernetes contracts appropriate to each command. The React console
+  uses the same control-plane resource, transcript, and terminal APIs.
+- **`sandboxd`.** A small daemon in each Environment provides authenticated gRPC services for
+  connection-bound exec, keyed managed processes, workspace-confined filesystem access, one
+  shared terminal, a process-local port registry, and health. The port registry is not a
+  portal gateway.
+
+Portal proxying, inbox delivery and child-run spawning, branch/PR publication, and non-Pod
+Environment backends are not implemented.
+
+### Current CRDs and sources of truth
+
+CRDs are the source of truth for desired and observed infrastructure state. PostgreSQL is
+used for durable transcript events, not as a second infrastructure-state store. Browser
+sessions are bounded process-local state and are lost when the control plane restarts.
+
+All current CRDs are namespaced:
+
+| Resource | Current contract |
+|---|---|
+| `Project` | One repository URL (represented as a one-item list), a same-namespace default Template reference, changes-workflow metadata, and a reserved egress allowlist. A non-empty allowlist is rejected when an Environment uses the Project. |
+| `EnvironmentTemplate` | Pod image, size/resources, disk, runtime class, idle timeout, warm-pool minimum, and backend. Admission currently permits only the `pod` backend. |
+| `Environment` | Template/Project selection, explicit hold policy and bounded wake/suspend/activity intents; status owns readiness, lifecycle suspension and epoch, exact Run claim, Pod endpoint observations, activity, and recovery state. |
+| `Run` | Immutable agent task and Environment/Project/Template/credential selection plus monotonic cancellation; status records normalized lifecycle, exact Environment name/UID and ownership, exact credential profile identity, and accepted lifecycle epoch. `notify` and `parentRef` are schema placeholders without an implemented inbox. |
+| `AgentCredentialProfile` | Immutable adapter and `APIKey` type metadata. Key bytes live in an owner-linked Secret whose name is derived from the profile UID. |
+
+The current ownership/reference shape is:
+
+```text
+Project -----same namespace----> EnvironmentTemplate
+   |                                  |
+   +--------> Run --------------------+
+                |                     |
+                | name + UID          v
+                +--------------> Environment
+                                      |
+                                      +--> Pod
+                                      +--> workspace PVC
+                                      +--> sandboxd credential Secret
+                                      +--> sandboxd ingress NetworkPolicy
+
+AgentCredentialProfile --owner UID--> Secret
+          ^
+          | exact name + UID in Run status
+          +---------------- Run
+```
+
+The Run controller creates an owned Environment or exclusively claims a reusable one.
+Owned allocations have a Run controller owner reference; claimed allocations carry Run name
+and UID in `Environment.status.claimedBy`. Exact UIDs prevent same-name replacements from
+inheriting allocation, cancellation, transcript, terminal, or credential authority.
+
+### Tenancy: current state
+
+Namespace-per-Project is **not enforced today**. Projects are ordinary namespaced objects;
+clients select a namespace (the CLI defaults to `default`), and Project, Template,
+Environment, Run, and credential references resolve within that selected namespace. The Helm
+chart creates configured Templates in the release namespace unless an entry explicitly names
+another namespace. Its operator and control-plane service accounts currently receive
+cluster-wide RBAC.
+
+Consequently, installing the production chart in a system namespace does not itself onboard a
+separate Project namespace or copy Templates there. Shared-cluster scoped reconciliation,
+installation namespace claims, Project offboarding, and enforced one-Project-per-namespace
+cardinality remain future work under the approved contract below.
+
+### Environment boundary and backend portability
+
+`sandboxd` is the only supported execution/filesystem/terminal contract into an Environment.
+Platform consumers receive a backend-neutral connector or adapter sandbox and do not inspect
+containers, PIDs, tmux, or OS signals. The protobuf uses logical paths, process owner/role keys,
+portable process controls, and opaque execution IDs. The sandboxd module is separate and has
+Windows coverage for process containment and filesystem behavior; the current shared terminal
+backend is tmux, not ConPTY.
+
+Only the Kubernetes **Pod backend** is implemented. The connector currently resolves an exact
+owned Pod, Pod IP, Pod UID, and per-Pod credential Secret behind its consumer interface.
+`kubevirt` and `external-runner` names are retained as planned Go API values, but CRD admission
+rejects them and the controller fails unsupported existing resources before provisioning.
+Backend pluggability is an invariant on interfaces, not a claim that those backends ship.
+
+Each Environment pod receives a per-incarnation TLS identity and capability tokens. The
+operator also creates an ingress NetworkPolicy allowing sandboxd traffic only from the
+release's control-plane- and operator-labeled pods in the configured control-plane namespace.
+NetworkPolicy enforcement is a cluster/CNI prerequisite; authenticated TLS and capabilities
+remain mandatory. Default-deny egress and an egress proxy do not exist today.
+
+### Run, Environment, pause, and execution lifecycle
+
+The Run UID is the idempotency key for allocation, adapter acceptance, and sandboxd managed
+process ownership. A durable acceptance-attempt condition is written before calling an
+adapter, so cancellation remains conservative after an uncertain response. Run status exposes
+adapter-neutral milestones from allocation through terminal success, failure, or cancellation.
+
+One Environment controller owns suspension transitions. Explicit user/admin policy is a
+revisioned `spec.lifecycle.hold`; ordinary callers publish UID- and hold-revision-fenced wake,
+suspend, or source-keyed activity intents. The controller owns observed suspension state.
+Automatic idle suspension is prevented by an exact non-terminal Run owner or claim. Ordinary
+wakes cannot clear an explicit hold, and terminal traffic wakes only an Idle suspension.
+
+Pause is disk plus transcript, not process checkpointing:
+
+1. the lifecycle epoch increases before suspension;
+2. readiness and connection identity are withdrawn;
+3. the Environment pod and its sandboxd credential are deleted;
+4. the workspace PVC and already-ingested transcript remain;
+5. resume creates a fresh pod/credential epoch, runs the repository resume hook, and repeats
+   idempotent adapter acceptance with the same Run UID.
+
+The lifecycle epoch currently identifies suspension cycles; it is **not** a complete backend
+execution-generation contract for every Pod recovery. Terminal attachment additionally pins
+the exact Pod UID and revalidates Environment UID, lifecycle epoch, hold revision, and Run
+association. The approved general execution generation is described below and is not shipped.
+
+Only the Pod backend performs execution today. Project-backed initialization clones the
+Project's single repository into `/workspace`, runs `.agents/setup` once per workspace when
+present, and runs `.agents/resume` after resume when present. Terminal Pod failure has bounded
+replacement/backoff while retaining the PVC. Warm pools maintain ready unclaimed Environments;
+claiming a generic warm member for a Project recreates its pod so Project initialization runs
+before the Run becomes ready.
+
+### Adapters, processes, and transcripts
+
+The agent layer is adapters. Platform code supplies an immutable Run UID/task, an ephemeral
+credential, a backend-neutral sandboxd process dialer, and an opaque event sink. Adapters own
+agent command/protocol details and event payload meaning; the platform does not impose a shared
+transcript schema.
+
+The registered `claude-code` (default), `amp`, `codex`, and `pi` adapters each run a foreground
+CLI through sandboxd's keyed managed-process service. Starts are duplicate-safe within one
+sandboxd daemon epoch, and bounded output includes absolute offsets and observable gaps.
+Adapters map their own completion protocol to normalized Run state. Process exit alone is not
+a universal platform completion rule.
+
+Transcript transport is fenced by namespace, Run name, and immutable Run UID. It supplies
+idempotent append, monotonic per-Run cursors, bounded retention, explicit gaps, replay, and SSE.
+Production presets require an external PostgreSQL URL; live PostgreSQL delivery is currently
+database-polled. With no URL, the control plane logs a warning and uses a bounded, non-durable,
+process-local development store. Transcript rows are not currently garbage-collected when a
+Run is deleted.
+
+### Authentication and exact identity fences
+
+Normal control-plane bearer credentials are authenticated with Kubernetes TokenReview for the
+configured audience. SubjectAccessReview then authorizes the reviewed username, UID, groups,
+and extras against the exact API group, version, namespace, resource, subresource, verb, and,
+where applicable, object name. Namespace is taken from the route, never a query parameter.
+
+The optional bootstrap bearer token bypasses SAR for initial self-hosted setup. It cannot be
+exchanged for a browser session and should be removed after RBAC is configured. Browser login
+stores the Kubernetes token server-side behind an opaque, bounded, process-local cookie ID;
+each cookie use repeats TokenReview. Production cookies are Secure, HttpOnly, and SameSite
+Strict, and cookie-authenticated mutations require same-origin checks.
+
+Object names are not identities. Current sensitive operations add these fences:
+
+- Run cancellation compares the caller's expected Run UID with the live object.
+- Transcript append/read and reconnect target an expected Run UID; replacement Runs cannot
+  inherit old events.
+- Native Environment terminal access requires an expected Environment UID.
+- Run terminal access requires expected Run and Environment UIDs, exact current owned/claimed
+  association, separate Run and Environment authorization, and continued association checks.
+- The sandboxd connector pins an exact ready Environment, owned Pod UID and endpoint, per-Pod
+  TLS identity, and capability token. Terminal leases also revalidate lifecycle epoch and Pod
+  identity; per-execution sandboxd credential rotation prevents old connections authenticating
+  to a replacement pod.
+- Same-name Run-create recovery returns an existing object only after exact-name `get`
+  authorization and immutable-intent comparison. Run watches are separately namespace-level
+  `list`/`watch` operations and use opaque Kubernetes resource versions.
+
+The CLI and local MCP server carry the user's explicit control-plane bearer credential. MCP
+fixes all calls to one namespace and currently exposes bounded `create_run` and UID-fenced
+`read_transcript`; interactive terminal attachment is deliberately not an MCP tool.
+
+### Credentials
+
+API-key profiles are namespace-shared and adapter-bound. Immediately before acceptance, the
+operator uncached-reads and revalidates the exact profile UID, deterministic backing Secret,
+sole owner reference, Secret UID/resource version, type, key, and size. The key is then passed
+as write-only sandboxd launch material only to the selected child process:
+
+| Adapter | Child variable |
+|---|---|
+| `claude-code` | `ANTHROPIC_API_KEY` |
+| `amp` | `AMP_API_KEY` |
+| `codex` | `CODEX_API_KEY` |
+| `pi` | Credential profiles are rejected |
+
+The key is absent from public process specifications, setup/resume hooks, sandboxd's ambient
+environment, and ordinary exec calls. The selected agent and descendants can still read or
+emit it; same-UID peers are not strongly isolated and transcript redaction is not guaranteed.
+OAuth/subscription credentials, refresh/writeback, per-user profiles, Git/setup/service
+credentials, and GitHub App token minting are not implemented.
+
+### Terminal and operations console
+
+`swe attach`, `swe tui`, and the browser console bridge a WebSocket to sandboxd's bidirectional
+terminal RPC. Clients open with dimensions, exchange binary terminal bytes, and can resize.
+All clients share the Environment's `swe` tmux session. Terminal open and heartbeat record
+bounded lifecycle activity; stale hold, Run association, Environment, epoch, or Pod identity
+revokes the lease.
+
+The embedded React console and terminal TUI are agent-neutral operations clients. They list,
+watch, create, inspect, and cancel Runs; show exact Environment detail and opaque transcripts;
+and attach only when the API returns exact terminal identities. They do not contact Kubernetes
+or sandboxd directly. Portal UI/proxying and Project/Template/credential administration are
+not implemented.
+
+### Chart, presets, tests, and deployment topology
+
+The Helm chart installs CRDs, operator, singleton control plane, service accounts/RBAC, and
+optional namespaced EnvironmentTemplates. It does not install PostgreSQL, ingress/TLS,
+StorageClasses, RuntimeClasses, an egress proxy, or a portal gateway. The control plane is
+fixed at one replica with `Recreate`; PostgreSQL makes transcripts durable, but browser
+sessions and full control-plane HA are still process-local limitations.
+
+- `values-kind.yaml` uses local `:dev` images and insecure HTTP sessions for development.
+- `values-argocd.yaml` is a separate local mirror of `main` using mutable `:latest` images.
+- `values-k3s.yaml`, `values-gke.yaml`, and `values-eks.yaml` use coordinated immutable chart
+  `appVersion` images and require an out-of-band PostgreSQL Secret. GKE selects `gvisor`; k3s
+  and EKS use the cluster default runtime unless explicitly overridden.
+
+CI builds, vets, and tests both Go modules, runs PostgreSQL transcript integration tests,
+checks UI lint/type/tests/build, exercises focused sandboxd Windows portability, verifies
+generated CRDs/chart copies, and lints/renders every preset. The kind acceptance workflow
+builds and loads local images and covers CRD upgrade, Runs/warm pools/lifecycle, adapters and
+process-scoped credentials, TokenReview/SAR and browser sessions, resource APIs/watches,
+transcript SSE/CLI/MCP, terminal authorization and identity fencing, and UI embedding. It is
+path-filtered for pull requests and can be manually dispatched; a documentation-only change
+does not add dummy source changes merely to trigger it.
+
+Local development uses `swe-dev`; `make kind-up` adds gVisor plus snapshot-capable CSI. The
+Argo mirror uses a separate `swe-argo` cluster tracking pushed `main`; the two operators must
+never reconcile the same resources. Published images are operator, control plane, and
+environment base for amd64/arm64.
+
+## Approved next contracts (not implemented)
+
+These decisions constrain future implementation. They do not add current API fields or imply
+that migrations, controllers, proxies, or gateways already exist.
+
+### One claimed namespace per Project
+
+The maintainer approved the [Project namespace decision in #11](https://github.com/Chris-Cullins/swe-platform/issues/11#issuecomment-5078431568):
+
+- platform services and PostgreSQL live in a system namespace;
+- each Project has one dedicated namespace, explicitly created or adopted under a stable
+  installation claim;
+- that namespace contains the Project, installation-managed local Template copies, Runs,
+  Environments/warm pools, credential profiles and owned Secrets, PVCs, quotas, RBAC, and
+  baseline policies;
+- normal references remain same-namespace; scoped mode manages only claimed namespaces, while
+  cluster-wide trusted-admin mode is an explicit opt-in;
+- CLI context is explicit rather than inferred from `default` or the release namespace; and
+- offboarding separates fence/disable, retain/archive, and purge, with explicit PVC and
+  exact-UID transcript handling.
+
+### Durable services and gateway ownership
+
+The maintainer approved the [three-owner service model in #16](https://github.com/Chris-Cullins/swe-platform/issues/16#issuecomment-5078805652):
+
+- the Environment owns durable desired Service records with immutable service identity;
+- `.swe/services.yaml` and the CLI declare exposure; listening alone never grants visibility;
+- sandboxd reports backend-portable listener/health observations fenced to the exact current
+  execution; and
+- the control-plane/gateway owns Project-only URLs, authentication, authorization, routing,
+  route generation, and revocation.
+
+A stable service URL may survive a process restart, showing unavailable until healthy, but
+never an Environment replacement. Pause disables routing immediately; resume republishes only
+after fresh-execution health. Uncertain or stale identity and health fail closed. Old execution
+observations and routes cannot target a resumed, recovered, or same-name replacement
+Environment. Anonymous/public exposure is deferred.
+
+### Fail-closed proxy-only egress
+
+The maintainer approved the [outbound-network contract in #68](https://github.com/Chris-Cullins/swe-platform/issues/68#issuecomment-5078805740):
+
+- production requires a demonstrably enforcing CNI and fails before execution when enforcement
+  is unavailable; any unrestricted local mode is explicitly non-production;
+- Environment traffic is technically forced through an authenticated shared proxy, with no
+  direct fallback; proxy environment variables are compatibility, not enforcement;
+- installation administrators define a destination ceiling and Projects may select only a
+  subset;
+- the first version allows canonical HTTPS FQDN destinations on port 443 and HTTPS Git, not
+  direct IPs, Git SSH/`git://`, arbitrary TCP/UDP, QUIC, private Project networks, or alternate
+  DNS paths;
+- the proxy authenticates immutable Project, Environment, and execution identity and never
+  trusts repository-controlled headers or source claims;
+- the proxy resolves destinations itself and validates every A, AAAA, and CNAME result and
+  re-resolution, rejecting metadata, loopback, link-local, pod, service, node, control-plane,
+  and private ranges; proxy egress itself is restricted;
+- policy contraction terminates tunnels or replaces execution, while pause/resume, recovery,
+  and replacement invalidate stale identity and cache; and
+- required Git, package, provider, and CDN traffic is explicit and observable, and denials
+  provide useful operator evidence.
+
+The current non-empty Project allowlist rejection remains until identity, proxy readiness, and
+path forcing ship together after Project namespace claims.
+
+### Backend-neutral execution generation
+
+The maintainer approved the matching [Run observation decision in #122](https://github.com/Chris-Cullins/swe-platform/issues/122#issuecomment-5078805815)
+and [terminal activity decision in #125](https://github.com/Chris-Cullins/swe-platform/issues/125#issuecomment-5078805886):
+
+- add a dedicated backend-neutral execution generation, separate from lifecycle epoch;
+- increment it for every actual backend execution replacement, including initial provision,
+  pause/resume, recovery, security replacement, and equivalent non-Pod transitions;
+- delayed operations capture Environment UID plus execution generation and, where relevant,
+  hold-policy revision;
+- stale adapter observations are discarded before Run status publication, and terminal activity
+  updates reject stale Environment/execution/hold identity atomically; and
+- service observations, portal routes, and egress identity use the same fence, while Pod names,
+  IPs, endpoints, and UIDs remain backend-specific connector observations.
+
+## Remaining decisions and open work
+
+The approved contracts above still require reviewable API sketches, migration/rollout plans,
+controller ownership, and acceptance tests before implementation. This document intentionally
+does not invent those details.
+
+Other unimplemented areas include portal transport, inbox and child-run semantics, changes
+publication, transcript garbage collection, additional credential forms, ConPTY, non-Pod
+backends, and control-plane HA. Their detailed contracts remain issue work unless and until a
+maintainer decision is recorded. In particular, schema placeholders or portable interfaces do
+not by themselves make these features implemented.
+
+## Maintainer references
+
+- [#11 — Project namespace onboarding and Template scope](https://github.com/Chris-Cullins/swe-platform/issues/11)
+- [#16 — durable Service observations and gateway ownership](https://github.com/Chris-Cullins/swe-platform/issues/16)
+- [#68 — fail-closed egress proxy](https://github.com/Chris-Cullins/swe-platform/issues/68)
+- [#122 — stale adapter observation fencing](https://github.com/Chris-Cullins/swe-platform/issues/122)
+- [#125 — terminal execution fencing](https://github.com/Chris-Cullins/swe-platform/issues/125)
+- [`sandboxd` managed-process contract](sandboxd/proto/sandboxd/v1/PROCESS_LIFECYCLE.md)
+- [`sandboxd` filesystem contract](sandboxd/proto/sandboxd/v1/FILESYSTEM.md)
+- [Helm deployment and preset documentation](charts/swe-platform/README.md)
+- [Security model](SECURITY.md)

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 Open-source platform for running coding agents unattended in ephemeral, isolated Kubernetes environments.
 
 Give an agent a task — from the CLI, web UI, or an MCP call — and the platform provisions a
-fresh environment (repo clone, toolchain, secrets, setup hooks), runs the agent in it,
-streams everything back live, auto-pauses when idle so compute cost drops to ~$0, and ends
-with a reviewable diff, branch, or PR.
+fresh environment (repo clone, toolchain, process-scoped agent credentials, setup hooks), runs
+the agent in it, streams everything back live, and auto-pauses when idle so compute cost drops
+to ~$0. Reviewable diff, branch, and PR publication remain planned work.
 
 > **Status: early.** The P0 scaffold is in — CRDs, operator, `sandboxd`, CLI — with a
 > passing kind end-to-end (`./hack/e2e.sh`). A first control-plane service accepts and
@@ -27,7 +27,7 @@ with a reviewable diff, branch, or PR.
   hardened containers, sandboxd authentication, restricted sandboxd ingress, and optional
   RuntimeClasses such as gVisor. Default-deny egress is not implemented yet.
 - **Pause economics** — idle environments are paused (pod deleted, disk retained) and
-  woken on demand. An agent waiting on its children costs ~$0.
+  woken on demand. A suspended Environment costs ~$0 in compute.
 - **Agent-agnostic** — existing agents plug in via adapters; the platform never depends
   on one agent's internals.
 - **Self-hosted** — your cluster, your credentials, your data. Runs on anything from a
@@ -41,29 +41,32 @@ with a reviewable diff, branch, or PR.
 | **Run** | One agent task executing in an environment |
 | **Project** | One or more git repos + config: setup hooks, size, changes workflow |
 | **Template** | Environment class: image, size, runtime, warm pool |
-| **Inbox** | Addressable message queue per run — how agents talk to each other |
-| **Portal** | Authenticated URL exposing a dev server inside an environment |
+| **Inbox** | Planned addressable message queue per Run |
+| **Portal** | Planned authenticated URL exposing a dev server inside an Environment |
 
 ## Architecture (short version)
+
+See [`ARCHITECTURE.md`](ARCHITECTURE.md) for the canonical tracked description of what is
+implemented today, approved next contracts, and remaining open work.
 
 - **`sandboxd`** — a small daemon inside every environment exposing one gRPC contract:
   exec, filesystem, terminal, port registry, health. The control plane never touches a
   pod except through it.
 - **Operator + CRDs** — `Environment`, `EnvironmentTemplate`, `Run`, `Project`, with
   controllers for lifecycle, warm pools (pre-booted environments), and idle reaping.
-- **Control plane** — API, auth, transcripts, and wake-on-request: any traffic to a
-  paused environment resumes it.
-- **Gateway** — live output streaming, a web terminal sharing a tmux session with the
-  agent, and reverse proxying for portals.
-- **Runs as actors** — every run has an address and an inbox. Agents can spawn child
-  runs, message each other, and get resumed when a message arrives.
+- **Control plane** — API, auth, transcripts, resource watches, and a web terminal sharing
+  the Environment's tmux session; terminal requests can wake Idle suspension.
+- **Planned gateway** — authenticated portal URLs and reverse proxying are not implemented.
+- **Planned Run actors** — inboxes, child spawning, messaging, and wake-on-message are not
+  implemented.
 
 ```
    CLI · Web UI · MCP
           │
-   Control plane ──► CRDs ──► Operator ──► Environment pods (gVisor)
+   Control plane ──► CRDs ──► Operator ──► Environment pods
           │                                    │  agent + sandboxd
-   Gateway (stream/terminal/portals) ◄─────────┘  workspace volume
+          └──────── terminal via sandboxd ─────┘  workspace volume
+                    (gVisor when configured)
 ```
 
 ### Run and process lifecycle
@@ -88,9 +91,10 @@ sandboxd process dial handle.
 Every adapter lifecycle operation is idempotent. A foreground CLI adapter can map one
 managed agent process's state to Run status; a long-lived service adapter can keep an
 Environment-scoped service process and map its task-acknowledgement/events instead. The
-platform does not assume that agent-process exit means task completion. The same contract
-maps to pod, KubeVirt, Windows, and external-runner backends because it exposes no Pod,
-container, PID, tmux, or OS-signal semantics.
+platform does not assume that agent-process exit means task completion. The same contract is
+intended to map to Pod, KubeVirt, Windows, and external-runner backends because it exposes no
+Pod, container, PID, tmux, or OS-signal semantics. Only the Pod backend is currently
+implemented.
 
 The committed sandboxd process contract is documented beside its protobuf in
 [`PROCESS_LIFECYCLE.md`](sandboxd/proto/sandboxd/v1/PROCESS_LIFECYCLE.md). In short,

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ to ~$0. Reviewable diff, branch, and PR publication remain planned work.
 |---|---|
 | **Environment** | One ephemeral machine an agent works in (pod + volume + network policy) |
 | **Run** | One agent task executing in an environment |
-| **Project** | One or more git repos + config: setup hooks, size, changes workflow |
+| **Project** | One git repo today (list-shaped for future multi-repo support) + config |
 | **Template** | Environment class: image, size, runtime, warm pool |
 | **Inbox** | Planned addressable message queue per Run |
 | **Portal** | Planned authenticated URL exposing a dev server inside an Environment |

--- a/charts/swe-platform/README.md
+++ b/charts/swe-platform/README.md
@@ -180,8 +180,8 @@ that separate smoke test for its pinned gVisor installation. Templates that omit
 continue to select the cluster default runtime as documented in the preset table above.
 
 The operator creates a default ingress NetworkPolicy for each environment. It permits the
-environment's sandboxd port only from this release's control-plane-labeled pods in the release
-namespace. The cluster CNI must enforce
+environment's sandboxd port only from this release's control-plane- and operator-labeled pods
+in the configured control-plane namespace. The cluster CNI must enforce
 Kubernetes NetworkPolicy for this defense in depth; TLS identity and capability authorization
 remain mandatory regardless. See [the security model](../../SECURITY.md) for credential
 lifecycle and backend requirements.


### PR DESCRIPTION
## Summary

- add root `ARCHITECTURE.md` as the canonical tracked architecture source
- distinguish implemented behavior from approved next contracts and unresolved work
- record the approved decisions from #11, #16, #68, #122, and #125 without presenting them as shipped
- retire stale private/gitignored architecture guidance in `AGENTS.md` and point CRD synchronization at the tracked root document
- link and reconcile the README architecture summary, including the current NetworkPolicy source description

## Scope

Documentation only. No CRD, controller, control-plane, sandboxd, UI, chart template/value, or workflow behavior changed.

Base verified before authoring and again before commit:

```
origin/main c115faf13ab62aead857e44c135fae6c2777f38e
```

## Validation

- `git diff --cached --check`
- local Markdown target and balanced-fence validation for all changed Markdown files
- HTTP 200 validation for the exact approved decision-comment links on #11, #16, #68, #122, and #125
- reviewed current CRDs/controllers/lifecycle/adapters/credentials/transcripts/control-plane auth and identity fences/terminal/sandboxd boundary/UI/chart presets/CI and acceptance workflow against each factual claim

The path-filtered `kind` workflow is not expected to run for this docs-only PR; no dummy source change was added. It remains available through `workflow_dispatch` if a central acceptance run is desired.
