### PR TITLE
Add control-plane operational metrics

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -39,8 +39,10 @@ CLI / TUI / local MCP / browser console
   namespace; each onboarded Project and its resources live in one dedicated claimed namespace.
 - **Control plane.** A singleton HTTP service exposes typed Run and Environment operations,
   Run watches, transcript ingestion/SSE, browser sessions, the embedded operations console,
-  and terminal WebSockets. It acts through Kubernetes APIs and the sandboxd connector; it
-  does not exec into Environment pods.
+  and terminal WebSockets. A separate internal HTTP listener exposes bounded-cardinality
+  Prometheus process and operational metrics at `/metrics`; it does not serve application
+  routes. The control plane acts through Kubernetes APIs and the sandboxd connector; it does
+  not exec into Environment pods.
 - **Clients.** `swe run`, `logs`, `attach`, `tui`, and the bounded local stdio MCP server use
   the control-plane or Kubernetes contracts appropriate to each command. The React console
   uses the same control-plane resource, transcript, and terminal APIs.

--- a/charts/swe-platform/README.md
+++ b/charts/swe-platform/README.md
@@ -36,6 +36,52 @@ durable transcripts and encrypted PostgreSQL browser sessions survive process re
 open SSE/WebSocket connections do not and this release makes no control-plane HA claim. Portal
 proxying is not implemented yet.
 
+## Control-plane metrics
+
+The stable control-plane Service exposes a dedicated internal Prometheus scrape port named
+`metrics` (8082 by default). Scrape `/metrics` on that port; the listener serves no console,
+session, transcript, terminal, or other application route. The binary's
+`--metrics-bind-address` defaults to `127.0.0.1:8082` for fail-closed direct execution, while
+the chart explicitly binds `:<controlPlane.metrics.port>` so the cluster-internal Service is a
+usable scrape target. The port must be 1-65535 and cannot overlap the API's Service port 80 or
+container port 8080. The chart
+does not install a ServiceMonitor or make the Service externally reachable; apply cluster-local
+scrape discovery and NetworkPolicy appropriate to your Prometheus installation.
+
+All custom labels are fixed outcome, kind, or reason sets. They never contain credentials,
+sessions, users, namespaces, repositories, URLs, Runs, or Environments. Healthy traffic should
+show committed/replayed appends, admitted subscribers returning to baseline, delivered replay
+or live events with low lag, terminal grants, and allowed authentication reviews. Investigate:
+
+| Metric | Labels |
+|---|---|
+| `swe_control_plane_transcript_appends_total` | `outcome`: `committed`, `replayed`, `rejected`, `error` |
+| `swe_control_plane_transcript_append_duration_seconds` | same `outcome` values |
+| `swe_control_plane_transcript_sse_subscribers` | none |
+| `swe_control_plane_transcript_sse_deliveries_total` | `kind`: `replay`, `live`, `gap`; `outcome`: `delivered`, `error`, plus `dropped` for live delivery |
+| `swe_control_plane_transcript_sse_delivery_lag_seconds` | `kind`: `replay`, `live` |
+| `swe_control_plane_terminal_lease_grants_total` | `outcome`: `granted`, `failed` |
+| `swe_control_plane_terminal_lease_revocations_total` | `reason`: `run_association_changed`, `environment_changed`, `execution_changed`, `hold_policy_changed` |
+| `swe_control_plane_token_reviews_total` | `outcome`: `authenticated`, `denied`, `error` |
+| `swe_control_plane_token_review_duration_seconds` | same `outcome` values |
+| `swe_control_plane_subject_access_reviews_total` | `outcome`: `allowed`, `denied`, `error` |
+| `swe_control_plane_subject_access_review_duration_seconds` | same `outcome` values |
+
+- sustained `swe_control_plane_transcript_appends_total{outcome="error"}` or
+  `{outcome="rejected"}` growth;
+- a `swe_control_plane_transcript_sse_subscribers` gauge that does not fall after clients
+  disconnect, `swe_control_plane_transcript_sse_deliveries_total{outcome="dropped"}` growth,
+  or rising `swe_control_plane_transcript_sse_delivery_lag_seconds`;
+- repeated `swe_control_plane_terminal_lease_grants_total{outcome="failed"}` or unexpected
+  `swe_control_plane_terminal_lease_revocations_total` growth; and
+- `swe_control_plane_token_reviews_total` or
+  `swe_control_plane_subject_access_reviews_total` denial/error spikes, together with elevated
+  matching review duration histograms. Denials can be expected for unauthorized traffic, so
+  correlate them with request volume and audit logs rather than paging on every denial.
+
+Histogram families add the standard `_bucket`, `_sum`, and `_count` series. Prometheus Go and
+process collectors are also exposed for runtime and process health.
+
 The operator reconciles each `Run` as the single task intent and allocates or claims its
 `Environment`; clients must not create the two resources independently. Its RBAC permits
 Run status/finalizer updates and Environment allocation/claim updates. Process execution

--- a/charts/swe-platform/templates/000-validate.yaml
+++ b/charts/swe-platform/templates/000-validate.yaml
@@ -18,3 +18,7 @@
 {{- else if .Values.controlPlane.sessions.keyringSecret.name -}}
   {{- fail "controlPlane.sessions.backend=memory must not set controlPlane.sessions.keyringSecret.name" -}}
 {{- end -}}
+{{- $metricsPort := int .Values.controlPlane.metrics.port -}}
+{{- if or (lt $metricsPort 1) (gt $metricsPort 65535) (eq $metricsPort 80) (eq $metricsPort 8080) -}}
+{{- fail "controlPlane.metrics.port must be from 1 through 65535 and must not be 80 or 8080" -}}
+{{- end -}}

--- a/charts/swe-platform/templates/control-plane-deployment.yaml
+++ b/charts/swe-platform/templates/control-plane-deployment.yaml
@@ -37,7 +37,9 @@ spec:
         - name: control-plane
           image: "{{ .Values.controlPlane.image.repository }}:{{ .Values.controlPlane.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.controlPlane.image.pullPolicy }}
-          args: ["--listen-address=:8080"]
+          args:
+            - --listen-address=:8080
+            - --metrics-bind-address=:{{ int .Values.controlPlane.metrics.port }}
           env:
             - name: SWE_TOKEN_AUDIENCE
               value: {{ .Values.controlPlane.auth.tokenAudience | quote }}
@@ -90,6 +92,8 @@ spec:
           ports:
             - name: http
               containerPort: 8080
+            - name: metrics
+              containerPort: {{ int .Values.controlPlane.metrics.port }}
           livenessProbe:
             httpGet: {path: /healthz, port: http}
           readinessProbe:

--- a/charts/swe-platform/templates/control-plane-service.yaml
+++ b/charts/swe-platform/templates/control-plane-service.yaml
@@ -16,4 +16,7 @@ spec:
     - name: http
       port: 80
       targetPort: http
+    - name: metrics
+      port: {{ int .Values.controlPlane.metrics.port }}
+      targetPort: metrics
 {{- end }}

--- a/charts/swe-platform/values-argocd.yaml
+++ b/charts/swe-platform/values-argocd.yaml
@@ -9,6 +9,8 @@ image:
   pullPolicy: Always
 
 controlPlane:
+  metrics:
+    port: 8082
   # Development sessions are intentionally process-local.
   sessions:
     backend: memory

--- a/charts/swe-platform/values-eks.yaml
+++ b/charts/swe-platform/values-eks.yaml
@@ -7,6 +7,8 @@ tenancy:
 replicaCount: 2
 
 controlPlane:
+  metrics:
+    port: 8082
   sessions:
     backend: postgres
     keyringSecret:

--- a/charts/swe-platform/values-gke.yaml
+++ b/charts/swe-platform/values-gke.yaml
@@ -7,6 +7,8 @@ tenancy:
 replicaCount: 2
 
 controlPlane:
+  metrics:
+    port: 8082
   sessions:
     backend: postgres
     keyringSecret:

--- a/charts/swe-platform/values-k3s.yaml
+++ b/charts/swe-platform/values-k3s.yaml
@@ -6,6 +6,8 @@ tenancy:
   mode: scoped
 
 controlPlane:
+  metrics:
+    port: 8082
   sessions:
     backend: postgres
     keyringSecret:

--- a/charts/swe-platform/values-kind.yaml
+++ b/charts/swe-platform/values-kind.yaml
@@ -4,6 +4,8 @@ image:
   pullPolicy: IfNotPresent
 
 controlPlane:
+  metrics:
+    port: 8082
   # Development sessions are intentionally process-local.
   sessions:
     backend: memory

--- a/charts/swe-platform/values.yaml
+++ b/charts/swe-platform/values.yaml
@@ -9,6 +9,9 @@ image:
 controlPlane:
   enabled: true
   replicaCount: 1
+  metrics:
+    # Exposed on the internal control-plane Service as a dedicated listener.
+    port: 8082
   sessions:
     # memory is development-only. Production presets explicitly select postgres.
     backend: memory

--- a/cmd/control-plane/main.go
+++ b/cmd/control-plane/main.go
@@ -16,6 +16,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -33,6 +34,7 @@ const shutdownTimeout = 10 * time.Second
 
 func main() {
 	address := flag.String("listen-address", ":8080", "Address for the control-plane HTTP API")
+	metricsAddress := flag.String("metrics-bind-address", "127.0.0.1:8082", "Address for the internal Prometheus metrics endpoint")
 	flag.Parse()
 
 	log := slog.New(slog.NewJSONHandler(os.Stdout, nil))
@@ -67,11 +69,15 @@ func main() {
 		os.Exit(1)
 	}
 	defer closeStores()
+	metricsRegistry := prometheus.NewRegistry()
+	metricsRegistry.MustRegister(prometheus.NewGoCollector(), prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
+	metrics := controlplane.NewMetrics(metricsRegistry)
 	access := controlplane.KubernetesAccessController{
 		Client:         clientset,
 		BootstrapToken: bootstrapToken,
 		Audience:       os.Getenv("SWE_TOKEN_AUDIENCE"),
 		Sessions:       sessions,
+		Metrics:        metrics,
 	}
 	mode, err := tenancy.ParseMode(os.Getenv("SWE_TENANCY_MODE"))
 	if err != nil {
@@ -109,7 +115,7 @@ func main() {
 	resources := &controlplane.KubernetesResourceService{Client: kubeClient}
 	streamLifecycle, cancelStreams := context.WithCancel(context.Background())
 	defer cancelStreams()
-	server := &http.Server{
+	apiServer := &http.Server{
 		Addr: *address,
 		Handler: controlplane.NewServer(log, controlplane.ServerOptions{
 			Access:                resourceAccess,
@@ -117,27 +123,83 @@ func main() {
 			Resources:             resources,
 			Runs:                  controlplane.KubernetesRunResolver{Client: kubeClient},
 			TranscriptStore:       transcripts,
-			TerminalDialer:        controlplane.KubernetesTerminalDialer{Client: kubeClient},
+			TerminalDialer:        controlplane.KubernetesTerminalDialer{Client: kubeClient, Metrics: metrics},
 			ConsoleAssets:         consoleui.Assets(),
 			TrustProxy:            strings.EqualFold(os.Getenv("SWE_TRUST_PROXY_HEADERS"), "true"),
 			AllowInsecureSessions: strings.EqualFold(os.Getenv("SWE_ALLOW_INSECURE_SESSIONS"), "true"),
 			StreamLifecycle:       streamLifecycle,
+			Metrics:               metrics,
 		}).Handler(),
 		ReadHeaderTimeout: 5 * time.Second,
 		IdleTimeout:       2 * time.Minute,
 	}
-	listener, err := net.Listen("tcp", *address)
+	metricsServer := &http.Server{
+		Addr:              *metricsAddress,
+		Handler:           controlplane.MetricsHandler(metricsRegistry),
+		ReadHeaderTimeout: 5 * time.Second,
+		IdleTimeout:       30 * time.Second,
+	}
+	apiListener, err := net.Listen("tcp", *address)
 	if err != nil {
 		log.Error("listen for control-plane API", "address", *address, "error", err)
 		os.Exit(1)
 	}
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
-	log.Info("starting control-plane API", "address", *address)
-	if err := runHTTPServer(ctx, log, server, listener, shutdownTimeout, cancelStreams); err != nil {
-		log.Error("control-plane API stopped", "error", err)
+	metricsListener, err := net.Listen("tcp", *metricsAddress)
+	if err != nil {
+		_ = apiListener.Close()
+		log.Error("listen for control-plane metrics", "address", *metricsAddress, "error", err)
 		os.Exit(1)
 	}
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	log.Info("starting control-plane", "apiAddress", *address, "metricsAddress", *metricsAddress)
+	if err := runHTTPServers(ctx, log, []httpServerListener{
+		{name: "API", server: apiServer, listener: apiListener, cancelStreams: cancelStreams},
+		{name: "metrics", server: metricsServer, listener: metricsListener},
+	}, shutdownTimeout); err != nil {
+		log.Error("control-plane stopped", "error", err)
+		os.Exit(1)
+	}
+}
+
+type httpServerListener struct {
+	name          string
+	server        *http.Server
+	listener      net.Listener
+	cancelStreams context.CancelFunc
+}
+
+func runHTTPServers(ctx context.Context, log *slog.Logger, servers []httpServerListener, drainTimeout time.Duration) error {
+	serveContext, cancel := context.WithCancel(ctx)
+	defer cancel()
+	type result struct {
+		name string
+		err  error
+	}
+	results := make(chan result, len(servers))
+	for _, configured := range servers {
+		configured := configured
+		cancelStreams := configured.cancelStreams
+		if cancelStreams == nil {
+			cancelStreams = func() {}
+		}
+		go func() {
+			results <- result{configured.name, runHTTPServer(serveContext, log, configured.server, configured.listener, drainTimeout, cancelStreams)}
+		}()
+	}
+	first := <-results
+	cancel()
+	var firstErr error
+	if first.err != nil {
+		firstErr = fmt.Errorf("%s server: %w", first.name, first.err)
+	}
+	for range len(servers) - 1 {
+		completed := <-results
+		if firstErr == nil && completed.err != nil {
+			firstErr = fmt.Errorf("%s server: %w", completed.name, completed.err)
+		}
+	}
+	return firstErr
 }
 
 func parseTenancyNamespaces(value string) (map[string]struct{}, error) {

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/muesli/cancelreader v0.2.2
+	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/term v0.44.0
 	google.golang.org/grpc v1.82.1
@@ -66,7 +67,6 @@ require (
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect

--- a/internal/controlplane/auth.go
+++ b/internal/controlplane/auth.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
 	authorizationv1 "k8s.io/api/authorization/v1"
@@ -63,6 +64,7 @@ type KubernetesAccessController struct {
 	BootstrapToken string
 	Audience       string
 	Sessions       SessionStore
+	Metrics        *Metrics
 }
 
 // Authorize authenticates a bearer token (or, for browser reads, a session cookie) and
@@ -93,6 +95,7 @@ func (a KubernetesAccessController) AuthorizePrincipal(r *http.Request, access R
 	if a.Client == nil {
 		return "", fmt.Errorf("authorize request: Kubernetes client is unavailable")
 	}
+	reviewStarted := time.Now()
 	review, err := a.Client.AuthorizationV1().SubjectAccessReviews().Create(r.Context(), &authorizationv1.SubjectAccessReview{
 		Spec: authorizationv1.SubjectAccessReviewSpec{
 			User:   user.name,
@@ -111,14 +114,18 @@ func (a KubernetesAccessController) AuthorizePrincipal(r *http.Request, access R
 		},
 	}, metav1.CreateOptions{})
 	if err != nil {
+		a.Metrics.observeReview("subject_access", "error", reviewStarted)
 		return "", fmt.Errorf("authorize request: %w", err)
 	}
 	if review.Status.EvaluationError != "" {
+		a.Metrics.observeReview("subject_access", "error", reviewStarted)
 		return "", fmt.Errorf("authorize request: %s", review.Status.EvaluationError)
 	}
 	if !review.Status.Allowed {
+		a.Metrics.observeReview("subject_access", "denied", reviewStarted)
 		return "", errForbidden
 	}
+	a.Metrics.observeReview("subject_access", "allowed", reviewStarted)
 	if user.uid != "" {
 		return user.uid, nil
 	}
@@ -228,16 +235,20 @@ func (a KubernetesAccessController) authenticate(ctx context.Context, token stri
 	if audience == "" {
 		audience = defaultTokenAudience
 	}
+	reviewStarted := time.Now()
 	review, err := a.Client.AuthenticationV1().TokenReviews().Create(ctx, &authenticationv1.TokenReview{
 		Spec: authenticationv1.TokenReviewSpec{Token: token, Audiences: []string{audience}},
 	}, metav1.CreateOptions{})
 	if err != nil {
+		a.Metrics.observeReview("token", "error", reviewStarted)
 		return principal{}, fmt.Errorf("authenticate request: %w", err)
 	}
 	if review.Status.Error != "" {
+		a.Metrics.observeReview("token", "error", reviewStarted)
 		return principal{}, fmt.Errorf("authenticate request: %s", review.Status.Error)
 	}
 	if !review.Status.Authenticated {
+		a.Metrics.observeReview("token", "denied", reviewStarted)
 		return principal{}, errUnauthenticated
 	}
 	audienceMatched := false
@@ -248,8 +259,10 @@ func (a KubernetesAccessController) authenticate(ctx context.Context, token stri
 		}
 	}
 	if !audienceMatched {
+		a.Metrics.observeReview("token", "denied", reviewStarted)
 		return principal{}, errUnauthenticated
 	}
+	a.Metrics.observeReview("token", "authenticated", reviewStarted)
 	extra := make(map[string]authorizationv1.ExtraValue, len(review.Status.User.Extra))
 	for key, values := range review.Status.User.Extra {
 		extra[key] = append(authorizationv1.ExtraValue(nil), values...)

--- a/internal/controlplane/auth_test.go
+++ b/internal/controlplane/auth_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -15,6 +17,7 @@ import (
 )
 
 func TestKubernetesAccessControllerReviewsExactResourceIdentity(t *testing.T) {
+	metrics := NewMetrics(prometheus.NewRegistry())
 	client := fake.NewClientset()
 	client.PrependReactor("create", "tokenreviews", func(action ktesting.Action) (bool, runtime.Object, error) {
 		review := action.(ktesting.CreateAction).GetObject().(*authenticationv1.TokenReview)
@@ -53,11 +56,20 @@ func TestKubernetesAccessControllerReviewsExactResourceIdentity(t *testing.T) {
 
 	request := httptest.NewRequest(http.MethodGet, transcriptURL, nil)
 	request.Header.Set("Authorization", "Bearer reader-token")
-	err := (KubernetesAccessController{Client: client}).Authorize(request, ResourceAccess{
+	err := (KubernetesAccessController{Client: client, Metrics: metrics}).Authorize(request, ResourceAccess{
 		Namespace: "project-a", Verb: "get", Resource: "runs", Subresource: "transcript", Name: "shared",
 	}, true)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if got := testutil.ToFloat64(metrics.tokenReviews.WithLabelValues("authenticated")); got != 1 {
+		t.Fatalf("authenticated TokenReviews = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(metrics.subjectAccessReviews.WithLabelValues("allowed")); got != 1 {
+		t.Fatalf("allowed SubjectAccessReviews = %v, want 1", got)
+	}
+	if got := histogramCount(t, metrics.tokenReviewLatency.WithLabelValues("authenticated")); got != 1 {
+		t.Fatalf("TokenReview latency observations = %d, want 1", got)
 	}
 }
 
@@ -69,6 +81,7 @@ func TestKubernetesAccessControllerRejectsAnonymousAndDeniedUsers(t *testing.T) 
 	}
 
 	client := fake.NewClientset()
+	metrics := NewMetrics(prometheus.NewRegistry())
 	client.PrependReactor("create", "tokenreviews", func(ktesting.Action) (bool, runtime.Object, error) {
 		return true, &authenticationv1.TokenReview{Status: authenticationv1.TokenReviewStatus{
 			Authenticated: true,
@@ -80,8 +93,46 @@ func TestKubernetesAccessControllerRejectsAnonymousAndDeniedUsers(t *testing.T) 
 		return true, &authorizationv1.SubjectAccessReview{Status: authorizationv1.SubjectAccessReviewStatus{Allowed: false}}, nil
 	})
 	request.Header.Set("Authorization", "Bearer producer-token")
-	if err := (KubernetesAccessController{Client: client}).Authorize(request, ResourceAccess{}, false); !errors.Is(err, errForbidden) {
+	if err := (KubernetesAccessController{Client: client, Metrics: metrics}).Authorize(request, ResourceAccess{}, false); !errors.Is(err, errForbidden) {
 		t.Fatalf("denied error = %v, want forbidden", err)
+	}
+	if got := testutil.ToFloat64(metrics.subjectAccessReviews.WithLabelValues("denied")); got != 1 {
+		t.Fatalf("denied SubjectAccessReviews = %v, want 1", got)
+	}
+}
+
+func TestKubernetesAccessControllerRecordsReviewErrors(t *testing.T) {
+	metrics := NewMetrics(prometheus.NewRegistry())
+	tokenFailure := fake.NewClientset()
+	tokenFailure.PrependReactor("create", "tokenreviews", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("token webhook unavailable")
+	})
+	request := httptest.NewRequest(http.MethodGet, transcriptURL, nil)
+	request.Header.Set("Authorization", "Bearer token")
+	if err := (KubernetesAccessController{Client: tokenFailure, Metrics: metrics}).Authorize(request, ResourceAccess{}, false); err == nil {
+		t.Fatal("TokenReview failure was accepted")
+	}
+
+	sarFailure := fake.NewClientset()
+	sarFailure.PrependReactor("create", "tokenreviews", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, &authenticationv1.TokenReview{Status: authenticationv1.TokenReviewStatus{
+			Authenticated: true, Audiences: []string{defaultTokenAudience}, User: authenticationv1.UserInfo{Username: "reader"},
+		}}, nil
+	})
+	sarFailure.PrependReactor("create", "subjectaccessreviews", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, &authorizationv1.SubjectAccessReview{Status: authorizationv1.SubjectAccessReviewStatus{EvaluationError: "authorization webhook unavailable"}}, nil
+	})
+	if err := (KubernetesAccessController{Client: sarFailure, Metrics: metrics}).Authorize(request, ResourceAccess{}, false); err == nil {
+		t.Fatal("SubjectAccessReview evaluation failure was accepted")
+	}
+	if got := testutil.ToFloat64(metrics.tokenReviews.WithLabelValues("error")); got != 1 {
+		t.Fatalf("TokenReview errors = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(metrics.subjectAccessReviews.WithLabelValues("error")); got != 1 {
+		t.Fatalf("SubjectAccessReview errors = %v, want 1", got)
+	}
+	if got := histogramCount(t, metrics.subjectAccessLatency.WithLabelValues("error")); got != 1 {
+		t.Fatalf("SubjectAccessReview error latency observations = %d, want 1", got)
 	}
 }
 

--- a/internal/controlplane/metrics.go
+++ b/internal/controlplane/metrics.go
@@ -1,0 +1,160 @@
+package controlplane
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+const metricsNamespace = "swe_control_plane"
+
+// Metrics owns the control plane's bounded-cardinality operational metrics.
+// Each process uses one instance and one registry so tests and embedded users do
+// not share global collector state.
+type Metrics struct {
+	transcriptAppends       *prometheus.CounterVec
+	transcriptAppendLatency *prometheus.HistogramVec
+	transcriptSubscribers   prometheus.Gauge
+	transcriptDeliveries    *prometheus.CounterVec
+	transcriptDeliveryLag   *prometheus.HistogramVec
+	terminalLeaseGrants     *prometheus.CounterVec
+	terminalRevocations     *prometheus.CounterVec
+	tokenReviews            *prometheus.CounterVec
+	tokenReviewLatency      *prometheus.HistogramVec
+	subjectAccessReviews    *prometheus.CounterVec
+	subjectAccessLatency    *prometheus.HistogramVec
+}
+
+// NewMetrics registers the control-plane collectors with registerer.
+func NewMetrics(registerer prometheus.Registerer) *Metrics {
+	m := &Metrics{
+		transcriptAppends: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricsNamespace, Name: "transcript_appends_total",
+			Help: "Transcript append attempts by outcome.",
+		}, []string{"outcome"}),
+		transcriptAppendLatency: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: metricsNamespace, Name: "transcript_append_duration_seconds",
+			Help:    "Transcript store append latency by outcome.",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"outcome"}),
+		transcriptSubscribers: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: metricsNamespace, Name: "transcript_sse_subscribers",
+			Help: "Current admitted transcript SSE subscribers.",
+		}),
+		transcriptDeliveries: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricsNamespace, Name: "transcript_sse_deliveries_total",
+			Help: "Transcript SSE delivery outcomes by delivery kind.",
+		}, []string{"kind", "outcome"}),
+		transcriptDeliveryLag: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: metricsNamespace, Name: "transcript_sse_delivery_lag_seconds",
+			Help:    "Time from transcript event creation to successful SSE delivery.",
+			Buckets: []float64{.01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60, 300, 900, 3600},
+		}, []string{"kind"}),
+		terminalLeaseGrants: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricsNamespace, Name: "terminal_lease_grants_total",
+			Help: "Terminal lease grant attempts by outcome.",
+		}, []string{"outcome"}),
+		terminalRevocations: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricsNamespace, Name: "terminal_lease_revocations_total",
+			Help: "Granted terminal leases revoked by the control plane.",
+		}, []string{"reason"}),
+		tokenReviews: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricsNamespace, Name: "token_reviews_total",
+			Help: "Kubernetes TokenReview outcomes.",
+		}, []string{"outcome"}),
+		tokenReviewLatency: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: metricsNamespace, Name: "token_review_duration_seconds",
+			Help:    "Kubernetes TokenReview latency by outcome.",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"outcome"}),
+		subjectAccessReviews: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricsNamespace, Name: "subject_access_reviews_total",
+			Help: "Kubernetes SubjectAccessReview outcomes.",
+		}, []string{"outcome"}),
+		subjectAccessLatency: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: metricsNamespace, Name: "subject_access_review_duration_seconds",
+			Help:    "Kubernetes SubjectAccessReview latency by outcome.",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"outcome"}),
+	}
+	registerer.MustRegister(
+		m.transcriptAppends, m.transcriptAppendLatency, m.transcriptSubscribers,
+		m.transcriptDeliveries, m.transcriptDeliveryLag, m.terminalLeaseGrants,
+		m.terminalRevocations, m.tokenReviews, m.tokenReviewLatency,
+		m.subjectAccessReviews, m.subjectAccessLatency,
+	)
+	for _, outcome := range []string{"committed", "replayed", "rejected", "error"} {
+		m.transcriptAppends.WithLabelValues(outcome)
+		m.transcriptAppendLatency.WithLabelValues(outcome)
+	}
+	for _, labels := range [][2]string{
+		{"replay", "delivered"}, {"replay", "error"},
+		{"live", "delivered"}, {"live", "error"}, {"live", "dropped"},
+		{"gap", "delivered"}, {"gap", "error"},
+	} {
+		m.transcriptDeliveries.WithLabelValues(labels[0], labels[1])
+	}
+	for _, kind := range []string{"replay", "live"} {
+		m.transcriptDeliveryLag.WithLabelValues(kind)
+	}
+	for _, outcome := range []string{"granted", "failed"} {
+		m.terminalLeaseGrants.WithLabelValues(outcome)
+	}
+	for _, reason := range []string{"run_association_changed", "environment_changed", "execution_changed", "hold_policy_changed"} {
+		m.terminalRevocations.WithLabelValues(reason)
+	}
+	for _, outcome := range []string{"authenticated", "denied", "error"} {
+		m.tokenReviews.WithLabelValues(outcome)
+		m.tokenReviewLatency.WithLabelValues(outcome)
+	}
+	for _, outcome := range []string{"allowed", "denied", "error"} {
+		m.subjectAccessReviews.WithLabelValues(outcome)
+		m.subjectAccessLatency.WithLabelValues(outcome)
+	}
+	return m
+}
+
+// MetricsHandler exposes only the Prometheus scrape route. It deliberately
+// does not reuse the application handler or its authenticated API routes.
+func MetricsHandler(gatherer prometheus.Gatherer) http.Handler {
+	mux := http.NewServeMux()
+	mux.Handle("GET /metrics", promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{}))
+	return mux
+}
+
+func (m *Metrics) observeAppend(start time.Time, outcome string) {
+	if m == nil {
+		return
+	}
+	m.transcriptAppends.WithLabelValues(outcome).Inc()
+	m.transcriptAppendLatency.WithLabelValues(outcome).Observe(time.Since(start).Seconds())
+}
+
+func (m *Metrics) observeDelivery(kind, outcome string, event *TranscriptEvent) {
+	if m == nil {
+		return
+	}
+	m.transcriptDeliveries.WithLabelValues(kind, outcome).Inc()
+	if outcome == "delivered" && event != nil {
+		lag := time.Since(event.CreatedAt).Seconds()
+		if lag < 0 {
+			lag = 0
+		}
+		m.transcriptDeliveryLag.WithLabelValues(kind).Observe(lag)
+	}
+}
+
+func (m *Metrics) observeReview(kind, outcome string, start time.Time) {
+	if m == nil {
+		return
+	}
+	if kind == "token" {
+		m.tokenReviews.WithLabelValues(outcome).Inc()
+		m.tokenReviewLatency.WithLabelValues(outcome).Observe(time.Since(start).Seconds())
+		return
+	}
+	m.subjectAccessReviews.WithLabelValues(outcome).Inc()
+	m.subjectAccessLatency.WithLabelValues(outcome).Observe(time.Since(start).Seconds())
+}

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -51,6 +51,7 @@ type Server struct {
 	watchAdmission        *watchAdmission
 	terminalOpenTimeout   time.Duration
 	terminalWriteTimeout  time.Duration
+	metrics               *Metrics
 }
 
 // RunResolver verifies that a namespaced Run exists before transcript state is used.
@@ -89,6 +90,7 @@ type ServerOptions struct {
 	// TranscriptHeartbeatInterval controls SSE keepalive comments. Values less
 	// than or equal to zero use the production default.
 	TranscriptHeartbeatInterval time.Duration
+	Metrics                     *Metrics
 }
 
 // NewServer constructs a control-plane API handler.
@@ -120,6 +122,7 @@ func NewServer(log *slog.Logger, options ServerOptions) *Server {
 		watchAdmission:        processWatchAdmission,
 		terminalOpenTimeout:   terminalHandshakeTimeout,
 		terminalWriteTimeout:  terminalStreamingWriteTimeout,
+		metrics:               options.Metrics,
 	}
 }
 
@@ -388,6 +391,7 @@ func (s *Server) appendTranscript(w http.ResponseWriter, r *http.Request, run Ru
 		return
 	}
 
+	appendStarted := time.Now()
 	result, err := s.store.Append(r.Context(), run, AppendTranscriptInput{
 		Source:         request.Source,
 		SourceSequence: request.SourceSequence,
@@ -396,11 +400,21 @@ func (s *Server) appendTranscript(w http.ResponseWriter, r *http.Request, run Ru
 		Data:           request.Data,
 	})
 	if err != nil {
+		outcome := "error"
+		if isTranscriptContractError(err) {
+			outcome = "rejected"
+		}
+		s.metrics.observeAppend(appendStarted, outcome)
 		if !isTranscriptContractError(err) {
 			s.log.Error("append transcript event", "namespace", run.Namespace, "runUID", run.UID, "error", err)
 		}
 		writeTranscriptStoreError(w, err)
 		return
+	}
+	if result.Replayed {
+		s.metrics.observeAppend(appendStarted, "replayed")
+	} else {
+		s.metrics.observeAppend(appendStarted, "committed")
 	}
 	w.Header().Set("Content-Type", "application/json")
 	if legacy {
@@ -435,6 +449,10 @@ func (s *Server) streamTranscript(w http.ResponseWriter, r *http.Request, run Ru
 		return
 	}
 	defer subscription.Unsubscribe()
+	if s.metrics != nil {
+		s.metrics.transcriptSubscribers.Inc()
+		defer s.metrics.transcriptSubscribers.Dec()
+	}
 
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
@@ -463,22 +481,30 @@ func (s *Server) streamTranscript(w http.ResponseWriter, r *http.Request, run Ru
 		if err != nil {
 			return err
 		}
-		return write(fmt.Sprintf("id: %s\nevent: transcript\ndata: %s\n\n", event.ID, payload))
+		if err := write(fmt.Sprintf("id: %s\nevent: transcript\ndata: %s\n\n", event.ID, payload)); err != nil {
+			return err
+		}
+		return nil
 	}
 	if subscription.Gap != nil {
 		payload, marshalErr := json.Marshal(subscription.Gap)
 		if marshalErr != nil {
+			s.metrics.observeDelivery("gap", "error", nil)
 			return
 		}
 		if err = write(fmt.Sprintf("event: transcript-gap\ndata: %s\n\n", payload)); err != nil {
+			s.metrics.observeDelivery("gap", "error", nil)
 			return
 		}
+		s.metrics.observeDelivery("gap", "delivered", nil)
 	}
 
 	for _, event := range subscription.History {
 		if err := writeEvent(event); err != nil {
+			s.metrics.observeDelivery("replay", "error", nil)
 			return
 		}
+		s.metrics.observeDelivery("replay", "delivered", &event)
 	}
 	subscription.History = nil
 	if err := controller.Flush(); err != nil {
@@ -491,9 +517,12 @@ func (s *Server) streamTranscript(w http.ResponseWriter, r *http.Request, run Ru
 		select {
 		case event := <-subscription.Events:
 			if err := writeEvent(event); err != nil {
+				s.metrics.observeDelivery("live", "error", nil)
 				return
 			}
+			s.metrics.observeDelivery("live", "delivered", &event)
 		case <-subscription.Dropped:
+			s.metrics.observeDelivery("live", "dropped", nil)
 			s.log.Warn("closing dropped transcript subscriber", "namespace", run.Namespace, "runUID", run.UID)
 			return
 		case <-heartbeats.C:

--- a/internal/controlplane/server_test.go
+++ b/internal/controlplane/server_test.go
@@ -13,6 +13,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -21,10 +24,20 @@ import (
 const transcriptURL = "/api/v1/namespaces/project-1/runs/run-1/transcript"
 
 func TestTranscriptReplayAndLiveStream(t *testing.T) {
-	server := httptest.NewServer(newTestServer(&fakeAccess{}).Handler())
+	metrics := NewMetrics(prometheus.NewRegistry())
+	server := httptest.NewServer(NewServer(nil, ServerOptions{
+		Access: &fakeAccess{}, Runs: &fakeRunResolver{},
+		TranscriptStore: NewMemoryTranscriptStore(MemoryTranscriptStoreOptions{}), Metrics: metrics,
+	}).Handler())
 	defer server.Close()
 
 	postEvent(t, server.URL, `{"source":"adapter","idempotencyKey":"first","type":"output","data":{"text":"first"}}`)
+	if got := testutil.ToFloat64(metrics.transcriptAppends.WithLabelValues("committed")); got != 1 {
+		t.Fatalf("committed append metric = %v, want 1", got)
+	}
+	if got := histogramCount(t, metrics.transcriptAppendLatency.WithLabelValues("committed")); got != 1 {
+		t.Fatalf("append latency observations = %d, want 1", got)
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -59,8 +72,28 @@ func TestTranscriptReplayAndLiveStream(t *testing.T) {
 	}()
 
 	assertEventText(t, nextLine(t, lines), "first")
+	if got := testutil.ToFloat64(metrics.transcriptSubscribers); got != 1 {
+		t.Fatalf("SSE subscriber gauge = %v, want 1", got)
+	}
 	postEvent(t, server.URL, `{"source":"adapter","idempotencyKey":"second","type":"output","data":{"text":"second"}}`)
 	assertEventText(t, nextLine(t, lines), "second")
+	if got := testutil.ToFloat64(metrics.transcriptDeliveries.WithLabelValues("replay", "delivered")); got != 1 {
+		t.Fatalf("replay delivery metric = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(metrics.transcriptDeliveries.WithLabelValues("live", "delivered")); got != 1 {
+		t.Fatalf("live delivery metric = %v, want 1", got)
+	}
+	if got := histogramCount(t, metrics.transcriptDeliveryLag.WithLabelValues("replay")); got != 1 {
+		t.Fatalf("replay lag observations = %d, want 1", got)
+	}
+	cancel()
+	_ = response.Body.Close()
+	for deadline := time.Now().Add(time.Second); testutil.ToFloat64(metrics.transcriptSubscribers) != 0 && time.Now().Before(deadline); {
+		time.Sleep(time.Millisecond)
+	}
+	if got := testutil.ToFloat64(metrics.transcriptSubscribers); got != 0 {
+		t.Fatalf("SSE subscriber gauge after close = %v, want 0", got)
+	}
 }
 
 func TestTranscriptStreamSendsHeartbeat(t *testing.T) {
@@ -92,6 +125,24 @@ func TestTranscriptStreamSendsHeartbeat(t *testing.T) {
 	}
 	if got := scanner.Text(); got != ": ping" {
 		t.Fatalf("heartbeat = %q, want %q", got, ": ping")
+	}
+}
+
+func TestMetricsHandlerDoesNotExposeApplicationRoutes(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	NewMetrics(registry)
+	handler := MetricsHandler(registry)
+	metrics := httptest.NewRecorder()
+	handler.ServeHTTP(metrics, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	if metrics.Code != http.StatusOK || !strings.Contains(metrics.Body.String(), "swe_control_plane_transcript_sse_subscribers") {
+		t.Fatalf("metrics response = %d %q", metrics.Code, metrics.Body.String())
+	}
+	for _, path := range []string{"/healthz", "/api/v1/session", transcriptURL, "/"} {
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, path, nil))
+		if response.Code != http.StatusNotFound {
+			t.Fatalf("metrics listener path %q status = %d, want 404", path, response.Code)
+		}
 	}
 }
 
@@ -599,4 +650,17 @@ func assertEventText(t *testing.T, line, want string) {
 	if data.Text != want {
 		t.Fatalf("event text = %q, want %q", data.Text, want)
 	}
+}
+
+func histogramCount(t *testing.T, observer prometheus.Observer) uint64 {
+	t.Helper()
+	metric, ok := observer.(prometheus.Metric)
+	if !ok {
+		t.Fatal("histogram observer does not implement prometheus.Metric")
+	}
+	var value dto.Metric
+	if err := metric.Write(&value); err != nil {
+		t.Fatal(err)
+	}
+	return value.GetHistogram().GetSampleCount()
 }

--- a/internal/controlplane/terminal.go
+++ b/internal/controlplane/terminal.go
@@ -54,6 +54,7 @@ type KubernetesTerminalDialer struct {
 	Client             client.Client
 	Metrics            *Metrics
 	policyPollInterval time.Duration
+	beforeLeaseAttach  func(*terminalConnectionLease)
 }
 
 type activeTerminalConnection struct {
@@ -204,28 +205,34 @@ func (d KubernetesTerminalDialer) dialTerminal(ctx context.Context, namespace, n
 	}
 	executionFence = lifecycle.CaptureExecutionFence(&environment)
 	terminal, health, execution, closeConnection, err := (sandboxclient.Connector{Reader: d.Client}).DialTerminal(ctx, executionFence)
-	if d.Metrics != nil {
-		outcome := "granted"
-		if err != nil {
-			outcome = "failed"
-		}
-		d.Metrics.terminalLeaseGrants.WithLabelValues(outcome).Inc()
-	}
 	if err != nil {
+		d.observeTerminalLeaseGrant("failed")
 		return nil, nil, nil, fmt.Errorf("connect to sandboxd: %w", err)
 	}
 	if association != nil {
 		if err := d.validateRunTerminalAssociation(ctx, namespace, association, nil); err != nil {
 			closeConnection()
+			d.observeTerminalLeaseGrant("failed")
 			return nil, nil, nil, err
 		}
 	}
+	if d.beforeLeaseAttach != nil {
+		d.beforeLeaseAttach(connectionLease)
+	}
 	if !connectionLease.attach(closeFunc(closeConnection), execution, executionFence) {
+		d.observeTerminalLeaseGrant("failed")
 		return nil, nil, nil, fmt.Errorf("environment became explicitly held while opening terminal")
 	}
+	d.observeTerminalLeaseGrant("granted")
 	closer := &activeTerminalConnection{Closer: connectionLease, cancel: cancelHeartbeat}
 	heartbeatTransferred = true
 	return terminal, health, closer, nil
+}
+
+func (d KubernetesTerminalDialer) observeTerminalLeaseGrant(outcome string) {
+	if d.Metrics != nil {
+		d.Metrics.terminalLeaseGrants.WithLabelValues(outcome).Inc()
+	}
 }
 
 func terminalAccessPolicyError(environment *platformv1alpha1.Environment) error {

--- a/internal/controlplane/terminal.go
+++ b/internal/controlplane/terminal.go
@@ -416,6 +416,9 @@ func (d KubernetesTerminalDialer) holdPolicyPollInterval() time.Duration {
 func (d KubernetesTerminalDialer) readTerminalPolicy(ctx context.Context, key types.NamespacedName, previousFence lifecycle.ExecutionFence, boundExecution func() (sandboxclient.TerminalExecution, lifecycle.ExecutionFence, bool)) (lifecycle.ExecutionFence, bool, error) {
 	var environment platformv1alpha1.Environment
 	if err := d.Client.Get(ctx, key, &environment); err != nil {
+		if apierrors.IsNotFound(err) {
+			return lifecycle.ExecutionFence{}, false, errTerminalEnvironmentIncarnationChanged
+		}
 		return lifecycle.ExecutionFence{}, false, err
 	}
 	var execution sandboxclient.TerminalExecution

--- a/internal/controlplane/terminal.go
+++ b/internal/controlplane/terminal.go
@@ -33,7 +33,10 @@ const (
 	maxTerminalUIDLength          = 128
 )
 
-var errTerminalEnvironmentIncarnationChanged = errors.New("environment incarnation changed")
+var (
+	errTerminalEnvironmentIncarnationChanged = errors.New("environment incarnation changed")
+	errTerminalExecutionChanged              = errors.New("terminal execution changed")
+)
 
 const (
 	RunUIDHeader         = "SWE-Run-UID"
@@ -49,6 +52,7 @@ type TerminalDialer interface {
 // KubernetesTerminalDialer resolves environment pods through the Kubernetes API.
 type KubernetesTerminalDialer struct {
 	Client             client.Client
+	Metrics            *Metrics
 	policyPollInterval time.Duration
 }
 
@@ -61,6 +65,7 @@ type terminalConnectionLease struct {
 	mu        sync.Mutex
 	closer    io.Closer
 	execution sandboxclient.TerminalExecution
+	fence     lifecycle.ExecutionFence
 	closed    bool
 }
 
@@ -73,11 +78,12 @@ func (c *activeTerminalConnection) Close() error {
 	return c.Closer.Close()
 }
 
-func (l *terminalConnectionLease) attach(closer io.Closer, execution sandboxclient.TerminalExecution) bool {
+func (l *terminalConnectionLease) attach(closer io.Closer, execution sandboxclient.TerminalExecution, fence lifecycle.ExecutionFence) bool {
 	l.mu.Lock()
 	if !l.closed {
 		l.closer = closer
 		l.execution = execution
+		l.fence = fence
 		l.mu.Unlock()
 		return true
 	}
@@ -86,25 +92,30 @@ func (l *terminalConnectionLease) attach(closer io.Closer, execution sandboxclie
 	return false
 }
 
-func (l *terminalConnectionLease) boundExecution() (sandboxclient.TerminalExecution, bool) {
+func (l *terminalConnectionLease) boundExecution() (sandboxclient.TerminalExecution, lifecycle.ExecutionFence, bool) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	return l.execution, l.closer != nil && !l.closed
+	return l.execution, l.fence, l.closer != nil && !l.closed
 }
 
 func (l *terminalConnectionLease) Close() error {
+	_, err := l.revoke()
+	return err
+}
+
+func (l *terminalConnectionLease) revoke() (bool, error) {
 	l.mu.Lock()
 	if l.closed {
 		l.mu.Unlock()
-		return nil
+		return false, nil
 	}
 	l.closed = true
 	closer := l.closer
 	l.mu.Unlock()
 	if closer != nil {
-		return closer.Close()
+		return true, closer.Close()
 	}
-	return nil
+	return false, nil
 }
 
 // DialTerminal records terminal activity, wakes a paused environment, and then
@@ -151,7 +162,10 @@ func (d KubernetesTerminalDialer) dialTerminal(ctx context.Context, namespace, n
 		}
 	}()
 	connectionLease := &terminalConnectionLease{}
-	go d.heartbeatActivity(heartbeatContext, types.NamespacedName{Namespace: namespace, Name: name}, executionFence, heartbeatInterval, association, connectionLease.boundExecution, func() { _ = connectionLease.Close() })
+	go d.heartbeatActivity(heartbeatContext, types.NamespacedName{Namespace: namespace, Name: name}, executionFence, heartbeatInterval, association, connectionLease.boundExecution, func() bool {
+		revoked, _ := connectionLease.revoke()
+		return revoked
+	})
 	if err := d.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &environment); err != nil {
 		return nil, nil, nil, fmt.Errorf("refresh environment lifecycle: %w", err)
 	}
@@ -190,6 +204,13 @@ func (d KubernetesTerminalDialer) dialTerminal(ctx context.Context, namespace, n
 	}
 	executionFence = lifecycle.CaptureExecutionFence(&environment)
 	terminal, health, execution, closeConnection, err := (sandboxclient.Connector{Reader: d.Client}).DialTerminal(ctx, executionFence)
+	if d.Metrics != nil {
+		outcome := "granted"
+		if err != nil {
+			outcome = "failed"
+		}
+		d.Metrics.terminalLeaseGrants.WithLabelValues(outcome).Inc()
+	}
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("connect to sandboxd: %w", err)
 	}
@@ -199,7 +220,7 @@ func (d KubernetesTerminalDialer) dialTerminal(ctx context.Context, namespace, n
 			return nil, nil, nil, err
 		}
 	}
-	if !connectionLease.attach(closeFunc(closeConnection), execution) {
+	if !connectionLease.attach(closeFunc(closeConnection), execution, executionFence) {
 		return nil, nil, nil, fmt.Errorf("environment became explicitly held while opening terminal")
 	}
 	closer := &activeTerminalConnection{Closer: connectionLease, cancel: cancelHeartbeat}
@@ -237,7 +258,12 @@ func (d KubernetesTerminalDialer) activityHeartbeatInterval(ctx context.Context,
 	return timeout / 2, nil
 }
 
-func (d KubernetesTerminalDialer) heartbeatActivity(ctx context.Context, key types.NamespacedName, fence lifecycle.ExecutionFence, interval time.Duration, association *RunTerminalAssociation, boundExecution func() (sandboxclient.TerminalExecution, bool), revoke func()) {
+func (d KubernetesTerminalDialer) heartbeatActivity(ctx context.Context, key types.NamespacedName, fence lifecycle.ExecutionFence, interval time.Duration, association *RunTerminalAssociation, boundExecution func() (sandboxclient.TerminalExecution, lifecycle.ExecutionFence, bool), revoke func() bool) {
+	revokeLease := func(reason string) {
+		if revoked := revoke(); revoked && d.Metrics != nil {
+			d.Metrics.terminalRevocations.WithLabelValues(reason).Inc()
+		}
+	}
 	retryInterval := interval / 4
 	if retryInterval <= 0 || retryInterval > time.Second {
 		retryInterval = time.Second
@@ -251,25 +277,33 @@ func (d KubernetesTerminalDialer) heartbeatActivity(ctx context.Context, key typ
 		case <-ctx.Done():
 			return
 		case <-policyTicker.C:
+			currentFence, held, err := d.readTerminalPolicy(ctx, key, fence, boundExecution)
+			if err != nil {
+				if errors.Is(err, errTerminalEnvironmentIncarnationChanged) {
+					revokeLease("environment_changed")
+					return
+				}
+				if errors.Is(err, errTerminalExecutionChanged) {
+					revokeLease("execution_changed")
+					return
+				}
+				continue
+			}
 			if association != nil {
 				if err := d.validateRunTerminalAssociation(ctx, key.Namespace, association, nil); err != nil {
+					if errors.Is(err, errTerminalEnvironmentIncarnationChanged) {
+						revokeLease("environment_changed")
+						return
+					}
 					if errors.Is(err, errRunTerminalAssociation) || errors.Is(err, errRunUIDConflict) {
-						revoke()
+						revokeLease("run_association_changed")
 						return
 					}
 					continue
 				}
 			}
-			currentFence, held, err := d.readTerminalPolicy(ctx, key, fence, boundExecution)
-			if err != nil {
-				if errors.Is(err, errTerminalEnvironmentIncarnationChanged) {
-					revoke()
-					return
-				}
-				continue
-			}
 			if held || currentFence.HoldPolicyRevision() < fence.HoldPolicyRevision() {
-				revoke()
+				revokeLease("hold_policy_changed")
 				return
 			}
 			fence = currentFence
@@ -278,14 +312,18 @@ func (d KubernetesTerminalDialer) heartbeatActivity(ctx context.Context, key typ
 				currentFence, held, err := d.readTerminalPolicy(ctx, key, fence, boundExecution)
 				if err != nil {
 					if errors.Is(err, errTerminalEnvironmentIncarnationChanged) {
-						revoke()
+						revokeLease("environment_changed")
+						return
+					}
+					if errors.Is(err, errTerminalExecutionChanged) {
+						revokeLease("execution_changed")
 						return
 					}
 					timer.Reset(retryInterval)
 					break
 				}
 				if held || currentFence.HoldPolicyRevision() < fence.HoldPolicyRevision() {
-					revoke()
+					revokeLease("hold_policy_changed")
 					return
 				}
 				fence = currentFence
@@ -295,12 +333,12 @@ func (d KubernetesTerminalDialer) heartbeatActivity(ctx context.Context, key typ
 					break
 				}
 				if errors.Is(err, errTerminalEnvironmentIncarnationChanged) {
-					revoke()
+					revokeLease("environment_changed")
 					return
 				}
 				if errors.Is(err, lifecycle.ErrExecutionFenceChanged) && !errors.Is(err, lifecycle.ErrHoldPolicyChanged) {
-					if _, bound := boundExecution(); bound {
-						revoke()
+					if _, _, bound := boundExecution(); bound {
+						revokeLease("execution_changed")
 						return
 					}
 					timer.Reset(retryInterval)
@@ -310,14 +348,18 @@ func (d KubernetesTerminalDialer) heartbeatActivity(ctx context.Context, key typ
 					refreshedFence, held, refreshErr := d.refreshHoldPolicy(ctx, key, fence, boundExecution)
 					if refreshErr != nil {
 						if errors.Is(refreshErr, errTerminalEnvironmentIncarnationChanged) {
-							revoke()
+							revokeLease("environment_changed")
+							return
+						}
+						if errors.Is(refreshErr, errTerminalExecutionChanged) {
+							revokeLease("execution_changed")
 							return
 						}
 						timer.Reset(retryInterval)
 						break
 					}
 					if held || refreshedFence.HoldPolicyRevision() <= fence.HoldPolicyRevision() {
-						revoke()
+						revokeLease("hold_policy_changed")
 						return
 					}
 					fence = refreshedFence
@@ -334,15 +376,12 @@ func (d KubernetesTerminalDialer) validateRunTerminalAssociation(ctx context.Con
 	var environment platformv1alpha1.Environment
 	if knownEnvironment == nil {
 		if err := d.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: association.EnvironmentName}, &environment); err != nil {
-			if apierrors.IsNotFound(err) {
-				return fmt.Errorf("%w: environment no longer exists", errRunTerminalAssociation)
-			}
 			return err
 		}
 		knownEnvironment = &environment
 	}
 	if string(knownEnvironment.UID) != association.EnvironmentUID {
-		return fmt.Errorf("%w: environment incarnation changed", errRunTerminalAssociation)
+		return fmt.Errorf("%w: %w", errRunTerminalAssociation, errTerminalEnvironmentIncarnationChanged)
 	}
 	var run platformv1alpha1.Run
 	if err := d.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: association.RunName}, &run); err != nil {
@@ -367,33 +406,47 @@ func (d KubernetesTerminalDialer) holdPolicyPollInterval() time.Duration {
 	return terminalPolicyPollInterval
 }
 
-func (d KubernetesTerminalDialer) readTerminalPolicy(ctx context.Context, key types.NamespacedName, previousFence lifecycle.ExecutionFence, boundExecution func() (sandboxclient.TerminalExecution, bool)) (lifecycle.ExecutionFence, bool, error) {
+func (d KubernetesTerminalDialer) readTerminalPolicy(ctx context.Context, key types.NamespacedName, previousFence lifecycle.ExecutionFence, boundExecution func() (sandboxclient.TerminalExecution, lifecycle.ExecutionFence, bool)) (lifecycle.ExecutionFence, bool, error) {
 	var environment platformv1alpha1.Environment
 	if err := d.Client.Get(ctx, key, &environment); err != nil {
 		return lifecycle.ExecutionFence{}, false, err
 	}
-	if environment.UID != previousFence.EnvironmentUID() {
-		return lifecycle.ExecutionFence{}, false, errTerminalEnvironmentIncarnationChanged
+	var execution sandboxclient.TerminalExecution
+	bound := false
+	if boundExecution != nil {
+		var boundFence lifecycle.ExecutionFence
+		execution, boundFence, bound = boundExecution()
+		if bound {
+			previousFence = boundFence
+		}
+	}
+	if err := previousFence.Validate(&environment); err != nil && !errors.Is(err, lifecycle.ErrHoldPolicyChanged) &&
+		(bound || errors.Is(err, lifecycle.ErrEnvironmentIncarnationChanged)) {
+		if errors.Is(err, lifecycle.ErrEnvironmentIncarnationChanged) {
+			return lifecycle.ExecutionFence{}, false, errTerminalEnvironmentIncarnationChanged
+		}
+		return lifecycle.ExecutionFence{}, false, errTerminalExecutionChanged
 	}
 	currentFence := lifecycle.CaptureExecutionFence(&environment)
-	if boundExecution != nil {
-		if execution, bound := boundExecution(); bound {
-			current, err := (sandboxclient.Connector{Reader: d.Client}).ExecutionCurrent(ctx, currentFence, execution)
-			if err != nil {
-				if errors.Is(err, lifecycle.ErrExecutionFenceChanged) && !errors.Is(err, lifecycle.ErrHoldPolicyChanged) {
-					return lifecycle.ExecutionFence{}, false, errTerminalEnvironmentIncarnationChanged
-				}
-				return lifecycle.ExecutionFence{}, false, err
-			}
-			if !current {
+	if bound {
+		current, err := (sandboxclient.Connector{Reader: d.Client}).ExecutionCurrent(ctx, currentFence, execution)
+		if err != nil {
+			if errors.Is(err, lifecycle.ErrEnvironmentIncarnationChanged) {
 				return lifecycle.ExecutionFence{}, false, errTerminalEnvironmentIncarnationChanged
 			}
+			if errors.Is(err, lifecycle.ErrExecutionFenceChanged) && !errors.Is(err, lifecycle.ErrHoldPolicyChanged) {
+				return lifecycle.ExecutionFence{}, false, errTerminalExecutionChanged
+			}
+			return lifecycle.ExecutionFence{}, false, err
+		}
+		if !current {
+			return lifecycle.ExecutionFence{}, false, errTerminalExecutionChanged
 		}
 	}
 	return currentFence, environment.Spec.Lifecycle.Hold != nil && environment.Spec.Lifecycle.Hold.Enabled, nil
 }
 
-func (d KubernetesTerminalDialer) refreshHoldPolicy(ctx context.Context, key types.NamespacedName, previousFence lifecycle.ExecutionFence, boundExecution func() (sandboxclient.TerminalExecution, bool)) (lifecycle.ExecutionFence, bool, error) {
+func (d KubernetesTerminalDialer) refreshHoldPolicy(ctx context.Context, key types.NamespacedName, previousFence lifecycle.ExecutionFence, boundExecution func() (sandboxclient.TerminalExecution, lifecycle.ExecutionFence, bool)) (lifecycle.ExecutionFence, bool, error) {
 	currentFence, held, err := d.readTerminalPolicy(ctx, key, previousFence, boundExecution)
 	if err != nil {
 		return lifecycle.ExecutionFence{}, false, err

--- a/internal/controlplane/terminal_test.go
+++ b/internal/controlplane/terminal_test.go
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
@@ -531,7 +533,7 @@ func TestTerminalHeartbeatRecoversAfterTransientGetFailure(t *testing.T) {
 	dialer := KubernetesTerminalDialer{Client: transient}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), 5*time.Millisecond, nil, nil, func() {})
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), 5*time.Millisecond, nil, nil, func() bool { return false })
 
 	deadline := time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {
@@ -560,11 +562,12 @@ func TestTerminalHeartbeatAdoptsNewerDisabledHoldRevision(t *testing.T) {
 		}},
 	}
 	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment).Build()
-	dialer := KubernetesTerminalDialer{Client: kubeClient, policyPollInterval: time.Millisecond}
+	metrics := NewMetrics(prometheus.NewRegistry())
+	dialer := KubernetesTerminalDialer{Client: kubeClient, Metrics: metrics, policyPollInterval: time.Millisecond}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	revoked := atomic.Bool{}
-	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), 20*time.Millisecond, nil, nil, func() { revoked.Store(true) })
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), 20*time.Millisecond, nil, nil, func() bool { revoked.Store(true); return true })
 
 	var updated platformv1alpha1.Environment
 	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(environment), &updated); err != nil {
@@ -581,6 +584,7 @@ func TestTerminalHeartbeatAdoptsNewerDisabledHoldRevision(t *testing.T) {
 }
 
 func TestTerminalPolicyRetriesDisabledHoldRevisionRacingExecutionProof(t *testing.T) {
+	metrics := NewMetrics(prometheus.NewRegistry())
 	scheme := runtime.NewScheme()
 	if err := corev1.AddToScheme(scheme); err != nil {
 		t.Fatal(err)
@@ -617,23 +621,29 @@ func TestTerminalPolicyRetriesDisabledHoldRevisionRacingExecutionProof(t *testin
 		},
 		podRead: provedAfterRace,
 	}
-	dialer := KubernetesTerminalDialer{Client: kubeClient, policyPollInterval: time.Millisecond}
+	dialer := KubernetesTerminalDialer{Client: kubeClient, Metrics: metrics, policyPollInterval: time.Millisecond}
 	lease := &terminalConnectionLease{}
-	if !lease.attach(closeFunc(func() error { return nil }), execution) {
+	if !lease.attach(closeFunc(func() error { return nil }), execution, lifecycle.CaptureExecutionFence(environment)) {
 		t.Fatal("failed to bind terminal execution")
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	revoked := atomic.Bool{}
-	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), time.Hour, nil, lease.boundExecution, func() { revoked.Store(true) })
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), 5*time.Millisecond, nil, lease.boundExecution, func() bool { revoked.Store(true); return true })
 
 	select {
 	case <-provedAfterRace:
 	case <-time.After(time.Second):
 		t.Fatal("terminal did not retry execution proof after disabled hold revision race")
 	}
+	waitForTerminalActivityRevision(t, baseClient, environment, 2)
 	if revoked.Load() {
 		t.Fatal("disabled hold revision racing execution proof revoked terminal")
+	}
+	for _, reason := range []string{"run_association_changed", "environment_changed", "execution_changed", "hold_policy_changed"} {
+		if got := testutil.ToFloat64(metrics.terminalRevocations.WithLabelValues(reason)); got != 0 {
+			t.Fatalf("%s revocations after disabled hold revision adoption = %v, want 0", reason, got)
+		}
 	}
 }
 
@@ -678,15 +688,16 @@ func TestTerminalHoldRefreshRevalidatesBoundExecution(t *testing.T) {
 			},
 		},
 	}
-	dialer := KubernetesTerminalDialer{Client: kubeClient, policyPollInterval: time.Hour}
+	metrics := NewMetrics(prometheus.NewRegistry())
+	dialer := KubernetesTerminalDialer{Client: kubeClient, Metrics: metrics, policyPollInterval: time.Hour}
 	lease := &terminalConnectionLease{}
 	closed := make(chan struct{})
-	if !lease.attach(closeFunc(func() error { close(closed); return nil }), execution) {
+	if !lease.attach(closeFunc(func() error { close(closed); return nil }), execution, lifecycle.CaptureExecutionFence(environment)) {
 		t.Fatal("failed to bind terminal execution")
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), 5*time.Millisecond, nil, lease.boundExecution, func() { _ = lease.Close() })
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), 5*time.Millisecond, nil, lease.boundExecution, func() bool { revoked, _ := lease.revoke(); return revoked })
 
 	select {
 	case <-closed:
@@ -700,9 +711,13 @@ func TestTerminalHoldRefreshRevalidatesBoundExecution(t *testing.T) {
 	if requests := lifecycle.ActivityRequests(&retained); len(requests) != 0 {
 		t.Fatalf("current activity after changed execution during hold refresh = %#v, want none", requests)
 	}
+	if got := testutil.ToFloat64(metrics.terminalRevocations.WithLabelValues("execution_changed")); got != 1 {
+		t.Fatalf("execution-change revocations = %v, want 1", got)
+	}
 }
 
 func TestTerminalHeartbeatRevokesConnectionWhenHoldEnabled(t *testing.T) {
+	metrics := NewMetrics(prometheus.NewRegistry())
 	scheme := runtime.NewScheme()
 	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
 		t.Fatal(err)
@@ -716,15 +731,15 @@ func TestTerminalHeartbeatRevokesConnectionWhenHoldEnabled(t *testing.T) {
 	}
 	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment).Build()
 	kubeClient := &activityCountingClient{Client: baseClient}
-	dialer := KubernetesTerminalDialer{Client: kubeClient, policyPollInterval: time.Millisecond}
+	dialer := KubernetesTerminalDialer{Client: kubeClient, Metrics: metrics, policyPollInterval: time.Millisecond}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	closed := make(chan struct{})
 	lease := &terminalConnectionLease{}
-	if !lease.attach(closeFunc(func() error { close(closed); return nil }), sandboxclient.TerminalExecution{}) {
+	if !lease.attach(closeFunc(func() error { close(closed); return nil }), sandboxclient.TerminalExecution{}, lifecycle.CaptureExecutionFence(environment)) {
 		t.Fatal("failed to attach test terminal connection")
 	}
-	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), time.Hour, nil, nil, func() { _ = lease.Close() })
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), time.Hour, nil, nil, func() bool { revoked, _ := lease.revoke(); return revoked })
 
 	var updated platformv1alpha1.Environment
 	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(environment), &updated); err != nil {
@@ -739,12 +754,58 @@ func TestTerminalHeartbeatRevokesConnectionWhenHoldEnabled(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("enabled hold did not revoke the live terminal connection")
 	}
+	if got := testutil.ToFloat64(metrics.terminalRevocations.WithLabelValues("hold_policy_changed")); got != 1 {
+		t.Fatalf("hold-policy revocations = %v, want 1", got)
+	}
 	if writes := kubeClient.count(); writes != 0 {
 		t.Fatalf("activity writes after enabled hold = %d, want 0", writes)
 	}
 }
 
+func TestTerminalHeartbeatRevokesConnectionWhenHoldRevisionBecomesStale(t *testing.T) {
+	metrics := NewMetrics(prometheus.NewRegistry())
+	scheme := runtime.NewScheme()
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	environment := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "env-1", Namespace: "project-1", UID: "env-uid"},
+		Status:     platformv1alpha1.EnvironmentStatus{ExecutionGeneration: 1},
+		Spec: platformv1alpha1.EnvironmentSpec{Lifecycle: platformv1alpha1.EnvironmentLifecycleSpec{
+			Hold: &platformv1alpha1.EnvironmentHoldPolicy{Revision: 2},
+		}},
+	}
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment).Build()
+	dialer := KubernetesTerminalDialer{Client: kubeClient, Metrics: metrics, policyPollInterval: time.Millisecond}
+	lease := &terminalConnectionLease{}
+	closed := make(chan struct{})
+	if !lease.attach(closeFunc(func() error { close(closed); return nil }), sandboxclient.TerminalExecution{}, lifecycle.CaptureExecutionFence(environment)) {
+		t.Fatal("failed to attach test terminal connection")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), time.Hour, nil, nil, func() bool { revoked, _ := lease.revoke(); return revoked })
+
+	var updated platformv1alpha1.Environment
+	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(environment), &updated); err != nil {
+		t.Fatal(err)
+	}
+	updated.Spec.Lifecycle.Hold = &platformv1alpha1.EnvironmentHoldPolicy{Revision: 1}
+	if err := kubeClient.Update(context.Background(), &updated); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("stale hold revision did not revoke the live terminal connection")
+	}
+	if got := testutil.ToFloat64(metrics.terminalRevocations.WithLabelValues("hold_policy_changed")); got != 1 {
+		t.Fatalf("hold-policy revocations = %v, want 1", got)
+	}
+}
+
 func TestTerminalPolicyPollRetriesTransientFailuresAndRevokesRecoveredHold(t *testing.T) {
+	metrics := NewMetrics(prometheus.NewRegistry())
 	scheme := runtime.NewScheme()
 	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
 		t.Fatal(err)
@@ -759,11 +820,11 @@ func TestTerminalPolicyPollRetriesTransientFailuresAndRevokesRecoveredHold(t *te
 	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment).Build()
 	failedGets := make(chan struct{}, 2)
 	transient := &transientTerminalGetClient{Client: baseClient, getFailures: 2, failedGets: failedGets}
-	dialer := KubernetesTerminalDialer{Client: transient, policyPollInterval: time.Millisecond}
+	dialer := KubernetesTerminalDialer{Client: transient, Metrics: metrics, policyPollInterval: time.Millisecond}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	closed := make(chan struct{})
-	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), time.Hour, nil, nil, func() { close(closed) })
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), time.Hour, nil, nil, func() bool { close(closed); return true })
 
 	for range 2 {
 		select {
@@ -776,6 +837,11 @@ func TestTerminalPolicyPollRetriesTransientFailuresAndRevokesRecoveredHold(t *te
 	case <-closed:
 		t.Fatal("transient policy Get failure revoked terminal")
 	default:
+	}
+	for _, reason := range []string{"run_association_changed", "environment_changed", "execution_changed", "hold_policy_changed"} {
+		if got := testutil.ToFloat64(metrics.terminalRevocations.WithLabelValues(reason)); got != 0 {
+			t.Fatalf("%s revocations after transient API failures = %v, want 0", reason, got)
+		}
 	}
 	var updated platformv1alpha1.Environment
 	if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(environment), &updated); err != nil {
@@ -793,21 +859,22 @@ func TestTerminalPolicyPollRetriesTransientFailuresAndRevokesRecoveredHold(t *te
 }
 
 func TestTerminalHeartbeatRevokesConnectionForReplacementUID(t *testing.T) {
+	metrics := NewMetrics(prometheus.NewRegistry())
 	scheme := runtime.NewScheme()
 	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
 		t.Fatal(err)
 	}
 	environment := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "env-1", Namespace: "project-1", UID: "old-uid"}, Status: platformv1alpha1.EnvironmentStatus{ExecutionGeneration: 1}}
 	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment).Build()
-	dialer := KubernetesTerminalDialer{Client: kubeClient, policyPollInterval: time.Millisecond}
+	dialer := KubernetesTerminalDialer{Client: kubeClient, Metrics: metrics, policyPollInterval: time.Millisecond}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	closed := make(chan struct{})
 	lease := &terminalConnectionLease{}
-	if !lease.attach(closeFunc(func() error { close(closed); return nil }), sandboxclient.TerminalExecution{}) {
+	if !lease.attach(closeFunc(func() error { close(closed); return nil }), sandboxclient.TerminalExecution{}, lifecycle.CaptureExecutionFence(environment)) {
 		t.Fatal("failed to attach test terminal connection")
 	}
-	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), time.Hour, nil, nil, func() { _ = lease.Close() })
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), time.Hour, nil, nil, func() bool { revoked, _ := lease.revoke(); return revoked })
 
 	if err := kubeClient.Delete(context.Background(), environment); err != nil {
 		t.Fatal(err)
@@ -820,6 +887,12 @@ func TestTerminalHeartbeatRevokesConnectionForReplacementUID(t *testing.T) {
 	case <-closed:
 	case <-time.After(time.Second):
 		t.Fatal("replacement Environment UID did not revoke the live terminal connection")
+	}
+	if got := testutil.ToFloat64(metrics.terminalRevocations.WithLabelValues("environment_changed")); got != 1 {
+		t.Fatalf("environment-change revocations = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(metrics.terminalRevocations.WithLabelValues("execution_changed")); got != 0 {
+		t.Fatalf("execution-change revocations = %v, want 0", got)
 	}
 	var retained platformv1alpha1.Environment
 	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(replacement), &retained); err != nil {
@@ -851,6 +924,22 @@ func TestTerminalHeartbeatRevokesConnectionWhenBoundExecutionChanges(t *testing.
 			updated.Status.Lifecycle.Epoch++
 			return kubeClient.Status().Update(ctx, &updated)
 		}},
+		{name: "execution generation", mutate: func(ctx context.Context, kubeClient client.Client, environment *platformv1alpha1.Environment, _ *corev1.Pod) error {
+			var updated platformv1alpha1.Environment
+			if err := kubeClient.Get(ctx, client.ObjectKeyFromObject(environment), &updated); err != nil {
+				return err
+			}
+			updated.Status.ExecutionGeneration++
+			return kubeClient.Status().Update(ctx, &updated)
+		}},
+		{name: "endpoint disappearance", mutate: func(ctx context.Context, kubeClient client.Client, environment *platformv1alpha1.Environment, _ *corev1.Pod) error {
+			var updated platformv1alpha1.Environment
+			if err := kubeClient.Get(ctx, client.ObjectKeyFromObject(environment), &updated); err != nil {
+				return err
+			}
+			updated.Status.Endpoints.Sandboxd = ""
+			return kubeClient.Status().Update(ctx, &updated)
+		}},
 		{name: "same-name Pod UID replacement", mutate: func(ctx context.Context, kubeClient client.Client, _ *platformv1alpha1.Environment, pod *corev1.Pod) error {
 			if err := kubeClient.Delete(ctx, pod); err != nil {
 				return err
@@ -865,6 +954,7 @@ func TestTerminalHeartbeatRevokesConnectionWhenBoundExecutionChanges(t *testing.
 		}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			metrics := NewMetrics(prometheus.NewRegistry())
 			scheme := runtime.NewScheme()
 			if err := corev1.AddToScheme(scheme); err != nil {
 				t.Fatal(err)
@@ -884,19 +974,19 @@ func TestTerminalHeartbeatRevokesConnectionWhenBoundExecutionChanges(t *testing.
 			kubeClient := &activityCountingClient{Client: baseClient}
 			// Delay the ordinary policy poll so only the activity timer's
 			// immediate execution check can revoke this stale lease.
-			dialer := KubernetesTerminalDialer{Client: kubeClient, policyPollInterval: time.Hour}
+			dialer := KubernetesTerminalDialer{Client: kubeClient, Metrics: metrics, policyPollInterval: time.Hour}
 			lease := &terminalConnectionLease{}
 			closed := make(chan struct{})
 			execution, err := (sandboxclient.Connector{Reader: baseClient}).ResolveExecution(context.Background(), lifecycle.CaptureExecutionFence(environment))
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !lease.attach(closeFunc(func() error { close(closed); return nil }), execution) {
+			if !lease.attach(closeFunc(func() error { close(closed); return nil }), execution, lifecycle.CaptureExecutionFence(environment)) {
 				t.Fatal("failed to bind terminal execution")
 			}
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), 10*time.Millisecond, nil, lease.boundExecution, func() { _ = lease.Close() })
+			go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), 10*time.Millisecond, nil, lease.boundExecution, func() bool { revoked, _ := lease.revoke(); return revoked })
 
 			if err := test.mutate(context.Background(), baseClient, environment, pod); err != nil {
 				t.Fatal(err)
@@ -906,6 +996,12 @@ func TestTerminalHeartbeatRevokesConnectionWhenBoundExecutionChanges(t *testing.
 			case <-time.After(time.Second):
 				t.Fatal("bound execution change did not revoke terminal")
 			}
+			if got := testutil.ToFloat64(metrics.terminalRevocations.WithLabelValues("execution_changed")); got != 1 {
+				t.Fatalf("execution-change revocations = %v, want 1", got)
+			}
+			if got := testutil.ToFloat64(metrics.terminalRevocations.WithLabelValues("environment_changed")); got != 0 {
+				t.Fatalf("environment-change revocations = %v, want 0", got)
+			}
 			if writes := kubeClient.count(); writes != 0 {
 				t.Fatalf("stale terminal activity reached replacement execution: got %d writes, want 0", writes)
 			}
@@ -913,7 +1009,57 @@ func TestTerminalHeartbeatRevokesConnectionWhenBoundExecutionChanges(t *testing.
 	}
 }
 
+func TestTerminalConnectionLeaseRevocationRequiresOpenGrant(t *testing.T) {
+	lease := &terminalConnectionLease{}
+	if revoked, err := lease.revoke(); err != nil || revoked {
+		t.Fatalf("pre-attachment revoke = %v, %v; want false, nil", revoked, err)
+	}
+	if lease.attach(io.NopCloser(strings.NewReader("")), sandboxclient.TerminalExecution{}, lifecycle.ExecutionFence{}) {
+		t.Fatal("attached a connection after pre-grant revocation")
+	}
+
+	lease = &terminalConnectionLease{}
+	if !lease.attach(io.NopCloser(strings.NewReader("")), sandboxclient.TerminalExecution{}, lifecycle.ExecutionFence{}) {
+		t.Fatal("failed to attach connection")
+	}
+	if err := lease.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if revoked, err := lease.revoke(); err != nil || revoked {
+		t.Fatalf("post-close revoke = %v, %v; want false, nil", revoked, err)
+	}
+}
+
+func TestTerminalConnectionLeaseConcurrentRevocationIsExactOnce(t *testing.T) {
+	lease := &terminalConnectionLease{}
+	var closes atomic.Int64
+	if !lease.attach(closeFunc(func() error { closes.Add(1); return nil }), sandboxclient.TerminalExecution{}, lifecycle.ExecutionFence{}) {
+		t.Fatal("failed to attach connection")
+	}
+	var revocations atomic.Int64
+	var wait sync.WaitGroup
+	for range 32 {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			if revoked, err := lease.revoke(); err != nil {
+				t.Errorf("revoke() error = %v", err)
+			} else if revoked {
+				revocations.Add(1)
+			}
+		}()
+	}
+	wait.Wait()
+	if got := revocations.Load(); got != 1 {
+		t.Fatalf("atomic revocations = %d, want 1", got)
+	}
+	if got := closes.Load(); got != 1 {
+		t.Fatalf("connection closes = %d, want 1", got)
+	}
+}
+
 func TestTerminalExecutionPolicyPollRetriesTransientPodRead(t *testing.T) {
+	metrics := NewMetrics(prometheus.NewRegistry())
 	scheme := runtime.NewScheme()
 	if err := corev1.AddToScheme(scheme); err != nil {
 		t.Fatal(err)
@@ -932,19 +1078,19 @@ func TestTerminalExecutionPolicyPollRetriesTransientPodRead(t *testing.T) {
 	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment, pod, template).Build()
 	failed := make(chan struct{}, 1)
 	kubeClient := &transientPodGetClient{Client: baseClient, failures: 1, failed: failed}
-	dialer := KubernetesTerminalDialer{Client: kubeClient, policyPollInterval: time.Millisecond}
+	dialer := KubernetesTerminalDialer{Client: kubeClient, Metrics: metrics, policyPollInterval: time.Millisecond}
 	lease := &terminalConnectionLease{}
 	closed := make(chan struct{})
 	execution, err := (sandboxclient.Connector{Reader: baseClient}).ResolveExecution(context.Background(), lifecycle.CaptureExecutionFence(environment))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !lease.attach(closeFunc(func() error { close(closed); return nil }), execution) {
+	if !lease.attach(closeFunc(func() error { close(closed); return nil }), execution, lifecycle.CaptureExecutionFence(environment)) {
 		t.Fatal("failed to bind terminal execution")
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), time.Hour, nil, lease.boundExecution, func() { _ = lease.Close() })
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), time.Hour, nil, lease.boundExecution, func() bool { revoked, _ := lease.revoke(); return revoked })
 
 	select {
 	case <-failed:
@@ -956,6 +1102,11 @@ func TestTerminalExecutionPolicyPollRetriesTransientPodRead(t *testing.T) {
 		t.Fatal("transient Pod read revoked terminal")
 	default:
 	}
+	for _, reason := range []string{"run_association_changed", "environment_changed", "execution_changed", "hold_policy_changed"} {
+		if got := testutil.ToFloat64(metrics.terminalRevocations.WithLabelValues(reason)); got != 0 {
+			t.Fatalf("%s revocations after transient Pod failure = %v, want 0", reason, got)
+		}
+	}
 	if err := baseClient.Delete(context.Background(), pod); err != nil {
 		t.Fatal(err)
 	}
@@ -963,6 +1114,9 @@ func TestTerminalExecutionPolicyPollRetriesTransientPodRead(t *testing.T) {
 	case <-closed:
 	case <-time.After(time.Second):
 		t.Fatal("policy poll did not revoke after Pod disappeared")
+	}
+	if got := testutil.ToFloat64(metrics.terminalRevocations.WithLabelValues("execution_changed")); got != 1 {
+		t.Fatalf("execution-change revocations = %v, want 1", got)
 	}
 }
 
@@ -1022,21 +1176,29 @@ func TestResolveRunTerminalRequiresExactCurrentAssociation(t *testing.T) {
 }
 
 func TestRunTerminalHeartbeatRevokesAfterAssociationLoss(t *testing.T) {
+	metrics := NewMetrics(prometheus.NewRegistry())
 	run := &platformv1alpha1.Run{
 		ObjectMeta: metav1.ObjectMeta{Name: "run", Namespace: "ns", UID: "run-uid"},
 		Status:     platformv1alpha1.RunStatus{EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{Name: "env", UID: "env-uid", Ownership: platformv1alpha1.EnvironmentOwnershipClaimed}},
 	}
 	environment := &platformv1alpha1.Environment{
 		ObjectMeta: metav1.ObjectMeta{Name: "env", Namespace: "ns", UID: "env-uid"},
-		Status:     platformv1alpha1.EnvironmentStatus{ClaimedBy: &platformv1alpha1.RunReference{Name: "run", UID: "run-uid"}},
+		Status: platformv1alpha1.EnvironmentStatus{
+			ExecutionGeneration: 1,
+			ClaimedBy:           &platformv1alpha1.RunReference{Name: "run", UID: "run-uid"},
+		},
 	}
 	kubeClient := fake.NewClientBuilder().WithScheme(resourceScheme(t)).WithStatusSubresource(environment, run).WithObjects(run, environment).Build()
-	dialer := KubernetesTerminalDialer{Client: kubeClient, policyPollInterval: time.Millisecond}
+	dialer := KubernetesTerminalDialer{Client: kubeClient, Metrics: metrics, policyPollInterval: time.Millisecond}
 	association := &RunTerminalAssociation{RunName: "run", RunUID: "run-uid", EnvironmentName: "env", EnvironmentUID: "env-uid", EnvironmentOwnership: string(platformv1alpha1.EnvironmentOwnershipClaimed)}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	revoked := make(chan struct{})
-	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), time.Hour, association, nil, func() { close(revoked) })
+	lease := &terminalConnectionLease{}
+	if !lease.attach(closeFunc(func() error { close(revoked); return nil }), sandboxclient.TerminalExecution{}, lifecycle.CaptureExecutionFence(environment)) {
+		t.Fatal("failed to attach test terminal connection")
+	}
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), time.Hour, association, nil, func() bool { revoked, _ := lease.revoke(); return revoked })
 
 	var updated platformv1alpha1.Environment
 	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(environment), &updated); err != nil {
@@ -1050,6 +1212,56 @@ func TestRunTerminalHeartbeatRevokesAfterAssociationLoss(t *testing.T) {
 	case <-revoked:
 	case <-time.After(time.Second):
 		t.Fatal("association loss did not revoke active Run terminal")
+	}
+	if got := testutil.ToFloat64(metrics.terminalRevocations.WithLabelValues("run_association_changed")); got != 1 {
+		t.Fatalf("run-association revocations = %v, want 1", got)
+	}
+}
+
+func TestRunTerminalHeartbeatClassifiesEnvironmentReplacement(t *testing.T) {
+	metrics := NewMetrics(prometheus.NewRegistry())
+	run := &platformv1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{Name: "run", Namespace: "ns", UID: "run-uid"},
+		Status:     platformv1alpha1.RunStatus{EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{Name: "env", UID: "env-uid", Ownership: platformv1alpha1.EnvironmentOwnershipClaimed}},
+	}
+	environment := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "env", Namespace: "ns", UID: "env-uid"},
+		Status: platformv1alpha1.EnvironmentStatus{
+			ExecutionGeneration: 1,
+			ClaimedBy:           &platformv1alpha1.RunReference{Name: "run", UID: "run-uid"},
+		},
+	}
+	kubeClient := fake.NewClientBuilder().WithScheme(resourceScheme(t)).WithStatusSubresource(environment, run).WithObjects(run, environment).Build()
+	dialer := KubernetesTerminalDialer{Client: kubeClient, Metrics: metrics, policyPollInterval: time.Millisecond}
+	association := &RunTerminalAssociation{RunName: "run", RunUID: "run-uid", EnvironmentName: "env", EnvironmentUID: "env-uid", EnvironmentOwnership: string(platformv1alpha1.EnvironmentOwnershipClaimed)}
+	lease := &terminalConnectionLease{}
+	closed := make(chan struct{})
+	if !lease.attach(closeFunc(func() error { close(closed); return nil }), sandboxclient.TerminalExecution{}, lifecycle.CaptureExecutionFence(environment)) {
+		t.Fatal("failed to attach test terminal connection")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), time.Hour, association, nil, func() bool { revoked, _ := lease.revoke(); return revoked })
+
+	if err := kubeClient.Delete(context.Background(), environment); err != nil {
+		t.Fatal(err)
+	}
+	replacement := environment.DeepCopy()
+	replacement.ResourceVersion = ""
+	replacement.UID = "replacement-env-uid"
+	if err := kubeClient.Create(context.Background(), replacement); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("Environment replacement did not revoke active Run terminal")
+	}
+	if got := testutil.ToFloat64(metrics.terminalRevocations.WithLabelValues("environment_changed")); got != 1 {
+		t.Fatalf("environment-change revocations = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(metrics.terminalRevocations.WithLabelValues("run_association_changed")); got != 0 {
+		t.Fatalf("run-association revocations = %v, want 0", got)
 	}
 }
 
@@ -1105,13 +1317,16 @@ func (c *scheduledEnvironmentMutationClient) Get(ctx context.Context, key client
 			}
 		}
 	}
-	if _, ok := object.(*corev1.Pod); ok && c.podRead != nil {
-		select {
-		case c.podRead <- struct{}{}:
-		default:
+	err := c.Client.Get(ctx, key, object, options...)
+	if err == nil {
+		if _, ok := object.(*corev1.Pod); ok && c.podRead != nil {
+			select {
+			case c.podRead <- struct{}{}:
+			default:
+			}
 		}
 	}
-	return c.Client.Get(ctx, key, object, options...)
+	return err
 }
 
 func (c *transientPodGetClient) Get(ctx context.Context, key client.ObjectKey, object client.Object, options ...client.GetOption) error {
@@ -1160,6 +1375,7 @@ func (w *transientTerminalStatusWriter) Update(ctx context.Context, object clien
 }
 
 func TestKubernetesTerminalDialerActivityPreservesReadyGeneration(t *testing.T) {
+	metrics := NewMetrics(prometheus.NewRegistry())
 	scheme := runtime.NewScheme()
 	if err := corev1.AddToScheme(scheme); err != nil {
 		t.Fatal(err)
@@ -1190,7 +1406,7 @@ func TestKubernetesTerminalDialerActivityPreservesReadyGeneration(t *testing.T) 
 		t.Fatal(err)
 	}
 	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment, template, pod).Build()
-	dialer := KubernetesTerminalDialer{Client: kubeClient}
+	dialer := KubernetesTerminalDialer{Client: kubeClient, Metrics: metrics}
 
 	_, _, closer, err := dialer.DialTerminal(context.Background(), environment.Namespace, environment.Name, string(environment.UID))
 	if err != nil {
@@ -1198,6 +1414,9 @@ func TestKubernetesTerminalDialerActivityPreservesReadyGeneration(t *testing.T) 
 	}
 	if err := closer.Close(); err != nil {
 		t.Fatal(err)
+	}
+	if got := testutil.ToFloat64(metrics.terminalLeaseGrants.WithLabelValues("granted")); got != 1 {
+		t.Fatalf("granted terminal leases = %v, want 1", got)
 	}
 	var active platformv1alpha1.Environment
 	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(environment), &active); err != nil {
@@ -1209,6 +1428,7 @@ func TestKubernetesTerminalDialerActivityPreservesReadyGeneration(t *testing.T) 
 }
 
 func TestKubernetesTerminalDialerUsesRecreatedPodCredentialsAfterWake(t *testing.T) {
+	metrics := NewMetrics(prometheus.NewRegistry())
 	scheme := runtime.NewScheme()
 	if err := corev1.AddToScheme(scheme); err != nil {
 		t.Fatal(err)
@@ -1235,7 +1455,7 @@ func TestKubernetesTerminalDialerUsesRecreatedPodCredentialsAfterWake(t *testing
 			Namespace: environment.Namespace,
 			UID:       "new-pod-uid",
 			Annotations: map[string]string{
-				"swe.dev/execution-generation":  "1",
+				"swe.dev/execution-generation":  "2",
 				sandboxdauth.IdentityAnnotation: "new-incarnation.sandboxd.swe.dev",
 				sandboxdauth.TrustAnnotation:    testCertificatePEM(t, "new-incarnation.sandboxd.swe.dev"),
 				sandboxdauth.TokenAnnotation:    "new-terminal-token",
@@ -1248,7 +1468,11 @@ func TestKubernetesTerminalDialerUsesRecreatedPodCredentialsAfterWake(t *testing
 		t.Fatal(err)
 	}
 	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment, template, newPod).Build()
-	dialer := KubernetesTerminalDialer{Client: wakeReadyClient{Client: baseClient, podName: newPod.Name}}
+	dialer := KubernetesTerminalDialer{
+		Client:             wakeReadyClient{Client: baseClient, podName: newPod.Name, delayAfterReady: 20 * time.Millisecond},
+		Metrics:            metrics,
+		policyPollInterval: time.Millisecond,
+	}
 
 	_, _, closer, err := dialer.DialTerminal(context.Background(), environment.Namespace, environment.Name, string(environment.UID))
 	if err != nil {
@@ -1263,6 +1487,14 @@ func TestKubernetesTerminalDialerUsesRecreatedPodCredentialsAfterWake(t *testing
 	}
 	if woken.Spec.Lifecycle.Wake == nil || woken.Spec.Lifecycle.Wake.ExpectedSuspensionReason != platformv1alpha1.EnvironmentSuspensionReasonIdle {
 		t.Fatalf("idle terminal wake = %#v", woken.Spec.Lifecycle.Wake)
+	}
+	if woken.Status.ExecutionGeneration != 2 {
+		t.Fatalf("woken execution generation = %d, want 2", woken.Status.ExecutionGeneration)
+	}
+	for _, reason := range []string{"run_association_changed", "environment_changed", "execution_changed", "hold_policy_changed"} {
+		if got := testutil.ToFloat64(metrics.terminalRevocations.WithLabelValues(reason)); got != 0 {
+			t.Fatalf("%s revocations across wake = %v, want 0", reason, got)
+		}
 	}
 }
 
@@ -1330,6 +1562,7 @@ func TestTerminalHeartbeatCancelsWhenWakeOrDialFails(t *testing.T) {
 		{name: "dial"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			metrics := NewMetrics(prometheus.NewRegistry())
 			scheme := runtime.NewScheme()
 			if err := corev1.AddToScheme(scheme); err != nil {
 				t.Fatal(err)
@@ -1353,10 +1586,20 @@ func TestTerminalHeartbeatCancelsWhenWakeOrDialFails(t *testing.T) {
 			if test.paused {
 				kubeClient = &failingWakeClient{activityCountingClient: activityClient}
 			}
-			dialer := KubernetesTerminalDialer{Client: kubeClient}
+			dialer := KubernetesTerminalDialer{Client: kubeClient, Metrics: metrics}
 
 			if _, _, _, err := dialer.DialTerminal(context.Background(), environment.Namespace, environment.Name, string(environment.UID)); err == nil {
 				t.Fatalf("DialTerminal() succeeded during %s failure", test.name)
+			}
+			wantFailed := float64(1)
+			if test.paused {
+				wantFailed = 0
+			}
+			if got := testutil.ToFloat64(metrics.terminalLeaseGrants.WithLabelValues("failed")); got != wantFailed {
+				t.Fatalf("failed terminal leases = %v, want %v", got, wantFailed)
+			}
+			if got := testutil.ToFloat64(metrics.terminalLeaseGrants.WithLabelValues("granted")); got != 0 {
+				t.Fatalf("granted terminal leases = %v, want 0", got)
 			}
 			writesAfterFailure := waitForActivityWritesToQuiesce(t, activityClient, 60*time.Millisecond)
 			time.Sleep(60 * time.Millisecond)
@@ -1496,7 +1739,8 @@ func currentExecutionPod(environment *platformv1alpha1.Environment, uid types.UI
 
 type wakeReadyClient struct {
 	client.Client
-	podName string
+	podName         string
+	delayAfterReady time.Duration
 }
 
 func (c wakeReadyClient) Patch(ctx context.Context, object client.Object, patch client.Patch, options ...client.PatchOption) error {
@@ -1511,10 +1755,11 @@ func (c wakeReadyClient) Patch(ctx context.Context, object client.Object, patch 
 	if err := c.Client.Get(ctx, client.ObjectKeyFromObject(environment), &current); err != nil {
 		return err
 	}
-	if current.Spec.Lifecycle.Wake == nil {
+	if current.Spec.Lifecycle.Wake == nil || !current.Status.Lifecycle.Suspended {
 		return nil
 	}
 	current.Status.Phase = platformv1alpha1.EnvironmentPhaseReady
+	current.Status.ExecutionGeneration++
 	current.Status.Lifecycle.Suspended = false
 	current.Status.Lifecycle.SuspensionReason = ""
 	current.Status.PodName = c.podName
@@ -1528,7 +1773,11 @@ func (c wakeReadyClient) Patch(ctx context.Context, object client.Object, patch 
 		Type: platformv1alpha1.EnvironmentConditionReady, Status: metav1.ConditionTrue,
 		ObservedGeneration: current.Generation, Reason: "SandboxdReady", Message: "sandboxd is ready",
 	})
-	return c.Client.Status().Update(ctx, &current)
+	if err := c.Client.Status().Update(ctx, &current); err != nil {
+		return err
+	}
+	time.Sleep(c.delayAfterReady)
+	return nil
 }
 
 func testCertificatePEM(t *testing.T, serverName string) string {

--- a/internal/controlplane/terminal_test.go
+++ b/internal/controlplane/terminal_test.go
@@ -1374,6 +1374,119 @@ func (w *transientTerminalStatusWriter) Update(ctx context.Context, object clien
 	return w.SubResourceWriter.Update(ctx, object, options...)
 }
 
+func TestKubernetesTerminalDialerCountsOnlyAttachedLeaseAsGranted(t *testing.T) {
+	newFixture := func(t *testing.T) (client.Client, *platformv1alpha1.Run, *platformv1alpha1.Environment) {
+		t.Helper()
+		scheme := runtime.NewScheme()
+		if err := corev1.AddToScheme(scheme); err != nil {
+			t.Fatal(err)
+		}
+		if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+			t.Fatal(err)
+		}
+		run := &platformv1alpha1.Run{
+			ObjectMeta: metav1.ObjectMeta{Name: "run-1", Namespace: "project-1", UID: "run-uid"},
+			Status: platformv1alpha1.RunStatus{EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{
+				Name: "env-1", UID: "env-uid", Ownership: platformv1alpha1.EnvironmentOwnershipClaimed,
+			}},
+		}
+		environment := &platformv1alpha1.Environment{
+			ObjectMeta: metav1.ObjectMeta{Name: "env-1", Namespace: "project-1", UID: "env-uid", Generation: 1},
+			Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "default"},
+			Status:     platformv1alpha1.EnvironmentStatus{ClaimedBy: &platformv1alpha1.RunReference{Name: run.Name, UID: run.UID}},
+		}
+		applyReadyTerminalStatus(environment, "env-pod")
+		template := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: environment.Namespace}}
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "env-pod", Namespace: environment.Namespace, UID: "pod-uid",
+				Annotations: map[string]string{
+					"swe.dev/execution-generation":  "1",
+					sandboxdauth.IdentityAnnotation: "env-pod.sandboxd.swe.dev",
+					sandboxdauth.TrustAnnotation:    testCertificatePEM(t, "env-pod.sandboxd.swe.dev"),
+					sandboxdauth.TokenAnnotation:    "terminal-token",
+				},
+			},
+			Spec:   corev1.PodSpec{RestartPolicy: corev1.RestartPolicyNever},
+			Status: corev1.PodStatus{PodIP: "192.0.2.10", Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}},
+		}
+		if err := controllerutil.SetControllerReference(environment, pod, scheme); err != nil {
+			t.Fatal(err)
+		}
+		kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment, run).WithObjects(run, environment, template, pod).Build()
+		return kubeClient, run, environment
+	}
+	assertFailedOnly := func(t *testing.T, metrics *Metrics) {
+		t.Helper()
+		if got := testutil.ToFloat64(metrics.terminalLeaseGrants.WithLabelValues("failed")); got != 1 {
+			t.Fatalf("failed terminal leases = %v, want 1", got)
+		}
+		if got := testutil.ToFloat64(metrics.terminalLeaseGrants.WithLabelValues("granted")); got != 0 {
+			t.Fatalf("granted terminal leases = %v, want 0", got)
+		}
+		for _, reason := range []string{"run_association_changed", "environment_changed", "execution_changed", "hold_policy_changed"} {
+			if got := testutil.ToFloat64(metrics.terminalRevocations.WithLabelValues(reason)); got != 0 {
+				t.Fatalf("%s revocations for never-attached lease = %v, want 0", reason, got)
+			}
+		}
+	}
+
+	t.Run("post-dial association failure", func(t *testing.T) {
+		baseClient, run, environment := newFixture(t)
+		metrics := NewMetrics(prometheus.NewRegistry())
+		kubeClient := &postDialAssociationFailureClient{Client: baseClient}
+		dialer := KubernetesTerminalDialer{Client: kubeClient, Metrics: metrics}
+		association := RunTerminalAssociation{
+			RunName: run.Name, RunUID: string(run.UID), EnvironmentName: environment.Name,
+			EnvironmentUID: string(environment.UID), EnvironmentOwnership: string(platformv1alpha1.EnvironmentOwnershipClaimed),
+		}
+		if _, _, _, err := dialer.DialRunTerminal(context.Background(), environment.Namespace, association); !errors.Is(err, errRunTerminalAssociation) {
+			t.Fatalf("DialRunTerminal() error = %v, want association failure", err)
+		}
+		assertFailedOnly(t, metrics)
+	})
+
+	t.Run("pre-attachment revocation", func(t *testing.T) {
+		kubeClient, _, environment := newFixture(t)
+		metrics := NewMetrics(prometheus.NewRegistry())
+		dialer := KubernetesTerminalDialer{
+			Client: kubeClient, Metrics: metrics,
+			beforeLeaseAttach: func(lease *terminalConnectionLease) {
+				if revoked, err := lease.revoke(); err != nil || revoked {
+					t.Fatalf("pre-attachment revoke = %v, %v; want false, nil", revoked, err)
+				}
+			},
+		}
+		if _, _, _, err := dialer.DialTerminal(context.Background(), environment.Namespace, environment.Name, string(environment.UID)); err == nil {
+			t.Fatal("DialTerminal() succeeded after pre-attachment revocation")
+		}
+		assertFailedOnly(t, metrics)
+	})
+}
+
+type postDialAssociationFailureClient struct {
+	client.Client
+	mu      sync.Mutex
+	runGets int
+}
+
+func (c *postDialAssociationFailureClient) Get(ctx context.Context, key client.ObjectKey, object client.Object, options ...client.GetOption) error {
+	if err := c.Client.Get(ctx, key, object, options...); err != nil {
+		return err
+	}
+	run, ok := object.(*platformv1alpha1.Run)
+	if !ok {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.runGets++
+	if c.runGets == 3 {
+		run.Status.EnvironmentRef = nil
+	}
+	return nil
+}
+
 func TestKubernetesTerminalDialerActivityPreservesReadyGeneration(t *testing.T) {
 	metrics := NewMetrics(prometheus.NewRegistry())
 	scheme := runtime.NewScheme()

--- a/internal/controlplane/terminal_test.go
+++ b/internal/controlplane/terminal_test.go
@@ -996,6 +996,10 @@ func TestTerminalHeartbeatRevokesConnectionWhenBoundExecutionChanges(t *testing.
 			case <-time.After(time.Second):
 				t.Fatal("bound execution change did not revoke terminal")
 			}
+			deadline := time.Now().Add(time.Second)
+			for testutil.ToFloat64(metrics.terminalRevocations.WithLabelValues("execution_changed")) != 1 && time.Now().Before(deadline) {
+				time.Sleep(time.Millisecond)
+			}
 			if got := testutil.ToFloat64(metrics.terminalRevocations.WithLabelValues("execution_changed")); got != 1 {
 				t.Fatalf("execution-change revocations = %v, want 1", got)
 			}

--- a/internal/controlplane/terminal_test.go
+++ b/internal/controlplane/terminal_test.go
@@ -903,6 +903,38 @@ func TestTerminalHeartbeatRevokesConnectionForReplacementUID(t *testing.T) {
 	}
 }
 
+func TestTerminalHeartbeatRevokesConnectionWhenEnvironmentDeleted(t *testing.T) {
+	metrics := NewMetrics(prometheus.NewRegistry())
+	scheme := runtime.NewScheme()
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	environment := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "env-1", Namespace: "project-1", UID: "env-uid"}, Status: platformv1alpha1.EnvironmentStatus{ExecutionGeneration: 1}}
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment).Build()
+	dialer := KubernetesTerminalDialer{Client: kubeClient, Metrics: metrics, policyPollInterval: time.Millisecond}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	closed := make(chan struct{})
+	lease := &terminalConnectionLease{}
+	if !lease.attach(closeFunc(func() error { close(closed); return nil }), sandboxclient.TerminalExecution{}, lifecycle.CaptureExecutionFence(environment)) {
+		t.Fatal("failed to attach test terminal connection")
+	}
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), time.Hour, nil, nil, func() bool { revoked, _ := lease.revoke(); return revoked })
+
+	if err := kubeClient.Delete(context.Background(), environment); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("deleted Environment did not close the live terminal connection")
+	}
+	waitForTerminalRevocationMetric(t, metrics, "environment_changed", 1)
+	if got := testutil.ToFloat64(metrics.terminalRevocations.WithLabelValues("environment_changed")); got != 1 {
+		t.Fatalf("environment-change revocations = %v, want exactly 1", got)
+	}
+}
+
 func TestTerminalHeartbeatRevokesConnectionWhenBoundExecutionChanges(t *testing.T) {
 	for _, test := range []struct {
 		name   string
@@ -1267,6 +1299,60 @@ func TestRunTerminalHeartbeatClassifiesEnvironmentReplacement(t *testing.T) {
 	if got := testutil.ToFloat64(metrics.terminalRevocations.WithLabelValues("run_association_changed")); got != 0 {
 		t.Fatalf("run-association revocations = %v, want 0", got)
 	}
+}
+
+func TestRunTerminalHeartbeatRevokesConnectionWhenEnvironmentDeleted(t *testing.T) {
+	metrics := NewMetrics(prometheus.NewRegistry())
+	run := &platformv1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{Name: "run", Namespace: "ns", UID: "run-uid"},
+		Status:     platformv1alpha1.RunStatus{EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{Name: "env", UID: "env-uid", Ownership: platformv1alpha1.EnvironmentOwnershipClaimed}},
+	}
+	environment := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "env", Namespace: "ns", UID: "env-uid"},
+		Status: platformv1alpha1.EnvironmentStatus{
+			ExecutionGeneration: 1,
+			ClaimedBy:           &platformv1alpha1.RunReference{Name: "run", UID: "run-uid"},
+		},
+	}
+	kubeClient := fake.NewClientBuilder().WithScheme(resourceScheme(t)).WithStatusSubresource(environment, run).WithObjects(run, environment).Build()
+	dialer := KubernetesTerminalDialer{Client: kubeClient, Metrics: metrics, policyPollInterval: time.Millisecond}
+	association := &RunTerminalAssociation{RunName: "run", RunUID: "run-uid", EnvironmentName: "env", EnvironmentUID: "env-uid", EnvironmentOwnership: string(platformv1alpha1.EnvironmentOwnershipClaimed)}
+	lease := &terminalConnectionLease{}
+	closed := make(chan struct{})
+	if !lease.attach(closeFunc(func() error { close(closed); return nil }), sandboxclient.TerminalExecution{}, lifecycle.CaptureExecutionFence(environment)) {
+		t.Fatal("failed to attach test terminal connection")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), time.Hour, association, nil, func() bool { revoked, _ := lease.revoke(); return revoked })
+
+	if err := kubeClient.Delete(context.Background(), environment); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("deleted Environment did not close the active Run terminal")
+	}
+	waitForTerminalRevocationMetric(t, metrics, "environment_changed", 1)
+	if got := testutil.ToFloat64(metrics.terminalRevocations.WithLabelValues("environment_changed")); got != 1 {
+		t.Fatalf("environment-change revocations = %v, want exactly 1", got)
+	}
+	if got := testutil.ToFloat64(metrics.terminalRevocations.WithLabelValues("run_association_changed")); got != 0 {
+		t.Fatalf("run-association revocations = %v, want 0", got)
+	}
+}
+
+func waitForTerminalRevocationMetric(t *testing.T, metrics *Metrics, reason string, want float64) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if got := testutil.ToFloat64(metrics.terminalRevocations.WithLabelValues(reason)); got == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("%s terminal revocations did not reach %v", reason, want)
 }
 
 func waitForTerminalActivityRevision(t *testing.T, kubeClient client.Client, environment *platformv1alpha1.Environment, revision int64) {


### PR DESCRIPTION
## Summary

- expose a dedicated internal Prometheus `/metrics` listener owned by the singleton control-plane process
- instrument bounded-cardinality transcript append/SSE delivery, terminal lease, and Kubernetes TokenReview/SAR signals
- expose the listener through the stable Helm Service on a configurable validated port and document scraping plus healthy/investigate signals
- cover real append, replay/live delivery, subscriber release, terminal grant/revocation, and auth allow/deny/error paths

The metrics listener uses a separate mux and does not serve control-plane application routes. No custom label contains credentials, sessions, users, namespaces, repositories, URLs, Run identity, or Environment identity.

This PR is cleanly stacked on open PR #155 (`feat/142-execution-fence`). Its complete opaque `lifecycle.ExecutionFence` remains the terminal lifecycle/currentness contract; terminal grant metrics count failed connector/post-dial validation or attachment attempts and count granted only after lease attachment; revocations count only atomically revoked open leases.

## Validation

- repeated focused terminal race tests (`-count=10` and `-count=20`) covering post-dial association failure, pre-attachment revocation, disabled hold adoption, hold-refresh execution changes, execution replacement, wake generation changes, and exact-once revocation
- `go test -race ./internal/controlplane ./cmd/control-plane`
- `make test`
- `make vet`
- `make build`
- Helm lint and render for the base chart and `values-kind.yaml`, `values-argocd.yaml`, `values-k3s.yaml`, `values-gke.yaml`, and `values-eks.yaml`
- invalid metrics-port render rejection for `0`, `80`, `8080`, and `65536`
- `git diff --check`

Refs #146