### PR TITLE
Add browser session store boundary

### DIFF
--- a/internal/controlplane/auth.go
+++ b/internal/controlplane/auth.go
@@ -177,7 +177,7 @@ func (a KubernetesAccessController) CurrentSession(r *http.Request) (Session, er
 
 func (a KubernetesAccessController) DeleteSession(r *http.Request) error {
 	if a.Sessions == nil {
-		return errSessionUnavailable
+		return ErrSessionUnavailable
 	}
 	if cookie, err := r.Cookie(sessionCookieName); err == nil {
 		return sessionStoreAccessError(a.Sessions.Delete(r.Context(), cookie.Value))
@@ -208,7 +208,7 @@ func sessionStoreAccessError(err error) error {
 	if err == nil {
 		return nil
 	}
-	if errors.Is(err, errSessionUnauthenticated) || errors.Is(err, errSessionNotFound) || errors.Is(err, errSessionExpired) {
+	if errors.Is(err, ErrSessionUnauthenticated) || errors.Is(err, ErrSessionNotFound) || errors.Is(err, ErrSessionExpired) {
 		return errUnauthenticated
 	}
 	return err

--- a/internal/controlplane/auth.go
+++ b/internal/controlplane/auth.go
@@ -53,7 +53,7 @@ type principalAccessController interface {
 type SessionAuthenticator interface {
 	CreateSession(*http.Request) (Session, string, error)
 	CurrentSession(*http.Request) (Session, error)
-	DeleteSession(*http.Request)
+	DeleteSession(*http.Request) error
 }
 
 // KubernetesAccessController uses TokenReview and SubjectAccessReview. BootstrapToken,
@@ -62,7 +62,7 @@ type KubernetesAccessController struct {
 	Client         kubernetes.Interface
 	BootstrapToken string
 	Audience       string
-	Sessions       *MemorySessionStore
+	Sessions       SessionStore
 }
 
 // Authorize authenticates a bearer token (or, for browser reads, a session cookie) and
@@ -80,8 +80,10 @@ func (a KubernetesAccessController) AuthorizePrincipal(r *http.Request, access R
 	}
 	user, err := a.authenticate(r.Context(), token, bearer)
 	if err != nil {
-		if sessionID != "" {
-			a.Sessions.Delete(sessionID)
+		if sessionID != "" && errors.Is(err, errUnauthenticated) {
+			if deleteErr := a.Sessions.Delete(r.Context(), sessionID); deleteErr != nil {
+				return "", sessionStoreAccessError(deleteErr)
+			}
 		}
 		return "", err
 	}
@@ -134,8 +136,8 @@ func (a KubernetesAccessController) CreateSession(r *http.Request) (Session, str
 	if a.Sessions == nil {
 		return Session{}, "", fmt.Errorf("create session: session store is unavailable")
 	}
-	if !a.Sessions.acceptsToken(token) {
-		return Session{}, "", errUnauthenticated
+	if err := a.Sessions.ValidateToken(token); err != nil {
+		return Session{}, "", sessionStoreAccessError(err)
 	}
 	user, err := a.authenticate(r.Context(), token, bearer)
 	if err != nil {
@@ -144,9 +146,9 @@ func (a KubernetesAccessController) CreateSession(r *http.Request) (Session, str
 	if user.bootstrap {
 		return Session{}, "", errForbidden
 	}
-	sessionID, err := a.Sessions.Create(token)
+	sessionID, err := a.Sessions.Create(r.Context(), token)
 	if err != nil {
-		return Session{}, "", err
+		return Session{}, "", sessionStoreAccessError(err)
 	}
 	return Session{Authenticated: true, Username: user.name}, sessionID, nil
 }
@@ -157,25 +159,30 @@ func (a KubernetesAccessController) CurrentSession(r *http.Request) (Session, er
 	if err != nil || cookie.Value == "" || a.Sessions == nil {
 		return Session{}, errUnauthenticated
 	}
-	token, err := a.Sessions.Resolve(cookie.Value)
+	token, err := a.Sessions.Resolve(r.Context(), cookie.Value)
 	if err != nil {
-		return Session{}, err
+		return Session{}, sessionStoreAccessError(err)
 	}
 	user, err := a.authenticate(r.Context(), token, false)
 	if err != nil {
-		a.Sessions.Delete(cookie.Value)
+		if errors.Is(err, errUnauthenticated) {
+			if deleteErr := a.Sessions.Delete(r.Context(), cookie.Value); deleteErr != nil {
+				return Session{}, sessionStoreAccessError(deleteErr)
+			}
+		}
 		return Session{}, err
 	}
 	return Session{Authenticated: true, Username: user.name}, nil
 }
 
-func (a KubernetesAccessController) DeleteSession(r *http.Request) {
+func (a KubernetesAccessController) DeleteSession(r *http.Request) error {
 	if a.Sessions == nil {
-		return
+		return errSessionUnavailable
 	}
 	if cookie, err := r.Cookie(sessionCookieName); err == nil {
-		a.Sessions.Delete(cookie.Value)
+		return sessionStoreAccessError(a.Sessions.Delete(r.Context(), cookie.Value))
 	}
+	return nil
 }
 
 func (a KubernetesAccessController) requestCredential(r *http.Request, allowSession bool) (token string, bearer bool, sessionID string, err error) {
@@ -190,11 +197,21 @@ func (a KubernetesAccessController) requestCredential(r *http.Request, allowSess
 	if cookieErr != nil || cookie.Value == "" {
 		return "", false, "", errUnauthenticated
 	}
-	token, err = a.Sessions.Resolve(cookie.Value)
+	token, err = a.Sessions.Resolve(r.Context(), cookie.Value)
 	if err != nil {
-		return "", false, "", err
+		return "", false, "", sessionStoreAccessError(err)
 	}
 	return token, false, cookie.Value, nil
+}
+
+func sessionStoreAccessError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, errSessionUnauthenticated) || errors.Is(err, errSessionNotFound) || errors.Is(err, errSessionExpired) {
+		return errUnauthenticated
+	}
+	return err
 }
 
 func (a KubernetesAccessController) authenticate(ctx context.Context, token string, bearer bool) (principal, error) {

--- a/internal/controlplane/auth.go
+++ b/internal/controlplane/auth.go
@@ -82,7 +82,7 @@ func (a KubernetesAccessController) AuthorizePrincipal(r *http.Request, access R
 	if err != nil {
 		if sessionID != "" && errors.Is(err, errUnauthenticated) {
 			if deleteErr := a.Sessions.Delete(r.Context(), sessionID); deleteErr != nil {
-				return "", sessionStoreAccessError(deleteErr)
+				return "", errors.Join(err, sessionStoreAccessError(deleteErr))
 			}
 		}
 		return "", err
@@ -167,7 +167,7 @@ func (a KubernetesAccessController) CurrentSession(r *http.Request) (Session, er
 	if err != nil {
 		if errors.Is(err, errUnauthenticated) {
 			if deleteErr := a.Sessions.Delete(r.Context(), cookie.Value); deleteErr != nil {
-				return Session{}, sessionStoreAccessError(deleteErr)
+				return Session{}, errors.Join(err, sessionStoreAccessError(deleteErr))
 			}
 		}
 		return Session{}, err

--- a/internal/controlplane/auth_test.go
+++ b/internal/controlplane/auth_test.go
@@ -1,6 +1,7 @@
 package controlplane
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -137,7 +138,7 @@ func TestBrowserSessionAuthenticatesReadsButNotProducerWrites(t *testing.T) {
 		return true, &authorizationv1.SubjectAccessReview{Status: authorizationv1.SubjectAccessReviewStatus{Allowed: true}}, nil
 	})
 	store := NewMemorySessionStore(MemorySessionStoreOptions{})
-	sessionID, err := store.Create("browser-session-token")
+	sessionID, err := store.Create(context.Background(), "browser-session-token")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/controlplane/session.go
+++ b/internal/controlplane/session.go
@@ -65,7 +65,10 @@ func (s *Server) deleteSession(w http.ResponseWriter, r *http.Request) {
 		writeProblem(w, http.StatusForbidden, "invalid-origin", "Invalid origin", "cookie-authenticated mutations require an exact same-origin Origin header")
 		return
 	}
-	s.sessions.DeleteSession(r)
+	if err := s.sessions.DeleteSession(r); err != nil {
+		writeProblem(w, http.StatusServiceUnavailable, "session-unavailable", "Session service unavailable", "browser session revocation could not be committed")
+		return
+	}
 	http.SetCookie(w, &http.Cookie{
 		Name:     sessionCookieName,
 		Value:    "",

--- a/internal/controlplane/session_store.go
+++ b/internal/controlplane/session_store.go
@@ -1,6 +1,7 @@
 package controlplane
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
@@ -17,7 +18,59 @@ const (
 	defaultMaxActiveSessions    = 10_000
 )
 
-var errSessionCapacity = errors.New("session capacity reached")
+type sessionStoreErrorKind string
+
+const (
+	sessionStoreUnauthenticated sessionStoreErrorKind = "unauthenticated"
+	sessionStoreNotFound        sessionStoreErrorKind = "not-found"
+	sessionStoreExpired         sessionStoreErrorKind = "expired"
+	sessionStoreCapacity        sessionStoreErrorKind = "capacity"
+	sessionStoreUnavailable     sessionStoreErrorKind = "unavailable"
+)
+
+// sessionStoreError classifies failures consistently across session store
+// implementations without exposing backend details to authentication handlers.
+type sessionStoreError struct {
+	kind sessionStoreErrorKind
+	err  error
+}
+
+func (e *sessionStoreError) Error() string {
+	if e.err != nil {
+		return fmt.Sprintf("session store %s: %v", e.kind, e.err)
+	}
+	return "session store " + string(e.kind)
+}
+
+func (e *sessionStoreError) Unwrap() error { return e.err }
+
+func (e *sessionStoreError) Is(target error) bool {
+	other, ok := target.(*sessionStoreError)
+	return ok && e.kind == other.kind
+}
+
+var (
+	errSessionUnauthenticated = &sessionStoreError{kind: sessionStoreUnauthenticated}
+	errSessionNotFound        = &sessionStoreError{kind: sessionStoreNotFound}
+	errSessionExpired         = &sessionStoreError{kind: sessionStoreExpired}
+	errSessionCapacity        = &sessionStoreError{kind: sessionStoreCapacity}
+	errSessionUnavailable     = &sessionStoreError{kind: sessionStoreUnavailable}
+)
+
+// SessionStore retains Kubernetes bearer credentials behind opaque browser
+// session identifiers. ValidateToken must perform non-I/O input validation so
+// invalid credentials are rejected before TokenReview. Methods must classify
+// unauthenticated, absent, expired, capacity, and backend failures with the
+// typed errors above.
+type SessionStore interface {
+	ValidateToken(string) error
+	Create(context.Context, string) (string, error)
+	Resolve(context.Context, string) (string, error)
+	// Delete returns nil for absent or already-deleted identifiers. A nil result
+	// means revocation committed and subsequent Resolve calls cannot return the
+	// credential; cancellation or backend failures must be returned.
+	Delete(context.Context, string) error
+}
 
 type memorySession struct {
 	token     string
@@ -73,9 +126,16 @@ func NewMemorySessionStore(options MemorySessionStoreOptions) *MemorySessionStor
 	}
 }
 
-func (s *MemorySessionStore) Create(token string) (string, error) {
+func (s *MemorySessionStore) ValidateToken(token string) error {
 	if len(token) == 0 || len(token) > s.maxTokenBytes {
-		return "", errUnauthenticated
+		return errSessionUnauthenticated
+	}
+	return nil
+}
+
+func (s *MemorySessionStore) Create(_ context.Context, token string) (string, error) {
+	if err := s.ValidateToken(token); err != nil {
+		return "", err
 	}
 	now := s.now()
 
@@ -92,7 +152,7 @@ func (s *MemorySessionStore) Create(token string) (string, error) {
 	for attempt := 0; attempt < 4; attempt++ {
 		var raw [32]byte
 		if _, err := io.ReadFull(s.random, raw[:]); err != nil {
-			return "", fmt.Errorf("generate session identifier: %w", err)
+			return "", &sessionStoreError{kind: sessionStoreUnavailable, err: fmt.Errorf("generate session identifier: %w", err)}
 		}
 		id := base64.RawURLEncoding.EncodeToString(raw[:])
 		key := sha256.Sum256([]byte(id))
@@ -102,12 +162,12 @@ func (s *MemorySessionStore) Create(token string) (string, error) {
 		s.sessions[key] = memorySession{token: token, createdAt: now, expiresAt: now.Add(s.absoluteTTL)}
 		return id, nil
 	}
-	return "", fmt.Errorf("generate unique session identifier")
+	return "", &sessionStoreError{kind: sessionStoreUnavailable, err: errors.New("generate unique session identifier")}
 }
 
-func (s *MemorySessionStore) Resolve(id string) (string, error) {
+func (s *MemorySessionStore) Resolve(_ context.Context, id string) (string, error) {
 	if id == "" {
-		return "", errUnauthenticated
+		return "", errSessionUnauthenticated
 	}
 	key := sha256.Sum256([]byte(id))
 	now := s.now()
@@ -115,22 +175,19 @@ func (s *MemorySessionStore) Resolve(id string) (string, error) {
 	defer s.mu.Unlock()
 	session, ok := s.sessions[key]
 	if !ok {
-		return "", errUnauthenticated
+		return "", errSessionNotFound
 	}
 	if !now.Before(session.expiresAt) {
 		delete(s.sessions, key)
-		return "", errUnauthenticated
+		return "", errSessionExpired
 	}
 	return session.token, nil
 }
 
-func (s *MemorySessionStore) Delete(id string) {
+func (s *MemorySessionStore) Delete(_ context.Context, id string) error {
 	key := sha256.Sum256([]byte(id))
 	s.mu.Lock()
 	delete(s.sessions, key)
 	s.mu.Unlock()
-}
-
-func (s *MemorySessionStore) acceptsToken(token string) bool {
-	return len(token) > 0 && len(token) <= s.maxTokenBytes
+	return nil
 }

--- a/internal/controlplane/session_store.go
+++ b/internal/controlplane/session_store.go
@@ -50,11 +50,16 @@ func (e *sessionStoreError) Is(target error) bool {
 }
 
 var (
-	errSessionUnauthenticated = &sessionStoreError{kind: sessionStoreUnauthenticated}
-	errSessionNotFound        = &sessionStoreError{kind: sessionStoreNotFound}
-	errSessionExpired         = &sessionStoreError{kind: sessionStoreExpired}
-	errSessionCapacity        = &sessionStoreError{kind: sessionStoreCapacity}
-	errSessionUnavailable     = &sessionStoreError{kind: sessionStoreUnavailable}
+	// ErrSessionUnauthenticated reports invalid session input.
+	ErrSessionUnauthenticated = &sessionStoreError{kind: sessionStoreUnauthenticated}
+	// ErrSessionNotFound reports an absent session identifier.
+	ErrSessionNotFound = &sessionStoreError{kind: sessionStoreNotFound}
+	// ErrSessionExpired reports a session removed at its absolute expiry.
+	ErrSessionExpired = &sessionStoreError{kind: sessionStoreExpired}
+	// ErrSessionCapacity reports rejection at the live-session bound.
+	ErrSessionCapacity = &sessionStoreError{kind: sessionStoreCapacity}
+	// ErrSessionUnavailable reports an indeterminate backend operation.
+	ErrSessionUnavailable = &sessionStoreError{kind: sessionStoreUnavailable}
 )
 
 // SessionStore retains Kubernetes bearer credentials behind opaque browser
@@ -128,7 +133,7 @@ func NewMemorySessionStore(options MemorySessionStoreOptions) *MemorySessionStor
 
 func (s *MemorySessionStore) ValidateToken(token string) error {
 	if len(token) == 0 || len(token) > s.maxTokenBytes {
-		return errSessionUnauthenticated
+		return ErrSessionUnauthenticated
 	}
 	return nil
 }
@@ -147,7 +152,7 @@ func (s *MemorySessionStore) Create(_ context.Context, token string) (string, er
 		}
 	}
 	if len(s.sessions) >= s.maxActiveSessions {
-		return "", errSessionCapacity
+		return "", ErrSessionCapacity
 	}
 	for attempt := 0; attempt < 4; attempt++ {
 		var raw [32]byte
@@ -167,7 +172,7 @@ func (s *MemorySessionStore) Create(_ context.Context, token string) (string, er
 
 func (s *MemorySessionStore) Resolve(_ context.Context, id string) (string, error) {
 	if id == "" {
-		return "", errSessionUnauthenticated
+		return "", ErrSessionUnauthenticated
 	}
 	key := sha256.Sum256([]byte(id))
 	now := s.now()
@@ -175,11 +180,11 @@ func (s *MemorySessionStore) Resolve(_ context.Context, id string) (string, erro
 	defer s.mu.Unlock()
 	session, ok := s.sessions[key]
 	if !ok {
-		return "", errSessionNotFound
+		return "", ErrSessionNotFound
 	}
 	if !now.Before(session.expiresAt) {
 		delete(s.sessions, key)
-		return "", errSessionExpired
+		return "", ErrSessionExpired
 	}
 	return session.token, nil
 }

--- a/internal/controlplane/session_store_test.go
+++ b/internal/controlplane/session_store_test.go
@@ -34,14 +34,14 @@ func (s *fakeSessionStore) ValidateToken(token string) error {
 
 func (s *fakeSessionStore) Create(ctx context.Context, token string) (string, error) {
 	if s.create == nil {
-		return "", errSessionUnavailable
+		return "", ErrSessionUnavailable
 	}
 	return s.create(ctx, token)
 }
 
 func (s *fakeSessionStore) Resolve(ctx context.Context, id string) (string, error) {
 	if s.resolve == nil {
-		return "", errSessionUnavailable
+		return "", ErrSessionUnavailable
 	}
 	return s.resolve(ctx, id)
 }
@@ -71,10 +71,10 @@ func TestMemorySessionStoreBoundsAndAbsoluteExpiry(t *testing.T) {
 	if err != nil || first == second {
 		t.Fatalf("second session = %q, err %v", second, err)
 	}
-	if _, err := store.Create(ctx, "three"); !errors.Is(err, errSessionCapacity) {
+	if _, err := store.Create(ctx, "three"); !errors.Is(err, ErrSessionCapacity) {
 		t.Fatalf("capacity error = %v", err)
 	}
-	if _, err := store.Create(ctx, "123456"); !errors.Is(err, errSessionUnauthenticated) {
+	if _, err := store.Create(ctx, "123456"); !errors.Is(err, ErrSessionUnauthenticated) {
 		t.Fatalf("oversized token error = %v", err)
 	}
 	key := sha256SessionKey(first)
@@ -82,10 +82,10 @@ func TestMemorySessionStoreBoundsAndAbsoluteExpiry(t *testing.T) {
 		t.Fatalf("stored times = %s/%s", entry.createdAt, entry.expiresAt)
 	}
 	now = now.Add(time.Minute)
-	if _, err := store.Resolve(ctx, first); !errors.Is(err, errSessionExpired) {
+	if _, err := store.Resolve(ctx, first); !errors.Is(err, ErrSessionExpired) {
 		t.Fatalf("expired resolve error = %v", err)
 	}
-	if _, err := store.Resolve(ctx, first); !errors.Is(err, errSessionNotFound) {
+	if _, err := store.Resolve(ctx, first); !errors.Is(err, ErrSessionNotFound) {
 		t.Fatalf("purged resolve error = %v", err)
 	}
 	if err := store.Delete(ctx, first); err != nil {
@@ -292,12 +292,12 @@ func TestSessionResolveFailureSkipsTokenReview(t *testing.T) {
 		return true, nil, errors.New("unexpected TokenReview")
 	})
 	store := &fakeSessionStore{resolve: func(context.Context, string) (string, error) {
-		return "", errSessionUnavailable
+		return "", ErrSessionUnavailable
 	}}
 	controller := KubernetesAccessController{Client: client, Sessions: store}
 	request := httptest.NewRequest(http.MethodGet, "https://console.test/api/v1/namespaces/ns/runs", nil)
 	request.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "session"})
-	if err := controller.Authorize(request, ResourceAccess{}, true); !errors.Is(err, errSessionUnavailable) {
+	if err := controller.Authorize(request, ResourceAccess{}, true); !errors.Is(err, ErrSessionUnavailable) {
 		t.Fatalf("resolve error = %v", err)
 	}
 	if reviews != 0 {
@@ -407,12 +407,12 @@ func TestDefinitiveRejectionDeleteFailureIsUnavailable(t *testing.T) {
 	})
 	store := &fakeSessionStore{
 		resolve: func(context.Context, string) (string, error) { return "resource-token", nil },
-		delete:  func(context.Context, string) error { return errSessionUnavailable },
+		delete:  func(context.Context, string) error { return ErrSessionUnavailable },
 	}
 	controller := KubernetesAccessController{Client: client, Sessions: store}
 	request := httptest.NewRequest(http.MethodGet, "https://console.test/api/v1/namespaces/ns/runs", nil)
 	request.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "session"})
-	if err := controller.Authorize(request, ResourceAccess{}, true); !errors.Is(err, errSessionUnavailable) {
+	if err := controller.Authorize(request, ResourceAccess{}, true); !errors.Is(err, ErrSessionUnavailable) {
 		t.Fatalf("delete failure error = %v", err)
 	}
 }

--- a/internal/controlplane/session_store_test.go
+++ b/internal/controlplane/session_store_test.go
@@ -2,6 +2,7 @@ package controlplane
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"errors"
 	"net/http"
@@ -17,6 +18,41 @@ import (
 	ktesting "k8s.io/client-go/testing"
 )
 
+type fakeSessionStore struct {
+	validate func(string) error
+	create   func(context.Context, string) (string, error)
+	resolve  func(context.Context, string) (string, error)
+	delete   func(context.Context, string) error
+}
+
+func (s *fakeSessionStore) ValidateToken(token string) error {
+	if s.validate == nil {
+		return nil
+	}
+	return s.validate(token)
+}
+
+func (s *fakeSessionStore) Create(ctx context.Context, token string) (string, error) {
+	if s.create == nil {
+		return "", errSessionUnavailable
+	}
+	return s.create(ctx, token)
+}
+
+func (s *fakeSessionStore) Resolve(ctx context.Context, id string) (string, error) {
+	if s.resolve == nil {
+		return "", errSessionUnavailable
+	}
+	return s.resolve(ctx, id)
+}
+
+func (s *fakeSessionStore) Delete(ctx context.Context, id string) error {
+	if s.delete == nil {
+		return nil
+	}
+	return s.delete(ctx, id)
+}
+
 func TestMemorySessionStoreBoundsAndAbsoluteExpiry(t *testing.T) {
 	now := time.Date(2026, 7, 19, 19, 0, 0, 0, time.UTC)
 	store := NewMemorySessionStore(MemorySessionStoreOptions{
@@ -26,18 +62,19 @@ func TestMemorySessionStoreBoundsAndAbsoluteExpiry(t *testing.T) {
 		Now:               func() time.Time { return now },
 		Random:            bytes.NewReader(append(bytes.Repeat([]byte{1}, 32), append(bytes.Repeat([]byte{2}, 32), bytes.Repeat([]byte{3}, 32)...)...)),
 	})
-	first, err := store.Create("one")
+	ctx := context.Background()
+	first, err := store.Create(ctx, "one")
 	if err != nil {
 		t.Fatal(err)
 	}
-	second, err := store.Create("two")
+	second, err := store.Create(ctx, "two")
 	if err != nil || first == second {
 		t.Fatalf("second session = %q, err %v", second, err)
 	}
-	if _, err := store.Create("three"); !errors.Is(err, errSessionCapacity) {
+	if _, err := store.Create(ctx, "three"); !errors.Is(err, errSessionCapacity) {
 		t.Fatalf("capacity error = %v", err)
 	}
-	if _, err := store.Create("123456"); !errors.Is(err, errUnauthenticated) {
+	if _, err := store.Create(ctx, "123456"); !errors.Is(err, errSessionUnauthenticated) {
 		t.Fatalf("oversized token error = %v", err)
 	}
 	key := sha256SessionKey(first)
@@ -45,12 +82,64 @@ func TestMemorySessionStoreBoundsAndAbsoluteExpiry(t *testing.T) {
 		t.Fatalf("stored times = %s/%s", entry.createdAt, entry.expiresAt)
 	}
 	now = now.Add(time.Minute)
-	if _, err := store.Resolve(first); !errors.Is(err, errUnauthenticated) {
+	if _, err := store.Resolve(ctx, first); !errors.Is(err, errSessionExpired) {
 		t.Fatalf("expired resolve error = %v", err)
 	}
-	if _, err := store.Create("new"); err != nil {
+	if _, err := store.Resolve(ctx, first); !errors.Is(err, errSessionNotFound) {
+		t.Fatalf("purged resolve error = %v", err)
+	}
+	if err := store.Delete(ctx, first); err != nil {
+		t.Fatalf("idempotent delete error = %v", err)
+	}
+	if _, err := store.Create(ctx, "new"); err != nil {
 		t.Fatalf("expired sessions did not release capacity: %v", err)
 	}
+}
+
+func TestSessionCreateUsesConfiguredStoreTokenBoundBeforeReview(t *testing.T) {
+	t.Run("below default", func(t *testing.T) {
+		reviews := 0
+		client := fake.NewClientset()
+		client.PrependReactor("create", "tokenreviews", func(ktesting.Action) (bool, runtime.Object, error) {
+			reviews++
+			return true, nil, errors.New("unexpected TokenReview")
+		})
+		controller := KubernetesAccessController{
+			Client:   client,
+			Sessions: NewMemorySessionStore(MemorySessionStoreOptions{MaxTokenBytes: 5}),
+		}
+		request := httptest.NewRequest(http.MethodPost, "https://console.test/api/v1/session", nil)
+		request.Header.Set("Authorization", "Bearer 123456")
+		if _, _, err := controller.CreateSession(request); !errors.Is(err, errUnauthenticated) {
+			t.Fatalf("create error = %v", err)
+		}
+		if reviews != 0 {
+			t.Fatalf("invalid token caused %d TokenReviews", reviews)
+		}
+	})
+
+	t.Run("above default", func(t *testing.T) {
+		token := strings.Repeat("x", defaultMaxSessionTokenBytes+1)
+		client := fake.NewClientset()
+		client.PrependReactor("create", "tokenreviews", func(ktesting.Action) (bool, runtime.Object, error) {
+			return true, &authenticationv1.TokenReview{Status: authenticationv1.TokenReviewStatus{
+				Authenticated: true,
+				Audiences:     []string{defaultTokenAudience},
+				User:          authenticationv1.UserInfo{Username: "console-user"},
+			}}, nil
+		})
+		controller := KubernetesAccessController{
+			Client: client,
+			Sessions: NewMemorySessionStore(MemorySessionStoreOptions{
+				MaxTokenBytes: len(token),
+			}),
+		}
+		request := httptest.NewRequest(http.MethodPost, "https://console.test/api/v1/session", nil)
+		request.Header.Set("Authorization", "Bearer "+token)
+		if _, _, err := controller.CreateSession(request); err != nil {
+			t.Fatalf("create error = %v", err)
+		}
+	})
 }
 
 func TestOpaqueSessionLogoutRevocationAndBearerPreference(t *testing.T) {
@@ -166,7 +255,7 @@ func TestCookieResourceAuthorizationReviewsEveryRequestAndRevokes(t *testing.T) 
 		return true, &authorizationv1.SubjectAccessReview{Status: authorizationv1.SubjectAccessReviewStatus{Allowed: true}}, nil
 	})
 	store := NewMemorySessionStore(MemorySessionStoreOptions{})
-	sessionID, err := store.Create("resource-token")
+	sessionID, err := store.Create(context.Background(), "resource-token")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,6 +281,189 @@ func TestCookieResourceAuthorizationReviewsEveryRequestAndRevokes(t *testing.T) 
 	}
 	if len(events) != eventCount {
 		t.Fatalf("deleted session replay reached Kubernetes: %v", events[eventCount:])
+	}
+}
+
+func TestSessionResolveFailureSkipsTokenReview(t *testing.T) {
+	reviews := 0
+	client := fake.NewClientset()
+	client.PrependReactor("create", "tokenreviews", func(ktesting.Action) (bool, runtime.Object, error) {
+		reviews++
+		return true, nil, errors.New("unexpected TokenReview")
+	})
+	store := &fakeSessionStore{resolve: func(context.Context, string) (string, error) {
+		return "", errSessionUnavailable
+	}}
+	controller := KubernetesAccessController{Client: client, Sessions: store}
+	request := httptest.NewRequest(http.MethodGet, "https://console.test/api/v1/namespaces/ns/runs", nil)
+	request.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "session"})
+	if err := controller.Authorize(request, ResourceAccess{}, true); !errors.Is(err, errSessionUnavailable) {
+		t.Fatalf("resolve error = %v", err)
+	}
+	if reviews != 0 {
+		t.Fatalf("resolve failure caused %d TokenReviews", reviews)
+	}
+}
+
+func TestTransientTokenReviewFailureRetainsSessionForRetry(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		firstResult *authenticationv1.TokenReview
+		firstError  error
+	}{
+		{name: "transport", firstError: errors.New("apiserver unavailable")},
+		{name: "status error", firstResult: &authenticationv1.TokenReview{Status: authenticationv1.TokenReviewStatus{Error: "webhook unavailable"}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reviews := 0
+			client := fake.NewClientset()
+			client.PrependReactor("create", "tokenreviews", func(ktesting.Action) (bool, runtime.Object, error) {
+				reviews++
+				if reviews == 1 {
+					return true, tc.firstResult, tc.firstError
+				}
+				return true, &authenticationv1.TokenReview{Status: authenticationv1.TokenReviewStatus{
+					Authenticated: true,
+					Audiences:     []string{defaultTokenAudience},
+					User:          authenticationv1.UserInfo{Username: "console-user"},
+				}}, nil
+			})
+			client.PrependReactor("create", "subjectaccessreviews", func(ktesting.Action) (bool, runtime.Object, error) {
+				return true, &authorizationv1.SubjectAccessReview{Status: authorizationv1.SubjectAccessReviewStatus{Allowed: true}}, nil
+			})
+			store := NewMemorySessionStore(MemorySessionStoreOptions{})
+			sessionID, err := store.Create(context.Background(), "resource-token")
+			if err != nil {
+				t.Fatal(err)
+			}
+			controller := KubernetesAccessController{Client: client, Sessions: store}
+			request := httptest.NewRequest(http.MethodGet, "https://console.test/api/v1/namespaces/ns/runs", nil)
+			request.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sessionID})
+			if err := controller.Authorize(request, ResourceAccess{}, true); err == nil || errors.Is(err, errUnauthenticated) {
+				t.Fatalf("transient TokenReview error = %v", err)
+			}
+			if err := controller.Authorize(request, ResourceAccess{}, true); err != nil {
+				t.Fatalf("retry failed: %v", err)
+			}
+			if reviews != 2 {
+				t.Fatalf("TokenReviews = %d, want 2", reviews)
+			}
+		})
+	}
+}
+
+func TestAudienceMismatchRevokesSession(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		operation func(KubernetesAccessController, *http.Request) error
+	}{
+		{name: "resource authorization", operation: func(controller KubernetesAccessController, request *http.Request) error {
+			return controller.Authorize(request, ResourceAccess{}, true)
+		}},
+		{name: "current session", operation: func(controller KubernetesAccessController, request *http.Request) error {
+			_, err := controller.CurrentSession(request)
+			return err
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewClientset()
+			client.PrependReactor("create", "tokenreviews", func(ktesting.Action) (bool, runtime.Object, error) {
+				return true, &authenticationv1.TokenReview{Status: authenticationv1.TokenReviewStatus{
+					Authenticated: true,
+					Audiences:     []string{"other-service"},
+					User:          authenticationv1.UserInfo{Username: "console-user"},
+				}}, nil
+			})
+			deletes := 0
+			contextKey := struct{}{}
+			store := &fakeSessionStore{
+				resolve: func(context.Context, string) (string, error) { return "resource-token", nil },
+				delete: func(ctx context.Context, id string) error {
+					deletes++
+					if id != "session" || ctx.Value(contextKey) != "request" {
+						t.Fatalf("delete id/context = %q/%v", id, ctx.Value(contextKey))
+					}
+					return nil
+				},
+			}
+			controller := KubernetesAccessController{Client: client, Sessions: store}
+			ctx := context.WithValue(context.Background(), contextKey, "request")
+			request := httptest.NewRequest(http.MethodGet, "https://console.test/api/v1/namespaces/ns/runs", nil).WithContext(ctx)
+			request.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "session"})
+			if err := tc.operation(controller, request); !errors.Is(err, errUnauthenticated) {
+				t.Fatalf("audience mismatch error = %v", err)
+			}
+			if deletes != 1 {
+				t.Fatalf("deletes = %d, want 1", deletes)
+			}
+		})
+	}
+}
+
+func TestDefinitiveRejectionDeleteFailureIsUnavailable(t *testing.T) {
+	client := fake.NewClientset()
+	client.PrependReactor("create", "tokenreviews", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, &authenticationv1.TokenReview{Status: authenticationv1.TokenReviewStatus{Authenticated: false}}, nil
+	})
+	store := &fakeSessionStore{
+		resolve: func(context.Context, string) (string, error) { return "resource-token", nil },
+		delete:  func(context.Context, string) error { return errSessionUnavailable },
+	}
+	controller := KubernetesAccessController{Client: client, Sessions: store}
+	request := httptest.NewRequest(http.MethodGet, "https://console.test/api/v1/namespaces/ns/runs", nil)
+	request.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "session"})
+	if err := controller.Authorize(request, ResourceAccess{}, true); !errors.Is(err, errSessionUnavailable) {
+		t.Fatalf("delete failure error = %v", err)
+	}
+}
+
+func TestSubjectAccessReviewFailureRetainsSession(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		first      authorizationv1.SubjectAccessReviewStatus
+		firstError error
+	}{
+		{name: "denied", first: authorizationv1.SubjectAccessReviewStatus{Allowed: false}},
+		{name: "transport", firstError: errors.New("apiserver unavailable")},
+		{name: "evaluation error", first: authorizationv1.SubjectAccessReviewStatus{EvaluationError: "webhook unavailable"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewClientset()
+			reviews := 0
+			client.PrependReactor("create", "tokenreviews", func(ktesting.Action) (bool, runtime.Object, error) {
+				reviews++
+				return true, &authenticationv1.TokenReview{Status: authenticationv1.TokenReviewStatus{
+					Authenticated: true,
+					Audiences:     []string{defaultTokenAudience},
+					User:          authenticationv1.UserInfo{Username: "console-user"},
+				}}, nil
+			})
+			sars := 0
+			client.PrependReactor("create", "subjectaccessreviews", func(ktesting.Action) (bool, runtime.Object, error) {
+				sars++
+				if sars == 1 {
+					return true, &authorizationv1.SubjectAccessReview{Status: tc.first}, tc.firstError
+				}
+				return true, &authorizationv1.SubjectAccessReview{Status: authorizationv1.SubjectAccessReviewStatus{Allowed: true}}, nil
+			})
+			store := NewMemorySessionStore(MemorySessionStoreOptions{})
+			sessionID, err := store.Create(context.Background(), "resource-token")
+			if err != nil {
+				t.Fatal(err)
+			}
+			controller := KubernetesAccessController{Client: client, Sessions: store}
+			request := httptest.NewRequest(http.MethodGet, "https://console.test/api/v1/namespaces/ns/runs", nil)
+			request.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sessionID})
+			if err := controller.Authorize(request, ResourceAccess{}, true); err == nil {
+				t.Fatal("first SAR unexpectedly succeeded")
+			}
+			if err := controller.Authorize(request, ResourceAccess{}, true); err != nil {
+				t.Fatalf("retry failed: %v", err)
+			}
+			if reviews != 2 || sars != 2 {
+				t.Fatalf("reviews = TokenReview %d, SAR %d; want 2 each", reviews, sars)
+			}
+		})
 	}
 }
 

--- a/internal/controlplane/session_store_test.go
+++ b/internal/controlplane/session_store_test.go
@@ -400,20 +400,58 @@ func TestAudienceMismatchRevokesSession(t *testing.T) {
 	}
 }
 
-func TestDefinitiveRejectionDeleteFailureIsUnavailable(t *testing.T) {
-	client := fake.NewClientset()
-	client.PrependReactor("create", "tokenreviews", func(ktesting.Action) (bool, runtime.Object, error) {
-		return true, &authenticationv1.TokenReview{Status: authenticationv1.TokenReviewStatus{Authenticated: false}}, nil
-	})
-	store := &fakeSessionStore{
-		resolve: func(context.Context, string) (string, error) { return "resource-token", nil },
-		delete:  func(context.Context, string) error { return ErrSessionUnavailable },
-	}
-	controller := KubernetesAccessController{Client: client, Sessions: store}
-	request := httptest.NewRequest(http.MethodGet, "https://console.test/api/v1/namespaces/ns/runs", nil)
-	request.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "session"})
-	if err := controller.Authorize(request, ResourceAccess{}, true); !errors.Is(err, ErrSessionUnavailable) {
-		t.Fatalf("delete failure error = %v", err)
+func TestDefinitiveRejectionDeleteFailureRemainsUnauthenticatedAndRetries(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		operation func(KubernetesAccessController, *http.Request) error
+		write     func(http.ResponseWriter, error)
+	}{
+		{name: "resource authorization", operation: func(controller KubernetesAccessController, request *http.Request) error {
+			return controller.Authorize(request, ResourceAccess{}, true)
+		}, write: writeAccessError},
+		{name: "current session", operation: func(controller KubernetesAccessController, request *http.Request) error {
+			_, err := controller.CurrentSession(request)
+			return err
+		}, write: writeRESTAccessError},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewClientset()
+			tokenReviews := 0
+			client.PrependReactor("create", "tokenreviews", func(ktesting.Action) (bool, runtime.Object, error) {
+				tokenReviews++
+				return true, &authenticationv1.TokenReview{Status: authenticationv1.TokenReviewStatus{Authenticated: false}}, nil
+			})
+			sars := 0
+			client.PrependReactor("create", "subjectaccessreviews", func(ktesting.Action) (bool, runtime.Object, error) {
+				sars++
+				return true, &authorizationv1.SubjectAccessReview{Status: authorizationv1.SubjectAccessReviewStatus{Allowed: true}}, nil
+			})
+			deletes := 0
+			store := &fakeSessionStore{
+				resolve: func(context.Context, string) (string, error) { return "resource-token", nil },
+				delete: func(context.Context, string) error {
+					deletes++
+					return ErrSessionUnavailable
+				},
+			}
+			controller := KubernetesAccessController{Client: client, Sessions: store}
+			request := httptest.NewRequest(http.MethodGet, "https://console.test/api/v1/namespaces/ns/runs", nil)
+			request.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "session"})
+			for attempt := 1; attempt <= 2; attempt++ {
+				err := tc.operation(controller, request)
+				if !errors.Is(err, errUnauthenticated) || !errors.Is(err, ErrSessionUnavailable) {
+					t.Fatalf("attempt %d error = %v", attempt, err)
+				}
+				response := httptest.NewRecorder()
+				tc.write(response, err)
+				if response.Code != http.StatusUnauthorized {
+					t.Fatalf("attempt %d status = %d, want 401", attempt, response.Code)
+				}
+			}
+			if tokenReviews != 2 || deletes != 2 || sars != 0 {
+				t.Fatalf("TokenReviews/deletes/SARs = %d/%d/%d, want 2/2/0", tokenReviews, deletes, sars)
+			}
+		})
 	}
 }
 

--- a/internal/controlplane/session_test.go
+++ b/internal/controlplane/session_test.go
@@ -178,7 +178,7 @@ func TestSessionDeleteStoreFailureRetainsCookie(t *testing.T) {
 	r.Header.Set("Origin", "https://example.test")
 	r.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "retryable"})
 	w := httptest.NewRecorder()
-	sessions := &fakeSessions{delete: func(*http.Request) error { return errSessionUnavailable }}
+	sessions := &fakeSessions{delete: func(*http.Request) error { return ErrSessionUnavailable }}
 	NewServer(nil, ServerOptions{Sessions: sessions}).Handler().ServeHTTP(w, r)
 	if w.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())

--- a/internal/controlplane/session_test.go
+++ b/internal/controlplane/session_test.go
@@ -11,6 +11,7 @@ import (
 type fakeSessions struct {
 	create  func(*http.Request) (Session, string, error)
 	current func(*http.Request) (Session, error)
+	delete  func(*http.Request) error
 	deleted bool
 }
 
@@ -18,7 +19,13 @@ func (f *fakeSessions) CreateSession(r *http.Request) (Session, string, error) {
 	return f.create(r)
 }
 func (f *fakeSessions) CurrentSession(r *http.Request) (Session, error) { return f.current(r) }
-func (f *fakeSessions) DeleteSession(*http.Request)                     { f.deleted = true }
+func (f *fakeSessions) DeleteSession(r *http.Request) error {
+	f.deleted = true
+	if f.delete != nil {
+		return f.delete(r)
+	}
+	return nil
+}
 
 func TestSessionCreateSecurityAndExplicitBearer(t *testing.T) {
 	for _, tc := range []struct {
@@ -163,5 +170,20 @@ func TestSessionDeleteOriginAndExpiry(t *testing.T) {
 	NewServer(nil, ServerOptions{Sessions: &fakeSessions{}}).Handler().ServeHTTP(w, r)
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("duplicate Origin status=%d", w.Code)
+	}
+}
+
+func TestSessionDeleteStoreFailureRetainsCookie(t *testing.T) {
+	r := httptest.NewRequest(http.MethodDelete, "https://example.test/api/v1/session", nil)
+	r.Header.Set("Origin", "https://example.test")
+	r.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "retryable"})
+	w := httptest.NewRecorder()
+	sessions := &fakeSessions{delete: func(*http.Request) error { return errSessionUnavailable }}
+	NewServer(nil, ServerOptions{Sessions: sessions}).Handler().ServeHTTP(w, r)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	if cookies := w.Result().Cookies(); len(cookies) != 0 {
+		t.Fatalf("store failure cleared cookie: %+v", cookies)
 	}
 }


### PR DESCRIPTION
## Summary
- introduce a context-aware `SessionStore` contract and adapt the bounded in-memory implementation with typed failure categories
- retain cookie sessions across transient TokenReview and all SAR failures while revoking definitive authentication/audience failures
- propagate idempotent logout revocation failures so retryable cookies are not cleared
- add focused memory, authentication, retry, and logout tests

## Validation
- `go test -race ./internal/controlplane`
- `make test`
- `make vet`
- `make build`

Refs #145