### PR TITLE
Fence work to environment execution generations

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -62,8 +62,8 @@ All current CRDs are namespaced:
 |---|---|
 | `Project` | One repository URL (represented as a one-item list), a same-namespace default Template reference, changes-workflow metadata, and a reserved egress allowlist. A non-empty allowlist is rejected when an Environment uses the Project. |
 | `EnvironmentTemplate` | Pod image, size/resources, disk, runtime class, idle timeout, warm-pool minimum, and backend. Admission currently permits only the `pod` backend. |
-| `Environment` | Template/Project selection, explicit hold policy and bounded wake/suspend/activity intents; status owns readiness, lifecycle suspension and epoch, exact Run claim, Pod endpoint observations, activity, and recovery state. |
-| `Run` | Immutable agent task and Environment/Project/Template/credential selection plus monotonic cancellation; status records normalized lifecycle, exact Environment name/UID and ownership, exact credential profile identity, and accepted lifecycle epoch. `notify` and `parentRef` are schema placeholders without an implemented inbox. |
+| `Environment` | Template/Project selection, explicit hold policy and bounded wake/suspend/activity intents; status owns readiness, lifecycle suspension and epoch, backend-neutral execution generation, exact Run claim, backend observations, activity, and recovery state. |
+| `Run` | Immutable agent task and Environment/Project/Template/credential selection plus monotonic cancellation; status records normalized lifecycle, exact Environment name/UID and ownership, exact credential profile identity, accepted lifecycle epoch, and accepted execution generation. `notify` and `parentRef` are schema placeholders without an implemented inbox. |
 | `AgentCredentialProfile` | Immutable adapter and `APIKey` type metadata. Key bytes live in an owner-linked Secret whose name is derived from the profile UID. |
 
 The current ownership/reference shape is:
@@ -116,7 +116,9 @@ Windows coverage for process containment and filesystem behavior; the current sh
 backend is tmux, not ConPTY.
 
 Only the Kubernetes **Pod backend** is implemented. The connector currently resolves an exact
-owned Pod, Pod IP, Pod UID, and per-Pod credential Secret behind its consumer interface.
+owned Pod, Pod IP, Pod UID, execution-generation annotation, restart policy, and per-Pod
+credential Secret behind its consumer interface. It also exposes an opaque, non-dialing
+execution handle/currentness check; Pod identity remains private to the connector.
 `kubevirt` and `external-runner` names are retained as planned Go API values, but CRD admission
 rejects them and the controller fails unsupported existing resources before provisioning.
 Backend pluggability is an invariant on interfaces, not a claim that those backends ship.
@@ -140,6 +142,16 @@ suspend, or source-keyed activity intents. The controller owns observed suspensi
 Automatic idle suspension is prevented by an exact non-terminal Run owner or claim. Ordinary
 wakes cannot clear an explicit hold, and terminal traffic wakes only an Idle suspension.
 
+The Environment lifecycle controller also owns a monotonically increasing, backend-neutral
+execution generation distinct from the suspension epoch. It reserves a fresh positive value
+before every actual backend creation attempt; failed or uncertain attempts may leave gaps, but
+values are never reused. Initial provision, pause/resume, terminal recovery, Project or security
+replacement, and equivalent future-backend replacement paths all pass through that reservation.
+Pod executions additionally require `restartPolicy: Never` and an exact canonical generation
+annotation, so one generation cannot silently contain a container restart. Legacy generation
+zero, missing/malformed annotations, and pre-generation activity intents or receipts fail closed
+until the lifecycle controller provisions a fresh execution.
+
 Pause is disk plus transcript, not process checkpointing:
 
 1. the lifecycle epoch increases before suspension;
@@ -149,10 +161,15 @@ Pause is disk plus transcript, not process checkpointing:
 5. resume creates a fresh pod/credential epoch, runs the repository resume hook, and repeats
    idempotent adapter acceptance with the same Run UID.
 
-The lifecycle epoch currently identifies suspension cycles; it is **not** a complete backend
-execution-generation contract for every Pod recovery. Terminal attachment additionally pins
-the exact Pod UID and revalidates Environment UID, lifecycle epoch, hold revision, and Run
-association. The approved general execution generation is described below and is not shipped.
+Terminal attachment captures Environment UID, execution generation, lifecycle epoch, and hold
+revision before publishing activity, then atomically rejects stale activity. Its connector-owned
+opaque handle also revalidates the exact live backend execution throughout the lease. Run adapter
+acceptance, observation, and cancellation similarly capture the allocated Environment UID,
+execution generation, epoch, and an opaque non-dialing connector execution handle. After each
+adapter call, the controller uncached-reads the exact allocation and asks the connector to prove
+that the same live backend execution remains current before publishing Run state, releasing a
+claim, or removing a finalizer. Delayed results from disappeared or same-name replacement Pods
+are therefore discarded even if Environment status has not yet advanced.
 
 Only the Pod backend performs execution today. Project-backed initialization clones the
 Project's single repository into `/workspace`, runs `.agents/setup` once per workspace when
@@ -340,26 +357,12 @@ The maintainer approved the [outbound-network contract in #68](https://github.co
 The current non-empty Project allowlist rejection remains until identity, proxy readiness, and
 path forcing ship together after Project namespace claims.
 
-### Backend-neutral execution generation
-
-The maintainer approved the matching [Run observation decision in #122](https://github.com/Chris-Cullins/swe-platform/issues/122#issuecomment-5078805815)
-and [terminal activity decision in #125](https://github.com/Chris-Cullins/swe-platform/issues/125#issuecomment-5078805886):
-
-- add a dedicated backend-neutral execution generation, separate from lifecycle epoch;
-- increment it for every actual backend execution replacement, including initial provision,
-  pause/resume, recovery, security replacement, and equivalent non-Pod transitions;
-- delayed operations capture Environment UID plus execution generation and, where relevant,
-  hold-policy revision;
-- stale adapter observations are discarded before Run status publication, and terminal activity
-  updates reject stale Environment/execution/hold identity atomically; and
-- service observations, portal routes, and egress identity use the same fence, while Pod names,
-  IPs, endpoints, and UIDs remain backend-specific connector observations.
-
 ## Remaining decisions and open work
 
 The approved contracts above still require reviewable API sketches, migration/rollout plans,
-controller ownership, and acceptance tests before implementation. This document intentionally
-does not invent those details.
+controller ownership, and acceptance tests before implementation. The execution-generation
+contract is implemented above; future service observations, portal routes, and egress identity
+must consume the same backend-neutral fence without exposing backend-specific identity.
 
 Other unimplemented areas include portal transport, inbox and child-run semantics, changes
 publication, transcript garbage collection, additional credential forms, ConPTY, non-Pod

--- a/api/v1alpha1/environment_types.go
+++ b/api/v1alpha1/environment_types.go
@@ -78,12 +78,24 @@ type EnvironmentWakeRequest struct {
 type EnvironmentActivityRequest struct {
 	Source                      EnvironmentActivitySource `json:"source"`
 	EnvironmentLifecycleRequest `json:",inline"`
+
+	// ExecutionGeneration is the exact backend execution that produced this
+	// activity. Missing or zero values are legacy and are never accepted.
+	// +kubebuilder:validation:Minimum=1
+	// +optional
+	ExecutionGeneration int64 `json:"executionGeneration,omitempty"`
 }
 
 // EnvironmentActivityReceipt records the latest request consumed for a source.
 type EnvironmentActivityReceipt struct {
 	Source    EnvironmentActivitySource `json:"source"`
 	RequestID string                    `json:"requestID"`
+
+	// ExecutionGeneration is absent on receipts written before execution
+	// fencing. Such receipts never acknowledge a generation-fenced request.
+	// +kubebuilder:validation:Minimum=1
+	// +optional
+	ExecutionGeneration int64 `json:"executionGeneration,omitempty"`
 }
 
 // EnvironmentHoldPolicy is explicit user/admin-owned policy. Changing Enabled
@@ -247,10 +259,20 @@ type EnvironmentEndpoints struct {
 }
 
 // EnvironmentStatus defines the observed state of Environment.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.executionGeneration) || (has(self.executionGeneration) && self.executionGeneration >= oldSelf.executionGeneration)",message="executionGeneration cannot decrease or be removed"
 type EnvironmentStatus struct {
 	// ObservedGeneration is the Environment generation reflected by this status.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
+	// ExecutionGeneration is the backend-neutral identity of the current or
+	// most recently reserved backend execution. The lifecycle controller
+	// reserves a strictly greater positive value before every backend creation
+	// attempt; gaps are allowed after failed or uncertain attempts. Zero is an
+	// uninitialized migration state and is never reachable by consumers.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	ExecutionGeneration int64 `json:"executionGeneration,omitempty"`
 
 	// +optional
 	Phase EnvironmentPhase `json:"phase,omitempty"`
@@ -314,7 +336,7 @@ func IsEnvironmentReady(environment *Environment) bool {
 		return false
 	}
 	condition := apimeta.FindStatusCondition(environment.Status.Conditions, EnvironmentConditionReady)
-	return environment.Status.ObservedGeneration == environment.Generation && condition != nil &&
+	return environment.Status.ExecutionGeneration > 0 && environment.Status.ObservedGeneration == environment.Generation && condition != nil &&
 		condition.ObservedGeneration == environment.Generation && condition.Status == metav1.ConditionTrue
 }
 

--- a/api/v1alpha1/run_types.go
+++ b/api/v1alpha1/run_types.go
@@ -155,6 +155,13 @@ type RunStatus struct {
 	// +optional
 	AcceptedEnvironmentEpoch *int64 `json:"acceptedEnvironmentEpoch,omitempty"`
 
+	// AcceptedEnvironmentExecutionGeneration is the exact backend execution in
+	// which the adapter most recently accepted this Run. Missing or different
+	// identity always requires fresh acceptance.
+	// +kubebuilder:validation:Minimum=1
+	// +optional
+	AcceptedEnvironmentExecutionGeneration *int64 `json:"acceptedEnvironmentExecutionGeneration,omitempty"`
+
 	// Branch is the git branch holding the run's changes, once pushed.
 	// +optional
 	Branch string `json:"branch,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -724,6 +724,11 @@ func (in *RunStatus) DeepCopyInto(out *RunStatus) {
 		*out = new(int64)
 		**out = **in
 	}
+	if in.AcceptedEnvironmentExecutionGeneration != nil {
+		in, out := &in.AcceptedEnvironmentExecutionGeneration, &out.AcceptedEnvironmentExecutionGeneration
+		*out = new(int64)
+		**out = **in
+	}
 	out.Usage = in.Usage
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions

--- a/charts/swe-platform/crds/swe.dev_environments.yaml
+++ b/charts/swe-platform/crds/swe.dev_environments.yaml
@@ -73,6 +73,13 @@ spec:
                           description: EnvironmentUID is the exact Environment incarnation
                             targeted.
                           type: string
+                        executionGeneration:
+                          description: |-
+                            ExecutionGeneration is the exact backend execution that produced this
+                            activity. Missing or zero values are legacy and are never accepted.
+                          format: int64
+                          minimum: 1
+                          type: integer
                         holdPolicyRevision:
                           description: HoldPolicyRevision is the policy revision observed
                             by the requester.
@@ -318,6 +325,16 @@ spec:
                     description: Terminal is the websocket address of the shared terminal.
                     type: string
                 type: object
+              executionGeneration:
+                description: |-
+                  ExecutionGeneration is the backend-neutral identity of the current or
+                  most recently reserved backend execution. The lifecycle controller
+                  reserves a strictly greater positive value before every backend creation
+                  attempt; gaps are allowed after failed or uncertain attempts. Zero is an
+                  uninitialized migration state and is never reachable by consumers.
+                format: int64
+                minimum: 0
+                type: integer
               imageID:
                 description: |-
                   ImageID is the immutable runtime image identity reported for the current
@@ -339,6 +356,13 @@ spec:
                       description: EnvironmentActivityReceipt records the latest request
                         consumed for a source.
                       properties:
+                        executionGeneration:
+                          description: |-
+                            ExecutionGeneration is absent on receipts written before execution
+                            fencing. Such receipts never acknowledge a generation-fenced request.
+                          format: int64
+                          minimum: 1
+                          type: integer
                         requestID:
                           type: string
                         source:
@@ -457,6 +481,10 @@ spec:
                   in-progress recovery attempt.
                 type: string
             type: object
+            x-kubernetes-validations:
+            - message: executionGeneration cannot decrease or be removed
+              rule: '!has(oldSelf.executionGeneration) || (has(self.executionGeneration)
+                && self.executionGeneration >= oldSelf.executionGeneration)'
         type: object
     served: true
     storage: true

--- a/charts/swe-platform/crds/swe.dev_runs.yaml
+++ b/charts/swe-platform/crds/swe.dev_runs.yaml
@@ -133,6 +133,14 @@ spec:
                 format: int64
                 minimum: 0
                 type: integer
+              acceptedEnvironmentExecutionGeneration:
+                description: |-
+                  AcceptedEnvironmentExecutionGeneration is the exact backend execution in
+                  which the adapter most recently accepted this Run. Missing or different
+                  identity always requires fresh acceptance.
+                format: int64
+                minimum: 1
+                type: integer
               branch:
                 description: Branch is the git branch holding the run's changes, once
                   pushed.

--- a/config/crd/bases/swe.dev_environments.yaml
+++ b/config/crd/bases/swe.dev_environments.yaml
@@ -73,6 +73,13 @@ spec:
                           description: EnvironmentUID is the exact Environment incarnation
                             targeted.
                           type: string
+                        executionGeneration:
+                          description: |-
+                            ExecutionGeneration is the exact backend execution that produced this
+                            activity. Missing or zero values are legacy and are never accepted.
+                          format: int64
+                          minimum: 1
+                          type: integer
                         holdPolicyRevision:
                           description: HoldPolicyRevision is the policy revision observed
                             by the requester.
@@ -318,6 +325,16 @@ spec:
                     description: Terminal is the websocket address of the shared terminal.
                     type: string
                 type: object
+              executionGeneration:
+                description: |-
+                  ExecutionGeneration is the backend-neutral identity of the current or
+                  most recently reserved backend execution. The lifecycle controller
+                  reserves a strictly greater positive value before every backend creation
+                  attempt; gaps are allowed after failed or uncertain attempts. Zero is an
+                  uninitialized migration state and is never reachable by consumers.
+                format: int64
+                minimum: 0
+                type: integer
               imageID:
                 description: |-
                   ImageID is the immutable runtime image identity reported for the current
@@ -339,6 +356,13 @@ spec:
                       description: EnvironmentActivityReceipt records the latest request
                         consumed for a source.
                       properties:
+                        executionGeneration:
+                          description: |-
+                            ExecutionGeneration is absent on receipts written before execution
+                            fencing. Such receipts never acknowledge a generation-fenced request.
+                          format: int64
+                          minimum: 1
+                          type: integer
                         requestID:
                           type: string
                         source:
@@ -457,6 +481,10 @@ spec:
                   in-progress recovery attempt.
                 type: string
             type: object
+            x-kubernetes-validations:
+            - message: executionGeneration cannot decrease or be removed
+              rule: '!has(oldSelf.executionGeneration) || (has(self.executionGeneration)
+                && self.executionGeneration >= oldSelf.executionGeneration)'
         type: object
     served: true
     storage: true

--- a/config/crd/bases/swe.dev_runs.yaml
+++ b/config/crd/bases/swe.dev_runs.yaml
@@ -133,6 +133,14 @@ spec:
                 format: int64
                 minimum: 0
                 type: integer
+              acceptedEnvironmentExecutionGeneration:
+                description: |-
+                  AcceptedEnvironmentExecutionGeneration is the exact backend execution in
+                  which the adapter most recently accepted this Run. Missing or different
+                  identity always requires fresh acceptance.
+                format: int64
+                minimum: 1
+                type: integer
               branch:
                 description: Branch is the git branch holding the run's changes, once
                   pushed.

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -245,8 +245,36 @@ git fetch --depth=1 origin "$PRE_SCOPED_CREDENTIALS_SHA"
 for resource in environments environmenttemplates projects runs; do
 	git show FETCH_HEAD:"config/crd/bases/swe.dev_${resource}.yaml" | kubectl create -f -
 done
+
+# Exercise the immediate pre-execution-generation schema with persisted nested
+# activity. The new nested fields must remain optional so this live object can
+# survive structural-schema replacement; controller handling fails closed.
+PRE_EXECUTION_GENERATION_SHA=c115faf13ab62aead857e44c135fae6c2777f38e
+git fetch --depth=1 origin "$PRE_EXECUTION_GENERATION_SHA"
+for resource in environments runs; do
+	git show "$PRE_EXECUTION_GENERATION_SHA:config/crd/bases/swe.dev_${resource}.yaml" | kubectl apply --server-side --force-conflicts -f -
+done
+cat <<'EOF' | kubectl create -f -
+apiVersion: swe.dev/v1alpha1
+kind: Environment
+metadata:
+  name: legacy-execution-generation-migration
+spec:
+  templateRef: small
+  lifecycle:
+    activity:
+    - source: Terminal
+      id: legacy-terminal-activity
+      environmentUID: legacy-environment-uid
+      holdPolicyRevision: 0
+EOF
+kubectl patch environment legacy-execution-generation-migration --subresource=status --type=merge -p \
+	'{"status":{"lifecycle":{"activityReceipts":[{"source":"Terminal","requestID":"legacy-terminal-activity"}]}}}'
 kubectl apply --server-side --force-conflicts -f charts/swe-platform/crds
 kubectl get crd agentcredentialprofiles.swe.dev >/dev/null
+kubectl get environment legacy-execution-generation-migration -o json | jq -e \
+	'.spec.lifecycle.activity[0].executionGeneration == null and .status.lifecycle.activityReceipts[0].executionGeneration == null' >/dev/null
+kubectl delete environment legacy-execution-generation-migration --wait=false
 
 echo "==> installing operator and kind template through Helm with upgraded CRDs"
 E2E_BOOTSTRAP_TOKEN="$(openssl rand -hex 32)"

--- a/internal/controllers/environment_controller.go
+++ b/internal/controllers/environment_controller.go
@@ -1693,7 +1693,13 @@ func (r *EnvironmentReconciler) reserveExecutionGeneration(ctx context.Context, 
 	}
 	next := current.Status.ExecutionGeneration + 1
 	before := current.DeepCopy()
-	applyEnvironmentStatus(&current, platformv1alpha1.EnvironmentPhaseCreating, "", "", "ExecutionProvisioning", fmt.Sprintf("backend execution generation %d is being provisioned", next), current.Status.LastActiveAt)
+	phase := platformv1alpha1.EnvironmentPhaseCreating
+	if current.Status.Phase == platformv1alpha1.EnvironmentPhaseResuming {
+		// Keep resume intent durable across a failed create. The next attempt
+		// must still run the Project resume hook for the retained workspace.
+		phase = platformv1alpha1.EnvironmentPhaseResuming
+	}
+	applyEnvironmentStatus(&current, phase, "", "", "ExecutionProvisioning", fmt.Sprintf("backend execution generation %d is being provisioned", next), current.Status.LastActiveAt)
 	current.Status.ExecutionGeneration = next
 	if err := r.Status().Patch(ctx, &current, client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{})); err != nil {
 		return 0, err

--- a/internal/controllers/environment_controller.go
+++ b/internal/controllers/environment_controller.go
@@ -14,8 +14,10 @@ import (
 	"encoding/pem"
 	stderrors "errors"
 	"fmt"
+	"math"
 	"math/big"
 	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -52,18 +54,19 @@ var sizePresets = map[string]corev1.ResourceList{
 }
 
 const (
-	defaultDiskSize           = "40Gi"
-	defaultIdleTimeout        = 15 * time.Minute
-	projectHookTimeout        = "30m"
-	hookKillAfter             = "5s"
-	podRecoveryLimit          = int32(3)
-	podRecoveryDelay          = 5 * time.Second
-	templateRefField          = "spec.templateRef"
-	projectRefField           = "spec.projectRef"
-	runtimeClassField         = "spec.runtimeClass"
-	warmPoolLabel             = "swe.dev/warm-pool"
-	projectAnnotation         = "swe.dev/project"
-	runtimeClassUIDAnnotation = "swe.dev/runtime-class-uid"
+	defaultDiskSize               = "40Gi"
+	defaultIdleTimeout            = 15 * time.Minute
+	projectHookTimeout            = "30m"
+	hookKillAfter                 = "5s"
+	podRecoveryLimit              = int32(3)
+	podRecoveryDelay              = 5 * time.Second
+	templateRefField              = "spec.templateRef"
+	projectRefField               = "spec.projectRef"
+	runtimeClassField             = "spec.runtimeClass"
+	warmPoolLabel                 = "swe.dev/warm-pool"
+	projectAnnotation             = "swe.dev/project"
+	runtimeClassUIDAnnotation     = "swe.dev/runtime-class-uid"
+	executionGenerationAnnotation = "swe.dev/execution-generation"
 )
 
 var (
@@ -132,6 +135,7 @@ fi
 // EnvironmentReconciler reconciles Environment objects into pods + workspace volumes.
 type EnvironmentReconciler struct {
 	client.Client
+	APIReader             client.Reader
 	Scheme                *runtime.Scheme
 	ControlPlaneNamespace string
 	ControlPlaneName      string
@@ -355,10 +359,11 @@ func (r *EnvironmentReconciler) reconcileLifecycleIntent(ctx context.Context, en
 	now := metav1.NewTime(r.now())
 	for i := range activityRequests {
 		request := &activityRequests[i]
-		if !valid(&request.EnvironmentLifecycleRequest) || activityReceipt(lifecycleStatus.ActivityReceipts, request.Source) == request.ID {
+		if !valid(&request.EnvironmentLifecycleRequest) || request.ExecutionGeneration != env.Status.ExecutionGeneration ||
+			activityReceipt(lifecycleStatus.ActivityReceipts, request.Source, request.ExecutionGeneration) == request.ID {
 			continue
 		}
-		setActivityReceipt(&lifecycleStatus.ActivityReceipts, request.Source, request.ID)
+		setActivityReceipt(&lifecycleStatus.ActivityReceipts, request.Source, request.ExecutionGeneration, request.ID)
 		if env.Status.LastActiveAt == nil || now.After(env.Status.LastActiveAt.Time) {
 			env.Status.LastActiveAt = &now
 		}
@@ -444,23 +449,24 @@ func validLifecycleRequest(env *platformv1alpha1.Environment, request *platformv
 	return request.EnvironmentUID == env.UID && request.HoldPolicyRevision == policyRevision
 }
 
-func activityReceipt(receipts []platformv1alpha1.EnvironmentActivityReceipt, source platformv1alpha1.EnvironmentActivitySource) string {
+func activityReceipt(receipts []platformv1alpha1.EnvironmentActivityReceipt, source platformv1alpha1.EnvironmentActivitySource, executionGeneration int64) string {
 	for i := range receipts {
-		if receipts[i].Source == source {
+		if receipts[i].Source == source && receipts[i].ExecutionGeneration == executionGeneration {
 			return receipts[i].RequestID
 		}
 	}
 	return ""
 }
 
-func setActivityReceipt(receipts *[]platformv1alpha1.EnvironmentActivityReceipt, source platformv1alpha1.EnvironmentActivitySource, requestID string) {
+func setActivityReceipt(receipts *[]platformv1alpha1.EnvironmentActivityReceipt, source platformv1alpha1.EnvironmentActivitySource, executionGeneration int64, requestID string) {
 	for i := range *receipts {
 		if (*receipts)[i].Source == source {
 			(*receipts)[i].RequestID = requestID
+			(*receipts)[i].ExecutionGeneration = executionGeneration
 			return
 		}
 	}
-	*receipts = append(*receipts, platformv1alpha1.EnvironmentActivityReceipt{Source: source, RequestID: requestID})
+	*receipts = append(*receipts, platformv1alpha1.EnvironmentActivityReceipt{Source: source, RequestID: requestID, ExecutionGeneration: executionGeneration})
 }
 
 // reconcilePendingPodRecovery advances persisted recovery before ensurePod can
@@ -982,8 +988,9 @@ func unsupportedEgressAllowlistMessage(projectName string) string {
 
 func (r *EnvironmentReconciler) ensurePodForProject(ctx context.Context, env *platformv1alpha1.Environment, tmpl *platformv1alpha1.EnvironmentTemplate, project *platformv1alpha1.Project, runtimeClassUID types.UID) (*corev1.Pod, error) {
 	podName := envPodName(env)
+	resuming := env.Status.Phase == platformv1alpha1.EnvironmentPhaseResuming
 	var pod corev1.Pod
-	err := r.Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: podName}, &pod)
+	err := r.apiReader().Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: podName}, &pod)
 	if err == nil {
 		if metav1.IsControlledBy(&pod, env) && !pod.DeletionTimestamp.IsZero() {
 			if pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodSucceeded {
@@ -1060,6 +1067,10 @@ func (r *EnvironmentReconciler) ensurePodForProject(ctx context.Context, env *pl
 	if err := r.Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: envCredentialName(env)}, &credentials); err != nil {
 		return nil, fmt.Errorf("get rotated sandboxd credentials: %w", err)
 	}
+	executionGeneration, err := r.reserveExecutionGeneration(ctx, env)
+	if err != nil {
+		return nil, fmt.Errorf("reserve execution generation: %w", err)
+	}
 
 	resources, ok := sizePresets[tmpl.Spec.Size]
 	if !ok {
@@ -1073,6 +1084,7 @@ func (r *EnvironmentReconciler) ensurePodForProject(ctx context.Context, env *pl
 			Labels:    envLabels(env),
 			Annotations: map[string]string{
 				projectAnnotation:                 env.Spec.ProjectRef,
+				executionGenerationAnnotation:     strconv.FormatInt(executionGeneration, 10),
 				sandboxdauth.IdentityAnnotation:   identity,
 				sandboxdauth.TrustAnnotation:      string(trust),
 				sandboxdauth.TokenAnnotation:      terminalToken,
@@ -1082,7 +1094,7 @@ func (r *EnvironmentReconciler) ensurePodForProject(ctx context.Context, env *pl
 			},
 		},
 		Spec: corev1.PodSpec{
-			RestartPolicy:                corev1.RestartPolicyAlways,
+			RestartPolicy:                corev1.RestartPolicyNever,
 			AutomountServiceAccountToken: ptr(false),
 			SecurityContext: &corev1.PodSecurityContext{
 				SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
@@ -1165,7 +1177,7 @@ func (r *EnvironmentReconciler) ensurePodForProject(ctx context.Context, env *pl
 			{Name: "SWE_HOOK_TIMEOUT", Value: projectHookTimeout},
 			{Name: "SWE_HOOK_KILL_AFTER", Value: hookKillAfter},
 		}
-		if env.Status.Phase == platformv1alpha1.EnvironmentPhaseResuming {
+		if resuming {
 			projectEnv = append(projectEnv, corev1.EnvVar{Name: "SWE_RESUMING", Value: "true"})
 		}
 		pod.Spec.InitContainers = []corev1.Container{{
@@ -1206,7 +1218,10 @@ func (r *EnvironmentReconciler) ensurePodForProject(ctx context.Context, env *pl
 }
 
 func (r *EnvironmentReconciler) currentSandboxdPod(ctx context.Context, env *platformv1alpha1.Environment, pod *corev1.Pod) (bool, error) {
-	if !metav1.IsControlledBy(pod, env) || pod.Annotations[sandboxdRevisionAnnotation] != sandboxdSecurityRevision ||
+	executionGeneration, generationValid := podExecutionGeneration(pod)
+	if !metav1.IsControlledBy(pod, env) || pod.Spec.RestartPolicy != corev1.RestartPolicyNever ||
+		!generationValid || executionGeneration != env.Status.ExecutionGeneration ||
+		pod.Annotations[sandboxdRevisionAnnotation] != sandboxdSecurityRevision ||
 		pod.Annotations[sandboxdauth.IdentityAnnotation] == "" || pod.Annotations[sandboxdauth.TrustAnnotation] == "" ||
 		pod.Annotations[sandboxdauth.TokenAnnotation] == "" || pod.Annotations[sandboxdauth.SecretNameAnnotation] != envCredentialName(env) {
 		return false, nil
@@ -1427,6 +1442,10 @@ func (r *EnvironmentReconciler) ensureSandboxdNetworkPolicy(ctx context.Context,
 // syncStatus maps Kubernetes-native pod readiness and container failure state
 // onto the Environment's generation-aware readiness contract.
 func (r *EnvironmentReconciler) syncStatus(ctx context.Context, env *platformv1alpha1.Environment, pod *corev1.Pod) error {
+	executionGeneration, ok := podExecutionGeneration(pod)
+	if !ok || executionGeneration != env.Status.ExecutionGeneration {
+		return fmt.Errorf("environment pod execution generation is not current")
+	}
 	phase, reason, message := environmentPodState(env, pod)
 	sandboxdEndpoint := ""
 	if phase == platformv1alpha1.EnvironmentPhaseReady {
@@ -1648,6 +1667,47 @@ func (r *EnvironmentReconciler) updateEnvironmentStatus(ctx context.Context, env
 	return err
 }
 
+func (r *EnvironmentReconciler) apiReader() client.Reader {
+	if r.APIReader != nil {
+		return r.APIReader
+	}
+	return r.Client
+}
+
+// reserveExecutionGeneration durably allocates a fresh backend-neutral
+// execution identity before a Pod creation attempt. Values may be skipped
+// after failed or uncertain creates, but are never reused.
+func (r *EnvironmentReconciler) reserveExecutionGeneration(ctx context.Context, env *platformv1alpha1.Environment) (int64, error) {
+	var current platformv1alpha1.Environment
+	if err := r.apiReader().Get(ctx, client.ObjectKeyFromObject(env), &current); err != nil {
+		return 0, err
+	}
+	if current.UID != env.UID {
+		return 0, errEnvironmentIncarnationChanged
+	}
+	if current.Generation != env.Generation || !current.DeletionTimestamp.IsZero() || current.Spec.Paused || current.Status.Lifecycle.Suspended {
+		return 0, fmt.Errorf("environment changed before backend creation")
+	}
+	if current.Status.ExecutionGeneration == math.MaxInt64 {
+		return 0, terminalEnvironment(fmt.Errorf("execution generation is exhausted"))
+	}
+	next := current.Status.ExecutionGeneration + 1
+	before := current.DeepCopy()
+	applyEnvironmentStatus(&current, platformv1alpha1.EnvironmentPhaseCreating, "", "", "ExecutionProvisioning", fmt.Sprintf("backend execution generation %d is being provisioned", next), current.Status.LastActiveAt)
+	current.Status.ExecutionGeneration = next
+	if err := r.Status().Patch(ctx, &current, client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{})); err != nil {
+		return 0, err
+	}
+	env.Status = current.Status
+	return next, nil
+}
+
+func podExecutionGeneration(pod *corev1.Pod) (int64, bool) {
+	value := pod.Annotations[executionGenerationAnnotation]
+	generation, err := strconv.ParseInt(value, 10, 64)
+	return generation, err == nil && generation > 0 && strconv.FormatInt(generation, 10) == value
+}
+
 // updatePodRecoveryStatus permits spec generation changes while refusing to
 // overwrite a concurrent recovery transition. Recovery is incarnation state:
 // only sandboxd readiness, not an ordinary spec edit, resets it.
@@ -1851,6 +1911,7 @@ func (r *EnvironmentReconciler) runtimeClassReferenceRequests(ctx context.Contex
 
 // SetupWithManager registers the controller with the manager.
 func (r *EnvironmentReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.APIReader = mgr.GetAPIReader()
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &platformv1alpha1.Environment{}, templateRefField, environmentTemplateRefIndex); err != nil {
 		return fmt.Errorf("index environments by template: %w", err)
 	}

--- a/internal/controllers/environment_controller.go
+++ b/internal/controllers/environment_controller.go
@@ -165,7 +165,7 @@ func (r *EnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}()
 
 	var env platformv1alpha1.Environment
-	if err := r.Get(ctx, req.NamespacedName, &env); err != nil {
+	if err := r.apiReader().Get(ctx, req.NamespacedName, &env); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
@@ -269,7 +269,7 @@ func (r *EnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 		runtimeClassUID = runtimeClass.UID
 		var pod corev1.Pod
-		if err := r.Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: envPodName(&env)}, &pod); err == nil {
+		if err := r.apiReader().Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: envPodName(&env)}, &pod); err == nil {
 			if exactControllerOwner(&pod, platformv1alpha1.GroupVersion.String(), "Environment", env.Name, env.UID) &&
 				pod.Annotations[runtimeClassUIDAnnotation] != string(runtimeClassUID) {
 				message := fmt.Sprintf("environment pod RuntimeClass %q incarnation does not match the current RuntimeClass; execution must be replaced", tmpl.Spec.RuntimeClass)
@@ -609,7 +609,7 @@ func (r *EnvironmentReconciler) reconcileInvalidProvisioningConfiguration(ctx co
 // concurrent spec correction wins without allowing stale teardown to begin.
 func (r *EnvironmentReconciler) setInvalidProvisioningStatus(ctx context.Context, env *platformv1alpha1.Environment, message string) (bool, error) {
 	var current platformv1alpha1.Environment
-	if err := r.Get(ctx, client.ObjectKeyFromObject(env), &current); err != nil {
+	if err := r.apiReader().Get(ctx, client.ObjectKeyFromObject(env), &current); err != nil {
 		return false, err
 	}
 	if current.UID != env.UID {
@@ -641,7 +641,7 @@ func invalidProvisioningFenceStarted(env *platformv1alpha1.Environment) bool {
 
 func (r *EnvironmentReconciler) reconcileInvalidProvisioningFence(ctx context.Context, env *platformv1alpha1.Environment) (ctrl.Result, bool, error) {
 	var pod corev1.Pod
-	if err := r.Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: envPodName(env)}, &pod); err == nil {
+	if err := r.apiReader().Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: envPodName(env)}, &pod); err == nil {
 		if exactControllerOwner(&pod, platformv1alpha1.GroupVersion.String(), "Environment", env.Name, env.UID) {
 			if err := r.deleteObservedChild(ctx, &pod); err != nil && !errors.IsNotFound(err) {
 				return ctrl.Result{}, true, fmt.Errorf("delete pod for invalid provisioning configuration: %w", err)
@@ -681,7 +681,7 @@ func (r *EnvironmentReconciler) reconcileUnsupportedBackend(ctx context.Context,
 	}
 
 	var pod corev1.Pod
-	if err := r.Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: envPodName(env)}, &pod); err == nil {
+	if err := r.apiReader().Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: envPodName(env)}, &pod); err == nil {
 		if !metav1.IsControlledBy(&pod, env) {
 			return ctrl.Result{}, nil
 		}
@@ -781,7 +781,7 @@ func (r *EnvironmentReconciler) reconcileDeleting(ctx context.Context, env *plat
 		return ctrl.Result{}, fmt.Errorf("withdraw readiness during environment deletion: %w", err)
 	}
 	var pod corev1.Pod
-	if err := r.Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: envPodName(env)}, &pod); err == nil {
+	if err := r.apiReader().Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: envPodName(env)}, &pod); err == nil {
 		if !metav1.IsControlledBy(&pod, env) {
 			// A foreign fixed-name object must not be destroyed by this finalizer.
 		} else if err := r.deleteObservedChild(ctx, &pod); err != nil && !errors.IsNotFound(err) {
@@ -842,7 +842,7 @@ func (r *EnvironmentReconciler) reconcilePaused(ctx context.Context, env *platfo
 	}
 	podName := envPodName(env)
 	var pod corev1.Pod
-	err := r.Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: podName}, &pod)
+	err := r.apiReader().Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: podName}, &pod)
 	if err == nil {
 		if !exactControllerOwner(&pod, platformv1alpha1.GroupVersion.String(), "Environment", env.Name, env.UID) {
 			return ctrl.Result{}, &childOwnershipCollisionError{kind: "Pod", name: podName}
@@ -1645,7 +1645,7 @@ func (r *EnvironmentReconciler) updateEnvironmentStatus(ctx context.Context, env
 	expectedGeneration := env.Generation
 	var updated platformv1alpha1.Environment
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		if err := r.Get(ctx, key, &updated); err != nil {
+		if err := r.apiReader().Get(ctx, key, &updated); err != nil {
 			return err
 		}
 		if updated.UID != expectedUID {
@@ -1723,7 +1723,7 @@ func (r *EnvironmentReconciler) updatePodRecoveryStatus(ctx context.Context, env
 	expected := env.Status
 	var updated platformv1alpha1.Environment
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		if err := r.Get(ctx, key, &updated); err != nil {
+		if err := r.apiReader().Get(ctx, key, &updated); err != nil {
 			return err
 		}
 		if updated.UID != expectedUID {

--- a/internal/controllers/environment_controller_test.go
+++ b/internal/controllers/environment_controller_test.go
@@ -1449,6 +1449,186 @@ func TestReconcileDropsStaleEnvironmentIncarnationStatusWrites(t *testing.T) {
 	}
 }
 
+func TestReconcileUsesUncachedEnvironmentWithLiveExecution(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*platformv1alpha1.Environment)
+	}{
+		{name: "cached status generation is stale", mutate: func(stale *platformv1alpha1.Environment) {
+			stale.Status.ExecutionGeneration--
+		}},
+		{name: "cached spec generation is stale", mutate: func(stale *platformv1alpha1.Environment) {
+			stale.Generation--
+			stale.Spec.TemplateRef = "old-template"
+			stale.Status.ExecutionGeneration--
+		}},
+		{name: "cached UID is stale", mutate: func(stale *platformv1alpha1.Environment) {
+			stale.UID = "old-env-uid"
+			stale.Status.ExecutionGeneration--
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			if err := corev1.AddToScheme(scheme); err != nil {
+				t.Fatal(err)
+			}
+			if err := networkingv1.AddToScheme(scheme); err != nil {
+				t.Fatal(err)
+			}
+			if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+				t.Fatal(err)
+			}
+			current := &platformv1alpha1.Environment{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "env-uid", Generation: 2, Finalizers: []string{environmentFinalizer}},
+				Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small"},
+				Status: platformv1alpha1.EnvironmentStatus{
+					ObservedGeneration: 2, ExecutionGeneration: 2, Phase: platformv1alpha1.EnvironmentPhaseCreating,
+				},
+			}
+			stale := current.DeepCopy()
+			test.mutate(stale)
+			template := &platformv1alpha1.EnvironmentTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: current.Namespace},
+				Spec:       platformv1alpha1.EnvironmentTemplateSpec{Image: "example/environment:latest", Size: "small"},
+			}
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: envPodName(current), Namespace: current.Namespace, UID: "pod-uid",
+					Annotations: map[string]string{
+						executionGenerationAnnotation:     "2",
+						sandboxdRevisionAnnotation:        sandboxdSecurityRevision,
+						sandboxdauth.IdentityAnnotation:   "current.sandboxd.swe.dev",
+						sandboxdauth.TrustAnnotation:      "trust",
+						sandboxdauth.TokenAnnotation:      "terminal-token",
+						sandboxdauth.SecretNameAnnotation: envCredentialName(current),
+						sandboxdauth.SecretUIDAnnotation:  "secret-uid",
+					},
+				},
+				Spec: corev1.PodSpec{RestartPolicy: corev1.RestartPolicyNever},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning, PodIP: "10.0.0.2",
+					Conditions:        []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+					ContainerStatuses: []corev1.ContainerStatus{{Name: "environment", ImageID: "example/environment@sha256:current"}},
+				},
+			}
+			secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Name: envCredentialName(current), Namespace: current.Namespace, UID: "secret-uid",
+				Annotations: map[string]string{sandboxdauth.IdentityAnnotation: "current.sandboxd.swe.dev", sandboxdauth.PodUIDAnnotation: string(pod.UID)},
+			}, Data: map[string][]byte{
+				sandboxdauth.TLSCertKey: []byte("cert"), sandboxdauth.TLSKeyKey: []byte("key"), sandboxdauth.CapabilitiesKey: []byte("capabilities"),
+				sandboxdauth.HealthTokenKey: []byte("health"), sandboxdauth.ProcessTokenKey: []byte("process"),
+			}}
+			for _, object := range []client.Object{pod, secret} {
+				if err := controllerutil.SetControllerReference(current, object, scheme); err != nil {
+					t.Fatal(err)
+				}
+			}
+			live := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(current).WithObjects(current, template, pod, secret).Build()
+			podDeletes := 0
+			cached := interceptor.NewClient(live, interceptor.Funcs{
+				Get: func(ctx context.Context, underlying client.WithWatch, key client.ObjectKey, object client.Object, options ...client.GetOption) error {
+					if environment, ok := object.(*platformv1alpha1.Environment); ok && key == client.ObjectKeyFromObject(current) {
+						*environment = *stale.DeepCopy()
+						return nil
+					}
+					return underlying.Get(ctx, key, object, options...)
+				},
+				Delete: func(ctx context.Context, underlying client.WithWatch, object client.Object, options ...client.DeleteOption) error {
+					if _, ok := object.(*corev1.Pod); ok {
+						podDeletes++
+					}
+					return underlying.Delete(ctx, object, options...)
+				},
+			})
+			reconciler := &EnvironmentReconciler{Client: cached, APIReader: live, Scheme: scheme}
+
+			if _, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(current)}); err != nil {
+				t.Fatal(err)
+			}
+			if podDeletes != 0 {
+				t.Fatalf("valid live Pod was deleted %d times", podDeletes)
+			}
+			if err := live.Get(context.Background(), client.ObjectKeyFromObject(pod), &corev1.Pod{}); err != nil {
+				t.Fatalf("valid live Pod was not retained: %v", err)
+			}
+			var published platformv1alpha1.Environment
+			if err := live.Get(context.Background(), client.ObjectKeyFromObject(current), &published); err != nil {
+				t.Fatal(err)
+			}
+			ready := apimeta.FindStatusCondition(published.Status.Conditions, platformv1alpha1.EnvironmentConditionReady)
+			if published.UID != current.UID || published.Generation != current.Generation || published.Spec.TemplateRef != current.Spec.TemplateRef ||
+				published.Status.ExecutionGeneration != 2 || published.Status.PodName != pod.Name || ready == nil || ready.Status != metav1.ConditionTrue {
+				t.Fatalf("status publication did not preserve live Environment identity: %#v", published)
+			}
+		})
+	}
+}
+
+func TestExecutionFencesUseUncachedPodReads(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		deleting  bool
+		reconcile func(context.Context, *EnvironmentReconciler, *platformv1alpha1.Environment) (ctrl.Result, error)
+	}{
+		{name: "pause", reconcile: func(ctx context.Context, reconciler *EnvironmentReconciler, env *platformv1alpha1.Environment) (ctrl.Result, error) {
+			return reconciler.reconcilePaused(ctx, env)
+		}},
+		{name: "deletion", deleting: true, reconcile: func(ctx context.Context, reconciler *EnvironmentReconciler, env *platformv1alpha1.Environment) (ctrl.Result, error) {
+			return reconciler.reconcileDeleting(ctx, env)
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			if err := corev1.AddToScheme(scheme); err != nil {
+				t.Fatal(err)
+			}
+			if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+				t.Fatal(err)
+			}
+			env := &platformv1alpha1.Environment{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "env-uid", Finalizers: []string{environmentFinalizer}},
+				Status: platformv1alpha1.EnvironmentStatus{
+					ExecutionGeneration: 3, Phase: platformv1alpha1.EnvironmentPhaseIdle,
+					Lifecycle: platformv1alpha1.EnvironmentLifecycleStatus{Suspended: true},
+				},
+			}
+			if test.deleting {
+				deletedAt := metav1.Now()
+				env.DeletionTimestamp = &deletedAt
+			}
+			pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: envPodName(env), Namespace: env.Namespace, UID: "live-pod"}}
+			if err := controllerutil.SetControllerReference(env, pod, scheme); err != nil {
+				t.Fatal(err)
+			}
+			live := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env, pod).Build()
+			cached := interceptor.NewClient(live, interceptor.Funcs{Get: func(ctx context.Context, underlying client.WithWatch, key client.ObjectKey, object client.Object, options ...client.GetOption) error {
+				if _, ok := object.(*corev1.Pod); ok {
+					return apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, key.Name)
+				}
+				return underlying.Get(ctx, key, object, options...)
+			}})
+			reconciler := &EnvironmentReconciler{Client: cached, APIReader: live, Scheme: scheme}
+
+			result, err := test.reconcile(context.Background(), reconciler, env.DeepCopy())
+			if err != nil || !result.Requeue {
+				t.Fatalf("execution fence = (%#v, %v), want requeue after live Pod deletion", result, err)
+			}
+			if err := live.Get(context.Background(), client.ObjectKeyFromObject(pod), &corev1.Pod{}); !apierrors.IsNotFound(err) {
+				t.Fatalf("live Pod survived cached NotFound: %v", err)
+			}
+			if test.deleting {
+				var retained platformv1alpha1.Environment
+				if err := live.Get(context.Background(), client.ObjectKeyFromObject(env), &retained); err != nil {
+					t.Fatal(err)
+				}
+				if !controllerutil.ContainsFinalizer(&retained, environmentFinalizer) {
+					t.Fatal("deletion finalizer was removed before uncached Pod fence")
+				}
+			}
+		})
+	}
+}
+
 func TestNewEnvironmentRefusesTerminatingPriorIncarnationPVC(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := corev1.AddToScheme(scheme); err != nil {

--- a/internal/controllers/environment_controller_test.go
+++ b/internal/controllers/environment_controller_test.go
@@ -357,7 +357,8 @@ func TestFailedPodCreateLeavesGenerationGap(t *testing.T) {
 	}
 	env := &platformv1alpha1.Environment{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "env-uid"},
-		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small"},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small", ProjectRef: "project"},
+		Status:     platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhaseResuming},
 	}
 	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env).Build()
 	failCreate := true
@@ -373,8 +374,9 @@ func TestFailedPodCreateLeavesGenerationGap(t *testing.T) {
 	})
 	reconciler := &EnvironmentReconciler{Client: intercepted, Scheme: scheme}
 	template := &platformv1alpha1.EnvironmentTemplate{Spec: platformv1alpha1.EnvironmentTemplateSpec{Image: "example/environment:latest", Size: "small"}}
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "project", Namespace: env.Namespace}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/example/repo"}}}
 
-	if pod, err := reconciler.ensurePod(context.Background(), env, template); pod != nil || !stderrors.Is(err, transientErr) {
+	if pod, err := reconciler.ensurePodForProject(context.Background(), env, template, project, ""); pod != nil || !stderrors.Is(err, transientErr) {
 		t.Fatalf("first create = (%#v, %v), want transient error", pod, err)
 	}
 	var reserved platformv1alpha1.Environment
@@ -384,12 +386,22 @@ func TestFailedPodCreateLeavesGenerationGap(t *testing.T) {
 	if reserved.Status.ExecutionGeneration != 1 {
 		t.Fatalf("failed create reservation = %d, want 1", reserved.Status.ExecutionGeneration)
 	}
-	replacement, err := reconciler.ensurePod(context.Background(), &reserved, template)
+	if reserved.Status.Phase != platformv1alpha1.EnvironmentPhaseResuming {
+		t.Fatalf("failed create lost resume intent: phase %q", reserved.Status.Phase)
+	}
+	replacement, err := reconciler.ensurePodForProject(context.Background(), &reserved, template, project, "")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if replacement.Annotations[executionGenerationAnnotation] != "2" {
 		t.Fatalf("retry reused failed generation: %#v", replacement.Annotations)
+	}
+	resume := false
+	for _, variable := range replacement.Spec.InitContainers[0].Env {
+		resume = resume || variable.Name == "SWE_RESUMING" && variable.Value == "true"
+	}
+	if !resume {
+		t.Fatalf("retry omitted resume hook intent: %#v", replacement.Spec.InitContainers[0].Env)
 	}
 }
 

--- a/internal/controllers/environment_controller_test.go
+++ b/internal/controllers/environment_controller_test.go
@@ -7,9 +7,11 @@ import (
 	"encoding/pem"
 	stderrors "errors"
 	"fmt"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -51,16 +53,16 @@ func TestEnsurePodUsesOnlyNonSecretProjectValues(t *testing.T) {
 			Repositories: []string{"https://github.com/example/repo"},
 		},
 	}
-	reconciler := &EnvironmentReconciler{
-		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(project).Build(),
-		Scheme: scheme,
-	}
 	env := &platformv1alpha1.Environment{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "environment-uid"},
 		Spec: platformv1alpha1.EnvironmentSpec{
 			ProjectRef:  project.Name,
 			TemplateRef: "small",
 		},
+	}
+	reconciler := &EnvironmentReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(project, env).Build(),
+		Scheme: scheme,
 	}
 	tmpl := &platformv1alpha1.EnvironmentTemplate{
 		Spec: platformv1alpha1.EnvironmentTemplateSpec{Image: "example/environment:latest", Size: "small"},
@@ -69,6 +71,16 @@ func TestEnsurePodUsesOnlyNonSecretProjectValues(t *testing.T) {
 	pod, err := reconciler.ensurePod(context.Background(), env, tmpl)
 	if err != nil {
 		t.Fatalf("ensurePod() error = %v", err)
+	}
+	if pod.Spec.RestartPolicy != corev1.RestartPolicyNever || pod.Annotations[executionGenerationAnnotation] != "1" {
+		t.Fatalf("initial Pod execution contract = restart %q, generation %q", pod.Spec.RestartPolicy, pod.Annotations[executionGenerationAnnotation])
+	}
+	var reserved platformv1alpha1.Environment
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(env), &reserved); err != nil {
+		t.Fatal(err)
+	}
+	if reserved.Status.ExecutionGeneration != 1 {
+		t.Fatalf("initial execution generation = %d, want 1", reserved.Status.ExecutionGeneration)
 	}
 	if len(pod.Spec.Containers[0].EnvFrom) != 0 {
 		t.Fatalf("environment EnvFrom = %#v, want no ambient project secrets", pod.Spec.Containers[0].EnvFrom)
@@ -193,12 +205,12 @@ func TestEnsurePodCreatesAndRotatesEphemeralSandboxdCredentials(t *testing.T) {
 	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
 		t.Fatal(err)
 	}
-	reconciler := &EnvironmentReconciler{
-		Client: fake.NewClientBuilder().WithScheme(scheme).Build(),
-		Scheme: scheme,
-	}
 	env := &platformv1alpha1.Environment{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "environment-uid"},
+	}
+	reconciler := &EnvironmentReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env).Build(),
+		Scheme: scheme,
 	}
 	tmpl := &platformv1alpha1.EnvironmentTemplate{
 		Spec: platformv1alpha1.EnvironmentTemplateSpec{Image: "example/environment:latest", Size: "small"},
@@ -300,6 +312,155 @@ func TestEnsurePodCreatesAndRotatesEphemeralSandboxdCredentials(t *testing.T) {
 	}
 }
 
+func TestExecutionGenerationReservationSurvivesControllerRestart(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	environment := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "environment", Namespace: "default", UID: "env-uid", Generation: 1},
+		Status:     platformv1alpha1.EnvironmentStatus{ExecutionGeneration: 4},
+	}
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment).Build()
+	first := &EnvironmentReconciler{Client: kubeClient}
+	if generation, err := first.reserveExecutionGeneration(context.Background(), environment); err != nil || generation != 5 {
+		t.Fatalf("first reservation = (%d, %v), want 5", generation, err)
+	}
+	var persisted platformv1alpha1.Environment
+	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(environment), &persisted); err != nil {
+		t.Fatal(err)
+	}
+	second := &EnvironmentReconciler{Client: kubeClient}
+	if generation, err := second.reserveExecutionGeneration(context.Background(), &persisted); err != nil || generation != 6 {
+		t.Fatalf("post-restart reservation = (%d, %v), want 6", generation, err)
+	}
+	if err := second.Get(context.Background(), client.ObjectKeyFromObject(environment), &persisted); err != nil {
+		t.Fatal(err)
+	}
+	persisted.Status.ExecutionGeneration = math.MaxInt64
+	if err := second.Status().Update(context.Background(), &persisted); err != nil {
+		t.Fatal(err)
+	}
+	var terminal *terminalEnvironmentError
+	if generation, err := second.reserveExecutionGeneration(context.Background(), &persisted); generation != 0 || !stderrors.As(err, &terminal) {
+		t.Fatalf("exhausted reservation = (%d, %v), want terminal error", generation, err)
+	}
+}
+
+func TestFailedPodCreateLeavesGenerationGap(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	env := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "env-uid"},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small"},
+	}
+	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env).Build()
+	failCreate := true
+	transientErr := stderrors.New("transient Pod create failure")
+	intercepted := interceptor.NewClient(baseClient, interceptor.Funcs{
+		Create: func(ctx context.Context, underlying client.WithWatch, object client.Object, options ...client.CreateOption) error {
+			if _, ok := object.(*corev1.Pod); ok && failCreate {
+				failCreate = false
+				return transientErr
+			}
+			return underlying.Create(ctx, object, options...)
+		},
+	})
+	reconciler := &EnvironmentReconciler{Client: intercepted, Scheme: scheme}
+	template := &platformv1alpha1.EnvironmentTemplate{Spec: platformv1alpha1.EnvironmentTemplateSpec{Image: "example/environment:latest", Size: "small"}}
+
+	if pod, err := reconciler.ensurePod(context.Background(), env, template); pod != nil || !stderrors.Is(err, transientErr) {
+		t.Fatalf("first create = (%#v, %v), want transient error", pod, err)
+	}
+	var reserved platformv1alpha1.Environment
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(env), &reserved); err != nil {
+		t.Fatal(err)
+	}
+	if reserved.Status.ExecutionGeneration != 1 {
+		t.Fatalf("failed create reservation = %d, want 1", reserved.Status.ExecutionGeneration)
+	}
+	replacement, err := reconciler.ensurePod(context.Background(), &reserved, template)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replacement.Annotations[executionGenerationAnnotation] != "2" {
+		t.Fatalf("retry reused failed generation: %#v", replacement.Annotations)
+	}
+}
+
+func TestCurrentSandboxdPodRejectsRestartableLegacyPod(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	env := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "env-uid"}, Status: platformv1alpha1.EnvironmentStatus{ExecutionGeneration: 1}}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: "env-test", Namespace: env.Namespace, UID: "pod-uid",
+		Annotations: map[string]string{executionGenerationAnnotation: "1"},
+	}}
+	if err := controllerutil.SetControllerReference(env, pod, scheme); err != nil {
+		t.Fatal(err)
+	}
+	for _, policy := range []corev1.RestartPolicy{corev1.RestartPolicyAlways, corev1.RestartPolicyOnFailure, ""} {
+		pod.Spec.RestartPolicy = policy
+		current, err := (&EnvironmentReconciler{}).currentSandboxdPod(context.Background(), env, pod)
+		if err != nil || current {
+			t.Fatalf("restart policy %q current = (%t, %v), want false", policy, current, err)
+		}
+	}
+}
+
+func TestEnsurePodReplacesLegacyOnFailureExecution(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	env := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "env-uid"},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small"},
+		Status:     platformv1alpha1.EnvironmentStatus{ExecutionGeneration: 1},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: envPodName(env), Namespace: env.Namespace, UID: "legacy-pod", Annotations: map[string]string{executionGenerationAnnotation: "1"}},
+		Spec:       corev1.PodSpec{RestartPolicy: corev1.RestartPolicyOnFailure},
+	}
+	if err := controllerutil.SetControllerReference(env, pod, scheme); err != nil {
+		t.Fatal(err)
+	}
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env, pod).Build()
+	reconciler := &EnvironmentReconciler{Client: kubeClient, Scheme: scheme}
+	template := &platformv1alpha1.EnvironmentTemplate{Spec: platformv1alpha1.EnvironmentTemplateSpec{Image: "example/environment:latest", Size: "small"}}
+
+	if current, err := reconciler.ensurePod(context.Background(), env, template); err != nil || current != nil {
+		t.Fatalf("legacy replacement step = (%#v, %v)", current, err)
+	}
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(pod), &corev1.Pod{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("legacy OnFailure Pod remains: %v", err)
+	}
+	var replacing platformv1alpha1.Environment
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(env), &replacing); err != nil {
+		t.Fatal(err)
+	}
+	replacement, err := reconciler.ensurePod(context.Background(), &replacing, template)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replacement.Spec.RestartPolicy != corev1.RestartPolicyNever || replacement.Annotations[executionGenerationAnnotation] != "2" {
+		t.Fatalf("replacement execution = restart %q, generation %q", replacement.Spec.RestartPolicy, replacement.Annotations[executionGenerationAnnotation])
+	}
+}
+
 func TestSandboxdNetworkPolicyOnlyAllowsControlPlaneIngress(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := networkingv1.AddToScheme(scheme); err != nil {
@@ -391,13 +552,15 @@ func TestEnsurePodRetainsCurrentPodWhenSecretReadFails(t *testing.T) {
 	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 		Name: envPodName(env), Namespace: env.Namespace,
 		Annotations: map[string]string{
+			executionGenerationAnnotation:     "1",
 			sandboxdRevisionAnnotation:        sandboxdSecurityRevision,
 			sandboxdauth.IdentityAnnotation:   "current.sandboxd.swe.dev",
 			sandboxdauth.TrustAnnotation:      "public trust bundle",
 			sandboxdauth.TokenAnnotation:      "terminal token",
 			sandboxdauth.SecretNameAnnotation: envCredentialName(env),
 		},
-	}}
+	}, Spec: corev1.PodSpec{RestartPolicy: corev1.RestartPolicyNever}}
+	env.Status.ExecutionGeneration = 1
 	if err := controllerutil.SetControllerReference(env, pod, scheme); err != nil {
 		t.Fatal(err)
 	}
@@ -431,13 +594,15 @@ func TestEnsurePodRetainsCurrentPodAndForeignSecretOnCollision(t *testing.T) {
 	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 		Name: envPodName(env), Namespace: env.Namespace,
 		Annotations: map[string]string{
+			executionGenerationAnnotation:     "1",
 			sandboxdRevisionAnnotation:        sandboxdSecurityRevision,
 			sandboxdauth.IdentityAnnotation:   "current.sandboxd.swe.dev",
 			sandboxdauth.TrustAnnotation:      "public trust bundle",
 			sandboxdauth.TokenAnnotation:      "terminal token",
 			sandboxdauth.SecretNameAnnotation: envCredentialName(env),
 		},
-	}}
+	}, Spec: corev1.PodSpec{RestartPolicy: corev1.RestartPolicyNever}}
+	env.Status.ExecutionGeneration = 1
 	if err := controllerutil.SetControllerReference(env, pod, scheme); err != nil {
 		t.Fatal(err)
 	}
@@ -794,7 +959,7 @@ func TestTerminatingFailedPodPersistsRecoveryBeforeReplacement(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "env-uid", Generation: 2, Finalizers: []string{environmentFinalizer}},
 		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small"},
 		Status: platformv1alpha1.EnvironmentStatus{
-			ObservedGeneration: 1, Phase: platformv1alpha1.EnvironmentPhaseReady, PodName: "env-test",
+			ObservedGeneration: 1, ExecutionGeneration: 1, Phase: platformv1alpha1.EnvironmentPhaseReady, PodName: "env-test",
 			Endpoints: platformv1alpha1.EnvironmentEndpoints{Sandboxd: "10.0.0.1:50051"},
 			Conditions: []metav1.Condition{{Type: platformv1alpha1.EnvironmentConditionReady, Status: metav1.ConditionTrue,
 				ObservedGeneration: 1, Reason: "SandboxdReady", Message: "sandboxd is ready"}},
@@ -805,6 +970,7 @@ func TestTerminatingFailedPodPersistsRecoveryBeforeReplacement(t *testing.T) {
 	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 		Name: envPodName(env), Namespace: env.Namespace, UID: "dead-pod", DeletionTimestamp: &deletedAt, Finalizers: []string{"test/hold"},
 		Annotations: map[string]string{
+			executionGenerationAnnotation:     "1",
 			sandboxdRevisionAnnotation:        sandboxdSecurityRevision,
 			sandboxdauth.IdentityAnnotation:   "sandboxd.test",
 			sandboxdauth.TrustAnnotation:      "trust",
@@ -812,7 +978,7 @@ func TestTerminatingFailedPodPersistsRecoveryBeforeReplacement(t *testing.T) {
 			sandboxdauth.SecretNameAnnotation: envCredentialName(env),
 			sandboxdauth.SecretUIDAnnotation:  "secret-uid",
 		},
-	}, Status: corev1.PodStatus{Phase: corev1.PodFailed}}
+	}, Spec: corev1.PodSpec{RestartPolicy: corev1.RestartPolicyNever}, Status: corev1.PodStatus{Phase: corev1.PodFailed}}
 	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
 		Name: envCredentialName(env), Namespace: env.Namespace, UID: "secret-uid",
 		Annotations: map[string]string{sandboxdauth.IdentityAnnotation: "sandboxd.test", sandboxdauth.PodUIDAnnotation: string(pod.UID)},
@@ -1130,14 +1296,14 @@ func TestHealthReadyResetRejectsSameNameReplacementEnvironment(t *testing.T) {
 	}
 	next := metav1.Now()
 	stored := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "environment-u2", Generation: 2}, Status: platformv1alpha1.EnvironmentStatus{
-		ObservedGeneration: 2, Phase: platformv1alpha1.EnvironmentPhaseCreating,
+		ObservedGeneration: 2, ExecutionGeneration: 3, Phase: platformv1alpha1.EnvironmentPhaseCreating,
 		PodRecoveryAttempts: 2, PodRecoveryUID: "u2-terminal-pod", PodRecoveryNextAttemptAt: &next,
 		Conditions: []metav1.Condition{{Type: platformv1alpha1.EnvironmentConditionReady, Status: metav1.ConditionFalse,
 			ObservedGeneration: 2, Reason: "PodRecoveryPending", Message: "U2 recovery is pending"}},
 	}}
 	stale := stored.DeepCopy()
 	stale.UID = "environment-u1"
-	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "env-test", Namespace: "default"}, Status: corev1.PodStatus{
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "env-test", Namespace: "default", Annotations: map[string]string{executionGenerationAnnotation: "3"}}, Status: corev1.PodStatus{
 		Phase: corev1.PodRunning, PodIP: "10.0.0.1",
 		Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
 	}}
@@ -1385,7 +1551,10 @@ func TestOperationalFailureRetriesAndRecoversReadiness(t *testing.T) {
 	if result, err := reconciler.Reconcile(context.Background(), request); err != nil {
 		t.Fatalf("recovery Reconcile() = (%#v, %v), want provisioning to resume", result, err)
 	}
-	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod"}, Status: corev1.PodStatus{
+	if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(env), &retrying); err != nil {
+		t.Fatal(err)
+	}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Annotations: map[string]string{executionGenerationAnnotation: strconv.FormatInt(retrying.Status.ExecutionGeneration, 10)}}, Status: corev1.PodStatus{
 		Phase: corev1.PodRunning,
 		PodIP: "10.0.0.1",
 		Conditions: []corev1.PodCondition{{
@@ -2506,13 +2675,14 @@ func TestSyncStatusReportsSetupForProjectInitialization(t *testing.T) {
 
 	env := &platformv1alpha1.Environment{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "environment-uid"},
+		Status:     platformv1alpha1.EnvironmentStatus{ExecutionGeneration: 1},
 	}
 	reconciler := &EnvironmentReconciler{
 		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env).Build(),
 		Scheme: scheme,
 	}
 	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "env-test", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{Name: "env-test", Namespace: "default", Annotations: map[string]string{executionGenerationAnnotation: "1"}},
 		Spec:       corev1.PodSpec{InitContainers: []corev1.Container{{Name: "project-setup"}}},
 		Status:     corev1.PodStatus{Phase: corev1.PodPending},
 	}
@@ -2540,6 +2710,7 @@ func TestSyncStatusPublishesSandboxdEndpoint(t *testing.T) {
 
 	nextRecovery := metav1.Now()
 	env := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", Generation: 4}, Status: platformv1alpha1.EnvironmentStatus{
+		ExecutionGeneration: 1,
 		PodRecoveryAttempts: 2, PodRecoveryExhausted: true, PodRecoveryUID: "old-pod", PodRecoveryNextAttemptAt: &nextRecovery,
 	}}
 	reconciler := &EnvironmentReconciler{
@@ -2547,7 +2718,7 @@ func TestSyncStatusPublishesSandboxdEndpoint(t *testing.T) {
 		Scheme: scheme,
 	}
 	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "env-test", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{Name: "env-test", Namespace: "default", Annotations: map[string]string{executionGenerationAnnotation: "1"}},
 		Status: corev1.PodStatus{
 			Phase:      corev1.PodRunning,
 			PodIP:      "10.0.0.7",
@@ -2675,7 +2846,8 @@ func TestEnvironmentStatusRetriesConflictAndPreservesConditions(t *testing.T) {
 		t.Fatal(err)
 	}
 	env := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", Generation: 2}, Status: platformv1alpha1.EnvironmentStatus{
-		Conditions: []metav1.Condition{{Type: "Audit", Status: metav1.ConditionTrue, Reason: "Recorded", Message: "preserve me"}},
+		ExecutionGeneration: 1,
+		Conditions:          []metav1.Condition{{Type: "Audit", Status: metav1.ConditionTrue, Reason: "Recorded", Message: "preserve me"}},
 	}}
 	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env).Build()
 	conflicts := 0
@@ -2717,10 +2889,6 @@ func TestEnsurePodMarksProjectInitializationAsResume(t *testing.T) {
 			Repositories: []string{"https://github.com/example/repo"},
 		},
 	}
-	reconciler := &EnvironmentReconciler{
-		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(project).Build(),
-		Scheme: scheme,
-	}
 	env := &platformv1alpha1.Environment{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "environment-uid"},
 		Spec: platformv1alpha1.EnvironmentSpec{
@@ -2728,6 +2896,10 @@ func TestEnsurePodMarksProjectInitializationAsResume(t *testing.T) {
 			TemplateRef: "small",
 		},
 		Status: platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhaseResuming},
+	}
+	reconciler := &EnvironmentReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(project, env).Build(),
+		Scheme: scheme,
 	}
 	tmpl := &platformv1alpha1.EnvironmentTemplate{
 		Spec: platformv1alpha1.EnvironmentTemplateSpec{Image: "example/environment:latest", Size: "small"},
@@ -2754,14 +2926,14 @@ func TestSyncStatusPreservesResumingWhilePodStarts(t *testing.T) {
 
 	env := &platformv1alpha1.Environment{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
-		Status:     platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhaseResuming},
+		Status:     platformv1alpha1.EnvironmentStatus{ExecutionGeneration: 1, Phase: platformv1alpha1.EnvironmentPhaseResuming},
 	}
 	reconciler := &EnvironmentReconciler{
 		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env).Build(),
 		Scheme: scheme,
 	}
 	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "env-test", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{Name: "env-test", Namespace: "default", Annotations: map[string]string{executionGenerationAnnotation: "1"}},
 		Spec:       corev1.PodSpec{InitContainers: []corev1.Container{{Name: "project-setup"}}},
 		Status:     corev1.PodStatus{Phase: corev1.PodPending},
 	}
@@ -2888,6 +3060,44 @@ func TestReconcileIdleRequestsPauseAfterTimeout(t *testing.T) {
 	}
 }
 
+func TestLegacyActivityWithoutExecutionGenerationFailsClosed(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	oldActivity := metav1.NewTime(time.Date(2026, time.July, 20, 11, 0, 0, 0, time.UTC))
+	env := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "legacy", Namespace: "default", UID: "env-uid"},
+		Spec: platformv1alpha1.EnvironmentSpec{Lifecycle: platformv1alpha1.EnvironmentLifecycleSpec{Activity: []platformv1alpha1.EnvironmentActivityRequest{{
+			Source: platformv1alpha1.EnvironmentActivitySourceTerminal,
+			EnvironmentLifecycleRequest: platformv1alpha1.EnvironmentLifecycleRequest{
+				ID: "legacy-activity", EnvironmentUID: "env-uid", HoldPolicyRevision: 0,
+			},
+		}}}},
+		Status: platformv1alpha1.EnvironmentStatus{
+			ExecutionGeneration: 4, LastActiveAt: &oldActivity,
+			Lifecycle: platformv1alpha1.EnvironmentLifecycleStatus{ActivityReceipts: []platformv1alpha1.EnvironmentActivityReceipt{{
+				Source: platformv1alpha1.EnvironmentActivitySourceTerminal, RequestID: "legacy-activity",
+			}}},
+		},
+	}
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env).Build()
+	reconciler := &EnvironmentReconciler{Client: kubeClient, Now: func() time.Time { return oldActivity.Add(time.Hour) }}
+
+	changed, err := reconciler.reconcileLifecycleIntent(context.Background(), env)
+	if err != nil || changed {
+		t.Fatalf("legacy lifecycle reconcile = (%t, %v), want unchanged", changed, err)
+	}
+	var retained platformv1alpha1.Environment
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(env), &retained); err != nil {
+		t.Fatal(err)
+	}
+	if retained.Status.LastActiveAt == nil || !retained.Status.LastActiveAt.Equal(&oldActivity) ||
+		len(retained.Status.Lifecycle.ActivityReceipts) != 1 || retained.Status.Lifecycle.ActivityReceipts[0].ExecutionGeneration != 0 {
+		t.Fatalf("legacy activity was accepted or rewritten: %#v", retained.Status)
+	}
+}
+
 func TestLifecycleHoldConsumesButRefusesOrdinaryWake(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
@@ -2896,12 +3106,13 @@ func TestLifecycleHoldConsumesButRefusesOrdinaryWake(t *testing.T) {
 	now := time.Date(2026, time.July, 20, 12, 0, 0, 0, time.UTC)
 	env := &platformv1alpha1.Environment{
 		ObjectMeta: metav1.ObjectMeta{Name: "held", Namespace: "default", UID: "env-uid"},
+		Status:     platformv1alpha1.EnvironmentStatus{ExecutionGeneration: 1},
 		Spec: platformv1alpha1.EnvironmentSpec{Lifecycle: platformv1alpha1.EnvironmentLifecycleSpec{
 			Hold: &platformv1alpha1.EnvironmentHoldPolicy{Enabled: true, Revision: 4},
 			Wake: &platformv1alpha1.EnvironmentWakeRequest{EnvironmentLifecycleRequest: platformv1alpha1.EnvironmentLifecycleRequest{ID: "wake-1", EnvironmentUID: "env-uid", HoldPolicyRevision: 4}},
 			Activity: []platformv1alpha1.EnvironmentActivityRequest{{Source: platformv1alpha1.EnvironmentActivitySourceTerminal, EnvironmentLifecycleRequest: platformv1alpha1.EnvironmentLifecycleRequest{
 				ID: "activity-1", EnvironmentUID: "env-uid", HoldPolicyRevision: 4,
-			}}},
+			}, ExecutionGeneration: 1}},
 		}},
 	}
 	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env).Build()
@@ -3472,9 +3683,10 @@ func TestWakeAndHoldReleaseWaitForBackendFence(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "shared", Namespace: "default", UID: "env-uid", Finalizers: []string{environmentFinalizer}},
 				Spec:       platformv1alpha1.EnvironmentSpec{ProjectRef: project.Name, TemplateRef: template.Name, Lifecycle: test.spec},
 				Status: platformv1alpha1.EnvironmentStatus{
-					Phase:     platformv1alpha1.EnvironmentPhaseIdle,
-					PodName:   envPodName(&platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "shared"}}),
-					Endpoints: platformv1alpha1.EnvironmentEndpoints{Sandboxd: "192.0.2.10:50051"},
+					ExecutionGeneration: 7,
+					Phase:               platformv1alpha1.EnvironmentPhaseIdle,
+					PodName:             envPodName(&platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "shared"}}),
+					Endpoints:           platformv1alpha1.EnvironmentEndpoints{Sandboxd: "192.0.2.10:50051"},
 					Lifecycle: platformv1alpha1.EnvironmentLifecycleStatus{
 						Suspended: true, SuspensionReason: test.reason, Epoch: 1, ObservedHoldPolicyRevision: lifecycle.HoldPolicyRevision(&platformv1alpha1.Environment{Spec: platformv1alpha1.EnvironmentSpec{Lifecycle: test.spec}}),
 					},
@@ -3587,6 +3799,12 @@ func TestWakeAndHoldReleaseWaitForBackendFence(t *testing.T) {
 			}
 			if replacementPod.Annotations[sandboxdauth.IdentityAnnotation] == oldIdentity || replacementCredentials.Annotations[sandboxdauth.IdentityAnnotation] == oldIdentity || replacementPod.Annotations[sandboxdauth.IdentityAnnotation] != replacementCredentials.Annotations[sandboxdauth.IdentityAnnotation] {
 				t.Fatalf("replacement reused old execution identity: pod=%q credentials=%q", replacementPod.Annotations[sandboxdauth.IdentityAnnotation], replacementCredentials.Annotations[sandboxdauth.IdentityAnnotation])
+			}
+			if err := reconciler.Get(context.Background(), key, &fencing); err != nil {
+				t.Fatal(err)
+			}
+			if replacementPod.Annotations[executionGenerationAnnotation] != "8" || fencing.Status.ExecutionGeneration != 8 {
+				t.Fatalf("resume execution generation = status %d, Pod %q, want 8", fencing.Status.ExecutionGeneration, replacementPod.Annotations[executionGenerationAnnotation])
 			}
 			setup := replacementPod.Spec.InitContainers[0]
 			resuming := false
@@ -3931,10 +4149,10 @@ func TestSyncStatusRefreshesActivityWhenSetupBecomesReady(t *testing.T) {
 	oldActivity := metav1.NewTime(time.Now().Add(-time.Hour))
 	env := &platformv1alpha1.Environment{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
-		Status:     platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhaseSetup, LastActiveAt: &oldActivity},
+		Status:     platformv1alpha1.EnvironmentStatus{ExecutionGeneration: 1, Phase: platformv1alpha1.EnvironmentPhaseSetup, LastActiveAt: &oldActivity},
 	}
 	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "env-test", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{Name: "env-test", Namespace: "default", Annotations: map[string]string{executionGenerationAnnotation: "1"}},
 		Status: corev1.PodStatus{
 			Phase: corev1.PodRunning, PodIP: "10.0.0.1",
 			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
@@ -3971,12 +4189,13 @@ func TestActivityIntentPreservesReadyGenerationAndProtectsIdle(t *testing.T) {
 			Hold: &platformv1alpha1.EnvironmentHoldPolicy{Revision: 2},
 		}},
 	}
+	environment.Status.ExecutionGeneration = 1
 	applyEnvironmentStatus(environment, platformv1alpha1.EnvironmentPhaseReady, "env-test", "10.0.0.1:50051", "SandboxdReady", "ready", nil)
 	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment).Build()
 	reconciler := &EnvironmentReconciler{Client: kubeClient, Scheme: scheme, Now: func() time.Time { return now }}
 	key := client.ObjectKeyFromObject(environment)
 
-	if err := lifecycle.RecordActivity(context.Background(), kubeClient, key, environment.UID, 2, platformv1alpha1.EnvironmentActivitySourceTerminal, "terminal-2"); err != nil {
+	if err := lifecycle.RecordActivity(context.Background(), kubeClient, key, environment.UID, 1, 2, platformv1alpha1.EnvironmentActivitySourceTerminal, "terminal-2"); err != nil {
 		t.Fatal(err)
 	}
 	var activity platformv1alpha1.Environment
@@ -3993,7 +4212,7 @@ func TestActivityIntentPreservesReadyGenerationAndProtectsIdle(t *testing.T) {
 	if err := kubeClient.Get(context.Background(), key, &consumed); err != nil {
 		t.Fatal(err)
 	}
-	if consumed.Status.LastActiveAt == nil || !consumed.Status.LastActiveAt.Equal(&metav1.Time{Time: now}) || activityReceipt(consumed.Status.Lifecycle.ActivityReceipts, platformv1alpha1.EnvironmentActivitySourceTerminal) != "terminal-2" || consumed.Status.Lifecycle.ObservedHoldPolicyRevision != 2 {
+	if consumed.Status.LastActiveAt == nil || !consumed.Status.LastActiveAt.Equal(&metav1.Time{Time: now}) || activityReceipt(consumed.Status.Lifecycle.ActivityReceipts, platformv1alpha1.EnvironmentActivitySourceTerminal, 1) != "terminal-2" || consumed.Status.Lifecycle.ObservedHoldPolicyRevision != 2 {
 		t.Fatalf("consumed activity = %#v", consumed.Status)
 	}
 	if consumed.Status.ObservedGeneration != consumed.Generation || !platformv1alpha1.IsEnvironmentReady(&consumed) {

--- a/internal/controllers/run_controller.go
+++ b/internal/controllers/run_controller.go
@@ -261,11 +261,25 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			if !environmentReachable(env) || adapter == nil {
 				return r.requestEnvironmentFence(ctx, env)
 			}
+			execution, current, err := r.resolveAllocatedExecution(ctx, &run, env)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			if !current {
+				return ctrl.Result{Requeue: true}, nil
+			}
 			if err := adapter.Cancel(ctx, adapterTask(&run), r.adapterSandbox(&run, env)); err != nil {
 				if errors.Is(err, ErrAdapterCancellationPending) {
 					return ctrl.Result{RequeueAfter: adapterPollInterval}, nil
 				}
 				return ctrl.Result{}, err
+			}
+			current, err = r.allocatedExecutionCurrent(ctx, &run, env, execution)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			if !current {
+				return ctrl.Result{Requeue: true}, nil
 			}
 		}
 		return ctrl.Result{}, r.setRunState(ctx, &run, platformv1alpha1.RunStateCancelled, "Cancelled", "cancellation completed", environmentReachable(env))
@@ -298,8 +312,8 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	if !environmentReachable(env) {
 		return ctrl.Result{RequeueAfter: adapterPollInterval}, r.setRunState(ctx, &run, platformv1alpha1.RunStateAllocating, "EnvironmentNotReachable", "sandboxd endpoint is not currently reachable", false)
 	}
-	if runAccepted(&run) && !acceptedEnvironmentEpochCurrent(&run, env) && run.Status.State != platformv1alpha1.RunStateEnvironmentReady {
-		return ctrl.Result{Requeue: true}, r.setRunState(ctx, &run, platformv1alpha1.RunStateEnvironmentReady, "EnvironmentEpochChanged", "fresh environment lifecycle epoch requires adapter acceptance", true)
+	if runAccepted(&run) && !acceptedEnvironmentExecutionCurrent(&run, env) && run.Status.State != platformv1alpha1.RunStateEnvironmentReady {
+		return ctrl.Result{Requeue: true}, r.setRunState(ctx, &run, platformv1alpha1.RunStateEnvironmentReady, "EnvironmentExecutionChanged", "fresh environment execution requires adapter acceptance", true)
 	}
 
 	if run.Status.State == platformv1alpha1.RunStateAllocating || run.Status.State == platformv1alpha1.RunStatePaused || run.Status.State == "" {
@@ -327,20 +341,51 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		if credential != nil {
 			defer clear(credential.APIKey)
 		}
-		if err := adapter.EnsureAccepted(ctx, adapterTask(&run), r.adapterSandbox(&run, env), credential); err != nil {
-			if errors.Is(err, ErrAdapterTaskRejected) {
-				return ctrl.Result{}, r.setRunState(ctx, &run, platformv1alpha1.RunStateFailed, "AdapterRejected", err.Error(), true)
-			}
+		expectedExecutionGeneration := env.Status.ExecutionGeneration
+		expectedEpoch := env.Status.Lifecycle.Epoch
+		execution, current, err := r.resolveAllocatedExecution(ctx, &run, env)
+		if err != nil {
 			return ctrl.Result{}, err
 		}
-		acceptedEpoch := env.Status.Lifecycle.Epoch
-		run.Status.AcceptedEnvironmentEpoch = &acceptedEpoch
+		if !current {
+			return ctrl.Result{Requeue: true}, nil
+		}
+		acceptErr := adapter.EnsureAccepted(ctx, adapterTask(&run), r.adapterSandbox(&run, env), credential)
+		current, err = r.allocatedExecutionCurrent(ctx, &run, env, execution)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if !current {
+			return ctrl.Result{Requeue: true}, nil
+		}
+		if acceptErr != nil {
+			if errors.Is(acceptErr, ErrAdapterTaskRejected) {
+				return ctrl.Result{}, r.setRunState(ctx, &run, platformv1alpha1.RunStateFailed, "AdapterRejected", acceptErr.Error(), true)
+			}
+			return ctrl.Result{}, acceptErr
+		}
+		run.Status.AcceptedEnvironmentEpoch = &expectedEpoch
+		run.Status.AcceptedEnvironmentExecutionGeneration = &expectedExecutionGeneration
 		return ctrl.Result{Requeue: true}, r.setRunState(ctx, &run, platformv1alpha1.RunStateAdapterAccepted, "AdapterAccepted", "adapter accepted the task", true)
 	}
 
+	execution, current, err := r.resolveAllocatedExecution(ctx, &run, env)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if !current {
+		return ctrl.Result{Requeue: true}, nil
+	}
 	observation, message, err := adapter.Observe(ctx, adapterTask(&run), r.adapterSandbox(&run, env))
 	if err != nil {
 		return ctrl.Result{}, err
+	}
+	current, err = r.allocatedExecutionCurrent(ctx, &run, env, execution)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if !current {
+		return ctrl.Result{Requeue: true}, nil
 	}
 	state := platformv1alpha1.RunStateAdapterAccepted
 	switch observation {
@@ -798,7 +843,7 @@ func explicitHoldEnabled(env *platformv1alpha1.Environment) bool {
 }
 
 func environmentReachable(env *platformv1alpha1.Environment) bool {
-	return !environmentSuspended(env) && platformv1alpha1.IsEnvironmentReady(env) && env.Status.PodName != "" && env.Status.Endpoints.Sandboxd != ""
+	return env.Status.ExecutionGeneration > 0 && !environmentSuspended(env) && platformv1alpha1.IsEnvironmentReady(env) && env.Status.PodName != "" && env.Status.Endpoints.Sandboxd != ""
 }
 
 func exactControllerOwner(object metav1.Object, apiVersion, kind, name string, uid types.UID) bool {
@@ -845,6 +890,11 @@ func acceptedEnvironmentEpochCurrent(run *platformv1alpha1.Run, env *platformv1a
 		return env.Status.Lifecycle.Epoch == 0
 	}
 	return *run.Status.AcceptedEnvironmentEpoch == env.Status.Lifecycle.Epoch
+}
+
+func acceptedEnvironmentExecutionCurrent(run *platformv1alpha1.Run, env *platformv1alpha1.Environment) bool {
+	return env.Status.ExecutionGeneration > 0 && run.Status.AcceptedEnvironmentExecutionGeneration != nil &&
+		*run.Status.AcceptedEnvironmentExecutionGeneration == env.Status.ExecutionGeneration && acceptedEnvironmentEpochCurrent(run, env)
 }
 
 func acceptanceAttempted(run *platformv1alpha1.Run) bool {
@@ -910,11 +960,25 @@ func (r *RunReconciler) cleanupTerminal(ctx context.Context, run *platformv1alph
 		if !environmentReachable(env) || adapter == nil {
 			return r.requestEnvironmentFence(ctx, env)
 		}
+		execution, current, err := r.resolveAllocatedExecution(ctx, run, env)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if !current {
+			return ctrl.Result{Requeue: true}, nil
+		}
 		if err := adapter.Cancel(ctx, adapterTask(run), r.adapterSandbox(run, env)); err != nil {
 			if errors.Is(err, ErrAdapterCancellationPending) {
 				return ctrl.Result{RequeueAfter: adapterPollInterval}, nil
 			}
 			return ctrl.Result{}, err
+		}
+		current, err = r.allocatedExecutionCurrent(ctx, run, env, execution)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if !current {
+			return ctrl.Result{Requeue: true}, nil
 		}
 	}
 	if env.Spec.Lifecycle.Suspend != nil || env.Status.Lifecycle.PendingSuspendRequestID != "" {
@@ -975,11 +1039,25 @@ func (r *RunReconciler) finalize(ctx context.Context, run *platformv1alpha1.Run)
 				if !environmentReachable(env) || adapter == nil {
 					return r.requestEnvironmentFence(ctx, env)
 				}
+				execution, current, resolveErr := r.resolveAllocatedExecution(ctx, run, env)
+				if resolveErr != nil {
+					return ctrl.Result{}, resolveErr
+				}
+				if !current {
+					return ctrl.Result{Requeue: true}, nil
+				}
 				if err := adapter.Cancel(ctx, adapterTask(run), r.adapterSandbox(run, env)); err != nil {
 					if errors.Is(err, ErrAdapterCancellationPending) {
 						return ctrl.Result{RequeueAfter: adapterPollInterval}, nil
 					}
 					return ctrl.Result{}, err
+				}
+				current, resolveErr = r.allocatedExecutionCurrent(ctx, run, env, execution)
+				if resolveErr != nil {
+					return ctrl.Result{}, resolveErr
+				}
+				if !current {
+					return ctrl.Result{Requeue: true}, nil
 				}
 			}
 			if env.Spec.Lifecycle.Suspend != nil || env.Status.Lifecycle.PendingSuspendRequestID != "" {
@@ -1061,6 +1139,7 @@ func adapterTask(run *platformv1alpha1.Run) AdapterTask {
 
 func (r *RunReconciler) adapterSandbox(run *platformv1alpha1.Run, env *platformv1alpha1.Environment) AdapterSandbox {
 	expectedEpoch := env.Status.Lifecycle.Epoch
+	expectedExecutionGeneration := env.Status.ExecutionGeneration
 	sandbox := AdapterSandbox{EnvironmentName: env.Name, EnvironmentUID: env.UID,
 		DialProcess: func(ctx context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
 			reader := r.apiReader()
@@ -1068,7 +1147,10 @@ func (r *RunReconciler) adapterSandbox(run *platformv1alpha1.Run, env *platformv
 			if err != nil {
 				return nil, nil, err
 			}
-			return (sandboxclient.Connector{Reader: reader}).DialProcessForEpoch(ctx, current.Namespace, current.Name, current.UID, expectedEpoch)
+			if current.Status.ExecutionGeneration != expectedExecutionGeneration {
+				return nil, nil, fmt.Errorf("environment execution generation changed")
+			}
+			return (sandboxclient.Connector{Reader: reader}).DialProcessForExecution(ctx, current.Namespace, current.Name, current.UID, expectedExecutionGeneration, expectedEpoch)
 		}}
 	if r.EventSink != nil {
 		runUID := string(run.UID)
@@ -1077,6 +1159,40 @@ func (r *RunReconciler) adapterSandbox(run *platformv1alpha1.Run, env *platformv
 		}
 	}
 	return sandbox
+}
+
+func (r *RunReconciler) resolveAllocatedExecution(ctx context.Context, run *platformv1alpha1.Run, expected *platformv1alpha1.Environment) (sandboxclient.Execution, bool, error) {
+	current, err := getAllocatedEnvironment(ctx, r.apiReader(), run)
+	if apierrors.IsNotFound(err) || errors.Is(err, errAllocatedEnvironmentGone) {
+		return sandboxclient.Execution{}, false, nil
+	}
+	if err != nil {
+		return sandboxclient.Execution{}, false, err
+	}
+	if current.UID != expected.UID || current.Status.ExecutionGeneration != expected.Status.ExecutionGeneration ||
+		current.Status.Lifecycle.Epoch != expected.Status.Lifecycle.Epoch || !environmentReachable(current) {
+		return sandboxclient.Execution{}, false, nil
+	}
+	execution, err := (sandboxclient.Connector{Reader: r.apiReader()}).ResolveExecution(ctx, current.Namespace, current.Name, current.UID, current.Status.ExecutionGeneration, current.Status.Lifecycle.Epoch)
+	if err != nil {
+		return sandboxclient.Execution{}, false, err
+	}
+	return execution, true, nil
+}
+
+func (r *RunReconciler) allocatedExecutionCurrent(ctx context.Context, run *platformv1alpha1.Run, expected *platformv1alpha1.Environment, execution sandboxclient.Execution) (bool, error) {
+	current, err := getAllocatedEnvironment(ctx, r.apiReader(), run)
+	if apierrors.IsNotFound(err) || errors.Is(err, errAllocatedEnvironmentGone) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if current.UID != expected.UID || current.Status.ExecutionGeneration != expected.Status.ExecutionGeneration ||
+		current.Status.Lifecycle.Epoch != expected.Status.Lifecycle.Epoch || !environmentReachable(current) {
+		return false, nil
+	}
+	return (sandboxclient.Connector{Reader: r.apiReader()}).ExecutionCurrent(ctx, current.Namespace, current.Name, execution)
 }
 
 // SetupWithManager registers Run watches. Owned Environments enqueue through

--- a/internal/controllers/run_controller_test.go
+++ b/internal/controllers/run_controller_test.go
@@ -32,11 +32,30 @@ type scriptedAdapter struct {
 	accepted, observed    int
 	cancelled             int
 	acceptErr             error
+	onAccept              func()
 	onCancel              func()
 	cancelErr             error
 	acceptedCredentials   [][]byte
 	retainedCredentialKey []byte
 }
+
+type blockingObserveAdapter struct {
+	observation AdapterObservation
+	started     chan struct{}
+	release     chan struct{}
+}
+
+func (*blockingObserveAdapter) EnsureAccepted(context.Context, AdapterTask, AdapterSandbox, *AdapterCredential) error {
+	return nil
+}
+
+func (a *blockingObserveAdapter) Observe(context.Context, AdapterTask, AdapterSandbox) (AdapterObservation, string, error) {
+	close(a.started)
+	<-a.release
+	return a.observation, string(a.observation), nil
+}
+
+func (*blockingObserveAdapter) Cancel(context.Context, AdapterTask, AdapterSandbox) error { return nil }
 
 type failAcceptedStatusClient struct {
 	client.Client
@@ -93,6 +112,9 @@ func (a *serviceAdapter) Cancel(context.Context, AdapterTask, AdapterSandbox) er
 
 func (a *scriptedAdapter) EnsureAccepted(_ context.Context, _ AdapterTask, _ AdapterSandbox, credential *AdapterCredential) error {
 	a.accepted++
+	if a.onAccept != nil {
+		a.onAccept()
+	}
 	if credential == nil {
 		a.acceptedCredentials = append(a.acceptedCredentials, nil)
 	} else {
@@ -132,9 +154,19 @@ func runScheme(t *testing.T) *runtime.Scheme {
 func reconciler(t *testing.T, adapter AdapterLifecycle, objects ...client.Object) *RunReconciler {
 	t.Helper()
 	s := runScheme(t)
+	templates := make(map[types.NamespacedName]bool)
+	for _, object := range objects {
+		if template, ok := object.(*platformv1alpha1.EnvironmentTemplate); ok {
+			templates[types.NamespacedName{Namespace: template.Namespace, Name: template.Name}] = true
+		}
+	}
 	for _, object := range objects {
 		env, ok := object.(*platformv1alpha1.Environment)
 		if ok && (env.Status.Phase == platformv1alpha1.EnvironmentPhaseReady || env.Status.Phase == platformv1alpha1.EnvironmentPhaseRunning) {
+			if env.Spec.TemplateRef == "" {
+				env.Spec.TemplateRef = "default"
+			}
+			env.Status.ExecutionGeneration = 1
 			applyEnvironmentStatus(env, env.Status.Phase, env.Status.PodName, env.Status.Endpoints.Sandboxd, "SandboxdReady", "sandboxd is ready", env.Status.LastActiveAt)
 		}
 	}
@@ -143,7 +175,7 @@ func reconciler(t *testing.T, adapter AdapterLifecycle, objects ...client.Object
 	// reachable endpoint; mismatch tests construct their reconciler directly.
 	for _, object := range objects {
 		run, ok := object.(*platformv1alpha1.Run)
-		if !ok || run.Status.EnvironmentRef == nil || run.Status.EnvironmentRef.Ownership != platformv1alpha1.EnvironmentOwnershipOwned {
+		if !ok || run.Status.EnvironmentRef == nil {
 			continue
 		}
 		for _, candidate := range objects {
@@ -151,15 +183,67 @@ func reconciler(t *testing.T, adapter AdapterLifecycle, objects ...client.Object
 			if !ok || env.Name != run.Status.EnvironmentRef.Name || env.UID != run.Status.EnvironmentRef.UID {
 				continue
 			}
-			env.OwnerReferences = []metav1.OwnerReference{{APIVersion: platformv1alpha1.GroupVersion.String(), Kind: "Run", Name: run.Name, UID: run.UID, Controller: ptr(true)}}
+			if run.Status.EnvironmentRef.Ownership == platformv1alpha1.EnvironmentOwnershipOwned {
+				env.OwnerReferences = []metav1.OwnerReference{{APIVersion: platformv1alpha1.GroupVersion.String(), Kind: "Run", Name: run.Name, UID: run.UID, Controller: ptr(true)}}
+			}
 			if env.Status.Phase == platformv1alpha1.EnvironmentPhaseReady || env.Status.Phase == platformv1alpha1.EnvironmentPhaseRunning {
 				env.Status.PodName = "env-" + env.Name
 				env.Status.Endpoints.Sandboxd = "10.0.0.1:50051"
+				if runAccepted(run) && run.Status.AcceptedEnvironmentExecutionGeneration == nil {
+					acceptedExecutionGeneration := env.Status.ExecutionGeneration
+					run.Status.AcceptedEnvironmentExecutionGeneration = &acceptedExecutionGeneration
+				}
 			}
 		}
 	}
+	for _, object := range append([]client.Object(nil), objects...) {
+		env, ok := object.(*platformv1alpha1.Environment)
+		if !ok || !environmentReachable(env) {
+			continue
+		}
+		key := types.NamespacedName{Namespace: env.Namespace, Name: env.Spec.TemplateRef}
+		if !templates[key] {
+			objects = append(objects, &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace}})
+			templates[key] = true
+		}
+		objects = append(objects, runExecutionPod(env, types.UID("pod-"+env.Name), "10.0.0.1"))
+	}
 	c := fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&platformv1alpha1.Run{}, &platformv1alpha1.Environment{}).WithObjects(objects...).Build()
 	return &RunReconciler{Client: c, Scheme: s, Adapters: map[string]AdapterLifecycle{"test": adapter}}
+}
+
+func runExecutionPod(env *platformv1alpha1.Environment, uid types.UID, podIP string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: env.Status.PodName, Namespace: env.Namespace, UID: uid,
+			Annotations: map[string]string{executionGenerationAnnotation: fmt.Sprintf("%d", env.Status.ExecutionGeneration)},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: platformv1alpha1.GroupVersion.String(), Kind: "Environment", Name: env.Name,
+				UID: env.UID, Controller: ptr(true),
+			}},
+		},
+		Spec: corev1.PodSpec{RestartPolicy: corev1.RestartPolicyNever},
+		Status: corev1.PodStatus{
+			PodIP: podIP, Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+		},
+	}
+}
+
+func runExecutionBackendObjects(t *testing.T, r *RunReconciler, env *platformv1alpha1.Environment) []client.Object {
+	t.Helper()
+	var current platformv1alpha1.Environment
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(env), &current); err != nil {
+		t.Fatal(err)
+	}
+	var template platformv1alpha1.EnvironmentTemplate
+	if err := r.Get(context.Background(), types.NamespacedName{Namespace: current.Namespace, Name: current.Spec.TemplateRef}, &template); err != nil {
+		t.Fatal(err)
+	}
+	var pod corev1.Pod
+	if err := r.Get(context.Background(), types.NamespacedName{Namespace: current.Namespace, Name: current.Status.PodName}, &pod); err != nil {
+		t.Fatal(err)
+	}
+	return []client.Object{current.DeepCopy(), template.DeepCopy(), pod.DeepCopy()}
 }
 
 func credentialProfileAndSecret(run *platformv1alpha1.Run, value []byte) (*platformv1alpha1.AgentCredentialProfile, *corev1.Secret) {
@@ -608,28 +692,34 @@ func TestAcceptedRunIgnoresActivityWithoutRereadingCredentials(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			acceptedEpoch := int64(0)
+			acceptedExecutionGeneration := int64(1)
 			run := &platformv1alpha1.Run{
 				ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid", Finalizers: []string{runFinalizer}},
 				Spec:       platformv1alpha1.RunSpec{Agent: "test", CredentialProfileRef: "removed-profile"},
 				Status: platformv1alpha1.RunStatus{
-					State:                    test.state,
-					AcceptedEnvironmentEpoch: &acceptedEpoch,
-					EnvironmentRef:           &platformv1alpha1.RunEnvironmentReference{Name: "e", UID: "env-uid", Ownership: platformv1alpha1.EnvironmentOwnershipOwned},
-					CredentialProfileRef:     &platformv1alpha1.RunCredentialProfileReference{Name: "removed-profile", UID: "removed-profile-uid"},
-					Conditions:               []metav1.Condition{{Type: runConditionAdapterAccepted, Status: metav1.ConditionTrue, Reason: "AdapterAccepted"}},
+					State:                                  test.state,
+					AcceptedEnvironmentEpoch:               &acceptedEpoch,
+					AcceptedEnvironmentExecutionGeneration: &acceptedExecutionGeneration,
+					EnvironmentRef:                         &platformv1alpha1.RunEnvironmentReference{Name: "e", UID: "env-uid", Ownership: platformv1alpha1.EnvironmentOwnershipOwned},
+					CredentialProfileRef:                   &platformv1alpha1.RunCredentialProfileReference{Name: "removed-profile", UID: "removed-profile-uid"},
+					Conditions:                             []metav1.Condition{{Type: runConditionAdapterAccepted, Status: metav1.ConditionTrue, Reason: "AdapterAccepted"}},
 				},
 			}
 			environment := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "e", Namespace: "ns", UID: "env-uid", Generation: 1}}
+			environment.Status.ExecutionGeneration = 1
 			applyEnvironmentStatus(environment, platformv1alpha1.EnvironmentPhaseReady, "env-e", "10.0.0.1:50051", "SandboxdReady", "ready", nil)
 			adapter := &scriptedAdapter{observations: []AdapterObservation{test.observation}}
 			r := reconciler(t, adapter, run, environment)
 			credentialReads := 0
-			r.APIReader = interceptor.NewClient(r.Client.(client.WithWatch), interceptor.Funcs{Get: func(context.Context, client.WithWatch, client.ObjectKey, client.Object, ...client.GetOption) error {
+			r.APIReader = interceptor.NewClient(r.Client.(client.WithWatch), interceptor.Funcs{Get: func(ctx context.Context, delegate client.WithWatch, key client.ObjectKey, object client.Object, options ...client.GetOption) error {
+				if _, ok := object.(*platformv1alpha1.Environment); ok {
+					return delegate.Get(ctx, key, object, options...)
+				}
 				credentialReads++
 				return apierrors.NewNotFound(platformv1alpha1.GroupVersion.WithResource("agentcredentialprofiles").GroupResource(), "removed-profile")
 			}})
 
-			if err := lifecycle.RecordActivity(context.Background(), r.Client, client.ObjectKeyFromObject(environment), environment.UID, 0, platformv1alpha1.EnvironmentActivitySourceTerminal, "terminal-1"); err != nil {
+			if err := lifecycle.RecordActivity(context.Background(), r.Client, client.ObjectKeyFromObject(environment), environment.UID, 1, 0, platformv1alpha1.EnvironmentActivitySourceTerminal, "terminal-1"); err != nil {
 				t.Fatal(err)
 			}
 			var activity platformv1alpha1.Environment
@@ -984,10 +1074,11 @@ func TestNonterminalAdapterObservationSchedulesPolling(t *testing.T) {
 
 func TestEnvironmentReachableRequiresCurrentGenerationReady(t *testing.T) {
 	env := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Generation: 2}, Status: platformv1alpha1.EnvironmentStatus{
-		ObservedGeneration: 1,
-		Phase:              platformv1alpha1.EnvironmentPhaseReady,
-		PodName:            "env-test",
-		Endpoints:          platformv1alpha1.EnvironmentEndpoints{Sandboxd: "10.0.0.1:50051"},
+		ObservedGeneration:  1,
+		ExecutionGeneration: 1,
+		Phase:               platformv1alpha1.EnvironmentPhaseReady,
+		PodName:             "env-test",
+		Endpoints:           platformv1alpha1.EnvironmentEndpoints{Sandboxd: "10.0.0.1:50051"},
 		Conditions: []metav1.Condition{{
 			Type: platformv1alpha1.EnvironmentConditionReady, Status: metav1.ConditionTrue,
 			ObservedGeneration: 1, Reason: "SandboxdReady", Message: "stale readiness",
@@ -2024,7 +2115,8 @@ func TestCredentialAcceptanceUsesUncachedCurrentKeyAndClearsCopy(t *testing.T) {
 	_, currentSecret := credentialProfileAndSecret(run, []byte("!!CURRENT-UNCACHED-KEY!!"))
 	adapter := &scriptedAdapter{}
 	r := reconciler(t, adapter, run, env, profile, staleSecret)
-	liveReader := fake.NewClientBuilder().WithScheme(r.Scheme).WithObjects(profile.DeepCopy(), currentSecret).Build()
+	liveObjects := append(runExecutionBackendObjects(t, r, env), profile.DeepCopy(), currentSecret)
+	liveReader := fake.NewClientBuilder().WithScheme(r.Scheme).WithObjects(liveObjects...).Build()
 	r.APIReader = liveReader
 
 	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)}); err != nil {
@@ -2093,9 +2185,20 @@ func TestCredentialRotationIsRematerializedAfterResumeEpoch(t *testing.T) {
 		t.Fatal(err)
 	}
 	applyEnvironmentStatus(&currentEnv, platformv1alpha1.EnvironmentPhaseReady, "env-e", "10.0.0.2:50051", "SandboxdReady", "ready", nil)
+	currentEnv.Status.ExecutionGeneration = 2
 	currentEnv.Status.Lifecycle.Suspended = false
 	currentEnv.Status.Lifecycle.SuspensionReason = ""
 	if err := r.Status().Update(context.Background(), &currentEnv); err != nil {
+		t.Fatal(err)
+	}
+	var oldPod corev1.Pod
+	if err := r.Get(context.Background(), types.NamespacedName{Namespace: currentEnv.Namespace, Name: "env-e"}, &oldPod); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Delete(context.Background(), &oldPod); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Create(context.Background(), runExecutionPod(&currentEnv, "pod-e-resumed", "10.0.0.2")); err != nil {
 		t.Fatal(err)
 	}
 	reconcileRun(t, r, run.Name) // Paused -> EnvironmentReady.
@@ -2139,7 +2242,6 @@ func TestMissedPauseTransitionReacceptsFreshEnvironmentEpoch(t *testing.T) {
 			_, rotatedSecret := credentialProfileAndSecret(run, []byte("!!EPOCH-ONE-KEY!!"))
 			adapter := &scriptedAdapter{observations: []AdapterObservation{test.observation}}
 			r := reconciler(t, adapter, run, env, profile, staleSecret)
-			r.APIReader = fake.NewClientBuilder().WithScheme(r.Scheme).WithObjects(profile.DeepCopy(), rotatedSecret).Build()
 
 			// The Environment completes an entire pause/resume while the Run
 			// controller is unavailable. No Run reconcile occurs in this window.
@@ -2168,12 +2270,16 @@ func TestMissedPauseTransitionReacceptsFreshEnvironmentEpoch(t *testing.T) {
 				t.Fatal(err)
 			}
 			applyEnvironmentStatus(&currentEnv, platformv1alpha1.EnvironmentPhaseReady, "env-e-1", "10.0.0.2:50051", "SandboxdReady", "ready", nil)
+			currentEnv.Status.ExecutionGeneration = 2
 			currentEnv.Status.Lifecycle.Suspended = false
 			currentEnv.Status.Lifecycle.SuspensionReason = ""
 			currentEnv.Status.Lifecycle.Epoch = 1
 			if err := r.Status().Update(context.Background(), &currentEnv); err != nil {
 				t.Fatal(err)
 			}
+			livePod := runExecutionPod(&currentEnv, "pod-e-1", "10.0.0.2")
+			template := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: currentEnv.Spec.TemplateRef, Namespace: currentEnv.Namespace}}
+			r.APIReader = fake.NewClientBuilder().WithScheme(r.Scheme).WithObjects(currentEnv.DeepCopy(), template, livePod, profile.DeepCopy(), rotatedSecret).Build()
 
 			fenced := reconcileRun(t, r, run.Name)
 			if fenced.Status.State != platformv1alpha1.RunStateEnvironmentReady || adapter.accepted != 0 || adapter.observed != 0 {
@@ -2190,6 +2296,334 @@ func TestMissedPauseTransitionReacceptsFreshEnvironmentEpoch(t *testing.T) {
 				t.Fatalf("post-accept observation = state %s, acceptances %d, observations %d", observed.Status.State, adapter.accepted, adapter.observed)
 			}
 		})
+	}
+}
+
+func TestObserveDiscardsStaleExecutionResults(t *testing.T) {
+	for _, ownership := range []platformv1alpha1.EnvironmentOwnership{
+		platformv1alpha1.EnvironmentOwnershipOwned,
+		platformv1alpha1.EnvironmentOwnershipClaimed,
+	} {
+		for _, observation := range []AdapterObservation{AdapterObservationNeedsInput, AdapterObservationSucceeded} {
+			t.Run(string(ownership)+"/"+string(observation), func(t *testing.T) {
+				epoch := int64(0)
+				executionGeneration := int64(1)
+				run := &platformv1alpha1.Run{
+					ObjectMeta: metav1.ObjectMeta{Name: "run", Namespace: "ns", UID: "run-uid", Finalizers: []string{runFinalizer}},
+					Spec:       platformv1alpha1.RunSpec{Agent: "test"},
+					Status: platformv1alpha1.RunStatus{
+						State:                                  platformv1alpha1.RunStateRunning,
+						EnvironmentRef:                         &platformv1alpha1.RunEnvironmentReference{Name: "environment", UID: "env-uid", Ownership: ownership},
+						AcceptedEnvironmentEpoch:               &epoch,
+						AcceptedEnvironmentExecutionGeneration: &executionGeneration,
+						Conditions: []metav1.Condition{{
+							Type: runConditionAdapterAccepted, Status: metav1.ConditionTrue, Reason: "AdapterAccepted",
+						}},
+					},
+				}
+				environment := &platformv1alpha1.Environment{
+					ObjectMeta: metav1.ObjectMeta{Name: "environment", Namespace: "ns", UID: "env-uid"},
+					Status: platformv1alpha1.EnvironmentStatus{
+						ExecutionGeneration: 1, Phase: platformv1alpha1.EnvironmentPhaseReady,
+					},
+				}
+				if ownership == platformv1alpha1.EnvironmentOwnershipClaimed {
+					environment.Status.ClaimedBy = &platformv1alpha1.RunReference{Name: run.Name, UID: run.UID}
+				}
+				adapter := &blockingObserveAdapter{observation: observation, started: make(chan struct{}), release: make(chan struct{})}
+				r := reconciler(t, adapter, run, environment)
+				done := make(chan struct{})
+				var result ctrl.Result
+				var reconcileErr error
+				go func() {
+					result, reconcileErr = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)})
+					close(done)
+				}()
+				<-adapter.started
+
+				var replaced platformv1alpha1.Environment
+				if err := r.Get(context.Background(), client.ObjectKeyFromObject(environment), &replaced); err != nil {
+					t.Fatal(err)
+				}
+				replaced.Status.ExecutionGeneration = 2
+				if err := r.Status().Update(context.Background(), &replaced); err != nil {
+					t.Fatal(err)
+				}
+				close(adapter.release)
+				<-done
+				if reconcileErr != nil || !result.Requeue {
+					t.Fatalf("stale Observe reconcile = (%#v, %v)", result, reconcileErr)
+				}
+				var retained platformv1alpha1.Run
+				if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &retained); err != nil {
+					t.Fatal(err)
+				}
+				if retained.Status.State != platformv1alpha1.RunStateRunning || retained.Status.FinishedAt != nil ||
+					retained.Status.AcceptedEnvironmentExecutionGeneration == nil || *retained.Status.AcceptedEnvironmentExecutionGeneration != 1 {
+					t.Fatalf("stale %s observation mutated Run status: %#v", observation, retained.Status)
+				}
+			})
+		}
+	}
+}
+
+func TestAdapterResultsRequireSameLivePodWithUnchangedStatus(t *testing.T) {
+	for _, ownership := range []platformv1alpha1.EnvironmentOwnership{
+		platformv1alpha1.EnvironmentOwnershipOwned,
+		platformv1alpha1.EnvironmentOwnershipClaimed,
+	} {
+		for _, acceptErr := range []error{nil, ErrAdapterTaskRejected} {
+			name := "successful accept"
+			if acceptErr != nil {
+				name = "rejected accept"
+			}
+			t.Run(string(ownership)+"/"+name+" Pod disappears", func(t *testing.T) {
+				run, environment := adapterRaceObjects(ownership, platformv1alpha1.RunStateEnvironmentReady)
+				apiMeta.SetStatusCondition(&run.Status.Conditions, metav1.Condition{Type: runConditionAdapterAcceptanceAttempted, Status: metav1.ConditionTrue, Reason: "AcceptancePending"})
+				adapter := &scriptedAdapter{acceptErr: acceptErr}
+				r := reconciler(t, adapter, run, environment)
+				adapter.onAccept = func() { deleteRunExecutionPod(t, r, environment) }
+
+				result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)})
+				if err != nil || !result.Requeue || adapter.accepted != 1 {
+					t.Fatalf("stale acceptance = (%#v, %v), calls %d", result, err, adapter.accepted)
+				}
+				var retained platformv1alpha1.Run
+				if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &retained); err != nil {
+					t.Fatal(err)
+				}
+				if retained.Status.State != platformv1alpha1.RunStateEnvironmentReady || retained.Status.AcceptedEnvironmentExecutionGeneration != nil {
+					t.Fatalf("stale acceptance mutated Run: %#v", retained.Status)
+				}
+			})
+		}
+
+		t.Run(string(ownership)+"/observe Pod replaced", func(t *testing.T) {
+			run, environment := adapterRaceObjects(ownership, platformv1alpha1.RunStateRunning)
+			epoch, generation := int64(0), int64(1)
+			run.Status.AcceptedEnvironmentEpoch = &epoch
+			run.Status.AcceptedEnvironmentExecutionGeneration = &generation
+			apiMeta.SetStatusCondition(&run.Status.Conditions, metav1.Condition{Type: runConditionAdapterAccepted, Status: metav1.ConditionTrue, Reason: "AdapterAccepted"})
+			adapter := &scriptedAdapter{observations: []AdapterObservation{AdapterObservationSucceeded}}
+			r := reconciler(t, adapter, run, environment)
+			// scripted Observe is synchronous, so replace the Pod from its
+			// observation hook by using a one-shot wrapper.
+			wrapped := &mutatingObserveAdapter{scriptedAdapter: adapter, mutate: func() { replaceRunExecutionPod(t, r, environment) }}
+			r.Adapters["test"] = wrapped
+
+			result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)})
+			if err != nil || !result.Requeue || adapter.observed != 1 {
+				t.Fatalf("stale observation = (%#v, %v), calls %d", result, err, adapter.observed)
+			}
+			var retained platformv1alpha1.Run
+			if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &retained); err != nil {
+				t.Fatal(err)
+			}
+			if retained.Status.State != platformv1alpha1.RunStateRunning || retained.Status.FinishedAt != nil {
+				t.Fatalf("stale observation mutated Run: %#v", retained.Status)
+			}
+		})
+	}
+}
+
+type mutatingObserveAdapter struct {
+	*scriptedAdapter
+	mutate func()
+}
+
+func (a *mutatingObserveAdapter) Observe(ctx context.Context, task AdapterTask, sandbox AdapterSandbox) (AdapterObservation, string, error) {
+	observation, message, err := a.scriptedAdapter.Observe(ctx, task, sandbox)
+	a.mutate()
+	return observation, message, err
+}
+
+func adapterRaceObjects(ownership platformv1alpha1.EnvironmentOwnership, state platformv1alpha1.RunState) (*platformv1alpha1.Run, *platformv1alpha1.Environment) {
+	run := &platformv1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{Name: "run", Namespace: "ns", UID: "run-uid", Finalizers: []string{runFinalizer}},
+		Spec:       platformv1alpha1.RunSpec{Agent: "test"},
+		Status: platformv1alpha1.RunStatus{State: state, EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{
+			Name: "environment", UID: "env-uid", Ownership: ownership,
+		}},
+	}
+	environment := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "environment", Namespace: "ns", UID: "env-uid"},
+		Status:     platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhaseReady},
+	}
+	if ownership == platformv1alpha1.EnvironmentOwnershipClaimed {
+		environment.Status.ClaimedBy = &platformv1alpha1.RunReference{Name: run.Name, UID: run.UID}
+	}
+	return run, environment
+}
+
+func deleteRunExecutionPod(t *testing.T, r *RunReconciler, environment *platformv1alpha1.Environment) {
+	t.Helper()
+	var pod corev1.Pod
+	if err := r.Get(context.Background(), types.NamespacedName{Namespace: environment.Namespace, Name: "env-environment"}, &pod); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Delete(context.Background(), &pod); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func replaceRunExecutionPod(t *testing.T, r *RunReconciler, environment *platformv1alpha1.Environment) {
+	t.Helper()
+	deleteRunExecutionPod(t, r, environment)
+	var current platformv1alpha1.Environment
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(environment), &current); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Create(context.Background(), runExecutionPod(&current, "replacement-pod", "10.0.0.1")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCancelDiscardsResultWhenLiveExecutionDisappears(t *testing.T) {
+	for _, ownership := range []platformv1alpha1.EnvironmentOwnership{
+		platformv1alpha1.EnvironmentOwnershipOwned,
+		platformv1alpha1.EnvironmentOwnershipClaimed,
+	} {
+		t.Run(string(ownership), func(t *testing.T) {
+			epoch, executionGeneration := int64(0), int64(1)
+			run := &platformv1alpha1.Run{
+				ObjectMeta: metav1.ObjectMeta{Name: "run", Namespace: "ns", UID: "run-uid", Finalizers: []string{runFinalizer}},
+				Spec:       platformv1alpha1.RunSpec{Agent: "test", Cancel: true},
+				Status: platformv1alpha1.RunStatus{
+					State: platformv1alpha1.RunStateRunning,
+					EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{
+						Name: "environment", UID: "env-uid", Ownership: ownership,
+					},
+					AcceptedEnvironmentEpoch:               &epoch,
+					AcceptedEnvironmentExecutionGeneration: &executionGeneration,
+					Conditions:                             []metav1.Condition{{Type: runConditionAdapterAccepted, Status: metav1.ConditionTrue, Reason: "AdapterAccepted"}},
+				},
+			}
+			environment := &platformv1alpha1.Environment{
+				ObjectMeta: metav1.ObjectMeta{Name: "environment", Namespace: "ns", UID: "env-uid"},
+				Status:     platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhaseReady},
+			}
+			if ownership == platformv1alpha1.EnvironmentOwnershipClaimed {
+				environment.Status.ClaimedBy = &platformv1alpha1.RunReference{Name: run.Name, UID: run.UID}
+			}
+			adapter := &scriptedAdapter{}
+			r := reconciler(t, adapter, run, environment)
+			adapter.onCancel = func() {
+				var pod corev1.Pod
+				if err := r.Get(context.Background(), types.NamespacedName{Namespace: environment.Namespace, Name: "env-environment"}, &pod); err != nil {
+					t.Fatal(err)
+				}
+				if err := r.Delete(context.Background(), &pod); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)})
+			if err != nil || !result.Requeue || adapter.cancelled != 1 {
+				t.Fatalf("stale Cancel reconcile = (%#v, %v), calls %d", result, err, adapter.cancelled)
+			}
+			var retainedRun platformv1alpha1.Run
+			if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &retainedRun); err != nil {
+				t.Fatal(err)
+			}
+			if retainedRun.Status.State != platformv1alpha1.RunStateRunning || retainedRun.Status.FinishedAt != nil || !controllerutil.ContainsFinalizer(&retainedRun, runFinalizer) {
+				t.Fatalf("stale Cancel published terminal state or removed finalizer: %#v", retainedRun)
+			}
+			if ownership == platformv1alpha1.EnvironmentOwnershipClaimed {
+				var retainedEnvironment platformv1alpha1.Environment
+				if err := r.Get(context.Background(), client.ObjectKeyFromObject(environment), &retainedEnvironment); err != nil {
+					t.Fatal(err)
+				}
+				if retainedEnvironment.Status.ClaimedBy == nil || retainedEnvironment.Status.ClaimedBy.UID != run.UID {
+					t.Fatalf("stale Cancel released claim: %#v", retainedEnvironment.Status.ClaimedBy)
+				}
+			}
+		})
+	}
+}
+
+func TestTerminalCleanupRetainsClaimWhenExecutionChangesDuringCancel(t *testing.T) {
+	run, environment := adapterRaceObjects(platformv1alpha1.EnvironmentOwnershipClaimed, platformv1alpha1.RunStateSucceeded)
+	epoch, generation := int64(0), int64(1)
+	run.Status.AcceptedEnvironmentEpoch = &epoch
+	run.Status.AcceptedEnvironmentExecutionGeneration = &generation
+	apiMeta.SetStatusCondition(&run.Status.Conditions, metav1.Condition{Type: runConditionAdapterAccepted, Status: metav1.ConditionTrue, Reason: "AdapterAccepted"})
+	adapter := &scriptedAdapter{}
+	r := reconciler(t, adapter, run, environment)
+	adapter.onCancel = func() { replaceRunExecutionPod(t, r, environment) }
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)})
+	if err != nil || !result.Requeue || adapter.cancelled != 1 {
+		t.Fatalf("terminal cleanup stale Cancel = (%#v, %v), calls %d", result, err, adapter.cancelled)
+	}
+	var retainedEnvironment platformv1alpha1.Environment
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(environment), &retainedEnvironment); err != nil {
+		t.Fatal(err)
+	}
+	if retainedEnvironment.Status.ClaimedBy == nil || retainedEnvironment.Status.ClaimedBy.UID != run.UID {
+		t.Fatalf("terminal cleanup released claim after stale Cancel: %#v", retainedEnvironment.Status.ClaimedBy)
+	}
+	var retainedRun platformv1alpha1.Run
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &retainedRun); err != nil {
+		t.Fatal(err)
+	}
+	condition := apiMeta.FindStatusCondition(retainedRun.Status.Conditions, runConditionEnvironmentReady)
+	if condition != nil && condition.Reason == "EnvironmentReleased" {
+		t.Fatalf("terminal cleanup published release after stale Cancel: %#v", condition)
+	}
+}
+
+func TestFinalizerRetainsClaimWhenExecutionChangesDuringCancel(t *testing.T) {
+	now := metav1.Now()
+	epoch, executionGeneration := int64(0), int64(1)
+	run := &platformv1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{Name: "run", Namespace: "ns", UID: "run-uid", Finalizers: []string{runFinalizer}, DeletionTimestamp: &now},
+		Spec:       platformv1alpha1.RunSpec{Agent: "test"},
+		Status: platformv1alpha1.RunStatus{
+			State: platformv1alpha1.RunStateRunning,
+			EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{
+				Name: "environment", UID: "env-uid", Ownership: platformv1alpha1.EnvironmentOwnershipClaimed,
+			},
+			AcceptedEnvironmentEpoch:               &epoch,
+			AcceptedEnvironmentExecutionGeneration: &executionGeneration,
+			Conditions:                             []metav1.Condition{{Type: runConditionAdapterAccepted, Status: metav1.ConditionTrue, Reason: "AdapterAccepted"}},
+		},
+	}
+	environment := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "environment", Namespace: "ns", UID: "env-uid"},
+		Status: platformv1alpha1.EnvironmentStatus{
+			Phase: platformv1alpha1.EnvironmentPhaseReady, ClaimedBy: &platformv1alpha1.RunReference{Name: run.Name, UID: run.UID},
+		},
+	}
+	adapter := &scriptedAdapter{}
+	r := reconciler(t, adapter, run, environment)
+	adapter.onCancel = func() {
+		var pod corev1.Pod
+		if err := r.Get(context.Background(), types.NamespacedName{Namespace: environment.Namespace, Name: "env-environment"}, &pod); err != nil {
+			t.Fatal(err)
+		}
+		pod.UID = "replacement-pod"
+		if err := r.Update(context.Background(), &pod); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)})
+	if err != nil || !result.Requeue || adapter.cancelled != 1 {
+		t.Fatalf("finalizer stale Cancel reconcile = (%#v, %v), calls %d", result, err, adapter.cancelled)
+	}
+	var retainedRun platformv1alpha1.Run
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &retainedRun); err != nil {
+		t.Fatal(err)
+	}
+	if !controllerutil.ContainsFinalizer(&retainedRun, runFinalizer) {
+		t.Fatal("stale finalizer Cancel removed finalizer")
+	}
+	var retainedEnvironment platformv1alpha1.Environment
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(environment), &retainedEnvironment); err != nil {
+		t.Fatal(err)
+	}
+	if retainedEnvironment.Status.ClaimedBy == nil || retainedEnvironment.Status.ClaimedBy.UID != run.UID {
+		t.Fatalf("stale finalizer Cancel released claim: %#v", retainedEnvironment.Status.ClaimedBy)
 	}
 }
 

--- a/internal/controllers/warmpool_controller_test.go
+++ b/internal/controllers/warmpool_controller_test.go
@@ -388,6 +388,7 @@ func TestWarmPoolTransientFailureRecoversDuringGrace(t *testing.T) {
 	if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(env), &recovering); err != nil {
 		t.Fatal(err)
 	}
+	recovering.Status.ExecutionGeneration = 1
 	applyEnvironmentStatus(&recovering, platformv1alpha1.EnvironmentPhaseReady, "pod", "10.0.0.1:50051", "SandboxdReady", "ready", nil)
 	if err := baseClient.Status().Update(context.Background(), &recovering); err != nil {
 		t.Fatal(err)
@@ -639,6 +640,7 @@ func TestWarmPoolLiveMembershipSnapshotBoundsSurgeWithStaleCache(t *testing.T) {
 		if env.Status.Phase == platformv1alpha1.EnvironmentPhaseFailed {
 			continue
 		}
+		env.Status.ExecutionGeneration = 1
 		applyEnvironmentStatus(env, platformv1alpha1.EnvironmentPhaseReady, "pod-"+env.Name, "10.0.0.1:50051", "SandboxdReady", "ready", nil)
 		if err := liveClient.Status().Update(context.Background(), env); err != nil {
 			t.Fatal(err)
@@ -848,6 +850,9 @@ func TestWarmPoolTemplateGenerationChangePreventsMemberCreation(t *testing.T) {
 
 func setWarmPoolOwner(t *testing.T, scheme *runtime.Scheme, tmpl *platformv1alpha1.EnvironmentTemplate, env *platformv1alpha1.Environment) {
 	t.Helper()
+	if env.Status.Phase == platformv1alpha1.EnvironmentPhaseReady || env.Status.Phase == platformv1alpha1.EnvironmentPhaseRunning {
+		env.Status.ExecutionGeneration = 1
+	}
 	if err := controllerutil.SetControllerReference(tmpl, env, scheme, controllerutil.WithBlockOwnerDeletion(false)); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/controlplane/api_contract_test.go
+++ b/internal/controlplane/api_contract_test.go
@@ -43,11 +43,12 @@ func TestAPIContractFixturesAreCanonicalHandlerAndMapperOutput(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "run-fix-flaky-42", UID: "676d16c3-e625-4c36-a97c-e93065d05121", CreationTimestamp: metav1.NewTime(environmentCreated), Generation: 2},
 		Spec:       platformv1alpha1.EnvironmentSpec{ProjectRef: "org-repo", TemplateRef: "small", Backend: platformv1alpha1.EnvironmentBackendPod},
 		Status: platformv1alpha1.EnvironmentStatus{
-			ObservedGeneration: 2,
-			Phase:              platformv1alpha1.EnvironmentPhaseRunning,
-			ClaimedBy:          &platformv1alpha1.RunReference{Name: "fix-flaky-42", UID: types.UID("eb7e3ff7-8117-4caf-912d-167b70eaee21")},
-			LastActiveAt:       &lastActive,
-			Conditions:         []metav1.Condition{{Type: platformv1alpha1.EnvironmentConditionReady, Status: metav1.ConditionTrue, ObservedGeneration: 2}},
+			ObservedGeneration:  2,
+			ExecutionGeneration: 1,
+			Phase:               platformv1alpha1.EnvironmentPhaseRunning,
+			ClaimedBy:           &platformv1alpha1.RunReference{Name: "fix-flaky-42", UID: types.UID("eb7e3ff7-8117-4caf-912d-167b70eaee21")},
+			LastActiveAt:        &lastActive,
+			Conditions:          []metav1.Condition{{Type: platformv1alpha1.EnvironmentConditionReady, Status: metav1.ConditionTrue, ObservedGeneration: 2}},
 		},
 	}
 

--- a/internal/controlplane/resource_service_test.go
+++ b/internal/controlplane/resource_service_test.go
@@ -304,7 +304,7 @@ func TestResourceServiceEnvironmentReadinessDefaultAndRedaction(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "env", Namespace: "ns", UID: "uid", Generation: 2},
 		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small"},
 		Status: platformv1alpha1.EnvironmentStatus{
-			ObservedGeneration: 1, Phase: platformv1alpha1.EnvironmentPhaseReady,
+			ObservedGeneration: 1, ExecutionGeneration: 1, Phase: platformv1alpha1.EnvironmentPhaseReady,
 			Endpoints: platformv1alpha1.EnvironmentEndpoints{Sandboxd: "secret:123"}, PodName: "pod", ImageID: "sha256:secret", LastActiveAt: &now,
 			Conditions: []metav1.Condition{{Type: platformv1alpha1.EnvironmentConditionReady, Status: metav1.ConditionTrue, ObservedGeneration: 1}},
 		},

--- a/internal/controlplane/terminal.go
+++ b/internal/controlplane/terminal.go
@@ -134,10 +134,11 @@ func (d KubernetesTerminalDialer) dialTerminal(ctx context.Context, namespace, n
 		}
 	}
 	policyRevision := lifecycle.HoldPolicyRevision(&environment)
+	executionGeneration := environment.Status.ExecutionGeneration
 	if err := terminalAccessPolicyError(&environment); err != nil {
 		return nil, nil, nil, err
 	}
-	if err := d.markActive(ctx, &environment, expectedEnvironmentUID, policyRevision); err != nil {
+	if err := d.markActive(ctx, &environment, expectedEnvironmentUID, executionGeneration, policyRevision); err != nil {
 		return nil, nil, nil, err
 	}
 	heartbeatInterval, err := d.activityHeartbeatInterval(ctx, &environment)
@@ -152,7 +153,7 @@ func (d KubernetesTerminalDialer) dialTerminal(ctx context.Context, namespace, n
 		}
 	}()
 	connectionLease := &terminalConnectionLease{}
-	go d.heartbeatActivity(heartbeatContext, types.NamespacedName{Namespace: namespace, Name: name}, expectedEnvironmentUID, policyRevision, heartbeatInterval, association, connectionLease.boundExecution, func() { _ = connectionLease.Close() })
+	go d.heartbeatActivity(heartbeatContext, types.NamespacedName{Namespace: namespace, Name: name}, expectedEnvironmentUID, executionGeneration, policyRevision, heartbeatInterval, association, connectionLease.boundExecution, func() { _ = connectionLease.Close() })
 	if err := d.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &environment); err != nil {
 		return nil, nil, nil, fmt.Errorf("refresh environment lifecycle: %w", err)
 	}
@@ -175,7 +176,7 @@ func (d KubernetesTerminalDialer) dialTerminal(ctx context.Context, namespace, n
 		if err := d.waitUntilReady(ctx, namespace, name, expectedEnvironmentUID, &environment); err != nil {
 			return nil, nil, nil, err
 		}
-		if err := d.markActive(ctx, &environment, expectedEnvironmentUID, policyRevision); err != nil {
+		if err := d.markActive(ctx, &environment, expectedEnvironmentUID, environment.Status.ExecutionGeneration, policyRevision); err != nil {
 			return nil, nil, nil, err
 		}
 	}
@@ -236,7 +237,7 @@ func (d KubernetesTerminalDialer) activityHeartbeatInterval(ctx context.Context,
 	return timeout / 2, nil
 }
 
-func (d KubernetesTerminalDialer) heartbeatActivity(ctx context.Context, key types.NamespacedName, expectedUID types.UID, policyRevision int64, interval time.Duration, association *RunTerminalAssociation, boundExecution func() (sandboxclient.TerminalExecution, bool), revoke func()) {
+func (d KubernetesTerminalDialer) heartbeatActivity(ctx context.Context, key types.NamespacedName, expectedUID types.UID, executionGeneration, policyRevision int64, interval time.Duration, association *RunTerminalAssociation, boundExecution func() (sandboxclient.TerminalExecution, bool), revoke func()) {
 	retryInterval := interval / 4
 	if retryInterval <= 0 || retryInterval > time.Second {
 		retryInterval = time.Second
@@ -259,7 +260,7 @@ func (d KubernetesTerminalDialer) heartbeatActivity(ctx context.Context, key typ
 					continue
 				}
 			}
-			revision, held, err := d.readTerminalPolicy(ctx, key, expectedUID, boundExecution)
+			generation, revision, held, err := d.readTerminalPolicy(ctx, key, expectedUID, boundExecution)
 			if err != nil {
 				if errors.Is(err, errTerminalEnvironmentIncarnationChanged) {
 					revoke()
@@ -274,9 +275,10 @@ func (d KubernetesTerminalDialer) heartbeatActivity(ctx context.Context, key typ
 			if revision > policyRevision {
 				policyRevision = revision
 			}
+			executionGeneration = generation
 		case <-timer.C:
 			for {
-				revision, held, err := d.readTerminalPolicy(ctx, key, expectedUID, boundExecution)
+				generation, revision, held, err := d.readTerminalPolicy(ctx, key, expectedUID, boundExecution)
 				if err != nil {
 					if errors.Is(err, errTerminalEnvironmentIncarnationChanged) {
 						revoke()
@@ -292,8 +294,9 @@ func (d KubernetesTerminalDialer) heartbeatActivity(ctx context.Context, key typ
 				if revision > policyRevision {
 					policyRevision = revision
 				}
+				executionGeneration = generation
 				environment := platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Namespace: key.Namespace, Name: key.Name}}
-				err = d.markActive(ctx, &environment, expectedUID, policyRevision)
+				err = d.markActive(ctx, &environment, expectedUID, executionGeneration, policyRevision)
 				if err == nil {
 					timer.Reset(interval)
 					break
@@ -302,8 +305,16 @@ func (d KubernetesTerminalDialer) heartbeatActivity(ctx context.Context, key typ
 					revoke()
 					return
 				}
+				if errors.Is(err, lifecycle.ErrExecutionGenerationChanged) {
+					if _, bound := boundExecution(); bound {
+						revoke()
+						return
+					}
+					timer.Reset(retryInterval)
+					break
+				}
 				if errors.Is(err, lifecycle.ErrHoldPolicyChanged) {
-					revision, held, refreshErr := d.refreshHoldPolicy(ctx, key, expectedUID, policyRevision)
+					generation, revision, held, refreshErr := d.refreshHoldPolicy(ctx, key, expectedUID, policyRevision)
 					if refreshErr != nil {
 						if errors.Is(refreshErr, errTerminalEnvironmentIncarnationChanged) {
 							revoke()
@@ -312,6 +323,7 @@ func (d KubernetesTerminalDialer) heartbeatActivity(ctx context.Context, key typ
 						timer.Reset(retryInterval)
 						break
 					}
+					executionGeneration = generation
 					if held || revision <= policyRevision {
 						revoke()
 						return
@@ -363,44 +375,44 @@ func (d KubernetesTerminalDialer) holdPolicyPollInterval() time.Duration {
 	return terminalPolicyPollInterval
 }
 
-func (d KubernetesTerminalDialer) readTerminalPolicy(ctx context.Context, key types.NamespacedName, expectedUID types.UID, boundExecution func() (sandboxclient.TerminalExecution, bool)) (int64, bool, error) {
+func (d KubernetesTerminalDialer) readTerminalPolicy(ctx context.Context, key types.NamespacedName, expectedUID types.UID, boundExecution func() (sandboxclient.TerminalExecution, bool)) (int64, int64, bool, error) {
 	var environment platformv1alpha1.Environment
 	if err := d.Client.Get(ctx, key, &environment); err != nil {
-		return 0, false, err
+		return 0, 0, false, err
 	}
 	if environment.UID != expectedUID {
-		return 0, false, errTerminalEnvironmentIncarnationChanged
+		return 0, 0, false, errTerminalEnvironmentIncarnationChanged
 	}
 	if boundExecution != nil {
 		if execution, bound := boundExecution(); bound {
-			current, err := (sandboxclient.Connector{Reader: d.Client}).TerminalExecutionCurrent(ctx, key.Namespace, key.Name, execution)
+			current, err := (sandboxclient.Connector{Reader: d.Client}).ExecutionCurrent(ctx, key.Namespace, key.Name, execution)
 			if err != nil {
-				return 0, false, err
+				return 0, 0, false, err
 			}
 			if !current {
-				return 0, false, errTerminalEnvironmentIncarnationChanged
+				return 0, 0, false, errTerminalEnvironmentIncarnationChanged
 			}
 		}
 	}
 	revision := lifecycle.HoldPolicyRevision(&environment)
-	return revision, environment.Spec.Lifecycle.Hold != nil && environment.Spec.Lifecycle.Hold.Enabled, nil
+	return environment.Status.ExecutionGeneration, revision, environment.Spec.Lifecycle.Hold != nil && environment.Spec.Lifecycle.Hold.Enabled, nil
 }
 
-func (d KubernetesTerminalDialer) refreshHoldPolicy(ctx context.Context, key types.NamespacedName, expectedUID types.UID, previousRevision int64) (int64, bool, error) {
-	revision, held, err := d.readTerminalPolicy(ctx, key, expectedUID, nil)
+func (d KubernetesTerminalDialer) refreshHoldPolicy(ctx context.Context, key types.NamespacedName, expectedUID types.UID, previousRevision int64) (int64, int64, bool, error) {
+	generation, revision, held, err := d.readTerminalPolicy(ctx, key, expectedUID, nil)
 	if err != nil {
-		return 0, false, err
+		return 0, 0, false, err
 	}
 	if revision <= previousRevision {
-		return revision, true, nil
+		return generation, revision, true, nil
 	}
-	return revision, held, nil
+	return generation, revision, held, nil
 }
 
-func (d KubernetesTerminalDialer) markActive(ctx context.Context, environment *platformv1alpha1.Environment, expectedUID types.UID, policyRevision int64) error {
+func (d KubernetesTerminalDialer) markActive(ctx context.Context, environment *platformv1alpha1.Environment, expectedUID types.UID, executionGeneration, policyRevision int64) error {
 	key := client.ObjectKeyFromObject(environment)
 	requestID := fmt.Sprintf("terminal/activity/%d", time.Now().UnixNano())
-	if err := lifecycle.RecordActivity(ctx, d.Client, key, expectedUID, policyRevision, platformv1alpha1.EnvironmentActivitySourceTerminal, requestID); err != nil {
+	if err := lifecycle.RecordActivity(ctx, d.Client, key, expectedUID, executionGeneration, policyRevision, platformv1alpha1.EnvironmentActivitySourceTerminal, requestID); err != nil {
 		if errors.Is(err, lifecycle.ErrEnvironmentIncarnationChanged) {
 			return fmt.Errorf("record environment activity: %w", errTerminalEnvironmentIncarnationChanged)
 		}

--- a/internal/controlplane/terminal_test.go
+++ b/internal/controlplane/terminal_test.go
@@ -414,12 +414,12 @@ func TestKubernetesTerminalDialerMarksEnvironmentActive(t *testing.T) {
 	oldActivity := metav1.NewTime(time.Now().Add(-time.Hour))
 	environment := &platformv1alpha1.Environment{
 		ObjectMeta: metav1.ObjectMeta{Name: "env-1", Namespace: "project-1", UID: "env-uid"},
-		Status:     platformv1alpha1.EnvironmentStatus{LastActiveAt: &oldActivity},
+		Status:     platformv1alpha1.EnvironmentStatus{ExecutionGeneration: 1, LastActiveAt: &oldActivity},
 	}
 	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment).Build()
 	dialer := KubernetesTerminalDialer{Client: kubeClient}
 
-	if err := dialer.markActive(context.Background(), environment, environment.UID, 0); err != nil {
+	if err := dialer.markActive(context.Background(), environment, environment.UID, 1, 0); err != nil {
 		t.Fatalf("markActive() error = %v", err)
 	}
 	var updated platformv1alpha1.Environment
@@ -437,12 +437,12 @@ func TestKubernetesTerminalDialerDoesNotMarkReplacementEnvironmentActive(t *test
 	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
 		t.Fatal(err)
 	}
-	original := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "env-1", Namespace: "project-1", UID: "old-uid"}}
+	original := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "env-1", Namespace: "project-1", UID: "old-uid"}, Status: platformv1alpha1.EnvironmentStatus{ExecutionGeneration: 1}}
 	replacement := original.DeepCopy()
 	replacement.UID = "new-uid"
 	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(replacement).WithObjects(replacement).Build()
 	dialer := KubernetesTerminalDialer{Client: kubeClient}
-	if err := dialer.markActive(context.Background(), original, original.UID, 0); err == nil || !strings.Contains(err.Error(), "incarnation changed") {
+	if err := dialer.markActive(context.Background(), original, original.UID, 1, 0); err == nil || !strings.Contains(err.Error(), "incarnation changed") {
 		t.Fatalf("markActive() replacement error = %v", err)
 	}
 	var updated platformv1alpha1.Environment
@@ -525,13 +525,13 @@ func TestTerminalHeartbeatRecoversAfterTransientGetFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 	oldActivity := metav1.NewTime(time.Now().Add(-time.Hour))
-	environment := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "env-1", Namespace: "project-1", UID: "env-uid"}, Status: platformv1alpha1.EnvironmentStatus{LastActiveAt: &oldActivity}}
+	environment := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "env-1", Namespace: "project-1", UID: "env-uid"}, Status: platformv1alpha1.EnvironmentStatus{ExecutionGeneration: 1, LastActiveAt: &oldActivity}}
 	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment).Build()
 	transient := &transientTerminalGetClient{Client: baseClient, getFailures: 1, updateFailures: 1}
 	dialer := KubernetesTerminalDialer{Client: transient}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 0, 5*time.Millisecond, nil, nil, func() {})
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 1, 0, 5*time.Millisecond, nil, nil, func() {})
 
 	deadline := time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {
@@ -554,6 +554,7 @@ func TestTerminalHeartbeatAdoptsNewerDisabledHoldRevision(t *testing.T) {
 	}
 	environment := &platformv1alpha1.Environment{
 		ObjectMeta: metav1.ObjectMeta{Name: "env-1", Namespace: "project-1", UID: "env-uid"},
+		Status:     platformv1alpha1.EnvironmentStatus{ExecutionGeneration: 1},
 		Spec: platformv1alpha1.EnvironmentSpec{Lifecycle: platformv1alpha1.EnvironmentLifecycleSpec{
 			Hold: &platformv1alpha1.EnvironmentHoldPolicy{Revision: 1},
 		}},
@@ -563,7 +564,7 @@ func TestTerminalHeartbeatAdoptsNewerDisabledHoldRevision(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	revoked := atomic.Bool{}
-	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 1, 20*time.Millisecond, nil, nil, func() { revoked.Store(true) })
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 1, 1, 20*time.Millisecond, nil, nil, func() { revoked.Store(true) })
 
 	var updated platformv1alpha1.Environment
 	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(environment), &updated); err != nil {
@@ -586,6 +587,7 @@ func TestTerminalHeartbeatRevokesConnectionWhenHoldEnabled(t *testing.T) {
 	}
 	environment := &platformv1alpha1.Environment{
 		ObjectMeta: metav1.ObjectMeta{Name: "env-1", Namespace: "project-1", UID: "env-uid"},
+		Status:     platformv1alpha1.EnvironmentStatus{ExecutionGeneration: 1},
 		Spec: platformv1alpha1.EnvironmentSpec{Lifecycle: platformv1alpha1.EnvironmentLifecycleSpec{
 			Hold: &platformv1alpha1.EnvironmentHoldPolicy{Revision: 1},
 		}},
@@ -600,7 +602,7 @@ func TestTerminalHeartbeatRevokesConnectionWhenHoldEnabled(t *testing.T) {
 	if !lease.attach(closeFunc(func() error { close(closed); return nil }), sandboxclient.TerminalExecution{}) {
 		t.Fatal("failed to attach test terminal connection")
 	}
-	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 1, time.Hour, nil, nil, func() { _ = lease.Close() })
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 1, 1, time.Hour, nil, nil, func() { _ = lease.Close() })
 
 	var updated platformv1alpha1.Environment
 	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(environment), &updated); err != nil {
@@ -627,6 +629,7 @@ func TestTerminalPolicyPollRetriesTransientFailuresAndRevokesRecoveredHold(t *te
 	}
 	environment := &platformv1alpha1.Environment{
 		ObjectMeta: metav1.ObjectMeta{Name: "env-1", Namespace: "project-1", UID: "env-uid"},
+		Status:     platformv1alpha1.EnvironmentStatus{ExecutionGeneration: 1},
 		Spec: platformv1alpha1.EnvironmentSpec{Lifecycle: platformv1alpha1.EnvironmentLifecycleSpec{
 			Hold: &platformv1alpha1.EnvironmentHoldPolicy{Revision: 1},
 		}},
@@ -638,7 +641,7 @@ func TestTerminalPolicyPollRetriesTransientFailuresAndRevokesRecoveredHold(t *te
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	closed := make(chan struct{})
-	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 1, time.Hour, nil, nil, func() { close(closed) })
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 1, 1, time.Hour, nil, nil, func() { close(closed) })
 
 	for range 2 {
 		select {
@@ -672,7 +675,7 @@ func TestTerminalHeartbeatRevokesConnectionForReplacementUID(t *testing.T) {
 	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
 		t.Fatal(err)
 	}
-	environment := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "env-1", Namespace: "project-1", UID: "old-uid"}}
+	environment := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "env-1", Namespace: "project-1", UID: "old-uid"}, Status: platformv1alpha1.EnvironmentStatus{ExecutionGeneration: 1}}
 	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment).Build()
 	dialer := KubernetesTerminalDialer{Client: kubeClient, policyPollInterval: time.Millisecond}
 	ctx, cancel := context.WithCancel(context.Background())
@@ -682,7 +685,7 @@ func TestTerminalHeartbeatRevokesConnectionForReplacementUID(t *testing.T) {
 	if !lease.attach(closeFunc(func() error { close(closed); return nil }), sandboxclient.TerminalExecution{}) {
 		t.Fatal("failed to attach test terminal connection")
 	}
-	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 0, time.Hour, nil, nil, func() { _ = lease.Close() })
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 1, 0, time.Hour, nil, nil, func() { _ = lease.Close() })
 
 	if err := kubeClient.Delete(context.Background(), environment); err != nil {
 		t.Fatal(err)
@@ -749,24 +752,29 @@ func TestTerminalHeartbeatRevokesConnectionWhenBoundExecutionChanges(t *testing.
 			}
 			environment := &platformv1alpha1.Environment{
 				ObjectMeta: metav1.ObjectMeta{Name: "env-1", Namespace: "project-1", UID: "env-uid", Generation: 1},
+				Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "default"},
 				Status:     platformv1alpha1.EnvironmentStatus{Lifecycle: platformv1alpha1.EnvironmentLifecycleStatus{Epoch: 4}},
 			}
 			applyReadyTerminalStatus(environment, "env-env-1")
-			pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: environment.Status.PodName, Namespace: environment.Namespace, UID: "pod-uid-1"}}
-			baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment, pod).Build()
+			pod := currentExecutionPod(environment, "pod-uid-1")
+			template := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: environment.Namespace}}
+			baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment, pod, template).Build()
 			kubeClient := &activityCountingClient{Client: baseClient}
 			// Delay the ordinary policy poll so only the activity timer's
 			// immediate execution check can revoke this stale lease.
 			dialer := KubernetesTerminalDialer{Client: kubeClient, policyPollInterval: time.Hour}
 			lease := &terminalConnectionLease{}
 			closed := make(chan struct{})
-			execution := sandboxclient.TerminalExecution{EnvironmentUID: environment.UID, LifecycleEpoch: 4, PodName: pod.Name, PodUID: pod.UID}
+			execution, err := (sandboxclient.Connector{Reader: baseClient}).ResolveExecution(context.Background(), environment.Namespace, environment.Name, environment.UID, 1, 4)
+			if err != nil {
+				t.Fatal(err)
+			}
 			if !lease.attach(closeFunc(func() error { close(closed); return nil }), execution) {
 				t.Fatal("failed to bind terminal execution")
 			}
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 0, 10*time.Millisecond, nil, lease.boundExecution, func() { _ = lease.Close() })
+			go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 1, 0, 10*time.Millisecond, nil, lease.boundExecution, func() { _ = lease.Close() })
 
 			if err := test.mutate(context.Background(), baseClient, environment, pod); err != nil {
 				t.Fatal(err)
@@ -793,23 +801,28 @@ func TestTerminalExecutionPolicyPollRetriesTransientPodRead(t *testing.T) {
 	}
 	environment := &platformv1alpha1.Environment{
 		ObjectMeta: metav1.ObjectMeta{Name: "env-1", Namespace: "project-1", UID: "env-uid", Generation: 1},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "default"},
 		Status:     platformv1alpha1.EnvironmentStatus{Lifecycle: platformv1alpha1.EnvironmentLifecycleStatus{Epoch: 2}},
 	}
 	applyReadyTerminalStatus(environment, "env-env-1")
-	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: environment.Status.PodName, Namespace: environment.Namespace, UID: "pod-uid"}}
-	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment, pod).Build()
+	pod := currentExecutionPod(environment, "pod-uid")
+	template := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: environment.Namespace}}
+	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment, pod, template).Build()
 	failed := make(chan struct{}, 1)
 	kubeClient := &transientPodGetClient{Client: baseClient, failures: 1, failed: failed}
 	dialer := KubernetesTerminalDialer{Client: kubeClient, policyPollInterval: time.Millisecond}
 	lease := &terminalConnectionLease{}
 	closed := make(chan struct{})
-	execution := sandboxclient.TerminalExecution{EnvironmentUID: environment.UID, LifecycleEpoch: 2, PodName: pod.Name, PodUID: pod.UID}
+	execution, err := (sandboxclient.Connector{Reader: baseClient}).ResolveExecution(context.Background(), environment.Namespace, environment.Name, environment.UID, 1, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !lease.attach(closeFunc(func() error { close(closed); return nil }), execution) {
 		t.Fatal("failed to bind terminal execution")
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 0, time.Hour, nil, lease.boundExecution, func() { _ = lease.Close() })
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 1, 0, time.Hour, nil, lease.boundExecution, func() { _ = lease.Close() })
 
 	select {
 	case <-failed:
@@ -901,7 +914,7 @@ func TestRunTerminalHeartbeatRevokesAfterAssociationLoss(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	revoked := make(chan struct{})
-	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 0, time.Hour, association, nil, func() { close(revoked) })
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 1, 0, time.Hour, association, nil, func() { close(revoked) })
 
 	var updated platformv1alpha1.Environment
 	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(environment), &updated); err != nil {
@@ -1013,11 +1026,13 @@ func TestKubernetesTerminalDialerActivityPreservesReadyGeneration(t *testing.T) 
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "env-pod", Namespace: environment.Namespace, UID: "pod-uid",
 			Annotations: map[string]string{
+				"swe.dev/execution-generation":  "1",
 				sandboxdauth.IdentityAnnotation: "env-pod.sandboxd.swe.dev",
 				sandboxdauth.TrustAnnotation:    testCertificatePEM(t, "env-pod.sandboxd.swe.dev"),
 				sandboxdauth.TokenAnnotation:    "terminal-token",
 			},
 		},
+		Spec:   corev1.PodSpec{RestartPolicy: corev1.RestartPolicyNever},
 		Status: corev1.PodStatus{PodIP: "192.0.2.10", Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}},
 	}
 	if err := controllerutil.SetControllerReference(environment, pod, scheme); err != nil {
@@ -1056,7 +1071,7 @@ func TestKubernetesTerminalDialerUsesRecreatedPodCredentialsAfterWake(t *testing
 			TemplateRef: "default",
 		},
 		Status: platformv1alpha1.EnvironmentStatus{
-			Phase: platformv1alpha1.EnvironmentPhasePaused, PodName: "old-pod",
+			ExecutionGeneration: 1, Phase: platformv1alpha1.EnvironmentPhasePaused, PodName: "old-pod",
 			Lifecycle: platformv1alpha1.EnvironmentLifecycleStatus{Suspended: true, SuspensionReason: platformv1alpha1.EnvironmentSuspensionReasonIdle, Epoch: 1},
 		},
 	}
@@ -1069,11 +1084,13 @@ func TestKubernetesTerminalDialerUsesRecreatedPodCredentialsAfterWake(t *testing
 			Namespace: environment.Namespace,
 			UID:       "new-pod-uid",
 			Annotations: map[string]string{
+				"swe.dev/execution-generation":  "1",
 				sandboxdauth.IdentityAnnotation: "new-incarnation.sandboxd.swe.dev",
 				sandboxdauth.TrustAnnotation:    testCertificatePEM(t, "new-incarnation.sandboxd.swe.dev"),
 				sandboxdauth.TokenAnnotation:    "new-terminal-token",
 			},
 		},
+		Spec:   corev1.PodSpec{RestartPolicy: corev1.RestartPolicyNever},
 		Status: corev1.PodStatus{PodIP: "192.0.2.10", Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}},
 	}
 	if err := controllerutil.SetControllerReference(environment, newPod, scheme); err != nil {
@@ -1109,7 +1126,7 @@ func TestTerminalHeartbeatProtectsSlowWakeBeforeConnection(t *testing.T) {
 	environment := &platformv1alpha1.Environment{
 		ObjectMeta: metav1.ObjectMeta{Name: "env-1", Namespace: "project-1", UID: "current-environment"},
 		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "default"},
-		Status:     platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhasePaused, Lifecycle: platformv1alpha1.EnvironmentLifecycleStatus{Suspended: true, SuspensionReason: platformv1alpha1.EnvironmentSuspensionReasonIdle, Epoch: 1}},
+		Status:     platformv1alpha1.EnvironmentStatus{ExecutionGeneration: 1, Phase: platformv1alpha1.EnvironmentPhasePaused, Lifecycle: platformv1alpha1.EnvironmentLifecycleStatus{Suspended: true, SuspensionReason: platformv1alpha1.EnvironmentSuspensionReasonIdle, Epoch: 1}},
 	}
 	template := &platformv1alpha1.EnvironmentTemplate{
 		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: environment.Namespace},
@@ -1119,11 +1136,13 @@ func TestTerminalHeartbeatProtectsSlowWakeBeforeConnection(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "new-pod", Namespace: environment.Namespace, UID: "new-pod-uid",
 			Annotations: map[string]string{
+				"swe.dev/execution-generation":  "1",
 				sandboxdauth.IdentityAnnotation: "new-incarnation.sandboxd.swe.dev",
 				sandboxdauth.TrustAnnotation:    testCertificatePEM(t, "new-incarnation.sandboxd.swe.dev"),
 				sandboxdauth.TokenAnnotation:    "new-terminal-token",
 			},
 		},
+		Spec:   corev1.PodSpec{RestartPolicy: corev1.RestartPolicyNever},
 		Status: corev1.PodStatus{PodIP: "192.0.2.10", Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}},
 	}
 	if err := controllerutil.SetControllerReference(environment, pod, scheme); err != nil {
@@ -1294,6 +1313,7 @@ func (*failingWakeClient) Patch(context.Context, client.Object, client.Patch, ..
 }
 
 func applyReadyTerminalStatus(environment *platformv1alpha1.Environment, podName string) {
+	environment.Status.ExecutionGeneration = 1
 	environment.Status.Phase = platformv1alpha1.EnvironmentPhaseReady
 	environment.Status.Lifecycle.Suspended = false
 	environment.Status.Lifecycle.SuspensionReason = ""
@@ -1304,6 +1324,23 @@ func applyReadyTerminalStatus(environment *platformv1alpha1.Environment, podName
 		Type: platformv1alpha1.EnvironmentConditionReady, Status: metav1.ConditionTrue,
 		ObservedGeneration: environment.Generation, Reason: "SandboxdReady", Message: "sandboxd is ready",
 	})
+}
+
+func currentExecutionPod(environment *platformv1alpha1.Environment, uid types.UID) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: environment.Status.PodName, Namespace: environment.Namespace, UID: uid,
+			Annotations: map[string]string{"swe.dev/execution-generation": "1"},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: platformv1alpha1.GroupVersion.String(), Kind: "Environment", Name: environment.Name,
+				UID: environment.UID, Controller: ptrTo(true),
+			}},
+		},
+		Spec: corev1.PodSpec{RestartPolicy: corev1.RestartPolicyNever},
+		Status: corev1.PodStatus{
+			PodIP: "192.0.2.10", Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+		},
+	}
 }
 
 type wakeReadyClient struct {
@@ -1491,7 +1528,7 @@ func TestKubernetesTerminalDialerRejectsPodOwnedByAnotherEnvironmentIncarnation(
 		ObjectMeta: metav1.ObjectMeta{Name: "env-1", Namespace: "project-1", UID: "current-environment"},
 		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "default"},
 		Status: platformv1alpha1.EnvironmentStatus{
-			Phase: platformv1alpha1.EnvironmentPhaseReady, PodName: "env-env-1", Endpoints: platformv1alpha1.EnvironmentEndpoints{Sandboxd: "192.0.2.10:50051"},
+			ExecutionGeneration: 1, Phase: platformv1alpha1.EnvironmentPhaseReady, PodName: "env-env-1", Endpoints: platformv1alpha1.EnvironmentEndpoints{Sandboxd: "192.0.2.10:50051"},
 			Conditions: []metav1.Condition{{Type: platformv1alpha1.EnvironmentConditionReady, Status: metav1.ConditionTrue, Reason: "SandboxdReady", Message: "sandboxd is ready"}},
 		},
 	}

--- a/internal/lifecycle/intent.go
+++ b/internal/lifecycle/intent.go
@@ -17,6 +17,7 @@ import (
 )
 
 var ErrEnvironmentIncarnationChanged = errors.New("environment incarnation changed")
+var ErrExecutionGenerationChanged = errors.New("environment execution generation changed")
 var ErrHoldPolicyChanged = errors.New("environment hold policy changed")
 
 const activityAnnotationPrefix = "lifecycle.swe.dev/activity-"
@@ -76,12 +77,13 @@ func RequestSuspend(ctx context.Context, kube client.Client, key types.Namespace
 // RecordActivity publishes one source's latest activity intent. Activity uses
 // fixed metadata slots so heartbeats are durable without advancing generation;
 // only execution-contract changes make Environment status stale.
-func RecordActivity(ctx context.Context, kube client.Client, key types.NamespacedName, expectedUID types.UID, policyRevision int64, source platformv1alpha1.EnvironmentActivitySource, requestID string) error {
+func RecordActivity(ctx context.Context, kube client.Client, key types.NamespacedName, expectedUID types.UID, executionGeneration, policyRevision int64, source platformv1alpha1.EnvironmentActivitySource, requestID string) error {
 	request := platformv1alpha1.EnvironmentActivityRequest{
 		Source: source,
 		EnvironmentLifecycleRequest: platformv1alpha1.EnvironmentLifecycleRequest{
 			ID: requestID, EnvironmentUID: expectedUID, HoldPolicyRevision: policyRevision,
 		},
+		ExecutionGeneration: executionGeneration,
 	}
 	if err := validateActivityRequest(request); err != nil {
 		return err
@@ -90,7 +92,7 @@ func RecordActivity(ctx context.Context, kube client.Client, key types.Namespace
 	if err != nil {
 		return fmt.Errorf("encode activity request: %w", err)
 	}
-	return patchIntent(ctx, kube, key, expectedUID, policyRevision, func(environment *platformv1alpha1.Environment) {
+	return patchActivityIntent(ctx, kube, key, expectedUID, executionGeneration, policyRevision, func(environment *platformv1alpha1.Environment) {
 		if environment.Annotations == nil {
 			environment.Annotations = make(map[string]string)
 		}
@@ -114,7 +116,8 @@ func ActivityRequests(environment *platformv1alpha1.Environment) []platformv1alp
 		}
 		var request platformv1alpha1.EnvironmentActivityRequest
 		if json.Unmarshal([]byte(value), &request) != nil || request.Source != source || validateActivityRequest(request) != nil ||
-			request.EnvironmentUID != environment.UID || request.HoldPolicyRevision != HoldPolicyRevision(environment) {
+			request.EnvironmentUID != environment.UID || request.ExecutionGeneration != environment.Status.ExecutionGeneration ||
+			request.HoldPolicyRevision != HoldPolicyRevision(environment) {
 			continue
 		}
 		requests[request.Source] = request
@@ -145,6 +148,9 @@ func validateActivityRequest(request platformv1alpha1.EnvironmentActivityRequest
 	}
 	if request.EnvironmentUID == "" {
 		return fmt.Errorf("activity Environment UID must not be empty")
+	}
+	if request.ExecutionGeneration < 1 {
+		return fmt.Errorf("activity execution generation must be positive")
 	}
 	if request.HoldPolicyRevision < 0 {
 		return fmt.Errorf("activity hold policy revision must not be negative")
@@ -181,6 +187,30 @@ func patchIntent(ctx context.Context, kube client.Client, key types.NamespacedNa
 		before := environment.DeepCopy()
 		mutate(&environment)
 		if apiequality.Semantic.DeepEqual(before.Spec, environment.Spec) && apiequality.Semantic.DeepEqual(before.Annotations, environment.Annotations) {
+			return nil
+		}
+		return kube.Patch(ctx, &environment, client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{}))
+	})
+}
+
+func patchActivityIntent(ctx context.Context, kube client.Client, key types.NamespacedName, expectedUID types.UID, expectedExecutionGeneration, expectedPolicyRevision int64, mutate func(*platformv1alpha1.Environment)) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var environment platformv1alpha1.Environment
+		if err := kube.Get(ctx, key, &environment); err != nil {
+			return err
+		}
+		if environment.UID != expectedUID {
+			return ErrEnvironmentIncarnationChanged
+		}
+		if expectedExecutionGeneration < 1 || environment.Status.ExecutionGeneration != expectedExecutionGeneration {
+			return ErrExecutionGenerationChanged
+		}
+		if HoldPolicyRevision(&environment) != expectedPolicyRevision {
+			return ErrHoldPolicyChanged
+		}
+		before := environment.DeepCopy()
+		mutate(&environment)
+		if apiequality.Semantic.DeepEqual(before.Annotations, environment.Annotations) {
 			return nil
 		}
 		return kube.Patch(ctx, &environment, client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{}))

--- a/internal/lifecycle/intent_test.go
+++ b/internal/lifecycle/intent_test.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
 )
@@ -22,16 +23,17 @@ func TestRecordActivityIsSourceBoundedAndFenced(t *testing.T) {
 	environment.Name = "environment"
 	environment.Namespace = "project"
 	environment.UID = "env-uid"
+	environment.Status.ExecutionGeneration = 4
 	environment.Spec.Lifecycle.Hold = &platformv1alpha1.EnvironmentHoldPolicy{Revision: 3}
 	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(environment).Build()
 	key := client.ObjectKeyFromObject(environment)
 
 	for _, requestID := range []string{"terminal-1", "terminal-1", "terminal-2"} {
-		if err := RecordActivity(context.Background(), kubeClient, key, environment.UID, 3, platformv1alpha1.EnvironmentActivitySourceTerminal, requestID); err != nil {
+		if err := RecordActivity(context.Background(), kubeClient, key, environment.UID, 4, 3, platformv1alpha1.EnvironmentActivitySourceTerminal, requestID); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := RecordActivity(context.Background(), kubeClient, key, environment.UID, 3, platformv1alpha1.EnvironmentActivitySourcePortal, "portal-1"); err != nil {
+	if err := RecordActivity(context.Background(), kubeClient, key, environment.UID, 4, 3, platformv1alpha1.EnvironmentActivitySourcePortal, "portal-1"); err != nil {
 		t.Fatal(err)
 	}
 	var updated platformv1alpha1.Environment
@@ -45,7 +47,7 @@ func TestRecordActivityIsSourceBoundedAndFenced(t *testing.T) {
 	if updated.Generation != environment.Generation || len(updated.Spec.Lifecycle.Activity) != 0 {
 		t.Fatalf("activity changed execution spec: generation=%d spec=%#v", updated.Generation, updated.Spec.Lifecycle)
 	}
-	if err := RecordActivity(context.Background(), kubeClient, key, types.UID("replacement"), 3, platformv1alpha1.EnvironmentActivitySourceInbox, "stale"); err == nil {
+	if err := RecordActivity(context.Background(), kubeClient, key, types.UID("replacement"), 4, 3, platformv1alpha1.EnvironmentActivitySourceInbox, "stale"); err == nil {
 		t.Fatal("replacement UID activity was accepted")
 	}
 }
@@ -59,24 +61,27 @@ func TestRecordActivityRejectsMalformedRequests(t *testing.T) {
 	environment.Name = "environment"
 	environment.Namespace = "project"
 	environment.UID = "env-uid"
+	environment.Status.ExecutionGeneration = 4
 	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(environment).Build()
 	key := client.ObjectKeyFromObject(environment)
 
 	for _, test := range []struct {
-		name     string
-		uid      types.UID
-		revision int64
-		source   platformv1alpha1.EnvironmentActivitySource
-		id       string
+		name                string
+		uid                 types.UID
+		executionGeneration int64
+		revision            int64
+		source              platformv1alpha1.EnvironmentActivitySource
+		id                  string
 	}{
-		{name: "unknown source", uid: environment.UID, source: "Other", id: "request"},
-		{name: "empty ID", uid: environment.UID, source: platformv1alpha1.EnvironmentActivitySourceTerminal},
-		{name: "oversized ID", uid: environment.UID, source: platformv1alpha1.EnvironmentActivitySourceTerminal, id: string(make([]byte, 129))},
-		{name: "empty UID", source: platformv1alpha1.EnvironmentActivitySourceTerminal, id: "request"},
-		{name: "negative revision", uid: environment.UID, revision: -1, source: platformv1alpha1.EnvironmentActivitySourceTerminal, id: "request"},
+		{name: "unknown source", uid: environment.UID, executionGeneration: 4, source: "Other", id: "request"},
+		{name: "empty ID", uid: environment.UID, executionGeneration: 4, source: platformv1alpha1.EnvironmentActivitySourceTerminal},
+		{name: "oversized ID", uid: environment.UID, executionGeneration: 4, source: platformv1alpha1.EnvironmentActivitySourceTerminal, id: string(make([]byte, 129))},
+		{name: "empty UID", executionGeneration: 4, source: platformv1alpha1.EnvironmentActivitySourceTerminal, id: "request"},
+		{name: "zero execution generation", uid: environment.UID, source: platformv1alpha1.EnvironmentActivitySourceTerminal, id: "request"},
+		{name: "negative revision", uid: environment.UID, executionGeneration: 4, revision: -1, source: platformv1alpha1.EnvironmentActivitySourceTerminal, id: "request"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			if err := RecordActivity(context.Background(), kubeClient, key, test.uid, test.revision, test.source, test.id); err == nil {
+			if err := RecordActivity(context.Background(), kubeClient, key, test.uid, test.executionGeneration, test.revision, test.source, test.id); err == nil {
 				t.Fatal("RecordActivity() accepted malformed request")
 			}
 		})
@@ -93,9 +98,10 @@ func TestRecordActivityRejectsMalformedRequests(t *testing.T) {
 func TestMalformedAnnotationDoesNotShadowLegacyActivity(t *testing.T) {
 	environment := &platformv1alpha1.Environment{}
 	environment.UID = "env-uid"
+	environment.Status.ExecutionGeneration = 1
 	environment.Spec.Lifecycle.Activity = []platformv1alpha1.EnvironmentActivityRequest{{
 		Source:                      platformv1alpha1.EnvironmentActivitySourceTerminal,
-		EnvironmentLifecycleRequest: platformv1alpha1.EnvironmentLifecycleRequest{ID: "legacy", EnvironmentUID: environment.UID},
+		EnvironmentLifecycleRequest: platformv1alpha1.EnvironmentLifecycleRequest{ID: "legacy", EnvironmentUID: environment.UID}, ExecutionGeneration: 1,
 	}}
 	environment.Annotations = map[string]string{activityAnnotation(platformv1alpha1.EnvironmentActivitySourceTerminal): `{"source":"Terminal","id":"","environmentUID":"env-uid","holdPolicyRevision":0}`}
 
@@ -259,5 +265,47 @@ func TestStalePolicyPublisherCannotOverwriteCurrentIntent(t *testing.T) {
 	}
 	if retained.Spec.Lifecycle.Wake == nil || retained.Spec.Lifecycle.Wake.ID != "current" {
 		t.Fatalf("stale publisher replaced current wake: %#v", retained.Spec.Lifecycle.Wake)
+	}
+}
+
+func TestRecordActivityAtomicallyRejectsExecutionTransition(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	environment := &platformv1alpha1.Environment{}
+	environment.Name = "environment"
+	environment.Namespace = "project"
+	environment.UID = "env-uid"
+	environment.Status.ExecutionGeneration = 1
+	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment).Build()
+	transitioned := false
+	kubeClient := interceptor.NewClient(baseClient, interceptor.Funcs{
+		Patch: func(ctx context.Context, underlying client.WithWatch, object client.Object, patch client.Patch, options ...client.PatchOption) error {
+			if !transitioned {
+				transitioned = true
+				var current platformv1alpha1.Environment
+				if err := underlying.Get(ctx, client.ObjectKeyFromObject(environment), &current); err != nil {
+					return err
+				}
+				current.Status.ExecutionGeneration = 2
+				if err := underlying.Status().Update(ctx, &current); err != nil {
+					return err
+				}
+			}
+			return underlying.Patch(ctx, object, patch, options...)
+		},
+	})
+
+	err := RecordActivity(context.Background(), kubeClient, client.ObjectKeyFromObject(environment), environment.UID, 1, 0, platformv1alpha1.EnvironmentActivitySourceTerminal, "stale-terminal")
+	if !errors.Is(err, ErrExecutionGenerationChanged) {
+		t.Fatalf("RecordActivity() error = %v, want execution-generation fence", err)
+	}
+	var retained platformv1alpha1.Environment
+	if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(environment), &retained); err != nil {
+		t.Fatal(err)
+	}
+	if retained.Status.ExecutionGeneration != 2 || len(retained.Annotations) != 0 {
+		t.Fatalf("stale activity survived atomic transition: %#v", retained)
 	}
 }

--- a/internal/sandboxclient/process.go
+++ b/internal/sandboxclient/process.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"net"
+	"strconv"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -21,6 +22,7 @@ import (
 )
 
 const sandboxdPort = "50051"
+const executionGenerationAnnotation = "swe.dev/execution-generation"
 
 // Connector is the single Kubernetes resolution boundary for authenticated
 // sandboxd connections. Consumers identify an Environment and capability; they
@@ -32,20 +34,23 @@ type Connector struct {
 	Reader client.Reader
 }
 
-// TerminalExecution is the connector-owned identity of the exact backend
-// execution reached by a terminal connection. Consumers retain it opaquely and
-// ask the Connector whether it is still current.
-type TerminalExecution struct {
-	EnvironmentUID types.UID
-	LifecycleEpoch int64
-	PodName        string
-	PodUID         types.UID
+// Execution is a connector-owned opaque identity for one exact live backend
+// execution. Backend-specific observations never leave this package.
+type Execution struct {
+	environmentUID      types.UID
+	executionGeneration int64
+	lifecycleEpoch      int64
+	podName             string
+	podUID              types.UID
 }
+
+// TerminalExecution is retained as the terminal feature's opaque handle.
+type TerminalExecution = Execution
 
 // DialTerminal resolves the current ready Environment incarnation and returns
 // terminal and health clients sharing one authenticated, pod-pinned connection.
 func (c Connector) DialTerminal(ctx context.Context, namespace, environment string, environmentUID types.UID) (sandboxdv1.TerminalServiceClient, sandboxdv1.HealthServiceClient, TerminalExecution, func() error, error) {
-	env, pod, err := c.resolvePod(ctx, namespace, environment, environmentUID, nil)
+	env, pod, err := c.resolvePod(ctx, namespace, environment, environmentUID, nil, nil)
 	if err != nil {
 		return nil, nil, TerminalExecution{}, nil, err
 	}
@@ -57,17 +62,12 @@ func (c Connector) DialTerminal(ctx context.Context, namespace, environment stri
 	if err != nil {
 		return nil, nil, TerminalExecution{}, nil, err
 	}
-	execution := TerminalExecution{
-		EnvironmentUID: env.UID,
-		LifecycleEpoch: env.Status.Lifecycle.Epoch,
-		PodName:        pod.Name,
-		PodUID:         pod.UID,
-	}
+	execution := executionForPod(env, pod)
 	// Re-read after pinning the endpoint and credentials. A lifecycle transition
 	// or same-name Pod replacement racing the dial must not produce an attachment
 	// whose independent activity heartbeat can outlive that execution.
-	currentEnvironment, currentPod, err := c.resolvePod(ctx, namespace, environment, environmentUID, &execution.LifecycleEpoch)
-	if err != nil || currentEnvironment.Status.PodName != execution.PodName || currentPod.UID != execution.PodUID {
+	currentEnvironment, currentPod, err := c.resolvePod(ctx, namespace, environment, environmentUID, &execution.executionGeneration, &execution.lifecycleEpoch)
+	if err != nil || executionForPod(currentEnvironment, currentPod) != execution {
 		_ = conn.Close()
 		if err != nil {
 			return nil, nil, TerminalExecution{}, nil, fmt.Errorf("environment execution changed while resolving terminal endpoint: %w", err)
@@ -77,45 +77,71 @@ func (c Connector) DialTerminal(ctx context.Context, namespace, environment stri
 	return sandboxdv1.NewTerminalServiceClient(conn), sandboxdv1.NewHealthServiceClient(conn), execution, conn.Close, nil
 }
 
-// TerminalExecutionCurrent reports whether execution is still the active
-// backend for its Environment. Backend-specific identity checks stay behind
-// the connector boundary; API read failures remain retryable by the caller.
-func (c Connector) TerminalExecutionCurrent(ctx context.Context, namespace, environment string, execution TerminalExecution) (bool, error) {
-	var currentEnvironment platformv1alpha1.Environment
-	if err := c.Reader.Get(ctx, types.NamespacedName{Namespace: namespace, Name: environment}, &currentEnvironment); err != nil {
-		if apierrors.IsNotFound(err) {
-			return false, nil
-		}
+// ResolveExecution non-dialingly proves that an Environment generation maps to
+// one exact live backend execution and returns its opaque connector identity.
+func (c Connector) ResolveExecution(ctx context.Context, namespace, environment string, environmentUID types.UID, executionGeneration, lifecycleEpoch int64) (Execution, error) {
+	env, pod, err := c.resolvePod(ctx, namespace, environment, environmentUID, &executionGeneration, &lifecycleEpoch)
+	if err != nil {
+		return Execution{}, err
+	}
+	return executionForPod(env, pod), nil
+}
+
+// ExecutionCurrent reports whether execution is still the exact active live
+// backend execution. NotFound is a stale result rather than an operational
+// error; all other API read failures remain retryable by callers.
+func (c Connector) ExecutionCurrent(ctx context.Context, namespace, environment string, execution Execution) (bool, error) {
+	var env platformv1alpha1.Environment
+	if err := c.Reader.Get(ctx, types.NamespacedName{Namespace: namespace, Name: environment}, &env); apierrors.IsNotFound(err) {
+		return false, nil
+	} else if err != nil {
 		return false, err
 	}
-	if currentEnvironment.UID != execution.EnvironmentUID || currentEnvironment.Spec.Paused || currentEnvironment.Status.Lifecycle.Suspended ||
-		currentEnvironment.Status.Lifecycle.Epoch != execution.LifecycleEpoch || currentEnvironment.Status.PodName != execution.PodName {
+	if env.UID != execution.environmentUID || env.Status.ExecutionGeneration != execution.executionGeneration ||
+		env.Status.Lifecycle.Epoch != execution.lifecycleEpoch || env.Spec.Paused || env.Status.Lifecycle.Suspended ||
+		!platformv1alpha1.IsEnvironmentReady(&env) || env.Status.PodName != execution.podName || env.Status.Endpoints.Sandboxd == "" {
 		return false, nil
 	}
-	var currentPod corev1.Pod
-	if err := c.Reader.Get(ctx, types.NamespacedName{Namespace: namespace, Name: execution.PodName}, &currentPod); err != nil {
-		if apierrors.IsNotFound(err) {
-			return false, nil
-		}
+	var pod corev1.Pod
+	if err := c.Reader.Get(ctx, types.NamespacedName{Namespace: namespace, Name: execution.podName}, &pod); apierrors.IsNotFound(err) {
+		return false, nil
+	} else if err != nil {
 		return false, err
 	}
-	return currentPod.UID == execution.PodUID, nil
+	podGeneration, generationValid := parseExecutionGeneration(&pod)
+	return exactEnvironmentOwner(&pod, &env) && pod.UID == execution.podUID && pod.DeletionTimestamp.IsZero() &&
+		pod.Spec.RestartPolicy == corev1.RestartPolicyNever && processPodReady(&pod) && pod.Status.PodIP != "" &&
+		env.Status.Endpoints.Sandboxd == net.JoinHostPort(pod.Status.PodIP, sandboxdPort) && generationValid &&
+		podGeneration == execution.executionGeneration, nil
+}
+
+func executionForPod(env *platformv1alpha1.Environment, pod *corev1.Pod) Execution {
+	return Execution{
+		environmentUID: env.UID, executionGeneration: env.Status.ExecutionGeneration,
+		lifecycleEpoch: env.Status.Lifecycle.Epoch, podName: pod.Name, podUID: pod.UID,
+	}
 }
 
 // DialProcess resolves the exact Environment UID immediately before dialing
 // and returns a process-only sandboxd client.
 func (c Connector) DialProcess(ctx context.Context, namespace, environment string, environmentUID types.UID) (sandboxdv1.ProcessServiceClient, func() error, error) {
-	return c.dialProcess(ctx, namespace, environment, environmentUID, nil)
+	return c.dialProcess(ctx, namespace, environment, environmentUID, nil, nil)
 }
 
 // DialProcessForEpoch resolves a process client only when the current
 // Environment lifecycle epoch matches the caller's accepted execution epoch.
 func (c Connector) DialProcessForEpoch(ctx context.Context, namespace, environment string, environmentUID types.UID, expectedEpoch int64) (sandboxdv1.ProcessServiceClient, func() error, error) {
-	return c.dialProcess(ctx, namespace, environment, environmentUID, &expectedEpoch)
+	return c.dialProcess(ctx, namespace, environment, environmentUID, nil, &expectedEpoch)
 }
 
-func (c Connector) dialProcess(ctx context.Context, namespace, environment string, environmentUID types.UID, expectedEpoch *int64) (sandboxdv1.ProcessServiceClient, func() error, error) {
-	env, pod, err := c.resolvePod(ctx, namespace, environment, environmentUID, expectedEpoch)
+// DialProcessForExecution resolves a process client only for the exact accepted
+// backend execution and lifecycle epoch.
+func (c Connector) DialProcessForExecution(ctx context.Context, namespace, environment string, environmentUID types.UID, expectedExecutionGeneration, expectedEpoch int64) (sandboxdv1.ProcessServiceClient, func() error, error) {
+	return c.dialProcess(ctx, namespace, environment, environmentUID, &expectedExecutionGeneration, &expectedEpoch)
+}
+
+func (c Connector) dialProcess(ctx context.Context, namespace, environment string, environmentUID types.UID, expectedExecutionGeneration, expectedEpoch *int64) (sandboxdv1.ProcessServiceClient, func() error, error) {
+	env, pod, err := c.resolvePod(ctx, namespace, environment, environmentUID, expectedExecutionGeneration, expectedEpoch)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -146,7 +172,7 @@ func (c Connector) dialProcess(ctx context.Context, namespace, environment strin
 	if err != nil {
 		return nil, nil, err
 	}
-	if expectedEpoch != nil {
+	if expectedExecutionGeneration != nil || expectedEpoch != nil {
 		// Re-read after pinning the endpoint, TLS identity, and token. If an
 		// epoch transition raced resolution, reject this client; if transition
 		// starts after this check, the old credentials cannot authenticate to
@@ -156,7 +182,8 @@ func (c Connector) dialProcess(ctx context.Context, namespace, environment strin
 			_ = conn.Close()
 			return nil, nil, err
 		}
-		if current.UID != environmentUID || current.Status.Lifecycle.Epoch != *expectedEpoch ||
+		if current.UID != environmentUID || expectedExecutionGeneration != nil && current.Status.ExecutionGeneration != *expectedExecutionGeneration ||
+			expectedEpoch != nil && current.Status.Lifecycle.Epoch != *expectedEpoch ||
 			current.Spec.Paused || current.Status.Lifecycle.Suspended || !platformv1alpha1.IsEnvironmentReady(&current) ||
 			current.Status.PodName != env.Status.PodName || current.Status.Endpoints.Sandboxd != env.Status.Endpoints.Sandboxd {
 			_ = conn.Close()
@@ -166,13 +193,16 @@ func (c Connector) dialProcess(ctx context.Context, namespace, environment strin
 	return sandboxdv1.NewProcessServiceClient(conn), conn.Close, nil
 }
 
-func (c Connector) resolvePod(ctx context.Context, namespace, environment string, environmentUID types.UID, expectedEpoch *int64) (*platformv1alpha1.Environment, *corev1.Pod, error) {
+func (c Connector) resolvePod(ctx context.Context, namespace, environment string, environmentUID types.UID, expectedExecutionGeneration, expectedEpoch *int64) (*platformv1alpha1.Environment, *corev1.Pod, error) {
 	var env platformv1alpha1.Environment
 	if err := c.Reader.Get(ctx, types.NamespacedName{Namespace: namespace, Name: environment}, &env); err != nil {
 		return nil, nil, err
 	}
-	if environmentUID != "" && env.UID != environmentUID || env.Spec.Paused || env.Status.Lifecycle.Suspended || !platformv1alpha1.IsEnvironmentReady(&env) || env.Status.PodName == "" || env.Status.Endpoints.Sandboxd == "" {
+	if environmentUID != "" && env.UID != environmentUID || env.Status.ExecutionGeneration < 1 || env.Spec.Paused || env.Status.Lifecycle.Suspended || !platformv1alpha1.IsEnvironmentReady(&env) || env.Status.PodName == "" || env.Status.Endpoints.Sandboxd == "" {
 		return nil, nil, fmt.Errorf("environment is not the current reachable incarnation")
+	}
+	if expectedExecutionGeneration != nil && env.Status.ExecutionGeneration != *expectedExecutionGeneration {
+		return nil, nil, fmt.Errorf("environment execution generation changed: expected %d, got %d", *expectedExecutionGeneration, env.Status.ExecutionGeneration)
 	}
 	if expectedEpoch != nil && env.Status.Lifecycle.Epoch != *expectedEpoch {
 		return nil, nil, fmt.Errorf("environment lifecycle epoch changed: expected %d, got %d", *expectedEpoch, env.Status.Lifecycle.Epoch)
@@ -195,7 +225,20 @@ func (c Connector) resolvePod(ctx context.Context, namespace, environment string
 	if pod.UID == "" || !pod.DeletionTimestamp.IsZero() || !processPodReady(&pod) || pod.Status.PodIP == "" || env.Status.Endpoints.Sandboxd != wantEndpoint {
 		return nil, nil, fmt.Errorf("sandboxd endpoint does not identify the current environment pod")
 	}
+	if pod.Spec.RestartPolicy != corev1.RestartPolicyNever {
+		return nil, nil, fmt.Errorf("environment pod restart policy does not identify a single execution")
+	}
+	podGeneration, generationValid := parseExecutionGeneration(&pod)
+	if !generationValid || podGeneration != env.Status.ExecutionGeneration {
+		return nil, nil, fmt.Errorf("environment pod does not identify the current execution generation")
+	}
 	return &env, &pod, nil
+}
+
+func parseExecutionGeneration(pod *corev1.Pod) (int64, bool) {
+	value := pod.Annotations[executionGenerationAnnotation]
+	generation, err := strconv.ParseInt(value, 10, 64)
+	return generation, err == nil && generation > 0 && strconv.FormatInt(generation, 10) == value
 }
 
 func processPodReady(pod *corev1.Pod) bool {

--- a/internal/sandboxclient/process_test.go
+++ b/internal/sandboxclient/process_test.go
@@ -37,10 +37,11 @@ func TestDialTerminalBindsExactExecutionAfterFinalRead(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "environment", Namespace: "ns", UID: "env-uid"},
 		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "default"},
 		Status: platformv1alpha1.EnvironmentStatus{
-			Lifecycle: platformv1alpha1.EnvironmentLifecycleStatus{Epoch: 7},
-			Phase:     platformv1alpha1.EnvironmentPhaseReady,
-			PodName:   "env-environment",
-			Endpoints: platformv1alpha1.EnvironmentEndpoints{Sandboxd: "10.0.0.1:50051"},
+			ExecutionGeneration: 3,
+			Lifecycle:           platformv1alpha1.EnvironmentLifecycleStatus{Epoch: 7},
+			Phase:               platformv1alpha1.EnvironmentPhaseReady,
+			PodName:             "env-environment",
+			Endpoints:           platformv1alpha1.EnvironmentEndpoints{Sandboxd: "10.0.0.1:50051"},
 			Conditions: []metav1.Condition{{
 				Type: platformv1alpha1.EnvironmentConditionReady, Status: metav1.ConditionTrue,
 				Reason: "SandboxdReady", Message: "sandboxd is ready",
@@ -52,6 +53,7 @@ func TestDialTerminalBindsExactExecutionAfterFinalRead(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: environment.Status.PodName, Namespace: environment.Namespace, UID: "pod-uid-1",
 			Annotations: map[string]string{
+				executionGenerationAnnotation:   "3",
 				sandboxdauth.IdentityAnnotation: identity,
 				sandboxdauth.TrustAnnotation:    string(processTestCertificate(t, identity)),
 				sandboxdauth.TokenAnnotation:    "terminal-token",
@@ -61,6 +63,7 @@ func TestDialTerminalBindsExactExecutionAfterFinalRead(t *testing.T) {
 				UID: environment.UID, Controller: processTestPtr(true),
 			}},
 		},
+		Spec: corev1.PodSpec{RestartPolicy: corev1.RestartPolicyNever},
 		Status: corev1.PodStatus{
 			PodIP:      "10.0.0.1",
 			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
@@ -74,7 +77,7 @@ func TestDialTerminalBindsExactExecutionAfterFinalRead(t *testing.T) {
 	if err != nil || terminal == nil || health == nil || closeConnection == nil {
 		t.Fatalf("valid terminal dial: terminal nil=%t, health nil=%t, close nil=%t, error=%v", terminal == nil, health == nil, closeConnection == nil, err)
 	}
-	if execution.EnvironmentUID != environment.UID || execution.LifecycleEpoch != 7 || execution.PodName != pod.Name || execution.PodUID != pod.UID {
+	if execution.environmentUID != environment.UID || execution.executionGeneration != 3 || execution.lifecycleEpoch != 7 || execution.podName != pod.Name || execution.podUID != pod.UID {
 		t.Fatalf("terminal execution = %#v", execution)
 	}
 	if err := closeConnection(); err != nil {
@@ -88,6 +91,13 @@ func TestDialTerminalBindsExactExecutionAfterFinalRead(t *testing.T) {
 	terminal, health, execution, closeConnection, err = (Connector{Reader: epochRace}).DialTerminal(context.Background(), environment.Namespace, environment.Name, environment.UID)
 	if err == nil || !strings.Contains(err.Error(), "execution changed while resolving terminal endpoint") || epochRace.environmentGets != 2 || terminal != nil || health != nil || closeConnection != nil || execution != (TerminalExecution{}) {
 		t.Fatalf("post-dial lifecycle race: terminal nil=%t, health nil=%t, execution=%#v, close nil=%t, error=%v, Environment reads=%d", terminal == nil, health == nil, execution, closeConnection == nil, err, epochRace.environmentGets)
+	}
+	executionRace := &environmentChangingReader{Reader: newClient(), mutate: func(current *platformv1alpha1.Environment) {
+		current.Status.ExecutionGeneration++
+	}}
+	terminal, health, execution, closeConnection, err = (Connector{Reader: executionRace}).DialTerminal(context.Background(), environment.Namespace, environment.Name, environment.UID)
+	if err == nil || !strings.Contains(err.Error(), "execution changed while resolving terminal endpoint") || executionRace.environmentGets != 2 || terminal != nil || health != nil || closeConnection != nil || execution != (TerminalExecution{}) {
+		t.Fatalf("post-dial execution-generation race: terminal nil=%t, health nil=%t, execution=%#v, close nil=%t, error=%v, Environment reads=%d", terminal == nil, health == nil, execution, closeConnection == nil, err, executionRace.environmentGets)
 	}
 
 	podRace := &podChangingReader{Reader: newClient(), mutate: func(current *corev1.Pod) {
@@ -103,16 +113,16 @@ func TestDialProcessValidatesCurrentEnvironmentPodAndCredentialIncarnation(t *te
 	const identity = "pod-a.sandboxd.swe.dev"
 	certificate := processTestCertificate(t, identity)
 	env := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "environment", Namespace: "ns", UID: "env-uid"}, Status: platformv1alpha1.EnvironmentStatus{
-		Phase: platformv1alpha1.EnvironmentPhaseReady, PodName: "env-environment", Endpoints: platformv1alpha1.EnvironmentEndpoints{Sandboxd: "10.0.0.1:50051"},
+		ExecutionGeneration: 1, Phase: platformv1alpha1.EnvironmentPhaseReady, PodName: "env-environment", Endpoints: platformv1alpha1.EnvironmentEndpoints{Sandboxd: "10.0.0.1:50051"},
 		Conditions: []metav1.Condition{{Type: platformv1alpha1.EnvironmentConditionReady, Status: metav1.ConditionTrue, Reason: "SandboxdReady", Message: "sandboxd is ready"}},
 	}}
 	env.Spec.TemplateRef = "default"
 	template := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: env.Spec.TemplateRef, Namespace: env.Namespace}}
 	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: env.Status.PodName, Namespace: env.Namespace, UID: "pod-uid", Annotations: map[string]string{
-		sandboxdauth.IdentityAnnotation: identity, sandboxdauth.SecretUIDAnnotation: "secret-uid", sandboxdauth.SecretNameAnnotation: "env-environment-sandboxd",
+		sandboxdauth.IdentityAnnotation: identity, sandboxdauth.SecretUIDAnnotation: "secret-uid", sandboxdauth.SecretNameAnnotation: "env-environment-sandboxd", executionGenerationAnnotation: "1",
 	}, OwnerReferences: []metav1.OwnerReference{{APIVersion: platformv1alpha1.GroupVersion.String(), Kind: "Environment", Name: env.Name, UID: env.UID, Controller: processTestPtr(true)}}}, Status: corev1.PodStatus{
 		PodIP: "10.0.0.1", Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
-	}}
+	}, Spec: corev1.PodSpec{RestartPolicy: corev1.RestartPolicyNever}}
 	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "env-environment-sandboxd", Namespace: env.Namespace, UID: "secret-uid", Annotations: map[string]string{
 		sandboxdauth.IdentityAnnotation: identity, sandboxdauth.PodUIDAnnotation: string(pod.UID),
 	}, OwnerReferences: []metav1.OwnerReference{{APIVersion: platformv1alpha1.GroupVersion.String(), Kind: "Environment", Name: env.Name, UID: env.UID, Controller: processTestPtr(true)}}}, Data: map[string][]byte{
@@ -141,6 +151,28 @@ func TestDialProcessValidatesCurrentEnvironmentPodAndCredentialIncarnation(t *te
 	freshEpoch.Status.Lifecycle.Epoch = 1
 	if _, _, err := (Connector{Reader: newClient(freshEpoch, pod.DeepCopy(), secret.DeepCopy())}).DialProcessForEpoch(context.Background(), env.Namespace, env.Name, env.UID, 0); err == nil || !strings.Contains(err.Error(), "lifecycle epoch changed") {
 		t.Fatalf("stale lifecycle epoch error = %v", err)
+	}
+	if _, _, err := (Connector{Reader: newClient(env.DeepCopy(), pod.DeepCopy(), secret.DeepCopy())}).DialProcessForExecution(context.Background(), env.Namespace, env.Name, env.UID, 2, 0); err == nil || !strings.Contains(err.Error(), "execution generation changed") {
+		t.Fatalf("stale execution generation error = %v", err)
+	}
+	for _, policy := range []corev1.RestartPolicy{corev1.RestartPolicyAlways, corev1.RestartPolicyOnFailure, ""} {
+		restartable := pod.DeepCopy()
+		restartable.Spec.RestartPolicy = policy
+		if _, _, err := (Connector{Reader: newClient(env.DeepCopy(), restartable, secret.DeepCopy())}).DialProcess(context.Background(), env.Namespace, env.Name, env.UID); err == nil || !strings.Contains(err.Error(), "restart policy") {
+			t.Fatalf("restart policy %q error = %v", policy, err)
+		}
+	}
+	for _, annotation := range []string{"", "0", "01", "malformed", "2"} {
+		malformed := pod.DeepCopy()
+		malformed.Annotations[executionGenerationAnnotation] = annotation
+		if _, _, err := (Connector{Reader: newClient(env.DeepCopy(), malformed, secret.DeepCopy())}).DialProcess(context.Background(), env.Namespace, env.Name, env.UID); err == nil || !strings.Contains(err.Error(), "execution generation") {
+			t.Fatalf("execution annotation %q error = %v", annotation, err)
+		}
+	}
+	legacy := env.DeepCopy()
+	legacy.Status.ExecutionGeneration = 0
+	if _, _, err := (Connector{Reader: newClient(legacy, pod.DeepCopy(), secret.DeepCopy())}).DialProcess(context.Background(), env.Namespace, env.Name, env.UID); err == nil || !strings.Contains(err.Error(), "current reachable incarnation") {
+		t.Fatalf("legacy generation zero error = %v", err)
 	}
 	activityReader := &environmentChangingReader{Reader: newClient(env.DeepCopy(), pod.DeepCopy(), secret.DeepCopy()), mutate: func(environment *platformv1alpha1.Environment) {
 		environment.Annotations = map[string]string{"lifecycle.swe.dev/activity-terminal": `{"id":"activity"}`}


### PR DESCRIPTION
## Summary

- add a backend-neutral `Environment.status.executionGeneration`, separate from lifecycle suspension epoch, and capture it in accepted Run status and activity intents
- reserve a fresh generation before every Pod creation, annotate the Pod, require `restartPolicy: Never`, and replace legacy/malformed/restartable executions
- capture an opaque connector-owned exact live execution before adapter acceptance, observation, and cancellation, then uncached-revalidate it before publishing status, releasing claims, or removing finalizers
- atomically fence terminal activity by Environment UID, execution generation, and hold-policy revision
- preserve legacy nested activity requests/receipts through the CRD upgrade while treating missing generation as fail-closed
- update canonical architecture, generated CRDs, API contract coverage, lifecycle/recovery/warm-pool tests, and kind upgrade acceptance

## Migration

`executionGeneration` remains optional in pre-existing nested activity requests and receipts, with `minimum: 1` only when present. Existing values survive structural-schema replacement; generation zero is ignored by lifecycle consumers. Existing Environment Pods without a canonical matching generation annotation or with a restart policy other than `Never` are replaced through the normal lifecycle-owned creation funnel.

## Replacement-path audit

The single `ensurePodForProject` creation funnel reserves generation before initial provision and every replacement reached after pause/resume, terminal recovery, Project promotion/change, security revision mismatch, missing Pod recovery, and malformed legacy adoption. Failed/uncertain creates leave a durable gap and retries reserve a newer value. Warm-pool claim/release remains Run-UID fenced; generic Project promotion still forces replacement through the same funnel.

## Verification

- `make generate manifests`
- `make check-chart-crds`
- focused controller/control-plane/lifecycle/sandboxclient tests
- focused race suites for those packages
- API JSON contract golden test
- `make test`
- `make vet`
- `make build`
- `bash -n hack/e2e.sh`
- `git diff --check`
- independent expert review completed; stale rejected-acceptance publication and identified coverage gaps addressed

Closes #122
Completes residual #125
