### PR TITLE
sandboxd: add bounded service observation RPC

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -44,8 +44,9 @@ CLI / TUI / local MCP / browser console
   uses the same control-plane resource, transcript, and terminal APIs.
 - **`sandboxd`.** A small daemon in each Environment provides authenticated gRPC services for
   connection-bound exec, keyed managed processes, workspace-confined filesystem access, one
-  shared terminal, a process-local port registry, and health. The port registry is not a
-  portal gateway.
+  shared terminal, health, and bounded stateless TCP-connect observations from its logical
+  loopback. The observation primitive retains no declarations or results, and no operator token
+  or connector currently invokes it.
 
 Portal proxying, inbox delivery and child-run spawning, branch/PR publication, and non-Pod
 Environment backends are not implemented.
@@ -360,9 +361,11 @@ path forcing ship together after Project namespace claims.
 ## Remaining decisions and open work
 
 The approved contracts above still require reviewable API sketches, migration/rollout plans,
-controller ownership, and acceptance tests before implementation. The execution-generation
-contract is implemented above; future service observations, portal routes, and egress identity
-must consume the same backend-neutral fence without exposing backend-specific identity.
+controller ownership, and acceptance tests before implementation. sandboxd now has a stateless
+internal loopback observation primitive, but Environment declarations, an observation connector
+and controller-owned health status do not exist. The execution-generation contract is
+implemented above; future declaration observations, portal routes, and egress identity must
+consume the same backend-neutral fence without exposing backend-specific identity.
 
 Other unimplemented areas include portal transport, inbox and child-run semantics, changes
 publication, transcript garbage collection, additional credential forms, ConPTY, non-Pod

--- a/README.md
+++ b/README.md
@@ -50,13 +50,15 @@ See [`ARCHITECTURE.md`](ARCHITECTURE.md) for the canonical tracked description o
 implemented today, approved next contracts, and remaining open work.
 
 - **`sandboxd`** — a small daemon inside every environment exposing one gRPC contract:
-  exec, filesystem, terminal, port registry, health. The control plane never touches a
-  pod except through it.
+  exec, filesystem, terminal, health, and bounded stateless loopback service observations.
+  No platform connector or declaration observer uses that internal observation primitive yet;
+  the control plane never touches a pod except through sandboxd.
 - **Operator + CRDs** — `Environment`, `EnvironmentTemplate`, `Run`, `Project`, with
   controllers for lifecycle, warm pools (pre-booted environments), and idle reaping.
 - **Control plane** — API, auth, transcripts, resource watches, and a web terminal sharing
   the Environment's tmux session; terminal requests can wake Idle suspension.
-- **Planned gateway** — authenticated portal URLs and reverse proxying are not implemented.
+- **Planned gateway** — service declarations, health publication, authenticated portal URLs,
+  and reverse proxying are not implemented.
 - **Planned Run actors** — inboxes, child spawning, messaging, and wake-on-message are not
   implemented.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,12 +25,14 @@ to a different environment, a stale pod, or a process without the current privat
 fails.
 
 Bearer tokens are random per incarnation and map to explicit service capabilities (`health`,
-`terminal`, `exec`, `process`, `filesystem`, and `ports`). sandboxd interceptors authorize both
-unary and streaming RPCs before handlers run. The terminal credential grants `health` and
-`terminal`; a separate operator-held adapter credential grants only `process`. The mounted
-authorization file contains SHA-256 verifiers, not raw tokens, and the raw process token is not
-projected into the environment pod or published in pod annotations. Possession of one
-environment's token grants nothing in another environment.
+`terminal`, `exec`, `process`, `filesystem`, and `service-observation`). sandboxd interceptors
+authorize both unary and streaming RPCs before handlers run. The terminal credential grants
+`health` and `terminal`; a separate operator-held adapter credential grants only `process`.
+`service-observation` authorizes only bounded stateless TCP-connect probes against sandboxd's
+logical loopback; the operator does not yet issue that token and no connector invokes the RPC.
+The mounted authorization file contains SHA-256 verifiers, not raw tokens, and the raw process
+token is not projected into the environment pod or published in pod annotations. Possession of
+one environment's token grants nothing in another environment.
 
 The Environment-owned Secret contains the private key, authorization configuration, and raw
 process token. The public trust certificate and terminal token are published atomically as pod

--- a/sandboxd/auth/auth.go
+++ b/sandboxd/auth/auth.go
@@ -23,12 +23,12 @@ import (
 type Capability string
 
 const (
-	CapabilityHealth     Capability = "health"
-	CapabilityExec       Capability = "exec"
-	CapabilityProcess    Capability = "process"
-	CapabilityFilesystem Capability = "filesystem"
-	CapabilityTerminal   Capability = "terminal"
-	CapabilityPorts      Capability = "ports"
+	CapabilityHealth             Capability = "health"
+	CapabilityExec               Capability = "exec"
+	CapabilityProcess            Capability = "process"
+	CapabilityFilesystem         Capability = "filesystem"
+	CapabilityTerminal           Capability = "terminal"
+	CapabilityServiceObservation Capability = "service-observation"
 )
 
 // Credential bundle keys and identity annotation shared by provisioners and clients.
@@ -159,8 +159,8 @@ func methodCapability(method string) (Capability, bool) {
 		return CapabilityFilesystem, true
 	case "sandboxd.v1.TerminalService":
 		return CapabilityTerminal, true
-	case "sandboxd.v1.PortService":
-		return CapabilityPorts, true
+	case "sandboxd.v1.ServiceObservationService":
+		return CapabilityServiceObservation, true
 	default:
 		return "", false
 	}
@@ -168,7 +168,7 @@ func methodCapability(method string) (Capability, bool) {
 
 func validCapability(capability Capability) bool {
 	switch capability {
-	case CapabilityHealth, CapabilityExec, CapabilityProcess, CapabilityFilesystem, CapabilityTerminal, CapabilityPorts:
+	case CapabilityHealth, CapabilityExec, CapabilityProcess, CapabilityFilesystem, CapabilityTerminal, CapabilityServiceObservation:
 		return true
 	default:
 		return false

--- a/sandboxd/auth/auth_test.go
+++ b/sandboxd/auth/auth_test.go
@@ -91,6 +91,37 @@ func TestProcessCapabilityAuthorizesManagedProcesses(t *testing.T) {
 	}
 }
 
+func TestServiceObservationCapabilityIsExact(t *testing.T) {
+	authorizer := newTestAuthorizer(t, Config{Grants: []Grant{{
+		TokenHash:    TokenVerifier("observer-token"),
+		Capabilities: []Capability{CapabilityServiceObservation},
+	}, {
+		TokenHash:    TokenVerifier("process-token"),
+		Capabilities: []Capability{CapabilityProcess},
+	}}})
+	observerContext := metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+		"authorization", "Bearer observer-token",
+	))
+	if err := authorizer.authorize(observerContext, "/sandboxd.v1.ServiceObservationService/Observe"); err != nil {
+		t.Fatalf("authorize observation: %v", err)
+	}
+	for _, method := range []string{
+		"/sandboxd.v1.HealthService/Check",
+		"/sandboxd.v1.ProcessService/Start",
+		"/sandboxd.v1.TerminalService/Terminal",
+	} {
+		if err := authorizer.authorize(observerContext, method); status.Code(err) != codes.PermissionDenied {
+			t.Fatalf("method %s status = %v, want PermissionDenied", method, err)
+		}
+	}
+	processContext := metadata.NewIncomingContext(context.Background(), metadata.Pairs(
+		"authorization", "Bearer process-token",
+	))
+	if err := authorizer.authorize(processContext, "/sandboxd.v1.ServiceObservationService/Observe"); status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("process token observation status = %v, want PermissionDenied", err)
+	}
+}
+
 func TestTLSAndCapabilityInterceptorsEndToEnd(t *testing.T) {
 	const (
 		serverName   = "incarnation-a.sandboxd.swe.dev"

--- a/sandboxd/cmd/sandboxd/main.go
+++ b/sandboxd/cmd/sandboxd/main.go
@@ -82,7 +82,11 @@ func main() {
 	sandboxdv1.RegisterProcessServiceServer(grpcServer, processServer)
 	sandboxdv1.RegisterFilesystemServiceServer(grpcServer, filesystemServer)
 	sandboxdv1.RegisterTerminalServiceServer(grpcServer, server.NewTerminalServer(*workspace))
-	sandboxdv1.RegisterServiceObservationServiceServer(grpcServer, server.NewServiceObservationServer())
+	controlAddress, ok := lis.Addr().(*net.TCPAddr)
+	if !ok {
+		log.Fatalf("sandboxd listener has unexpected address type %T", lis.Addr())
+	}
+	sandboxdv1.RegisterServiceObservationServiceServer(grpcServer, server.NewServiceObservationServer(uint32(controlAddress.Port)))
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()

--- a/sandboxd/cmd/sandboxd/main.go
+++ b/sandboxd/cmd/sandboxd/main.go
@@ -82,7 +82,7 @@ func main() {
 	sandboxdv1.RegisterProcessServiceServer(grpcServer, processServer)
 	sandboxdv1.RegisterFilesystemServiceServer(grpcServer, filesystemServer)
 	sandboxdv1.RegisterTerminalServiceServer(grpcServer, server.NewTerminalServer(*workspace))
-	sandboxdv1.RegisterPortServiceServer(grpcServer, server.NewPortServer())
+	sandboxdv1.RegisterServiceObservationServiceServer(grpcServer, server.NewServiceObservationServer())
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()

--- a/sandboxd/gen/proto/sandboxd/v1/sandboxd.pb.go
+++ b/sandboxd/gen/proto/sandboxd/v1/sandboxd.pb.go
@@ -458,6 +458,113 @@ func (EntryType) EnumDescriptor() ([]byte, []int) {
 	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{7}
 }
 
+type ServiceProbeOutcome int32
+
+const (
+	ServiceProbeOutcome_SERVICE_PROBE_OUTCOME_UNSPECIFIED   ServiceProbeOutcome = 0
+	ServiceProbeOutcome_SERVICE_PROBE_OUTCOME_CONNECTED     ServiceProbeOutcome = 1
+	ServiceProbeOutcome_SERVICE_PROBE_OUTCOME_NOT_CONNECTED ServiceProbeOutcome = 2
+	ServiceProbeOutcome_SERVICE_PROBE_OUTCOME_TIMED_OUT     ServiceProbeOutcome = 3
+)
+
+// Enum value maps for ServiceProbeOutcome.
+var (
+	ServiceProbeOutcome_name = map[int32]string{
+		0: "SERVICE_PROBE_OUTCOME_UNSPECIFIED",
+		1: "SERVICE_PROBE_OUTCOME_CONNECTED",
+		2: "SERVICE_PROBE_OUTCOME_NOT_CONNECTED",
+		3: "SERVICE_PROBE_OUTCOME_TIMED_OUT",
+	}
+	ServiceProbeOutcome_value = map[string]int32{
+		"SERVICE_PROBE_OUTCOME_UNSPECIFIED":   0,
+		"SERVICE_PROBE_OUTCOME_CONNECTED":     1,
+		"SERVICE_PROBE_OUTCOME_NOT_CONNECTED": 2,
+		"SERVICE_PROBE_OUTCOME_TIMED_OUT":     3,
+	}
+)
+
+func (x ServiceProbeOutcome) Enum() *ServiceProbeOutcome {
+	p := new(ServiceProbeOutcome)
+	*p = x
+	return p
+}
+
+func (x ServiceProbeOutcome) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ServiceProbeOutcome) Descriptor() protoreflect.EnumDescriptor {
+	return file_proto_sandboxd_v1_sandboxd_proto_enumTypes[8].Descriptor()
+}
+
+func (ServiceProbeOutcome) Type() protoreflect.EnumType {
+	return &file_proto_sandboxd_v1_sandboxd_proto_enumTypes[8]
+}
+
+func (x ServiceProbeOutcome) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ServiceProbeOutcome.Descriptor instead.
+func (ServiceProbeOutcome) EnumDescriptor() ([]byte, []int) {
+	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{8}
+}
+
+type ServiceProbeReason int32
+
+const (
+	ServiceProbeReason_SERVICE_PROBE_REASON_UNSPECIFIED         ServiceProbeReason = 0
+	ServiceProbeReason_SERVICE_PROBE_REASON_CONNECTION_ACCEPTED ServiceProbeReason = 1
+	ServiceProbeReason_SERVICE_PROBE_REASON_CONNECTION_FAILED   ServiceProbeReason = 2
+	ServiceProbeReason_SERVICE_PROBE_REASON_DEADLINE_EXCEEDED   ServiceProbeReason = 3
+	ServiceProbeReason_SERVICE_PROBE_REASON_CANCELED            ServiceProbeReason = 4
+)
+
+// Enum value maps for ServiceProbeReason.
+var (
+	ServiceProbeReason_name = map[int32]string{
+		0: "SERVICE_PROBE_REASON_UNSPECIFIED",
+		1: "SERVICE_PROBE_REASON_CONNECTION_ACCEPTED",
+		2: "SERVICE_PROBE_REASON_CONNECTION_FAILED",
+		3: "SERVICE_PROBE_REASON_DEADLINE_EXCEEDED",
+		4: "SERVICE_PROBE_REASON_CANCELED",
+	}
+	ServiceProbeReason_value = map[string]int32{
+		"SERVICE_PROBE_REASON_UNSPECIFIED":         0,
+		"SERVICE_PROBE_REASON_CONNECTION_ACCEPTED": 1,
+		"SERVICE_PROBE_REASON_CONNECTION_FAILED":   2,
+		"SERVICE_PROBE_REASON_DEADLINE_EXCEEDED":   3,
+		"SERVICE_PROBE_REASON_CANCELED":            4,
+	}
+)
+
+func (x ServiceProbeReason) Enum() *ServiceProbeReason {
+	p := new(ServiceProbeReason)
+	*p = x
+	return p
+}
+
+func (x ServiceProbeReason) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ServiceProbeReason) Descriptor() protoreflect.EnumDescriptor {
+	return file_proto_sandboxd_v1_sandboxd_proto_enumTypes[9].Descriptor()
+}
+
+func (ServiceProbeReason) Type() protoreflect.EnumType {
+	return &file_proto_sandboxd_v1_sandboxd_proto_enumTypes[9]
+}
+
+func (x ServiceProbeReason) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ServiceProbeReason.Descriptor instead.
+func (ServiceProbeReason) EnumDescriptor() ([]byte, []int) {
+	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{9}
+}
+
 type ExecRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Kind:
@@ -2349,29 +2456,27 @@ func (x *TerminalResize) GetRows() uint32 {
 	return 0
 }
 
-type RegisterPortRequest struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// port of 0 asks sandboxd to pick a free one.
-	Port          uint32 `protobuf:"varint,1,opt,name=port,proto3" json:"port,omitempty"`
-	Label         string `protobuf:"bytes,2,opt,name=label,proto3" json:"label,omitempty"`
+type ObserveServicesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Probes        []*ServiceProbe        `protobuf:"bytes,1,rep,name=probes,proto3" json:"probes,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *RegisterPortRequest) Reset() {
-	*x = RegisterPortRequest{}
+func (x *ObserveServicesRequest) Reset() {
+	*x = ObserveServicesRequest{}
 	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *RegisterPortRequest) String() string {
+func (x *ObserveServicesRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*RegisterPortRequest) ProtoMessage() {}
+func (*ObserveServicesRequest) ProtoMessage() {}
 
-func (x *RegisterPortRequest) ProtoReflect() protoreflect.Message {
+func (x *ObserveServicesRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -2383,49 +2488,45 @@ func (x *RegisterPortRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use RegisterPortRequest.ProtoReflect.Descriptor instead.
-func (*RegisterPortRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use ObserveServicesRequest.ProtoReflect.Descriptor instead.
+func (*ObserveServicesRequest) Descriptor() ([]byte, []int) {
 	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{28}
 }
 
-func (x *RegisterPortRequest) GetPort() uint32 {
+func (x *ObserveServicesRequest) GetProbes() []*ServiceProbe {
 	if x != nil {
-		return x.Port
+		return x.Probes
 	}
-	return 0
+	return nil
 }
 
-func (x *RegisterPortRequest) GetLabel() string {
-	if x != nil {
-		return x.Label
-	}
-	return ""
-}
-
-type Port struct {
+type ServiceProbe struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	Port  uint32                 `protobuf:"varint,1,opt,name=port,proto3" json:"port,omitempty"`
-	Label string                 `protobuf:"bytes,2,opt,name=label,proto3" json:"label,omitempty"`
-	// url is filled in once the gateway has exposed the port; empty until then.
-	Url           string `protobuf:"bytes,3,opt,name=url,proto3" json:"url,omitempty"`
+	// id is opaque correlation data scoped only to this request.
+	Id         string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	TargetPort uint32 `protobuf:"varint,2,opt,name=target_port,json=targetPort,proto3" json:"target_port,omitempty"`
+	// Types that are valid to be assigned to Probe:
+	//
+	//	*ServiceProbe_TcpConnect
+	Probe         isServiceProbe_Probe `protobuf_oneof:"probe"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *Port) Reset() {
-	*x = Port{}
+func (x *ServiceProbe) Reset() {
+	*x = ServiceProbe{}
 	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *Port) String() string {
+func (x *ServiceProbe) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*Port) ProtoMessage() {}
+func (*ServiceProbe) ProtoMessage() {}
 
-func (x *Port) ProtoReflect() protoreflect.Message {
+func (x *ServiceProbe) ProtoReflect() protoreflect.Message {
 	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -2437,52 +2538,71 @@ func (x *Port) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use Port.ProtoReflect.Descriptor instead.
-func (*Port) Descriptor() ([]byte, []int) {
+// Deprecated: Use ServiceProbe.ProtoReflect.Descriptor instead.
+func (*ServiceProbe) Descriptor() ([]byte, []int) {
 	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{29}
 }
 
-func (x *Port) GetPort() uint32 {
+func (x *ServiceProbe) GetId() string {
 	if x != nil {
-		return x.Port
+		return x.Id
+	}
+	return ""
+}
+
+func (x *ServiceProbe) GetTargetPort() uint32 {
+	if x != nil {
+		return x.TargetPort
 	}
 	return 0
 }
 
-func (x *Port) GetLabel() string {
+func (x *ServiceProbe) GetProbe() isServiceProbe_Probe {
 	if x != nil {
-		return x.Label
+		return x.Probe
 	}
-	return ""
+	return nil
 }
 
-func (x *Port) GetUrl() string {
+func (x *ServiceProbe) GetTcpConnect() *TCPConnectProbe {
 	if x != nil {
-		return x.Url
+		if x, ok := x.Probe.(*ServiceProbe_TcpConnect); ok {
+			return x.TcpConnect
+		}
 	}
-	return ""
+	return nil
 }
 
-type ListPortsRequest struct {
+type isServiceProbe_Probe interface {
+	isServiceProbe_Probe()
+}
+
+type ServiceProbe_TcpConnect struct {
+	TcpConnect *TCPConnectProbe `protobuf:"bytes,3,opt,name=tcp_connect,json=tcpConnect,proto3,oneof"`
+}
+
+func (*ServiceProbe_TcpConnect) isServiceProbe_Probe() {}
+
+type TCPConnectProbe struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *ListPortsRequest) Reset() {
-	*x = ListPortsRequest{}
+func (x *TCPConnectProbe) Reset() {
+	*x = TCPConnectProbe{}
 	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ListPortsRequest) String() string {
+func (x *TCPConnectProbe) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ListPortsRequest) ProtoMessage() {}
+func (*TCPConnectProbe) ProtoMessage() {}
 
-func (x *ListPortsRequest) ProtoReflect() protoreflect.Message {
+func (x *TCPConnectProbe) ProtoReflect() protoreflect.Message {
 	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -2494,32 +2614,34 @@ func (x *ListPortsRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ListPortsRequest.ProtoReflect.Descriptor instead.
-func (*ListPortsRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use TCPConnectProbe.ProtoReflect.Descriptor instead.
+func (*TCPConnectProbe) Descriptor() ([]byte, []int) {
 	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{30}
 }
 
-type ListPortsResponse struct {
+type ServiceProbeObservation struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Ports         []*Port                `protobuf:"bytes,1,rep,name=ports,proto3" json:"ports,omitempty"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Outcome       ServiceProbeOutcome    `protobuf:"varint,2,opt,name=outcome,proto3,enum=sandboxd.v1.ServiceProbeOutcome" json:"outcome,omitempty"`
+	Reason        ServiceProbeReason     `protobuf:"varint,3,opt,name=reason,proto3,enum=sandboxd.v1.ServiceProbeReason" json:"reason,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *ListPortsResponse) Reset() {
-	*x = ListPortsResponse{}
+func (x *ServiceProbeObservation) Reset() {
+	*x = ServiceProbeObservation{}
 	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ListPortsResponse) String() string {
+func (x *ServiceProbeObservation) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ListPortsResponse) ProtoMessage() {}
+func (*ServiceProbeObservation) ProtoMessage() {}
 
-func (x *ListPortsResponse) ProtoReflect() protoreflect.Message {
+func (x *ServiceProbeObservation) ProtoReflect() protoreflect.Message {
 	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -2531,14 +2653,74 @@ func (x *ListPortsResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ListPortsResponse.ProtoReflect.Descriptor instead.
-func (*ListPortsResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use ServiceProbeObservation.ProtoReflect.Descriptor instead.
+func (*ServiceProbeObservation) Descriptor() ([]byte, []int) {
 	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{31}
 }
 
-func (x *ListPortsResponse) GetPorts() []*Port {
+func (x *ServiceProbeObservation) GetId() string {
 	if x != nil {
-		return x.Ports
+		return x.Id
+	}
+	return ""
+}
+
+func (x *ServiceProbeObservation) GetOutcome() ServiceProbeOutcome {
+	if x != nil {
+		return x.Outcome
+	}
+	return ServiceProbeOutcome_SERVICE_PROBE_OUTCOME_UNSPECIFIED
+}
+
+func (x *ServiceProbeObservation) GetReason() ServiceProbeReason {
+	if x != nil {
+		return x.Reason
+	}
+	return ServiceProbeReason_SERVICE_PROBE_REASON_UNSPECIFIED
+}
+
+type ObserveServicesResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// observations preserve request order and contain exactly one result per
+	// validated probe.
+	Observations  []*ServiceProbeObservation `protobuf:"bytes,1,rep,name=observations,proto3" json:"observations,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ObserveServicesResponse) Reset() {
+	*x = ObserveServicesResponse{}
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ObserveServicesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ObserveServicesResponse) ProtoMessage() {}
+
+func (x *ObserveServicesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ObserveServicesResponse.ProtoReflect.Descriptor instead.
+func (*ObserveServicesResponse) Descriptor() ([]byte, []int) {
+	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{32}
+}
+
+func (x *ObserveServicesResponse) GetObservations() []*ServiceProbeObservation {
+	if x != nil {
+		return x.Observations
 	}
 	return nil
 }
@@ -2551,7 +2733,7 @@ type HealthCheckRequest struct {
 
 func (x *HealthCheckRequest) Reset() {
 	*x = HealthCheckRequest{}
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[32]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2563,7 +2745,7 @@ func (x *HealthCheckRequest) String() string {
 func (*HealthCheckRequest) ProtoMessage() {}
 
 func (x *HealthCheckRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[32]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2576,7 +2758,7 @@ func (x *HealthCheckRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthCheckRequest.ProtoReflect.Descriptor instead.
 func (*HealthCheckRequest) Descriptor() ([]byte, []int) {
-	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{32}
+	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{33}
 }
 
 type HealthCheckResponse struct {
@@ -2589,7 +2771,7 @@ type HealthCheckResponse struct {
 
 func (x *HealthCheckResponse) Reset() {
 	*x = HealthCheckResponse{}
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[33]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2601,7 +2783,7 @@ func (x *HealthCheckResponse) String() string {
 func (*HealthCheckResponse) ProtoMessage() {}
 
 func (x *HealthCheckResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[33]
+	mi := &file_proto_sandboxd_v1_sandboxd_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2614,7 +2796,7 @@ func (x *HealthCheckResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthCheckResponse.ProtoReflect.Descriptor instead.
 func (*HealthCheckResponse) Descriptor() ([]byte, []int) {
-	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{33}
+	return file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *HealthCheckResponse) GetOk() bool {
@@ -2774,17 +2956,23 @@ const file_proto_sandboxd_v1_sandboxd_proto_rawDesc = "" +
 	"\x04rows\x18\x02 \x01(\rR\x04rows\"8\n" +
 	"\x0eTerminalResize\x12\x12\n" +
 	"\x04cols\x18\x01 \x01(\rR\x04cols\x12\x12\n" +
-	"\x04rows\x18\x02 \x01(\rR\x04rows\"?\n" +
-	"\x13RegisterPortRequest\x12\x12\n" +
-	"\x04port\x18\x01 \x01(\rR\x04port\x12\x14\n" +
-	"\x05label\x18\x02 \x01(\tR\x05label\"B\n" +
-	"\x04Port\x12\x12\n" +
-	"\x04port\x18\x01 \x01(\rR\x04port\x12\x14\n" +
-	"\x05label\x18\x02 \x01(\tR\x05label\x12\x10\n" +
-	"\x03url\x18\x03 \x01(\tR\x03url\"\x12\n" +
-	"\x10ListPortsRequest\"<\n" +
-	"\x11ListPortsResponse\x12'\n" +
-	"\x05ports\x18\x01 \x03(\v2\x11.sandboxd.v1.PortR\x05ports\"\x14\n" +
+	"\x04rows\x18\x02 \x01(\rR\x04rows\"K\n" +
+	"\x16ObserveServicesRequest\x121\n" +
+	"\x06probes\x18\x01 \x03(\v2\x19.sandboxd.v1.ServiceProbeR\x06probes\"\x89\x01\n" +
+	"\fServiceProbe\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1f\n" +
+	"\vtarget_port\x18\x02 \x01(\rR\n" +
+	"targetPort\x12?\n" +
+	"\vtcp_connect\x18\x03 \x01(\v2\x1c.sandboxd.v1.TCPConnectProbeH\x00R\n" +
+	"tcpConnectB\a\n" +
+	"\x05probe\"\x11\n" +
+	"\x0fTCPConnectProbe\"\x9e\x01\n" +
+	"\x17ServiceProbeObservation\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12:\n" +
+	"\aoutcome\x18\x02 \x01(\x0e2 .sandboxd.v1.ServiceProbeOutcomeR\aoutcome\x127\n" +
+	"\x06reason\x18\x03 \x01(\x0e2\x1f.sandboxd.v1.ServiceProbeReasonR\x06reason\"c\n" +
+	"\x17ObserveServicesResponse\x12H\n" +
+	"\fobservations\x18\x01 \x03(\v2$.sandboxd.v1.ServiceProbeObservationR\fobservations\"\x14\n" +
 	"\x12HealthCheckRequest\"?\n" +
 	"\x13HealthCheckResponse\x12\x0e\n" +
 	"\x02ok\x18\x01 \x01(\bR\x02ok\x12\x18\n" +
@@ -2835,7 +3023,18 @@ const file_proto_sandboxd_v1_sandboxd_proto_rawDesc = "" +
 	"\x0fENTRY_TYPE_FILE\x10\x01\x12\x18\n" +
 	"\x14ENTRY_TYPE_DIRECTORY\x10\x02\x12\x16\n" +
 	"\x12ENTRY_TYPE_SYMLINK\x10\x03\x12\x14\n" +
-	"\x10ENTRY_TYPE_OTHER\x10\x042N\n" +
+	"\x10ENTRY_TYPE_OTHER\x10\x04*\xaf\x01\n" +
+	"\x13ServiceProbeOutcome\x12%\n" +
+	"!SERVICE_PROBE_OUTCOME_UNSPECIFIED\x10\x00\x12#\n" +
+	"\x1fSERVICE_PROBE_OUTCOME_CONNECTED\x10\x01\x12'\n" +
+	"#SERVICE_PROBE_OUTCOME_NOT_CONNECTED\x10\x02\x12#\n" +
+	"\x1fSERVICE_PROBE_OUTCOME_TIMED_OUT\x10\x03*\xe3\x01\n" +
+	"\x12ServiceProbeReason\x12$\n" +
+	" SERVICE_PROBE_REASON_UNSPECIFIED\x10\x00\x12,\n" +
+	"(SERVICE_PROBE_REASON_CONNECTION_ACCEPTED\x10\x01\x12*\n" +
+	"&SERVICE_PROBE_REASON_CONNECTION_FAILED\x10\x02\x12*\n" +
+	"&SERVICE_PROBE_REASON_DEADLINE_EXCEEDED\x10\x03\x12!\n" +
+	"\x1dSERVICE_PROBE_REASON_CANCELED\x10\x042N\n" +
 	"\vExecService\x12?\n" +
 	"\x04Exec\x12\x18.sandboxd.v1.ExecRequest\x1a\x19.sandboxd.v1.ExecResponse(\x010\x012\x81\x03\n" +
 	"\x0eProcessService\x12?\n" +
@@ -2850,10 +3049,9 @@ const file_proto_sandboxd_v1_sandboxd_proto_rawDesc = "" +
 	"\x05Write\x12\x19.sandboxd.v1.WriteRequest\x1a\x1a.sandboxd.v1.WriteResponse(\x01\x12;\n" +
 	"\x04List\x12\x18.sandboxd.v1.ListRequest\x1a\x19.sandboxd.v1.ListResponse2]\n" +
 	"\x0fTerminalService\x12J\n" +
-	"\bTerminal\x12\x1c.sandboxd.v1.TerminalMessage\x1a\x1c.sandboxd.v1.TerminalMessage(\x010\x012\x95\x01\n" +
-	"\vPortService\x12?\n" +
-	"\bRegister\x12 .sandboxd.v1.RegisterPortRequest\x1a\x11.sandboxd.v1.Port\x12E\n" +
-	"\x04List\x12\x1d.sandboxd.v1.ListPortsRequest\x1a\x1e.sandboxd.v1.ListPortsResponse2[\n" +
+	"\bTerminal\x12\x1c.sandboxd.v1.TerminalMessage\x1a\x1c.sandboxd.v1.TerminalMessage(\x010\x012q\n" +
+	"\x19ServiceObservationService\x12T\n" +
+	"\aObserve\x12#.sandboxd.v1.ObserveServicesRequest\x1a$.sandboxd.v1.ObserveServicesResponse2[\n" +
 	"\rHealthService\x12J\n" +
 	"\x05Check\x12\x1f.sandboxd.v1.HealthCheckRequest\x1a .sandboxd.v1.HealthCheckResponseBQZOgithub.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1;sandboxdv1b\x06proto3"
 
@@ -2869,8 +3067,8 @@ func file_proto_sandboxd_v1_sandboxd_proto_rawDescGZIP() []byte {
 	return file_proto_sandboxd_v1_sandboxd_proto_rawDescData
 }
 
-var file_proto_sandboxd_v1_sandboxd_proto_enumTypes = make([]protoimpl.EnumInfo, 8)
-var file_proto_sandboxd_v1_sandboxd_proto_msgTypes = make([]protoimpl.MessageInfo, 37)
+var file_proto_sandboxd_v1_sandboxd_proto_enumTypes = make([]protoimpl.EnumInfo, 10)
+var file_proto_sandboxd_v1_sandboxd_proto_msgTypes = make([]protoimpl.MessageInfo, 38)
 var file_proto_sandboxd_v1_sandboxd_proto_goTypes = []any{
 	(ProcessControl)(0),                           // 0: sandboxd.v1.ProcessControl
 	(EnvironmentMode)(0),                          // 1: sandboxd.v1.EnvironmentMode
@@ -2880,111 +3078,116 @@ var file_proto_sandboxd_v1_sandboxd_proto_goTypes = []any{
 	(ProcessState)(0),                             // 5: sandboxd.v1.ProcessState
 	(WritePrecondition)(0),                        // 6: sandboxd.v1.WritePrecondition
 	(EntryType)(0),                                // 7: sandboxd.v1.EntryType
-	(*ExecRequest)(nil),                           // 8: sandboxd.v1.ExecRequest
-	(*ExecStdinEOF)(nil),                          // 9: sandboxd.v1.ExecStdinEOF
-	(*ExecControl)(nil),                           // 10: sandboxd.v1.ExecControl
-	(*OutputChunk)(nil),                           // 11: sandboxd.v1.OutputChunk
-	(*ExecStart)(nil),                             // 12: sandboxd.v1.ExecStart
-	(*ExecResponse)(nil),                          // 13: sandboxd.v1.ExecResponse
-	(*ExecExit)(nil),                              // 14: sandboxd.v1.ExecExit
-	(*ProcessKey)(nil),                            // 15: sandboxd.v1.ProcessKey
-	(*ProcessSpec)(nil),                           // 16: sandboxd.v1.ProcessSpec
-	(*StartProcessRequest)(nil),                   // 17: sandboxd.v1.StartProcessRequest
-	(*LaunchMaterial)(nil),                        // 18: sandboxd.v1.LaunchMaterial
-	(*StartProcessWithLaunchMaterialRequest)(nil), // 19: sandboxd.v1.StartProcessWithLaunchMaterialRequest
-	(*GetProcessRequest)(nil),                     // 20: sandboxd.v1.GetProcessRequest
-	(*StopProcessRequest)(nil),                    // 21: sandboxd.v1.StopProcessRequest
-	(*Process)(nil),                               // 22: sandboxd.v1.Process
-	(*ReadOutputRequest)(nil),                     // 23: sandboxd.v1.ReadOutputRequest
-	(*ReadOutputResponse)(nil),                    // 24: sandboxd.v1.ReadOutputResponse
-	(*ReadRequest)(nil),                           // 25: sandboxd.v1.ReadRequest
-	(*ReadResponse)(nil),                          // 26: sandboxd.v1.ReadResponse
-	(*WriteRequest)(nil),                          // 27: sandboxd.v1.WriteRequest
-	(*WriteHeader)(nil),                           // 28: sandboxd.v1.WriteHeader
-	(*WriteResponse)(nil),                         // 29: sandboxd.v1.WriteResponse
-	(*ListRequest)(nil),                           // 30: sandboxd.v1.ListRequest
-	(*ListResponse)(nil),                          // 31: sandboxd.v1.ListResponse
-	(*Entry)(nil),                                 // 32: sandboxd.v1.Entry
-	(*TerminalMessage)(nil),                       // 33: sandboxd.v1.TerminalMessage
-	(*TerminalOpen)(nil),                          // 34: sandboxd.v1.TerminalOpen
-	(*TerminalResize)(nil),                        // 35: sandboxd.v1.TerminalResize
-	(*RegisterPortRequest)(nil),                   // 36: sandboxd.v1.RegisterPortRequest
-	(*Port)(nil),                                  // 37: sandboxd.v1.Port
-	(*ListPortsRequest)(nil),                      // 38: sandboxd.v1.ListPortsRequest
-	(*ListPortsResponse)(nil),                     // 39: sandboxd.v1.ListPortsResponse
-	(*HealthCheckRequest)(nil),                    // 40: sandboxd.v1.HealthCheckRequest
-	(*HealthCheckResponse)(nil),                   // 41: sandboxd.v1.HealthCheckResponse
-	nil,                                           // 42: sandboxd.v1.ExecStart.EnvEntry
-	nil,                                           // 43: sandboxd.v1.ProcessSpec.EnvEntry
-	nil,                                           // 44: sandboxd.v1.LaunchMaterial.SecretEnvEntry
+	(ServiceProbeOutcome)(0),                      // 8: sandboxd.v1.ServiceProbeOutcome
+	(ServiceProbeReason)(0),                       // 9: sandboxd.v1.ServiceProbeReason
+	(*ExecRequest)(nil),                           // 10: sandboxd.v1.ExecRequest
+	(*ExecStdinEOF)(nil),                          // 11: sandboxd.v1.ExecStdinEOF
+	(*ExecControl)(nil),                           // 12: sandboxd.v1.ExecControl
+	(*OutputChunk)(nil),                           // 13: sandboxd.v1.OutputChunk
+	(*ExecStart)(nil),                             // 14: sandboxd.v1.ExecStart
+	(*ExecResponse)(nil),                          // 15: sandboxd.v1.ExecResponse
+	(*ExecExit)(nil),                              // 16: sandboxd.v1.ExecExit
+	(*ProcessKey)(nil),                            // 17: sandboxd.v1.ProcessKey
+	(*ProcessSpec)(nil),                           // 18: sandboxd.v1.ProcessSpec
+	(*StartProcessRequest)(nil),                   // 19: sandboxd.v1.StartProcessRequest
+	(*LaunchMaterial)(nil),                        // 20: sandboxd.v1.LaunchMaterial
+	(*StartProcessWithLaunchMaterialRequest)(nil), // 21: sandboxd.v1.StartProcessWithLaunchMaterialRequest
+	(*GetProcessRequest)(nil),                     // 22: sandboxd.v1.GetProcessRequest
+	(*StopProcessRequest)(nil),                    // 23: sandboxd.v1.StopProcessRequest
+	(*Process)(nil),                               // 24: sandboxd.v1.Process
+	(*ReadOutputRequest)(nil),                     // 25: sandboxd.v1.ReadOutputRequest
+	(*ReadOutputResponse)(nil),                    // 26: sandboxd.v1.ReadOutputResponse
+	(*ReadRequest)(nil),                           // 27: sandboxd.v1.ReadRequest
+	(*ReadResponse)(nil),                          // 28: sandboxd.v1.ReadResponse
+	(*WriteRequest)(nil),                          // 29: sandboxd.v1.WriteRequest
+	(*WriteHeader)(nil),                           // 30: sandboxd.v1.WriteHeader
+	(*WriteResponse)(nil),                         // 31: sandboxd.v1.WriteResponse
+	(*ListRequest)(nil),                           // 32: sandboxd.v1.ListRequest
+	(*ListResponse)(nil),                          // 33: sandboxd.v1.ListResponse
+	(*Entry)(nil),                                 // 34: sandboxd.v1.Entry
+	(*TerminalMessage)(nil),                       // 35: sandboxd.v1.TerminalMessage
+	(*TerminalOpen)(nil),                          // 36: sandboxd.v1.TerminalOpen
+	(*TerminalResize)(nil),                        // 37: sandboxd.v1.TerminalResize
+	(*ObserveServicesRequest)(nil),                // 38: sandboxd.v1.ObserveServicesRequest
+	(*ServiceProbe)(nil),                          // 39: sandboxd.v1.ServiceProbe
+	(*TCPConnectProbe)(nil),                       // 40: sandboxd.v1.TCPConnectProbe
+	(*ServiceProbeObservation)(nil),               // 41: sandboxd.v1.ServiceProbeObservation
+	(*ObserveServicesResponse)(nil),               // 42: sandboxd.v1.ObserveServicesResponse
+	(*HealthCheckRequest)(nil),                    // 43: sandboxd.v1.HealthCheckRequest
+	(*HealthCheckResponse)(nil),                   // 44: sandboxd.v1.HealthCheckResponse
+	nil,                                           // 45: sandboxd.v1.ExecStart.EnvEntry
+	nil,                                           // 46: sandboxd.v1.ProcessSpec.EnvEntry
+	nil,                                           // 47: sandboxd.v1.LaunchMaterial.SecretEnvEntry
 }
 var file_proto_sandboxd_v1_sandboxd_proto_depIdxs = []int32{
-	12, // 0: sandboxd.v1.ExecRequest.start:type_name -> sandboxd.v1.ExecStart
-	9,  // 1: sandboxd.v1.ExecRequest.stdin_eof:type_name -> sandboxd.v1.ExecStdinEOF
-	10, // 2: sandboxd.v1.ExecRequest.control:type_name -> sandboxd.v1.ExecControl
+	14, // 0: sandboxd.v1.ExecRequest.start:type_name -> sandboxd.v1.ExecStart
+	11, // 1: sandboxd.v1.ExecRequest.stdin_eof:type_name -> sandboxd.v1.ExecStdinEOF
+	12, // 2: sandboxd.v1.ExecRequest.control:type_name -> sandboxd.v1.ExecControl
 	0,  // 3: sandboxd.v1.ExecControl.control:type_name -> sandboxd.v1.ProcessControl
 	3,  // 4: sandboxd.v1.OutputChunk.stream:type_name -> sandboxd.v1.OutputStream
-	42, // 5: sandboxd.v1.ExecStart.env:type_name -> sandboxd.v1.ExecStart.EnvEntry
+	45, // 5: sandboxd.v1.ExecStart.env:type_name -> sandboxd.v1.ExecStart.EnvEntry
 	1,  // 6: sandboxd.v1.ExecStart.env_mode:type_name -> sandboxd.v1.EnvironmentMode
-	11, // 7: sandboxd.v1.ExecResponse.stdout:type_name -> sandboxd.v1.OutputChunk
-	11, // 8: sandboxd.v1.ExecResponse.stderr:type_name -> sandboxd.v1.OutputChunk
-	14, // 9: sandboxd.v1.ExecResponse.exit:type_name -> sandboxd.v1.ExecExit
+	13, // 7: sandboxd.v1.ExecResponse.stdout:type_name -> sandboxd.v1.OutputChunk
+	13, // 8: sandboxd.v1.ExecResponse.stderr:type_name -> sandboxd.v1.OutputChunk
+	16, // 9: sandboxd.v1.ExecResponse.exit:type_name -> sandboxd.v1.ExecExit
 	2,  // 10: sandboxd.v1.ExecExit.reason:type_name -> sandboxd.v1.TerminationReason
-	43, // 11: sandboxd.v1.ProcessSpec.env:type_name -> sandboxd.v1.ProcessSpec.EnvEntry
+	46, // 11: sandboxd.v1.ProcessSpec.env:type_name -> sandboxd.v1.ProcessSpec.EnvEntry
 	1,  // 12: sandboxd.v1.ProcessSpec.env_mode:type_name -> sandboxd.v1.EnvironmentMode
-	15, // 13: sandboxd.v1.StartProcessRequest.key:type_name -> sandboxd.v1.ProcessKey
-	16, // 14: sandboxd.v1.StartProcessRequest.spec:type_name -> sandboxd.v1.ProcessSpec
-	44, // 15: sandboxd.v1.LaunchMaterial.secret_env:type_name -> sandboxd.v1.LaunchMaterial.SecretEnvEntry
-	15, // 16: sandboxd.v1.StartProcessWithLaunchMaterialRequest.key:type_name -> sandboxd.v1.ProcessKey
-	16, // 17: sandboxd.v1.StartProcessWithLaunchMaterialRequest.spec:type_name -> sandboxd.v1.ProcessSpec
-	18, // 18: sandboxd.v1.StartProcessWithLaunchMaterialRequest.launch_material:type_name -> sandboxd.v1.LaunchMaterial
-	15, // 19: sandboxd.v1.GetProcessRequest.key:type_name -> sandboxd.v1.ProcessKey
-	15, // 20: sandboxd.v1.StopProcessRequest.key:type_name -> sandboxd.v1.ProcessKey
+	17, // 13: sandboxd.v1.StartProcessRequest.key:type_name -> sandboxd.v1.ProcessKey
+	18, // 14: sandboxd.v1.StartProcessRequest.spec:type_name -> sandboxd.v1.ProcessSpec
+	47, // 15: sandboxd.v1.LaunchMaterial.secret_env:type_name -> sandboxd.v1.LaunchMaterial.SecretEnvEntry
+	17, // 16: sandboxd.v1.StartProcessWithLaunchMaterialRequest.key:type_name -> sandboxd.v1.ProcessKey
+	18, // 17: sandboxd.v1.StartProcessWithLaunchMaterialRequest.spec:type_name -> sandboxd.v1.ProcessSpec
+	20, // 18: sandboxd.v1.StartProcessWithLaunchMaterialRequest.launch_material:type_name -> sandboxd.v1.LaunchMaterial
+	17, // 19: sandboxd.v1.GetProcessRequest.key:type_name -> sandboxd.v1.ProcessKey
+	17, // 20: sandboxd.v1.StopProcessRequest.key:type_name -> sandboxd.v1.ProcessKey
 	4,  // 21: sandboxd.v1.StopProcessRequest.mode:type_name -> sandboxd.v1.StopMode
-	15, // 22: sandboxd.v1.Process.key:type_name -> sandboxd.v1.ProcessKey
-	16, // 23: sandboxd.v1.Process.spec:type_name -> sandboxd.v1.ProcessSpec
+	17, // 22: sandboxd.v1.Process.key:type_name -> sandboxd.v1.ProcessKey
+	18, // 23: sandboxd.v1.Process.spec:type_name -> sandboxd.v1.ProcessSpec
 	5,  // 24: sandboxd.v1.Process.state:type_name -> sandboxd.v1.ProcessState
 	2,  // 25: sandboxd.v1.Process.reason:type_name -> sandboxd.v1.TerminationReason
-	15, // 26: sandboxd.v1.ReadOutputRequest.key:type_name -> sandboxd.v1.ProcessKey
+	17, // 26: sandboxd.v1.ReadOutputRequest.key:type_name -> sandboxd.v1.ProcessKey
 	3,  // 27: sandboxd.v1.ReadOutputRequest.stream:type_name -> sandboxd.v1.OutputStream
-	28, // 28: sandboxd.v1.WriteRequest.header:type_name -> sandboxd.v1.WriteHeader
+	30, // 28: sandboxd.v1.WriteRequest.header:type_name -> sandboxd.v1.WriteHeader
 	6,  // 29: sandboxd.v1.WriteHeader.precondition:type_name -> sandboxd.v1.WritePrecondition
-	32, // 30: sandboxd.v1.ListResponse.entries:type_name -> sandboxd.v1.Entry
+	34, // 30: sandboxd.v1.ListResponse.entries:type_name -> sandboxd.v1.Entry
 	7,  // 31: sandboxd.v1.Entry.type:type_name -> sandboxd.v1.EntryType
-	34, // 32: sandboxd.v1.TerminalMessage.open:type_name -> sandboxd.v1.TerminalOpen
-	35, // 33: sandboxd.v1.TerminalMessage.resize:type_name -> sandboxd.v1.TerminalResize
-	37, // 34: sandboxd.v1.ListPortsResponse.ports:type_name -> sandboxd.v1.Port
-	8,  // 35: sandboxd.v1.ExecService.Exec:input_type -> sandboxd.v1.ExecRequest
-	17, // 36: sandboxd.v1.ProcessService.Start:input_type -> sandboxd.v1.StartProcessRequest
-	19, // 37: sandboxd.v1.ProcessService.StartWithLaunchMaterial:input_type -> sandboxd.v1.StartProcessWithLaunchMaterialRequest
-	20, // 38: sandboxd.v1.ProcessService.Get:input_type -> sandboxd.v1.GetProcessRequest
-	21, // 39: sandboxd.v1.ProcessService.Stop:input_type -> sandboxd.v1.StopProcessRequest
-	23, // 40: sandboxd.v1.ProcessService.ReadOutput:input_type -> sandboxd.v1.ReadOutputRequest
-	25, // 41: sandboxd.v1.FilesystemService.Read:input_type -> sandboxd.v1.ReadRequest
-	27, // 42: sandboxd.v1.FilesystemService.Write:input_type -> sandboxd.v1.WriteRequest
-	30, // 43: sandboxd.v1.FilesystemService.List:input_type -> sandboxd.v1.ListRequest
-	33, // 44: sandboxd.v1.TerminalService.Terminal:input_type -> sandboxd.v1.TerminalMessage
-	36, // 45: sandboxd.v1.PortService.Register:input_type -> sandboxd.v1.RegisterPortRequest
-	38, // 46: sandboxd.v1.PortService.List:input_type -> sandboxd.v1.ListPortsRequest
-	40, // 47: sandboxd.v1.HealthService.Check:input_type -> sandboxd.v1.HealthCheckRequest
-	13, // 48: sandboxd.v1.ExecService.Exec:output_type -> sandboxd.v1.ExecResponse
-	22, // 49: sandboxd.v1.ProcessService.Start:output_type -> sandboxd.v1.Process
-	22, // 50: sandboxd.v1.ProcessService.StartWithLaunchMaterial:output_type -> sandboxd.v1.Process
-	22, // 51: sandboxd.v1.ProcessService.Get:output_type -> sandboxd.v1.Process
-	22, // 52: sandboxd.v1.ProcessService.Stop:output_type -> sandboxd.v1.Process
-	24, // 53: sandboxd.v1.ProcessService.ReadOutput:output_type -> sandboxd.v1.ReadOutputResponse
-	26, // 54: sandboxd.v1.FilesystemService.Read:output_type -> sandboxd.v1.ReadResponse
-	29, // 55: sandboxd.v1.FilesystemService.Write:output_type -> sandboxd.v1.WriteResponse
-	31, // 56: sandboxd.v1.FilesystemService.List:output_type -> sandboxd.v1.ListResponse
-	33, // 57: sandboxd.v1.TerminalService.Terminal:output_type -> sandboxd.v1.TerminalMessage
-	37, // 58: sandboxd.v1.PortService.Register:output_type -> sandboxd.v1.Port
-	39, // 59: sandboxd.v1.PortService.List:output_type -> sandboxd.v1.ListPortsResponse
-	41, // 60: sandboxd.v1.HealthService.Check:output_type -> sandboxd.v1.HealthCheckResponse
-	48, // [48:61] is the sub-list for method output_type
-	35, // [35:48] is the sub-list for method input_type
-	35, // [35:35] is the sub-list for extension type_name
-	35, // [35:35] is the sub-list for extension extendee
-	0,  // [0:35] is the sub-list for field type_name
+	36, // 32: sandboxd.v1.TerminalMessage.open:type_name -> sandboxd.v1.TerminalOpen
+	37, // 33: sandboxd.v1.TerminalMessage.resize:type_name -> sandboxd.v1.TerminalResize
+	39, // 34: sandboxd.v1.ObserveServicesRequest.probes:type_name -> sandboxd.v1.ServiceProbe
+	40, // 35: sandboxd.v1.ServiceProbe.tcp_connect:type_name -> sandboxd.v1.TCPConnectProbe
+	8,  // 36: sandboxd.v1.ServiceProbeObservation.outcome:type_name -> sandboxd.v1.ServiceProbeOutcome
+	9,  // 37: sandboxd.v1.ServiceProbeObservation.reason:type_name -> sandboxd.v1.ServiceProbeReason
+	41, // 38: sandboxd.v1.ObserveServicesResponse.observations:type_name -> sandboxd.v1.ServiceProbeObservation
+	10, // 39: sandboxd.v1.ExecService.Exec:input_type -> sandboxd.v1.ExecRequest
+	19, // 40: sandboxd.v1.ProcessService.Start:input_type -> sandboxd.v1.StartProcessRequest
+	21, // 41: sandboxd.v1.ProcessService.StartWithLaunchMaterial:input_type -> sandboxd.v1.StartProcessWithLaunchMaterialRequest
+	22, // 42: sandboxd.v1.ProcessService.Get:input_type -> sandboxd.v1.GetProcessRequest
+	23, // 43: sandboxd.v1.ProcessService.Stop:input_type -> sandboxd.v1.StopProcessRequest
+	25, // 44: sandboxd.v1.ProcessService.ReadOutput:input_type -> sandboxd.v1.ReadOutputRequest
+	27, // 45: sandboxd.v1.FilesystemService.Read:input_type -> sandboxd.v1.ReadRequest
+	29, // 46: sandboxd.v1.FilesystemService.Write:input_type -> sandboxd.v1.WriteRequest
+	32, // 47: sandboxd.v1.FilesystemService.List:input_type -> sandboxd.v1.ListRequest
+	35, // 48: sandboxd.v1.TerminalService.Terminal:input_type -> sandboxd.v1.TerminalMessage
+	38, // 49: sandboxd.v1.ServiceObservationService.Observe:input_type -> sandboxd.v1.ObserveServicesRequest
+	43, // 50: sandboxd.v1.HealthService.Check:input_type -> sandboxd.v1.HealthCheckRequest
+	15, // 51: sandboxd.v1.ExecService.Exec:output_type -> sandboxd.v1.ExecResponse
+	24, // 52: sandboxd.v1.ProcessService.Start:output_type -> sandboxd.v1.Process
+	24, // 53: sandboxd.v1.ProcessService.StartWithLaunchMaterial:output_type -> sandboxd.v1.Process
+	24, // 54: sandboxd.v1.ProcessService.Get:output_type -> sandboxd.v1.Process
+	24, // 55: sandboxd.v1.ProcessService.Stop:output_type -> sandboxd.v1.Process
+	26, // 56: sandboxd.v1.ProcessService.ReadOutput:output_type -> sandboxd.v1.ReadOutputResponse
+	28, // 57: sandboxd.v1.FilesystemService.Read:output_type -> sandboxd.v1.ReadResponse
+	31, // 58: sandboxd.v1.FilesystemService.Write:output_type -> sandboxd.v1.WriteResponse
+	33, // 59: sandboxd.v1.FilesystemService.List:output_type -> sandboxd.v1.ListResponse
+	35, // 60: sandboxd.v1.TerminalService.Terminal:output_type -> sandboxd.v1.TerminalMessage
+	42, // 61: sandboxd.v1.ServiceObservationService.Observe:output_type -> sandboxd.v1.ObserveServicesResponse
+	44, // 62: sandboxd.v1.HealthService.Check:output_type -> sandboxd.v1.HealthCheckResponse
+	51, // [51:63] is the sub-list for method output_type
+	39, // [39:51] is the sub-list for method input_type
+	39, // [39:39] is the sub-list for extension type_name
+	39, // [39:39] is the sub-list for extension extendee
+	0,  // [0:39] is the sub-list for field type_name
 }
 
 func init() { file_proto_sandboxd_v1_sandboxd_proto_init() }
@@ -3013,13 +3216,16 @@ func file_proto_sandboxd_v1_sandboxd_proto_init() {
 		(*TerminalMessage_Data)(nil),
 		(*TerminalMessage_Resize)(nil),
 	}
+	file_proto_sandboxd_v1_sandboxd_proto_msgTypes[29].OneofWrappers = []any{
+		(*ServiceProbe_TcpConnect)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_sandboxd_v1_sandboxd_proto_rawDesc), len(file_proto_sandboxd_v1_sandboxd_proto_rawDesc)),
-			NumEnums:      8,
-			NumMessages:   37,
+			NumEnums:      10,
+			NumMessages:   38,
 			NumExtensions: 0,
 			NumServices:   6,
 		},

--- a/sandboxd/gen/proto/sandboxd/v1/sandboxd_grpc.pb.go
+++ b/sandboxd/gen/proto/sandboxd/v1/sandboxd_grpc.pb.go
@@ -681,145 +681,110 @@ var TerminalService_ServiceDesc = grpc.ServiceDesc{
 }
 
 const (
-	PortService_Register_FullMethodName = "/sandboxd.v1.PortService/Register"
-	PortService_List_FullMethodName     = "/sandboxd.v1.PortService/List"
+	ServiceObservationService_Observe_FullMethodName = "/sandboxd.v1.ServiceObservationService/Observe"
 )
 
-// PortServiceClient is the client API for PortService service.
+// ServiceObservationServiceClient is the client API for ServiceObservationService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 //
-// PortService tracks ports in use inside the environment so the gateway
-// can expose them as portals.
-type PortServiceClient interface {
-	Register(ctx context.Context, in *RegisterPortRequest, opts ...grpc.CallOption) (*Port, error)
-	List(ctx context.Context, in *ListPortsRequest, opts ...grpc.CallOption) (*ListPortsResponse, error)
+// ServiceObservationService performs bounded, point-in-time TCP-connect
+// observations from the environment's logical loopback. It retains no state
+// and does not declare, register, allocate, expose, or route services.
+type ServiceObservationServiceClient interface {
+	Observe(ctx context.Context, in *ObserveServicesRequest, opts ...grpc.CallOption) (*ObserveServicesResponse, error)
 }
 
-type portServiceClient struct {
+type serviceObservationServiceClient struct {
 	cc grpc.ClientConnInterface
 }
 
-func NewPortServiceClient(cc grpc.ClientConnInterface) PortServiceClient {
-	return &portServiceClient{cc}
+func NewServiceObservationServiceClient(cc grpc.ClientConnInterface) ServiceObservationServiceClient {
+	return &serviceObservationServiceClient{cc}
 }
 
-func (c *portServiceClient) Register(ctx context.Context, in *RegisterPortRequest, opts ...grpc.CallOption) (*Port, error) {
+func (c *serviceObservationServiceClient) Observe(ctx context.Context, in *ObserveServicesRequest, opts ...grpc.CallOption) (*ObserveServicesResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(Port)
-	err := c.cc.Invoke(ctx, PortService_Register_FullMethodName, in, out, cOpts...)
+	out := new(ObserveServicesResponse)
+	err := c.cc.Invoke(ctx, ServiceObservationService_Observe_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *portServiceClient) List(ctx context.Context, in *ListPortsRequest, opts ...grpc.CallOption) (*ListPortsResponse, error) {
-	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(ListPortsResponse)
-	err := c.cc.Invoke(ctx, PortService_List_FullMethodName, in, out, cOpts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-// PortServiceServer is the server API for PortService service.
-// All implementations must embed UnimplementedPortServiceServer
+// ServiceObservationServiceServer is the server API for ServiceObservationService service.
+// All implementations must embed UnimplementedServiceObservationServiceServer
 // for forward compatibility.
 //
-// PortService tracks ports in use inside the environment so the gateway
-// can expose them as portals.
-type PortServiceServer interface {
-	Register(context.Context, *RegisterPortRequest) (*Port, error)
-	List(context.Context, *ListPortsRequest) (*ListPortsResponse, error)
-	mustEmbedUnimplementedPortServiceServer()
+// ServiceObservationService performs bounded, point-in-time TCP-connect
+// observations from the environment's logical loopback. It retains no state
+// and does not declare, register, allocate, expose, or route services.
+type ServiceObservationServiceServer interface {
+	Observe(context.Context, *ObserveServicesRequest) (*ObserveServicesResponse, error)
+	mustEmbedUnimplementedServiceObservationServiceServer()
 }
 
-// UnimplementedPortServiceServer must be embedded to have
+// UnimplementedServiceObservationServiceServer must be embedded to have
 // forward compatible implementations.
 //
 // NOTE: this should be embedded by value instead of pointer to avoid a nil
 // pointer dereference when methods are called.
-type UnimplementedPortServiceServer struct{}
+type UnimplementedServiceObservationServiceServer struct{}
 
-func (UnimplementedPortServiceServer) Register(context.Context, *RegisterPortRequest) (*Port, error) {
-	return nil, status.Error(codes.Unimplemented, "method Register not implemented")
+func (UnimplementedServiceObservationServiceServer) Observe(context.Context, *ObserveServicesRequest) (*ObserveServicesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method Observe not implemented")
 }
-func (UnimplementedPortServiceServer) List(context.Context, *ListPortsRequest) (*ListPortsResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "method List not implemented")
+func (UnimplementedServiceObservationServiceServer) mustEmbedUnimplementedServiceObservationServiceServer() {
 }
-func (UnimplementedPortServiceServer) mustEmbedUnimplementedPortServiceServer() {}
-func (UnimplementedPortServiceServer) testEmbeddedByValue()                     {}
+func (UnimplementedServiceObservationServiceServer) testEmbeddedByValue() {}
 
-// UnsafePortServiceServer may be embedded to opt out of forward compatibility for this service.
-// Use of this interface is not recommended, as added methods to PortServiceServer will
+// UnsafeServiceObservationServiceServer may be embedded to opt out of forward compatibility for this service.
+// Use of this interface is not recommended, as added methods to ServiceObservationServiceServer will
 // result in compilation errors.
-type UnsafePortServiceServer interface {
-	mustEmbedUnimplementedPortServiceServer()
+type UnsafeServiceObservationServiceServer interface {
+	mustEmbedUnimplementedServiceObservationServiceServer()
 }
 
-func RegisterPortServiceServer(s grpc.ServiceRegistrar, srv PortServiceServer) {
-	// If the following call panics, it indicates UnimplementedPortServiceServer was
+func RegisterServiceObservationServiceServer(s grpc.ServiceRegistrar, srv ServiceObservationServiceServer) {
+	// If the following call panics, it indicates UnimplementedServiceObservationServiceServer was
 	// embedded by pointer and is nil.  This will cause panics if an
 	// unimplemented method is ever invoked, so we test this at initialization
 	// time to prevent it from happening at runtime later due to I/O.
 	if t, ok := srv.(interface{ testEmbeddedByValue() }); ok {
 		t.testEmbeddedByValue()
 	}
-	s.RegisterService(&PortService_ServiceDesc, srv)
+	s.RegisterService(&ServiceObservationService_ServiceDesc, srv)
 }
 
-func _PortService_Register_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(RegisterPortRequest)
+func _ServiceObservationService_Observe_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ObserveServicesRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(PortServiceServer).Register(ctx, in)
+		return srv.(ServiceObservationServiceServer).Observe(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: PortService_Register_FullMethodName,
+		FullMethod: ServiceObservationService_Observe_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(PortServiceServer).Register(ctx, req.(*RegisterPortRequest))
+		return srv.(ServiceObservationServiceServer).Observe(ctx, req.(*ObserveServicesRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _PortService_List_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ListPortsRequest)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(PortServiceServer).List(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: PortService_List_FullMethodName,
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(PortServiceServer).List(ctx, req.(*ListPortsRequest))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-// PortService_ServiceDesc is the grpc.ServiceDesc for PortService service.
+// ServiceObservationService_ServiceDesc is the grpc.ServiceDesc for ServiceObservationService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
-var PortService_ServiceDesc = grpc.ServiceDesc{
-	ServiceName: "sandboxd.v1.PortService",
-	HandlerType: (*PortServiceServer)(nil),
+var ServiceObservationService_ServiceDesc = grpc.ServiceDesc{
+	ServiceName: "sandboxd.v1.ServiceObservationService",
+	HandlerType: (*ServiceObservationServiceServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
-			MethodName: "Register",
-			Handler:    _PortService_Register_Handler,
-		},
-		{
-			MethodName: "List",
-			Handler:    _PortService_List_Handler,
+			MethodName: "Observe",
+			Handler:    _ServiceObservationService_Observe_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/sandboxd/internal/server/server.go
+++ b/sandboxd/internal/server/server.go
@@ -11,10 +11,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"os/exec"
-	"sort"
 	"sync"
 	"time"
 
@@ -359,64 +357,4 @@ func (s *ExecServer) Exec(stream sandboxdv1.ExecService_ExecServer) error {
 			Exit: &sandboxdv1.ExecExit{Code: code, Error: errStr, Reason: terminalReason},
 		},
 	})
-}
-
-// PortServer implements PortService.
-type PortServer struct {
-	sandboxdv1.UnimplementedPortServiceServer
-
-	mu    sync.Mutex
-	ports map[uint32]*sandboxdv1.Port
-}
-
-// NewPortServer builds a PortServer with an empty registry.
-func NewPortServer() *PortServer {
-	return &PortServer{ports: map[uint32]*sandboxdv1.Port{}}
-}
-
-func (s *PortServer) Register(_ context.Context, req *sandboxdv1.RegisterPortRequest) (*sandboxdv1.Port, error) {
-	port := req.Port
-	if port == 0 {
-		free, err := freePort()
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "pick free port: %v", err)
-		}
-		port = free
-	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if p, ok := s.ports[port]; ok {
-		return p, nil
-	}
-	p := &sandboxdv1.Port{Port: port, Label: req.Label}
-	s.ports[port] = p
-	return p, nil
-}
-
-func (s *PortServer) List(_ context.Context, _ *sandboxdv1.ListPortsRequest) (*sandboxdv1.ListPortsResponse, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	resp := &sandboxdv1.ListPortsResponse{Ports: make([]*sandboxdv1.Port, 0, len(s.ports))}
-	for _, p := range s.ports {
-		resp.Ports = append(resp.Ports, p)
-	}
-	sort.Slice(resp.Ports, func(i, j int) bool { return resp.Ports[i].Port < resp.Ports[j].Port })
-	return resp, nil
-}
-
-// freePort asks the OS for an ephemeral port. There is an inherent race
-// between closing the probe listener and the caller binding the port;
-// acceptable for a registry of convenience.
-func freePort() (uint32, error) {
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		return 0, err
-	}
-	defer l.Close()
-	addr, ok := l.Addr().(*net.TCPAddr)
-	if !ok {
-		return 0, fmt.Errorf("unexpected address type %T", l.Addr())
-	}
-	return uint32(addr.Port), nil
 }

--- a/sandboxd/internal/server/server_test.go
+++ b/sandboxd/internal/server/server_test.go
@@ -47,7 +47,7 @@ func newConn(t *testing.T, workspace string) *grpc.ClientConn {
 	sandboxdv1.RegisterTerminalServiceServer(grpcServer, &TerminalServer{
 		backend: newTmuxTerminalBackend(workspace, socketName, []string{"sh"}),
 	})
-	sandboxdv1.RegisterServiceObservationServiceServer(grpcServer, NewServiceObservationServer())
+	sandboxdv1.RegisterServiceObservationServiceServer(grpcServer, NewServiceObservationServer(50051))
 	go func() { _ = grpcServer.Serve(lis) }()
 	t.Cleanup(func() { grpcServer.Stop(); processServer.Close() })
 

--- a/sandboxd/internal/server/server_test.go
+++ b/sandboxd/internal/server/server_test.go
@@ -47,7 +47,7 @@ func newConn(t *testing.T, workspace string) *grpc.ClientConn {
 	sandboxdv1.RegisterTerminalServiceServer(grpcServer, &TerminalServer{
 		backend: newTmuxTerminalBackend(workspace, socketName, []string{"sh"}),
 	})
-	sandboxdv1.RegisterPortServiceServer(grpcServer, NewPortServer())
+	sandboxdv1.RegisterServiceObservationServiceServer(grpcServer, NewServiceObservationServer())
 	go func() { _ = grpcServer.Serve(lis) }()
 	t.Cleanup(func() { grpcServer.Stop(); processServer.Close() })
 
@@ -449,28 +449,6 @@ func TestTerminalRequiresOpenFirst(t *testing.T) {
 	}
 	if _, err := stream.Recv(); status.Code(err) != codes.InvalidArgument {
 		t.Fatalf("expected InvalidArgument, got %v", err)
-	}
-}
-
-func TestPortRegistry(t *testing.T) {
-	conn := newConn(t, t.TempDir())
-	ports := sandboxdv1.NewPortServiceClient(conn)
-	ctx := context.Background()
-
-	p, err := ports.Register(ctx, &sandboxdv1.RegisterPortRequest{Port: 0, Label: "web"})
-	if err != nil {
-		t.Fatalf("register: %v", err)
-	}
-	if p.Port == 0 {
-		t.Fatal("expected an assigned port")
-	}
-
-	list, err := ports.List(ctx, &sandboxdv1.ListPortsRequest{})
-	if err != nil {
-		t.Fatalf("list: %v", err)
-	}
-	if len(list.Ports) != 1 || list.Ports[0].Label != "web" {
-		t.Fatalf("unexpected ports: %+v", list.Ports)
 	}
 }
 

--- a/sandboxd/internal/server/service_observation.go
+++ b/sandboxd/internal/server/service_observation.go
@@ -1,0 +1,149 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net"
+	"regexp"
+	"strconv"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
+)
+
+const (
+	maxServiceProbes             = 32
+	maxServiceProbeIDBytes       = 64
+	defaultServiceProbeTimeout   = time.Second
+	defaultServiceObserveTimeout = 2 * time.Second
+	defaultServiceProbeLimit     = 8
+	serviceObservationLoopback   = "127.0.0.1"
+)
+
+var serviceProbeIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+
+var reservedControlPorts = map[uint32]struct{}{
+	50051: {},
+}
+
+type dialContextFunc func(context.Context, string, string) (net.Conn, error)
+
+// ServiceObservationServer implements a stateless, bounded loopback observer.
+type ServiceObservationServer struct {
+	sandboxdv1.UnimplementedServiceObservationServiceServer
+
+	dialContext  dialContextFunc
+	probeTimeout time.Duration
+	callTimeout  time.Duration
+	probeSlots   chan struct{}
+}
+
+// NewServiceObservationServer creates an observer whose concurrency limit is
+// shared by every RPC handled by this server instance.
+func NewServiceObservationServer() *ServiceObservationServer {
+	dialer := &net.Dialer{}
+	return &ServiceObservationServer{
+		dialContext:  dialer.DialContext,
+		probeTimeout: defaultServiceProbeTimeout,
+		callTimeout:  defaultServiceObserveTimeout,
+		probeSlots:   make(chan struct{}, defaultServiceProbeLimit),
+	}
+}
+
+// Observe validates the complete request before performing any observation.
+// Results preserve request order and contain no operating-system error text.
+func (s *ServiceObservationServer) Observe(ctx context.Context, req *sandboxdv1.ObserveServicesRequest) (*sandboxdv1.ObserveServicesResponse, error) {
+	if err := validateServiceProbes(req.GetProbes()); err != nil {
+		return nil, err
+	}
+	if len(req.GetProbes()) == 0 {
+		return &sandboxdv1.ObserveServicesResponse{}, nil
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, s.callTimeout)
+	defer cancel()
+	observations := make([]*sandboxdv1.ServiceProbeObservation, len(req.Probes))
+	var wait sync.WaitGroup
+	wait.Add(len(req.Probes))
+	for i, probe := range req.Probes {
+		go func() {
+			defer wait.Done()
+			observations[i] = s.observeOne(callCtx, probe)
+		}()
+	}
+	wait.Wait()
+	if err := ctx.Err(); err != nil {
+		return nil, status.FromContextError(err).Err()
+	}
+	return &sandboxdv1.ObserveServicesResponse{Observations: observations}, nil
+}
+
+func validateServiceProbes(probes []*sandboxdv1.ServiceProbe) error {
+	if len(probes) > maxServiceProbes {
+		return status.Errorf(codes.InvalidArgument, "probes exceeds maximum of %d", maxServiceProbes)
+	}
+	ids := make(map[string]struct{}, len(probes))
+	for i, probe := range probes {
+		if probe == nil {
+			return status.Errorf(codes.InvalidArgument, "probe %d is required", i)
+		}
+		if len(probe.Id) == 0 || len(probe.Id) > maxServiceProbeIDBytes || !serviceProbeIDPattern.MatchString(probe.Id) {
+			return status.Errorf(codes.InvalidArgument, "probe %d id must be 1-%d bytes of portable correlation characters", i, maxServiceProbeIDBytes)
+		}
+		if _, duplicate := ids[probe.Id]; duplicate {
+			return status.Errorf(codes.InvalidArgument, "probe %d id is duplicated", i)
+		}
+		ids[probe.Id] = struct{}{}
+		if probe.TargetPort == 0 || probe.TargetPort > 65535 {
+			return status.Errorf(codes.InvalidArgument, "probe %d target_port must be between 1 and 65535", i)
+		}
+		if _, reserved := reservedControlPorts[probe.TargetPort]; reserved {
+			return status.Errorf(codes.InvalidArgument, "probe %d target_port is reserved for sandboxd control", i)
+		}
+		if probe.GetTcpConnect() == nil {
+			return status.Errorf(codes.InvalidArgument, "probe %d must select tcp_connect", i)
+		}
+	}
+	return nil
+}
+
+func (s *ServiceObservationServer) observeOne(ctx context.Context, probe *sandboxdv1.ServiceProbe) *sandboxdv1.ServiceProbeObservation {
+	result := &sandboxdv1.ServiceProbeObservation{Id: probe.Id}
+	select {
+	case s.probeSlots <- struct{}{}:
+		defer func() { <-s.probeSlots }()
+	case <-ctx.Done():
+		setServiceProbeContextResult(result, ctx.Err())
+		return result
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, s.probeTimeout)
+	defer cancel()
+	connection, err := s.dialContext(probeCtx, "tcp", net.JoinHostPort(serviceObservationLoopback, strconv.FormatUint(uint64(probe.TargetPort), 10)))
+	if err == nil {
+		_ = connection.Close()
+		result.Outcome = sandboxdv1.ServiceProbeOutcome_SERVICE_PROBE_OUTCOME_CONNECTED
+		result.Reason = sandboxdv1.ServiceProbeReason_SERVICE_PROBE_REASON_CONNECTION_ACCEPTED
+		return result
+	}
+	if probeCtx.Err() != nil {
+		setServiceProbeContextResult(result, probeCtx.Err())
+		return result
+	}
+	result.Outcome = sandboxdv1.ServiceProbeOutcome_SERVICE_PROBE_OUTCOME_NOT_CONNECTED
+	result.Reason = sandboxdv1.ServiceProbeReason_SERVICE_PROBE_REASON_CONNECTION_FAILED
+	return result
+}
+
+func setServiceProbeContextResult(result *sandboxdv1.ServiceProbeObservation, err error) {
+	result.Outcome = sandboxdv1.ServiceProbeOutcome_SERVICE_PROBE_OUTCOME_TIMED_OUT
+	if errors.Is(err, context.Canceled) {
+		result.Reason = sandboxdv1.ServiceProbeReason_SERVICE_PROBE_REASON_CANCELED
+		return
+	}
+	result.Reason = sandboxdv1.ServiceProbeReason_SERVICE_PROBE_REASON_DEADLINE_EXCEEDED
+}

--- a/sandboxd/internal/server/service_observation.go
+++ b/sandboxd/internal/server/service_observation.go
@@ -21,10 +21,11 @@ const (
 	defaultServiceProbeTimeout   = time.Second
 	defaultServiceObserveTimeout = 2 * time.Second
 	defaultServiceProbeLimit     = 8
-	serviceObservationLoopback   = "127.0.0.1"
 )
 
 var serviceProbeIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+
+var serviceObservationLoopbacks = []string{"127.0.0.1", "::1"}
 
 var reservedControlPorts = map[uint32]struct{}{
 	50051: {},
@@ -40,24 +41,26 @@ type ServiceObservationServer struct {
 	probeTimeout time.Duration
 	callTimeout  time.Duration
 	probeSlots   chan struct{}
+	controlPort  uint32
 }
 
 // NewServiceObservationServer creates an observer whose concurrency limit is
 // shared by every RPC handled by this server instance.
-func NewServiceObservationServer() *ServiceObservationServer {
+func NewServiceObservationServer(controlPort uint32) *ServiceObservationServer {
 	dialer := &net.Dialer{}
 	return &ServiceObservationServer{
 		dialContext:  dialer.DialContext,
 		probeTimeout: defaultServiceProbeTimeout,
 		callTimeout:  defaultServiceObserveTimeout,
 		probeSlots:   make(chan struct{}, defaultServiceProbeLimit),
+		controlPort:  controlPort,
 	}
 }
 
 // Observe validates the complete request before performing any observation.
 // Results preserve request order and contain no operating-system error text.
 func (s *ServiceObservationServer) Observe(ctx context.Context, req *sandboxdv1.ObserveServicesRequest) (*sandboxdv1.ObserveServicesResponse, error) {
-	if err := validateServiceProbes(req.GetProbes()); err != nil {
+	if err := validateServiceProbes(req.GetProbes(), s.controlPort); err != nil {
 		return nil, err
 	}
 	if len(req.GetProbes()) == 0 {
@@ -82,7 +85,7 @@ func (s *ServiceObservationServer) Observe(ctx context.Context, req *sandboxdv1.
 	return &sandboxdv1.ObserveServicesResponse{Observations: observations}, nil
 }
 
-func validateServiceProbes(probes []*sandboxdv1.ServiceProbe) error {
+func validateServiceProbes(probes []*sandboxdv1.ServiceProbe, controlPort uint32) error {
 	if len(probes) > maxServiceProbes {
 		return status.Errorf(codes.InvalidArgument, "probes exceeds maximum of %d", maxServiceProbes)
 	}
@@ -101,7 +104,8 @@ func validateServiceProbes(probes []*sandboxdv1.ServiceProbe) error {
 		if probe.TargetPort == 0 || probe.TargetPort > 65535 {
 			return status.Errorf(codes.InvalidArgument, "probe %d target_port must be between 1 and 65535", i)
 		}
-		if _, reserved := reservedControlPorts[probe.TargetPort]; reserved {
+		_, staticallyReserved := reservedControlPorts[probe.TargetPort]
+		if staticallyReserved || probe.TargetPort == controlPort {
 			return status.Errorf(codes.InvalidArgument, "probe %d target_port is reserved for sandboxd control", i)
 		}
 		if probe.GetTcpConnect() == nil {
@@ -113,19 +117,31 @@ func validateServiceProbes(probes []*sandboxdv1.ServiceProbe) error {
 
 func (s *ServiceObservationServer) observeOne(ctx context.Context, probe *sandboxdv1.ServiceProbe) *sandboxdv1.ServiceProbeObservation {
 	result := &sandboxdv1.ServiceProbeObservation{Id: probe.Id}
-	select {
-	case s.probeSlots <- struct{}{}:
-		defer func() { <-s.probeSlots }()
-	case <-ctx.Done():
-		setServiceProbeContextResult(result, ctx.Err())
-		return result
-	}
-
 	probeCtx, cancel := context.WithTimeout(ctx, s.probeTimeout)
 	defer cancel()
-	connection, err := s.dialContext(probeCtx, "tcp", net.JoinHostPort(serviceObservationLoopback, strconv.FormatUint(uint64(probe.TargetPort), 10)))
-	if err == nil {
-		_ = connection.Close()
+	type dialResult struct {
+		connected bool
+		err       error
+	}
+	dialResults := make(chan dialResult, len(serviceObservationLoopbacks))
+	for _, loopback := range serviceObservationLoopbacks {
+		go func() {
+			connected, err := s.dialLoopback(probeCtx, loopback, probe.TargetPort)
+			dialResults <- dialResult{connected: connected, err: err}
+		}()
+	}
+	connected := false
+	timedOut := false
+	for range serviceObservationLoopbacks {
+		dial := <-dialResults
+		if dial.connected {
+			connected = true
+			cancel()
+		} else if errors.Is(dial.err, context.DeadlineExceeded) {
+			timedOut = true
+		}
+	}
+	if connected {
 		result.Outcome = sandboxdv1.ServiceProbeOutcome_SERVICE_PROBE_OUTCOME_CONNECTED
 		result.Reason = sandboxdv1.ServiceProbeReason_SERVICE_PROBE_REASON_CONNECTION_ACCEPTED
 		return result
@@ -134,9 +150,28 @@ func (s *ServiceObservationServer) observeOne(ctx context.Context, probe *sandbo
 		setServiceProbeContextResult(result, probeCtx.Err())
 		return result
 	}
+	if timedOut {
+		setServiceProbeContextResult(result, context.DeadlineExceeded)
+		return result
+	}
 	result.Outcome = sandboxdv1.ServiceProbeOutcome_SERVICE_PROBE_OUTCOME_NOT_CONNECTED
 	result.Reason = sandboxdv1.ServiceProbeReason_SERVICE_PROBE_REASON_CONNECTION_FAILED
 	return result
+}
+
+func (s *ServiceObservationServer) dialLoopback(ctx context.Context, loopback string, port uint32) (bool, error) {
+	select {
+	case s.probeSlots <- struct{}{}:
+		defer func() { <-s.probeSlots }()
+	case <-ctx.Done():
+		return false, ctx.Err()
+	}
+	connection, err := s.dialContext(ctx, "tcp", net.JoinHostPort(loopback, strconv.FormatUint(uint64(port), 10)))
+	if err != nil {
+		return false, err
+	}
+	_ = connection.Close()
+	return true, nil
 }
 
 func setServiceProbeContextResult(result *sandboxdv1.ServiceProbeObservation, err error) {

--- a/sandboxd/internal/server/service_observation_test.go
+++ b/sandboxd/internal/server/service_observation_test.go
@@ -1,0 +1,208 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
+)
+
+func TestServiceObservationReportsConnectedAndNotConnectedInRequestOrder(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	connectedPort := uint32(listener.Addr().(*net.TCPAddr).Port)
+
+	closedListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	closedPort := uint32(closedListener.Addr().(*net.TCPAddr).Port)
+	if err := closedListener.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	conn := newConn(t, t.TempDir())
+	response, err := sandboxdv1.NewServiceObservationServiceClient(conn).Observe(context.Background(), &sandboxdv1.ObserveServicesRequest{Probes: []*sandboxdv1.ServiceProbe{
+		tcpServiceProbe("connected", connectedPort),
+		tcpServiceProbe("not-connected", closedPort),
+	}})
+	if err != nil {
+		t.Fatalf("observe: %v", err)
+	}
+	if len(response.Observations) != 2 {
+		t.Fatalf("observations = %d, want 2", len(response.Observations))
+	}
+	if got := response.Observations[0]; got.Id != "connected" || got.Outcome != sandboxdv1.ServiceProbeOutcome_SERVICE_PROBE_OUTCOME_CONNECTED || got.Reason != sandboxdv1.ServiceProbeReason_SERVICE_PROBE_REASON_CONNECTION_ACCEPTED {
+		t.Fatalf("connected observation = %#v", got)
+	}
+	if got := response.Observations[1]; got.Id != "not-connected" || got.Outcome != sandboxdv1.ServiceProbeOutcome_SERVICE_PROBE_OUTCOME_NOT_CONNECTED || got.Reason != sandboxdv1.ServiceProbeReason_SERVICE_PROBE_REASON_CONNECTION_FAILED {
+		t.Fatalf("not-connected observation = %#v", got)
+	}
+}
+
+func TestServiceObservationRejectsInvalidRequestsBeforeDialing(t *testing.T) {
+	valid := tcpServiceProbe("valid", 8080)
+	tests := map[string][]*sandboxdv1.ServiceProbe{
+		"nil probe":          {nil},
+		"empty id":           {tcpServiceProbe("", 8080)},
+		"oversized id":       {tcpServiceProbe(strings.Repeat("a", maxServiceProbeIDBytes+1), 8080)},
+		"non-portable id":    {tcpServiceProbe("not valid", 8080)},
+		"duplicate id":       {valid, tcpServiceProbe("valid", 8081)},
+		"zero port":          {tcpServiceProbe("zero", 0)},
+		"out-of-range port":  {tcpServiceProbe("large", 65536)},
+		"reserved port":      {tcpServiceProbe("sandboxd", 50051)},
+		"missing probe kind": {{Id: "missing", TargetPort: 8080}},
+	}
+	tooMany := make([]*sandboxdv1.ServiceProbe, maxServiceProbes+1)
+	for i := range tooMany {
+		tooMany[i] = tcpServiceProbe(string(rune('a'+i%26))+strings.Repeat("x", i/26), uint32(1000+i))
+	}
+	tests["too many probes"] = tooMany
+
+	for name, probes := range tests {
+		t.Run(name, func(t *testing.T) {
+			var dials atomic.Int32
+			observer := NewServiceObservationServer()
+			observer.dialContext = func(context.Context, string, string) (net.Conn, error) {
+				dials.Add(1)
+				return nil, errors.New("unexpected dial")
+			}
+			_, err := observer.Observe(context.Background(), &sandboxdv1.ObserveServicesRequest{Probes: probes})
+			if status.Code(err) != codes.InvalidArgument {
+				t.Fatalf("status = %v, want InvalidArgument", err)
+			}
+			if dials.Load() != 0 {
+				t.Fatalf("invalid request performed %d dials", dials.Load())
+			}
+		})
+	}
+}
+
+func TestServiceObservationBoundsErrorsAndPreservesCorrelation(t *testing.T) {
+	observer := NewServiceObservationServer()
+	observer.dialContext = func(_ context.Context, _, address string) (net.Conn, error) {
+		if strings.HasSuffix(address, ":8001") {
+			time.Sleep(20 * time.Millisecond)
+		}
+		return nil, errors.New("private operating-system detail")
+	}
+	response, err := observer.Observe(context.Background(), &sandboxdv1.ObserveServicesRequest{Probes: []*sandboxdv1.ServiceProbe{
+		tcpServiceProbe("first", 8001),
+		tcpServiceProbe("second", 8002),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(response.Observations) != 2 || response.Observations[0].Id != "first" || response.Observations[1].Id != "second" {
+		t.Fatalf("response correlation = %#v", response.Observations)
+	}
+	for _, observation := range response.Observations {
+		if observation.Outcome != sandboxdv1.ServiceProbeOutcome_SERVICE_PROBE_OUTCOME_NOT_CONNECTED || observation.Reason != sandboxdv1.ServiceProbeReason_SERVICE_PROBE_REASON_CONNECTION_FAILED {
+			t.Fatalf("bounded observation = %#v", observation)
+		}
+		if strings.Contains(observation.String(), "operating-system") {
+			t.Fatalf("observation disclosed dial error: %s", observation)
+		}
+	}
+}
+
+func TestServiceObservationEnforcesWholeCallAndGlobalConcurrencyBounds(t *testing.T) {
+	observer := NewServiceObservationServer()
+	observer.callTimeout = 40 * time.Millisecond
+	observer.probeTimeout = time.Second
+	observer.probeSlots = make(chan struct{}, 2)
+	var current atomic.Int32
+	var maximum atomic.Int32
+	observer.dialContext = func(ctx context.Context, _, _ string) (net.Conn, error) {
+		now := current.Add(1)
+		defer current.Add(-1)
+		for {
+			seen := maximum.Load()
+			if now <= seen || maximum.CompareAndSwap(seen, now) {
+				break
+			}
+		}
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	request := &sandboxdv1.ObserveServicesRequest{Probes: []*sandboxdv1.ServiceProbe{
+		tcpServiceProbe("one", 8001), tcpServiceProbe("two", 8002),
+		tcpServiceProbe("three", 8003), tcpServiceProbe("four", 8004),
+	}}
+	start := time.Now()
+	var wait sync.WaitGroup
+	wait.Add(2)
+	for range 2 {
+		go func() {
+			defer wait.Done()
+			response, err := observer.Observe(context.Background(), request)
+			if err != nil {
+				t.Errorf("observe: %v", err)
+				return
+			}
+			for _, observation := range response.Observations {
+				if observation.Outcome != sandboxdv1.ServiceProbeOutcome_SERVICE_PROBE_OUTCOME_TIMED_OUT {
+					t.Errorf("outcome = %s, want TIMED_OUT", observation.Outcome)
+				}
+			}
+		}()
+	}
+	wait.Wait()
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("whole-call bound took %s", elapsed)
+	}
+	if maximum.Load() != 2 {
+		t.Fatalf("maximum concurrent dials = %d, want 2", maximum.Load())
+	}
+	if len(observer.probeSlots) != 0 {
+		t.Fatalf("probe slots leaked: %d", len(observer.probeSlots))
+	}
+}
+
+func TestServiceObservationCancellationReleasesGlobalSlot(t *testing.T) {
+	observer := NewServiceObservationServer()
+	observer.callTimeout = time.Second
+	observer.probeTimeout = time.Second
+	observer.probeSlots = make(chan struct{}, 1)
+	started := make(chan struct{})
+	var once sync.Once
+	observer.dialContext = func(ctx context.Context, _, _ string) (net.Conn, error) {
+		once.Do(func() { close(started) })
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := observer.Observe(ctx, &sandboxdv1.ObserveServicesRequest{Probes: []*sandboxdv1.ServiceProbe{tcpServiceProbe("cancel", 8080)}})
+		done <- err
+	}()
+	<-started
+	cancel()
+	if err := <-done; status.Code(err) != codes.Canceled {
+		t.Fatalf("status = %v, want Canceled", err)
+	}
+	if len(observer.probeSlots) != 0 {
+		t.Fatalf("probe slot leaked after cancellation: %d", len(observer.probeSlots))
+	}
+}
+
+func tcpServiceProbe(id string, port uint32) *sandboxdv1.ServiceProbe {
+	return &sandboxdv1.ServiceProbe{
+		Id: id, TargetPort: port,
+		Probe: &sandboxdv1.ServiceProbe_TcpConnect{TcpConnect: &sandboxdv1.TCPConnectProbe{}},
+	}
+}

--- a/sandboxd/internal/server/service_observation_test.go
+++ b/sandboxd/internal/server/service_observation_test.go
@@ -52,6 +52,26 @@ func TestServiceObservationReportsConnectedAndNotConnectedInRequestOrder(t *test
 	}
 }
 
+func TestServiceObservationReportsIPv6LoopbackListener(t *testing.T) {
+	listener, err := net.Listen("tcp6", "[::1]:0")
+	if err != nil {
+		t.Skipf("IPv6 loopback is unavailable: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	port := uint32(listener.Addr().(*net.TCPAddr).Port)
+
+	conn := newConn(t, t.TempDir())
+	response, err := sandboxdv1.NewServiceObservationServiceClient(conn).Observe(context.Background(), &sandboxdv1.ObserveServicesRequest{
+		Probes: []*sandboxdv1.ServiceProbe{tcpServiceProbe("ipv6", port)},
+	})
+	if err != nil {
+		t.Fatalf("observe: %v", err)
+	}
+	if len(response.Observations) != 1 || response.Observations[0].Outcome != sandboxdv1.ServiceProbeOutcome_SERVICE_PROBE_OUTCOME_CONNECTED {
+		t.Fatalf("IPv6 observation = %#v", response.Observations)
+	}
+}
+
 func TestServiceObservationRejectsInvalidRequestsBeforeDialing(t *testing.T) {
 	valid := tcpServiceProbe("valid", 8080)
 	tests := map[string][]*sandboxdv1.ServiceProbe{
@@ -74,7 +94,7 @@ func TestServiceObservationRejectsInvalidRequestsBeforeDialing(t *testing.T) {
 	for name, probes := range tests {
 		t.Run(name, func(t *testing.T) {
 			var dials atomic.Int32
-			observer := NewServiceObservationServer()
+			observer := NewServiceObservationServer(50051)
 			observer.dialContext = func(context.Context, string, string) (net.Conn, error) {
 				dials.Add(1)
 				return nil, errors.New("unexpected dial")
@@ -90,8 +110,20 @@ func TestServiceObservationRejectsInvalidRequestsBeforeDialing(t *testing.T) {
 	}
 }
 
+func TestServiceObservationRejectsConfiguredControlPort(t *testing.T) {
+	observer := NewServiceObservationServer(50052)
+	for _, port := range []uint32{50051, 50052} {
+		_, err := observer.Observe(context.Background(), &sandboxdv1.ObserveServicesRequest{
+			Probes: []*sandboxdv1.ServiceProbe{tcpServiceProbe("control", port)},
+		})
+		if status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("port %d status = %v, want InvalidArgument", port, err)
+		}
+	}
+}
+
 func TestServiceObservationBoundsErrorsAndPreservesCorrelation(t *testing.T) {
-	observer := NewServiceObservationServer()
+	observer := NewServiceObservationServer(50051)
 	observer.dialContext = func(_ context.Context, _, address string) (net.Conn, error) {
 		if strings.HasSuffix(address, ":8001") {
 			time.Sleep(20 * time.Millisecond)
@@ -119,7 +151,7 @@ func TestServiceObservationBoundsErrorsAndPreservesCorrelation(t *testing.T) {
 }
 
 func TestServiceObservationEnforcesWholeCallAndGlobalConcurrencyBounds(t *testing.T) {
-	observer := NewServiceObservationServer()
+	observer := NewServiceObservationServer(50051)
 	observer.callTimeout = 40 * time.Millisecond
 	observer.probeTimeout = time.Second
 	observer.probeSlots = make(chan struct{}, 2)
@@ -173,7 +205,7 @@ func TestServiceObservationEnforcesWholeCallAndGlobalConcurrencyBounds(t *testin
 }
 
 func TestServiceObservationCancellationReleasesGlobalSlot(t *testing.T) {
-	observer := NewServiceObservationServer()
+	observer := NewServiceObservationServer(50051)
 	observer.callTimeout = time.Second
 	observer.probeTimeout = time.Second
 	observer.probeSlots = make(chan struct{}, 1)

--- a/sandboxd/proto/sandboxd/v1/sandboxd.proto
+++ b/sandboxd/proto/sandboxd/v1/sandboxd.proto
@@ -304,30 +304,53 @@ message TerminalResize {
   uint32 rows = 2;
 }
 
-// PortService tracks ports in use inside the environment so the gateway
-// can expose them as portals.
-service PortService {
-  rpc Register(RegisterPortRequest) returns (Port);
-  rpc List(ListPortsRequest) returns (ListPortsResponse);
+// ServiceObservationService performs bounded, point-in-time TCP-connect
+// observations from the environment's logical loopback. It retains no state
+// and does not declare, register, allocate, expose, or route services.
+service ServiceObservationService {
+  rpc Observe(ObserveServicesRequest) returns (ObserveServicesResponse);
 }
 
-message RegisterPortRequest {
-  // port of 0 asks sandboxd to pick a free one.
-  uint32 port = 1;
-  string label = 2;
+message ObserveServicesRequest {
+  repeated ServiceProbe probes = 1;
 }
 
-message Port {
-  uint32 port = 1;
-  string label = 2;
-  // url is filled in once the gateway has exposed the port; empty until then.
-  string url = 3;
+message ServiceProbe {
+  // id is opaque correlation data scoped only to this request.
+  string id = 1;
+  uint32 target_port = 2;
+  oneof probe {
+    TCPConnectProbe tcp_connect = 3;
+  }
 }
 
-message ListPortsRequest {}
+message TCPConnectProbe {}
 
-message ListPortsResponse {
-  repeated Port ports = 1;
+enum ServiceProbeOutcome {
+  SERVICE_PROBE_OUTCOME_UNSPECIFIED = 0;
+  SERVICE_PROBE_OUTCOME_CONNECTED = 1;
+  SERVICE_PROBE_OUTCOME_NOT_CONNECTED = 2;
+  SERVICE_PROBE_OUTCOME_TIMED_OUT = 3;
+}
+
+enum ServiceProbeReason {
+  SERVICE_PROBE_REASON_UNSPECIFIED = 0;
+  SERVICE_PROBE_REASON_CONNECTION_ACCEPTED = 1;
+  SERVICE_PROBE_REASON_CONNECTION_FAILED = 2;
+  SERVICE_PROBE_REASON_DEADLINE_EXCEEDED = 3;
+  SERVICE_PROBE_REASON_CANCELED = 4;
+}
+
+message ServiceProbeObservation {
+  string id = 1;
+  ServiceProbeOutcome outcome = 2;
+  ServiceProbeReason reason = 3;
+}
+
+message ObserveServicesResponse {
+  // observations preserve request order and contain exactly one result per
+  // validated probe.
+  repeated ServiceProbeObservation observations = 1;
 }
 
 // HealthService reports daemon liveness and version.


### PR DESCRIPTION
## Summary

- replace the unused in-memory PortService and racy port allocator with a stateless, bounded TCP-connect observation RPC
- probe only sandboxd's logical loopback with validated correlation IDs, explicit ports, request ordering, deadlines, cancellation, and daemon-wide concurrency limits
- replace the ports capability with an exact service-observation capability
- document that no operator token, connector, declaration observer, health status, URL, or portal exists yet

This is an implementation-only first slice and does not touch Environment CRDs, controllers, control-plane APIs, CLI, chart RBAC, or tenancy surfaces.

Refs #16

## Validation

- `go test -race ./...` (sandboxd)
- `go vet ./...` and `go build ./cmd/sandboxd` (sandboxd)
- Windows cross-compile of `./internal/server` and `./auth` tests
- `make test`
- `make vet`
- `make build`
- `make check-chart-crds`
- `make proto` with byte-for-byte generated binding drift check
- `git diff --check`
