### PR TITLE
Add mandatory Environment execution fence

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -215,14 +215,15 @@ Pause is disk plus transcript, not process checkpointing:
 5. resume creates a fresh pod/credential epoch, runs the repository resume hook, and repeats
    idempotent adapter acceptance with the same Run UID.
 
-Terminal attachment captures Environment UID, execution generation, lifecycle epoch, and hold
-revision before publishing activity, then atomically rejects stale activity. Its connector-owned
-opaque handle also revalidates the exact live backend execution throughout the lease. Run adapter
-acceptance, observation, and cancellation similarly capture the allocated Environment UID,
-execution generation, epoch, and an opaque non-dialing connector execution handle. After each
-adapter call, the controller uncached-reads the exact allocation and asks the connector to prove
-that the same live backend execution remains current before publishing Run state, releasing a
-claim, or removing a finalizer. Delayed results from disappeared or same-name replacement Pods
+`lifecycle.ExecutionFence` is the mandatory backend-neutral capture/revalidation mechanism for
+execution-scoped work. Its opaque value always carries the Environment UID, execution generation,
+lifecycle epoch, and hold-policy revision; callers cannot construct a partial fence. Terminal
+attachment captures one before publishing activity, then atomically rejects stale activity. Its
+connector-owned opaque handle also revalidates the exact live backend execution throughout the
+lease. Run adapter acceptance, observation, and cancellation use the same complete fence. After
+each adapter call, the controller uncached-reads the exact allocation and asks the connector to
+prove that the same live backend execution remains current before publishing Run state, releasing
+a claim, or removing a finalizer. Delayed results from disappeared or same-name replacement Pods
 are therefore discarded even if Environment status has not yet advanced.
 
 Only the Pod backend performs execution today. Project-backed initialization clones the
@@ -463,8 +464,9 @@ The remaining approved service contract still requires observation connector/con
 and gateway implementation. sandboxd has a stateless internal loopback observation primitive
 and Environments have durable declarations, but no connector invokes the primitive and no
 controller-owned health status exists. The execution-generation contract is implemented above;
-future declaration observations, portal routes, and egress identity must consume the same
-backend-neutral fence without exposing backend-specific identity.
+future declaration observations, portal routes, and egress identity must capture and revalidate
+the mandatory `lifecycle.ExecutionFence` without exposing backend-specific identity or selecting
+individual fence components.
 
 Other unimplemented areas include portal transport, inbox and child-run semantics, changes
 publication, transcript garbage collection, additional credential forms, ConPTY, non-Pod

--- a/internal/controllers/environment_controller_test.go
+++ b/internal/controllers/environment_controller_test.go
@@ -4387,7 +4387,7 @@ func TestActivityIntentPreservesReadyGenerationAndProtectsIdle(t *testing.T) {
 	reconciler := &EnvironmentReconciler{Client: kubeClient, Scheme: scheme, Now: func() time.Time { return now }}
 	key := client.ObjectKeyFromObject(environment)
 
-	if err := lifecycle.RecordActivity(context.Background(), kubeClient, key, environment.UID, 1, 2, platformv1alpha1.EnvironmentActivitySourceTerminal, "terminal-2"); err != nil {
+	if err := lifecycle.RecordActivity(context.Background(), kubeClient, lifecycle.CaptureExecutionFence(environment), platformv1alpha1.EnvironmentActivitySourceTerminal, "terminal-2"); err != nil {
 		t.Fatal(err)
 	}
 	var activity platformv1alpha1.Environment

--- a/internal/controllers/run_controller.go
+++ b/internal/controllers/run_controller.go
@@ -290,7 +290,8 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			if !current {
 				return ctrl.Result{Requeue: true}, nil
 			}
-			if err := adapter.Cancel(ctx, adapterTask(&run), r.adapterSandbox(&run, env)); err != nil {
+			executionFence := lifecycle.CaptureExecutionFence(env)
+			if err := adapter.Cancel(ctx, adapterTask(&run), r.adapterSandbox(&run, env, executionFence)); err != nil {
 				if errors.Is(err, ErrAdapterCancellationPending) {
 					return ctrl.Result{RequeueAfter: adapterPollInterval}, nil
 				}
@@ -363,8 +364,7 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		if credential != nil {
 			defer clear(credential.APIKey)
 		}
-		expectedExecutionGeneration := env.Status.ExecutionGeneration
-		expectedEpoch := env.Status.Lifecycle.Epoch
+		executionFence := lifecycle.CaptureExecutionFence(env)
 		execution, current, err := r.resolveAllocatedExecution(ctx, &run, env)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -372,7 +372,7 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		if !current {
 			return ctrl.Result{Requeue: true}, nil
 		}
-		acceptErr := adapter.EnsureAccepted(ctx, adapterTask(&run), r.adapterSandbox(&run, env), credential)
+		acceptErr := adapter.EnsureAccepted(ctx, adapterTask(&run), r.adapterSandbox(&run, env, executionFence), credential)
 		current, err = r.allocatedExecutionCurrent(ctx, &run, env, execution)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -386,8 +386,10 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			}
 			return ctrl.Result{}, acceptErr
 		}
-		run.Status.AcceptedEnvironmentEpoch = &expectedEpoch
-		run.Status.AcceptedEnvironmentExecutionGeneration = &expectedExecutionGeneration
+		acceptedEpoch := executionFence.LifecycleEpoch()
+		acceptedExecutionGeneration := executionFence.ExecutionGeneration()
+		run.Status.AcceptedEnvironmentEpoch = &acceptedEpoch
+		run.Status.AcceptedEnvironmentExecutionGeneration = &acceptedExecutionGeneration
 		return ctrl.Result{Requeue: true}, r.setRunState(ctx, &run, platformv1alpha1.RunStateAdapterAccepted, "AdapterAccepted", "adapter accepted the task", true)
 	}
 
@@ -398,7 +400,8 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	if !current {
 		return ctrl.Result{Requeue: true}, nil
 	}
-	observation, message, err := adapter.Observe(ctx, adapterTask(&run), r.adapterSandbox(&run, env))
+	executionFence := lifecycle.CaptureExecutionFence(env)
+	observation, message, err := adapter.Observe(ctx, adapterTask(&run), r.adapterSandbox(&run, env, executionFence))
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -1013,7 +1016,8 @@ func (r *RunReconciler) cleanupTerminal(ctx context.Context, run *platformv1alph
 		if !current {
 			return ctrl.Result{Requeue: true}, nil
 		}
-		if err := adapter.Cancel(ctx, adapterTask(run), r.adapterSandbox(run, env)); err != nil {
+		executionFence := lifecycle.CaptureExecutionFence(env)
+		if err := adapter.Cancel(ctx, adapterTask(run), r.adapterSandbox(run, env, executionFence)); err != nil {
 			if errors.Is(err, ErrAdapterCancellationPending) {
 				return ctrl.Result{RequeueAfter: adapterPollInterval}, nil
 			}
@@ -1092,7 +1096,8 @@ func (r *RunReconciler) finalize(ctx context.Context, run *platformv1alpha1.Run)
 				if !current {
 					return ctrl.Result{Requeue: true}, nil
 				}
-				if err := adapter.Cancel(ctx, adapterTask(run), r.adapterSandbox(run, env)); err != nil {
+				executionFence := lifecycle.CaptureExecutionFence(env)
+				if err := adapter.Cancel(ctx, adapterTask(run), r.adapterSandbox(run, env, executionFence)); err != nil {
 					if errors.Is(err, ErrAdapterCancellationPending) {
 						return ctrl.Result{RequeueAfter: adapterPollInterval}, nil
 					}
@@ -1183,9 +1188,7 @@ func adapterTask(run *platformv1alpha1.Run) AdapterTask {
 	return AdapterTask{ID: string(run.UID), Prompt: run.Spec.Prompt}
 }
 
-func (r *RunReconciler) adapterSandbox(run *platformv1alpha1.Run, env *platformv1alpha1.Environment) AdapterSandbox {
-	expectedEpoch := env.Status.Lifecycle.Epoch
-	expectedExecutionGeneration := env.Status.ExecutionGeneration
+func (r *RunReconciler) adapterSandbox(run *platformv1alpha1.Run, env *platformv1alpha1.Environment, fence lifecycle.ExecutionFence) AdapterSandbox {
 	sandbox := AdapterSandbox{EnvironmentName: env.Name, EnvironmentUID: env.UID,
 		DialProcess: func(ctx context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
 			reader := r.apiReader()
@@ -1193,10 +1196,10 @@ func (r *RunReconciler) adapterSandbox(run *platformv1alpha1.Run, env *platformv
 			if err != nil {
 				return nil, nil, err
 			}
-			if current.Status.ExecutionGeneration != expectedExecutionGeneration {
-				return nil, nil, fmt.Errorf("environment execution generation changed")
+			if err := fence.Validate(current); err != nil {
+				return nil, nil, err
 			}
-			return (sandboxclient.Connector{Reader: reader}).DialProcessForExecution(ctx, current.Namespace, current.Name, current.UID, expectedExecutionGeneration, expectedEpoch)
+			return (sandboxclient.Connector{Reader: reader}).DialProcess(ctx, fence)
 		}}
 	if r.EventSink != nil {
 		runUID := string(run.UID)
@@ -1208,6 +1211,7 @@ func (r *RunReconciler) adapterSandbox(run *platformv1alpha1.Run, env *platformv
 }
 
 func (r *RunReconciler) resolveAllocatedExecution(ctx context.Context, run *platformv1alpha1.Run, expected *platformv1alpha1.Environment) (sandboxclient.Execution, bool, error) {
+	fence := lifecycle.CaptureExecutionFence(expected)
 	current, err := getAllocatedEnvironment(ctx, r.apiReader(), run)
 	if apierrors.IsNotFound(err) || errors.Is(err, errAllocatedEnvironmentGone) {
 		return sandboxclient.Execution{}, false, nil
@@ -1215,11 +1219,10 @@ func (r *RunReconciler) resolveAllocatedExecution(ctx context.Context, run *plat
 	if err != nil {
 		return sandboxclient.Execution{}, false, err
 	}
-	if current.UID != expected.UID || current.Status.ExecutionGeneration != expected.Status.ExecutionGeneration ||
-		current.Status.Lifecycle.Epoch != expected.Status.Lifecycle.Epoch || !environmentReachable(current) {
+	if err := fence.Validate(current); err != nil || !environmentReachable(current) {
 		return sandboxclient.Execution{}, false, nil
 	}
-	execution, err := (sandboxclient.Connector{Reader: r.apiReader()}).ResolveExecution(ctx, current.Namespace, current.Name, current.UID, current.Status.ExecutionGeneration, current.Status.Lifecycle.Epoch)
+	execution, err := (sandboxclient.Connector{Reader: r.apiReader()}).ResolveExecution(ctx, fence)
 	if err != nil {
 		return sandboxclient.Execution{}, false, err
 	}
@@ -1227,6 +1230,7 @@ func (r *RunReconciler) resolveAllocatedExecution(ctx context.Context, run *plat
 }
 
 func (r *RunReconciler) allocatedExecutionCurrent(ctx context.Context, run *platformv1alpha1.Run, expected *platformv1alpha1.Environment, execution sandboxclient.Execution) (bool, error) {
+	fence := lifecycle.CaptureExecutionFence(expected)
 	current, err := getAllocatedEnvironment(ctx, r.apiReader(), run)
 	if apierrors.IsNotFound(err) || errors.Is(err, errAllocatedEnvironmentGone) {
 		return false, nil
@@ -1234,11 +1238,14 @@ func (r *RunReconciler) allocatedExecutionCurrent(ctx context.Context, run *plat
 	if err != nil {
 		return false, err
 	}
-	if current.UID != expected.UID || current.Status.ExecutionGeneration != expected.Status.ExecutionGeneration ||
-		current.Status.Lifecycle.Epoch != expected.Status.Lifecycle.Epoch || !environmentReachable(current) {
+	if err := fence.Validate(current); err != nil || !environmentReachable(current) {
 		return false, nil
 	}
-	return (sandboxclient.Connector{Reader: r.apiReader()}).ExecutionCurrent(ctx, current.Namespace, current.Name, execution)
+	currentExecution, err := (sandboxclient.Connector{Reader: r.apiReader()}).ExecutionCurrent(ctx, fence, execution)
+	if errors.Is(err, lifecycle.ErrExecutionFenceChanged) {
+		return false, nil
+	}
+	return currentExecution, err
 }
 
 // SetupWithManager registers Run watches. Owned Environments enqueue through

--- a/internal/controllers/run_controller_test.go
+++ b/internal/controllers/run_controller_test.go
@@ -729,7 +729,7 @@ func TestAcceptedRunIgnoresActivityWithoutRereadingCredentials(t *testing.T) {
 				return apierrors.NewNotFound(platformv1alpha1.GroupVersion.WithResource("agentcredentialprofiles").GroupResource(), "removed-profile")
 			}})
 
-			if err := lifecycle.RecordActivity(context.Background(), r.Client, client.ObjectKeyFromObject(environment), environment.UID, 1, 0, platformv1alpha1.EnvironmentActivitySourceTerminal, "terminal-1"); err != nil {
+			if err := lifecycle.RecordActivity(context.Background(), r.Client, lifecycle.CaptureExecutionFence(environment), platformv1alpha1.EnvironmentActivitySourceTerminal, "terminal-1"); err != nil {
 				t.Fatal(err)
 			}
 			var activity platformv1alpha1.Environment
@@ -2825,7 +2825,7 @@ func TestAdapterSandboxEmitEventSendsExactRunUID(t *testing.T) {
 		return nil
 	})
 	r := &RunReconciler{EventSink: sink}
-	sandbox := r.adapterSandbox(run, env)
+	sandbox := r.adapterSandbox(run, env, lifecycle.CaptureExecutionFence(env))
 	if sandbox.EmitEvent == nil {
 		t.Fatal("EmitEvent closure was not wired")
 	}

--- a/internal/controlplane/terminal.go
+++ b/internal/controlplane/terminal.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/gorilla/websocket"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -133,12 +132,11 @@ func (d KubernetesTerminalDialer) dialTerminal(ctx context.Context, namespace, n
 			return nil, nil, nil, err
 		}
 	}
-	policyRevision := lifecycle.HoldPolicyRevision(&environment)
-	executionGeneration := environment.Status.ExecutionGeneration
+	executionFence := lifecycle.CaptureExecutionFence(&environment)
 	if err := terminalAccessPolicyError(&environment); err != nil {
 		return nil, nil, nil, err
 	}
-	if err := d.markActive(ctx, &environment, expectedEnvironmentUID, executionGeneration, policyRevision); err != nil {
+	if err := d.markActive(ctx, executionFence); err != nil {
 		return nil, nil, nil, err
 	}
 	heartbeatInterval, err := d.activityHeartbeatInterval(ctx, &environment)
@@ -153,7 +151,7 @@ func (d KubernetesTerminalDialer) dialTerminal(ctx context.Context, namespace, n
 		}
 	}()
 	connectionLease := &terminalConnectionLease{}
-	go d.heartbeatActivity(heartbeatContext, types.NamespacedName{Namespace: namespace, Name: name}, expectedEnvironmentUID, executionGeneration, policyRevision, heartbeatInterval, association, connectionLease.boundExecution, func() { _ = connectionLease.Close() })
+	go d.heartbeatActivity(heartbeatContext, types.NamespacedName{Namespace: namespace, Name: name}, executionFence, heartbeatInterval, association, connectionLease.boundExecution, func() { _ = connectionLease.Close() })
 	if err := d.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &environment); err != nil {
 		return nil, nil, nil, fmt.Errorf("refresh environment lifecycle: %w", err)
 	}
@@ -170,13 +168,14 @@ func (d KubernetesTerminalDialer) dialTerminal(ctx context.Context, namespace, n
 	}
 	if environment.Status.Lifecycle.Suspended {
 		requestID := fmt.Sprintf("terminal/wake/%d", time.Now().UnixNano())
-		if err := lifecycle.RequestWake(ctx, d.Client, types.NamespacedName{Namespace: namespace, Name: name}, expectedEnvironmentUID, policyRevision, requestID); err != nil {
+		if err := lifecycle.RequestWake(ctx, d.Client, types.NamespacedName{Namespace: namespace, Name: name}, expectedEnvironmentUID, executionFence.HoldPolicyRevision(), requestID); err != nil {
 			return nil, nil, nil, fmt.Errorf("wake environment: %w", err)
 		}
 		if err := d.waitUntilReady(ctx, namespace, name, expectedEnvironmentUID, &environment); err != nil {
 			return nil, nil, nil, err
 		}
-		if err := d.markActive(ctx, &environment, expectedEnvironmentUID, environment.Status.ExecutionGeneration, policyRevision); err != nil {
+		executionFence = lifecycle.CaptureExecutionFence(&environment)
+		if err := d.markActive(ctx, executionFence); err != nil {
 			return nil, nil, nil, err
 		}
 	}
@@ -189,7 +188,8 @@ func (d KubernetesTerminalDialer) dialTerminal(ctx context.Context, namespace, n
 	if !platformv1alpha1.IsEnvironmentReady(&environment) {
 		return nil, nil, nil, fmt.Errorf("environment is not ready for its current generation")
 	}
-	terminal, health, execution, closeConnection, err := (sandboxclient.Connector{Reader: d.Client}).DialTerminal(ctx, namespace, name, expectedEnvironmentUID)
+	executionFence = lifecycle.CaptureExecutionFence(&environment)
+	terminal, health, execution, closeConnection, err := (sandboxclient.Connector{Reader: d.Client}).DialTerminal(ctx, executionFence)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("connect to sandboxd: %w", err)
 	}
@@ -237,7 +237,7 @@ func (d KubernetesTerminalDialer) activityHeartbeatInterval(ctx context.Context,
 	return timeout / 2, nil
 }
 
-func (d KubernetesTerminalDialer) heartbeatActivity(ctx context.Context, key types.NamespacedName, expectedUID types.UID, executionGeneration, policyRevision int64, interval time.Duration, association *RunTerminalAssociation, boundExecution func() (sandboxclient.TerminalExecution, bool), revoke func()) {
+func (d KubernetesTerminalDialer) heartbeatActivity(ctx context.Context, key types.NamespacedName, fence lifecycle.ExecutionFence, interval time.Duration, association *RunTerminalAssociation, boundExecution func() (sandboxclient.TerminalExecution, bool), revoke func()) {
 	retryInterval := interval / 4
 	if retryInterval <= 0 || retryInterval > time.Second {
 		retryInterval = time.Second
@@ -260,7 +260,7 @@ func (d KubernetesTerminalDialer) heartbeatActivity(ctx context.Context, key typ
 					continue
 				}
 			}
-			generation, revision, held, err := d.readTerminalPolicy(ctx, key, expectedUID, boundExecution)
+			currentFence, held, err := d.readTerminalPolicy(ctx, key, fence, boundExecution)
 			if err != nil {
 				if errors.Is(err, errTerminalEnvironmentIncarnationChanged) {
 					revoke()
@@ -268,17 +268,14 @@ func (d KubernetesTerminalDialer) heartbeatActivity(ctx context.Context, key typ
 				}
 				continue
 			}
-			if held || revision < policyRevision {
+			if held || currentFence.HoldPolicyRevision() < fence.HoldPolicyRevision() {
 				revoke()
 				return
 			}
-			if revision > policyRevision {
-				policyRevision = revision
-			}
-			executionGeneration = generation
+			fence = currentFence
 		case <-timer.C:
 			for {
-				generation, revision, held, err := d.readTerminalPolicy(ctx, key, expectedUID, boundExecution)
+				currentFence, held, err := d.readTerminalPolicy(ctx, key, fence, boundExecution)
 				if err != nil {
 					if errors.Is(err, errTerminalEnvironmentIncarnationChanged) {
 						revoke()
@@ -287,16 +284,12 @@ func (d KubernetesTerminalDialer) heartbeatActivity(ctx context.Context, key typ
 					timer.Reset(retryInterval)
 					break
 				}
-				if held || revision < policyRevision {
+				if held || currentFence.HoldPolicyRevision() < fence.HoldPolicyRevision() {
 					revoke()
 					return
 				}
-				if revision > policyRevision {
-					policyRevision = revision
-				}
-				executionGeneration = generation
-				environment := platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Namespace: key.Namespace, Name: key.Name}}
-				err = d.markActive(ctx, &environment, expectedUID, executionGeneration, policyRevision)
+				fence = currentFence
+				err = d.markActive(ctx, fence)
 				if err == nil {
 					timer.Reset(interval)
 					break
@@ -305,7 +298,7 @@ func (d KubernetesTerminalDialer) heartbeatActivity(ctx context.Context, key typ
 					revoke()
 					return
 				}
-				if errors.Is(err, lifecycle.ErrExecutionGenerationChanged) {
+				if errors.Is(err, lifecycle.ErrExecutionFenceChanged) && !errors.Is(err, lifecycle.ErrHoldPolicyChanged) {
 					if _, bound := boundExecution(); bound {
 						revoke()
 						return
@@ -314,7 +307,7 @@ func (d KubernetesTerminalDialer) heartbeatActivity(ctx context.Context, key typ
 					break
 				}
 				if errors.Is(err, lifecycle.ErrHoldPolicyChanged) {
-					generation, revision, held, refreshErr := d.refreshHoldPolicy(ctx, key, expectedUID, policyRevision)
+					refreshedFence, held, refreshErr := d.refreshHoldPolicy(ctx, key, fence, boundExecution)
 					if refreshErr != nil {
 						if errors.Is(refreshErr, errTerminalEnvironmentIncarnationChanged) {
 							revoke()
@@ -323,12 +316,11 @@ func (d KubernetesTerminalDialer) heartbeatActivity(ctx context.Context, key typ
 						timer.Reset(retryInterval)
 						break
 					}
-					executionGeneration = generation
-					if held || revision <= policyRevision {
+					if held || refreshedFence.HoldPolicyRevision() <= fence.HoldPolicyRevision() {
 						revoke()
 						return
 					}
-					policyRevision = revision
+					fence = refreshedFence
 					continue
 				}
 				timer.Reset(retryInterval)
@@ -375,44 +367,46 @@ func (d KubernetesTerminalDialer) holdPolicyPollInterval() time.Duration {
 	return terminalPolicyPollInterval
 }
 
-func (d KubernetesTerminalDialer) readTerminalPolicy(ctx context.Context, key types.NamespacedName, expectedUID types.UID, boundExecution func() (sandboxclient.TerminalExecution, bool)) (int64, int64, bool, error) {
+func (d KubernetesTerminalDialer) readTerminalPolicy(ctx context.Context, key types.NamespacedName, previousFence lifecycle.ExecutionFence, boundExecution func() (sandboxclient.TerminalExecution, bool)) (lifecycle.ExecutionFence, bool, error) {
 	var environment platformv1alpha1.Environment
 	if err := d.Client.Get(ctx, key, &environment); err != nil {
-		return 0, 0, false, err
+		return lifecycle.ExecutionFence{}, false, err
 	}
-	if environment.UID != expectedUID {
-		return 0, 0, false, errTerminalEnvironmentIncarnationChanged
+	if environment.UID != previousFence.EnvironmentUID() {
+		return lifecycle.ExecutionFence{}, false, errTerminalEnvironmentIncarnationChanged
 	}
+	currentFence := lifecycle.CaptureExecutionFence(&environment)
 	if boundExecution != nil {
 		if execution, bound := boundExecution(); bound {
-			current, err := (sandboxclient.Connector{Reader: d.Client}).ExecutionCurrent(ctx, key.Namespace, key.Name, execution)
+			current, err := (sandboxclient.Connector{Reader: d.Client}).ExecutionCurrent(ctx, currentFence, execution)
 			if err != nil {
-				return 0, 0, false, err
+				if errors.Is(err, lifecycle.ErrExecutionFenceChanged) && !errors.Is(err, lifecycle.ErrHoldPolicyChanged) {
+					return lifecycle.ExecutionFence{}, false, errTerminalEnvironmentIncarnationChanged
+				}
+				return lifecycle.ExecutionFence{}, false, err
 			}
 			if !current {
-				return 0, 0, false, errTerminalEnvironmentIncarnationChanged
+				return lifecycle.ExecutionFence{}, false, errTerminalEnvironmentIncarnationChanged
 			}
 		}
 	}
-	revision := lifecycle.HoldPolicyRevision(&environment)
-	return environment.Status.ExecutionGeneration, revision, environment.Spec.Lifecycle.Hold != nil && environment.Spec.Lifecycle.Hold.Enabled, nil
+	return currentFence, environment.Spec.Lifecycle.Hold != nil && environment.Spec.Lifecycle.Hold.Enabled, nil
 }
 
-func (d KubernetesTerminalDialer) refreshHoldPolicy(ctx context.Context, key types.NamespacedName, expectedUID types.UID, previousRevision int64) (int64, int64, bool, error) {
-	generation, revision, held, err := d.readTerminalPolicy(ctx, key, expectedUID, nil)
+func (d KubernetesTerminalDialer) refreshHoldPolicy(ctx context.Context, key types.NamespacedName, previousFence lifecycle.ExecutionFence, boundExecution func() (sandboxclient.TerminalExecution, bool)) (lifecycle.ExecutionFence, bool, error) {
+	currentFence, held, err := d.readTerminalPolicy(ctx, key, previousFence, boundExecution)
 	if err != nil {
-		return 0, 0, false, err
+		return lifecycle.ExecutionFence{}, false, err
 	}
-	if revision <= previousRevision {
-		return generation, revision, true, nil
+	if currentFence.HoldPolicyRevision() <= previousFence.HoldPolicyRevision() {
+		return currentFence, true, nil
 	}
-	return generation, revision, held, nil
+	return currentFence, held, nil
 }
 
-func (d KubernetesTerminalDialer) markActive(ctx context.Context, environment *platformv1alpha1.Environment, expectedUID types.UID, executionGeneration, policyRevision int64) error {
-	key := client.ObjectKeyFromObject(environment)
+func (d KubernetesTerminalDialer) markActive(ctx context.Context, fence lifecycle.ExecutionFence) error {
 	requestID := fmt.Sprintf("terminal/activity/%d", time.Now().UnixNano())
-	if err := lifecycle.RecordActivity(ctx, d.Client, key, expectedUID, executionGeneration, policyRevision, platformv1alpha1.EnvironmentActivitySourceTerminal, requestID); err != nil {
+	if err := lifecycle.RecordActivity(ctx, d.Client, fence, platformv1alpha1.EnvironmentActivitySourceTerminal, requestID); err != nil {
 		if errors.Is(err, lifecycle.ErrEnvironmentIncarnationChanged) {
 			return fmt.Errorf("record environment activity: %w", errTerminalEnvironmentIncarnationChanged)
 		}

--- a/internal/controlplane/terminal_test.go
+++ b/internal/controlplane/terminal_test.go
@@ -419,7 +419,7 @@ func TestKubernetesTerminalDialerMarksEnvironmentActive(t *testing.T) {
 	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment).Build()
 	dialer := KubernetesTerminalDialer{Client: kubeClient}
 
-	if err := dialer.markActive(context.Background(), environment, environment.UID, 1, 0); err != nil {
+	if err := dialer.markActive(context.Background(), lifecycle.CaptureExecutionFence(environment)); err != nil {
 		t.Fatalf("markActive() error = %v", err)
 	}
 	var updated platformv1alpha1.Environment
@@ -442,7 +442,7 @@ func TestKubernetesTerminalDialerDoesNotMarkReplacementEnvironmentActive(t *test
 	replacement.UID = "new-uid"
 	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(replacement).WithObjects(replacement).Build()
 	dialer := KubernetesTerminalDialer{Client: kubeClient}
-	if err := dialer.markActive(context.Background(), original, original.UID, 1, 0); err == nil || !strings.Contains(err.Error(), "incarnation changed") {
+	if err := dialer.markActive(context.Background(), lifecycle.CaptureExecutionFence(original)); err == nil || !strings.Contains(err.Error(), "incarnation changed") {
 		t.Fatalf("markActive() replacement error = %v", err)
 	}
 	var updated platformv1alpha1.Environment
@@ -531,7 +531,7 @@ func TestTerminalHeartbeatRecoversAfterTransientGetFailure(t *testing.T) {
 	dialer := KubernetesTerminalDialer{Client: transient}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 1, 0, 5*time.Millisecond, nil, nil, func() {})
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), 5*time.Millisecond, nil, nil, func() {})
 
 	deadline := time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {
@@ -564,7 +564,7 @@ func TestTerminalHeartbeatAdoptsNewerDisabledHoldRevision(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	revoked := atomic.Bool{}
-	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 1, 1, 20*time.Millisecond, nil, nil, func() { revoked.Store(true) })
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), 20*time.Millisecond, nil, nil, func() { revoked.Store(true) })
 
 	var updated platformv1alpha1.Environment
 	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(environment), &updated); err != nil {
@@ -577,6 +577,128 @@ func TestTerminalHeartbeatAdoptsNewerDisabledHoldRevision(t *testing.T) {
 	waitForTerminalActivityRevision(t, kubeClient, environment, 2)
 	if revoked.Load() {
 		t.Fatal("disabled hold-policy revision revoked terminal activity")
+	}
+}
+
+func TestTerminalPolicyRetriesDisabledHoldRevisionRacingExecutionProof(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	environment := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "env-1", Namespace: "project-1", UID: "env-uid", Generation: 1},
+		Spec: platformv1alpha1.EnvironmentSpec{TemplateRef: "default", Lifecycle: platformv1alpha1.EnvironmentLifecycleSpec{
+			Hold: &platformv1alpha1.EnvironmentHoldPolicy{Revision: 1},
+		}},
+	}
+	applyReadyTerminalStatus(environment, "env-env-1")
+	pod := currentExecutionPod(environment, "pod-uid")
+	template := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: environment.Namespace}}
+	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment, pod, template).Build()
+	execution, err := (sandboxclient.Connector{Reader: baseClient}).ResolveExecution(context.Background(), lifecycle.CaptureExecutionFence(environment))
+	if err != nil {
+		t.Fatal(err)
+	}
+	provedAfterRace := make(chan struct{}, 1)
+	kubeClient := &scheduledEnvironmentMutationClient{
+		Client: baseClient,
+		mutations: map[int]func(context.Context, client.Client) error{
+			2: func(ctx context.Context, underlying client.Client) error {
+				var current platformv1alpha1.Environment
+				if err := underlying.Get(ctx, client.ObjectKeyFromObject(environment), &current); err != nil {
+					return err
+				}
+				current.Spec.Lifecycle.Hold = &platformv1alpha1.EnvironmentHoldPolicy{Revision: 2}
+				return underlying.Update(ctx, &current)
+			},
+		},
+		podRead: provedAfterRace,
+	}
+	dialer := KubernetesTerminalDialer{Client: kubeClient, policyPollInterval: time.Millisecond}
+	lease := &terminalConnectionLease{}
+	if !lease.attach(closeFunc(func() error { return nil }), execution) {
+		t.Fatal("failed to bind terminal execution")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	revoked := atomic.Bool{}
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), time.Hour, nil, lease.boundExecution, func() { revoked.Store(true) })
+
+	select {
+	case <-provedAfterRace:
+	case <-time.After(time.Second):
+		t.Fatal("terminal did not retry execution proof after disabled hold revision race")
+	}
+	if revoked.Load() {
+		t.Fatal("disabled hold revision racing execution proof revoked terminal")
+	}
+}
+
+func TestTerminalHoldRefreshRevalidatesBoundExecution(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	environment := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "env-1", Namespace: "project-1", UID: "env-uid", Generation: 1},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "default"},
+	}
+	applyReadyTerminalStatus(environment, "env-env-1")
+	pod := currentExecutionPod(environment, "pod-uid")
+	template := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: environment.Namespace}}
+	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(environment, pod, template).Build()
+	execution, err := (sandboxclient.Connector{Reader: baseClient}).ResolveExecution(context.Background(), lifecycle.CaptureExecutionFence(environment))
+	if err != nil {
+		t.Fatal(err)
+	}
+	kubeClient := &scheduledEnvironmentMutationClient{
+		Client: baseClient,
+		mutations: map[int]func(context.Context, client.Client) error{
+			3: func(ctx context.Context, underlying client.Client) error {
+				var current platformv1alpha1.Environment
+				if err := underlying.Get(ctx, client.ObjectKeyFromObject(environment), &current); err != nil {
+					return err
+				}
+				current.Spec.Lifecycle.Hold = &platformv1alpha1.EnvironmentHoldPolicy{Revision: 1}
+				return underlying.Update(ctx, &current)
+			},
+			4: func(ctx context.Context, underlying client.Client) error {
+				var current platformv1alpha1.Environment
+				if err := underlying.Get(ctx, client.ObjectKeyFromObject(environment), &current); err != nil {
+					return err
+				}
+				current.Status.Lifecycle.Epoch++
+				return underlying.Status().Update(ctx, &current)
+			},
+		},
+	}
+	dialer := KubernetesTerminalDialer{Client: kubeClient, policyPollInterval: time.Hour}
+	lease := &terminalConnectionLease{}
+	closed := make(chan struct{})
+	if !lease.attach(closeFunc(func() error { close(closed); return nil }), execution) {
+		t.Fatal("failed to bind terminal execution")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), 5*time.Millisecond, nil, lease.boundExecution, func() { _ = lease.Close() })
+
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("hold refresh adopted a changed lifecycle epoch for the bound execution")
+	}
+	var retained platformv1alpha1.Environment
+	if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(environment), &retained); err != nil {
+		t.Fatal(err)
+	}
+	if requests := lifecycle.ActivityRequests(&retained); len(requests) != 0 {
+		t.Fatalf("current activity after changed execution during hold refresh = %#v, want none", requests)
 	}
 }
 
@@ -602,7 +724,7 @@ func TestTerminalHeartbeatRevokesConnectionWhenHoldEnabled(t *testing.T) {
 	if !lease.attach(closeFunc(func() error { close(closed); return nil }), sandboxclient.TerminalExecution{}) {
 		t.Fatal("failed to attach test terminal connection")
 	}
-	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 1, 1, time.Hour, nil, nil, func() { _ = lease.Close() })
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), time.Hour, nil, nil, func() { _ = lease.Close() })
 
 	var updated platformv1alpha1.Environment
 	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(environment), &updated); err != nil {
@@ -641,7 +763,7 @@ func TestTerminalPolicyPollRetriesTransientFailuresAndRevokesRecoveredHold(t *te
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	closed := make(chan struct{})
-	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 1, 1, time.Hour, nil, nil, func() { close(closed) })
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), time.Hour, nil, nil, func() { close(closed) })
 
 	for range 2 {
 		select {
@@ -685,7 +807,7 @@ func TestTerminalHeartbeatRevokesConnectionForReplacementUID(t *testing.T) {
 	if !lease.attach(closeFunc(func() error { close(closed); return nil }), sandboxclient.TerminalExecution{}) {
 		t.Fatal("failed to attach test terminal connection")
 	}
-	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 1, 0, time.Hour, nil, nil, func() { _ = lease.Close() })
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), time.Hour, nil, nil, func() { _ = lease.Close() })
 
 	if err := kubeClient.Delete(context.Background(), environment); err != nil {
 		t.Fatal(err)
@@ -765,7 +887,7 @@ func TestTerminalHeartbeatRevokesConnectionWhenBoundExecutionChanges(t *testing.
 			dialer := KubernetesTerminalDialer{Client: kubeClient, policyPollInterval: time.Hour}
 			lease := &terminalConnectionLease{}
 			closed := make(chan struct{})
-			execution, err := (sandboxclient.Connector{Reader: baseClient}).ResolveExecution(context.Background(), environment.Namespace, environment.Name, environment.UID, 1, 4)
+			execution, err := (sandboxclient.Connector{Reader: baseClient}).ResolveExecution(context.Background(), lifecycle.CaptureExecutionFence(environment))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -774,7 +896,7 @@ func TestTerminalHeartbeatRevokesConnectionWhenBoundExecutionChanges(t *testing.
 			}
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 1, 0, 10*time.Millisecond, nil, lease.boundExecution, func() { _ = lease.Close() })
+			go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), 10*time.Millisecond, nil, lease.boundExecution, func() { _ = lease.Close() })
 
 			if err := test.mutate(context.Background(), baseClient, environment, pod); err != nil {
 				t.Fatal(err)
@@ -813,7 +935,7 @@ func TestTerminalExecutionPolicyPollRetriesTransientPodRead(t *testing.T) {
 	dialer := KubernetesTerminalDialer{Client: kubeClient, policyPollInterval: time.Millisecond}
 	lease := &terminalConnectionLease{}
 	closed := make(chan struct{})
-	execution, err := (sandboxclient.Connector{Reader: baseClient}).ResolveExecution(context.Background(), environment.Namespace, environment.Name, environment.UID, 1, 2)
+	execution, err := (sandboxclient.Connector{Reader: baseClient}).ResolveExecution(context.Background(), lifecycle.CaptureExecutionFence(environment))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -822,7 +944,7 @@ func TestTerminalExecutionPolicyPollRetriesTransientPodRead(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 1, 0, time.Hour, nil, lease.boundExecution, func() { _ = lease.Close() })
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), time.Hour, nil, lease.boundExecution, func() { _ = lease.Close() })
 
 	select {
 	case <-failed:
@@ -914,7 +1036,7 @@ func TestRunTerminalHeartbeatRevokesAfterAssociationLoss(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	revoked := make(chan struct{})
-	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), environment.UID, 1, 0, time.Hour, association, nil, func() { close(revoked) })
+	go dialer.heartbeatActivity(ctx, client.ObjectKeyFromObject(environment), lifecycle.CaptureExecutionFence(environment), time.Hour, association, nil, func() { close(revoked) })
 
 	var updated platformv1alpha1.Environment
 	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(environment), &updated); err != nil {
@@ -961,6 +1083,35 @@ type transientPodGetClient struct {
 	mu       sync.Mutex
 	failures int
 	failed   chan<- struct{}
+}
+
+type scheduledEnvironmentMutationClient struct {
+	client.Client
+	mu        sync.Mutex
+	gets      int
+	mutations map[int]func(context.Context, client.Client) error
+	podRead   chan<- struct{}
+}
+
+func (c *scheduledEnvironmentMutationClient) Get(ctx context.Context, key client.ObjectKey, object client.Object, options ...client.GetOption) error {
+	if _, ok := object.(*platformv1alpha1.Environment); ok {
+		c.mu.Lock()
+		c.gets++
+		mutate := c.mutations[c.gets]
+		c.mu.Unlock()
+		if mutate != nil {
+			if err := mutate(ctx, c.Client); err != nil {
+				return err
+			}
+		}
+	}
+	if _, ok := object.(*corev1.Pod); ok && c.podRead != nil {
+		select {
+		case c.podRead <- struct{}{}:
+		default:
+		}
+	}
+	return c.Client.Get(ctx, key, object, options...)
 }
 
 func (c *transientPodGetClient) Get(ctx context.Context, key client.ObjectKey, object client.Object, options ...client.GetOption) error {

--- a/internal/lifecycle/execution_fence.go
+++ b/internal/lifecycle/execution_fence.go
@@ -1,0 +1,86 @@
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
+)
+
+var ErrExecutionFenceChanged = errors.New("environment execution fence changed")
+var ErrLifecycleEpochChanged = errors.New("environment lifecycle epoch changed")
+
+// ExecutionFence is the complete backend-neutral identity of one Environment
+// execution contract. Its fields are intentionally private so consumers can
+// only obtain a complete fence by capturing an Environment.
+type ExecutionFence struct {
+	key                 types.NamespacedName
+	environmentUID      types.UID
+	executionGeneration int64
+	lifecycleEpoch      int64
+	holdPolicyRevision  int64
+}
+
+// CaptureExecutionFence captures the exact Environment identity that must
+// remain current across an execution-scoped operation.
+func CaptureExecutionFence(environment *platformv1alpha1.Environment) ExecutionFence {
+	return ExecutionFence{
+		key:                 client.ObjectKeyFromObject(environment),
+		environmentUID:      environment.UID,
+		executionGeneration: environment.Status.ExecutionGeneration,
+		lifecycleEpoch:      environment.Status.Lifecycle.Epoch,
+		holdPolicyRevision:  HoldPolicyRevision(environment),
+	}
+}
+
+// Revalidate reads the Environment and rejects a change to any component of
+// the captured execution fence. Callers choose an uncached reader when this is
+// a post-call or current-identity proof.
+func (f ExecutionFence) Revalidate(ctx context.Context, reader client.Reader) (*platformv1alpha1.Environment, error) {
+	var environment platformv1alpha1.Environment
+	if err := reader.Get(ctx, f.key, &environment); err != nil {
+		return nil, err
+	}
+	if err := f.Validate(&environment); err != nil {
+		return nil, err
+	}
+	return &environment, nil
+}
+
+// Validate rejects a change to any component of the captured execution fence
+// on an Environment already read by the caller.
+func (f ExecutionFence) Validate(environment *platformv1alpha1.Environment) error {
+	if client.ObjectKeyFromObject(environment) != f.key || environment.UID != f.environmentUID {
+		return executionFenceChanged(ErrEnvironmentIncarnationChanged)
+	}
+	if f.executionGeneration < 1 || environment.Status.ExecutionGeneration != f.executionGeneration {
+		return executionFenceChanged(ErrExecutionGenerationChanged)
+	}
+	if environment.Status.Lifecycle.Epoch != f.lifecycleEpoch {
+		return executionFenceChanged(ErrLifecycleEpochChanged)
+	}
+	if HoldPolicyRevision(environment) != f.holdPolicyRevision {
+		return executionFenceChanged(ErrHoldPolicyChanged)
+	}
+	return nil
+}
+
+func executionFenceChanged(component error) error {
+	return fmt.Errorf("%w: %w", ErrExecutionFenceChanged, component)
+}
+
+// EnvironmentUID returns the immutable Environment identity in the fence.
+func (f ExecutionFence) EnvironmentUID() types.UID { return f.environmentUID }
+
+// ExecutionGeneration returns the backend-neutral execution generation.
+func (f ExecutionFence) ExecutionGeneration() int64 { return f.executionGeneration }
+
+// LifecycleEpoch returns the lifecycle suspension epoch.
+func (f ExecutionFence) LifecycleEpoch() int64 { return f.lifecycleEpoch }
+
+// HoldPolicyRevision returns the captured explicit hold-policy revision.
+func (f ExecutionFence) HoldPolicyRevision() int64 { return f.holdPolicyRevision }

--- a/internal/lifecycle/execution_fence_test.go
+++ b/internal/lifecycle/execution_fence_test.go
@@ -1,0 +1,70 @@
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
+)
+
+func TestExecutionFenceRevalidateRejectsEachStaleComponent(t *testing.T) {
+	environment := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "environment", Namespace: "project", UID: "env-uid"},
+		Spec: platformv1alpha1.EnvironmentSpec{Lifecycle: platformv1alpha1.EnvironmentLifecycleSpec{
+			Hold: &platformv1alpha1.EnvironmentHoldPolicy{Revision: 11},
+		}},
+		Status: platformv1alpha1.EnvironmentStatus{
+			ExecutionGeneration: 7,
+			Lifecycle:           platformv1alpha1.EnvironmentLifecycleStatus{Epoch: 5},
+		},
+	}
+	fence := CaptureExecutionFence(environment)
+
+	for _, test := range []struct {
+		name   string
+		want   error
+		mutate func(*platformv1alpha1.Environment)
+	}{
+		{name: "UID", want: ErrEnvironmentIncarnationChanged, mutate: func(current *platformv1alpha1.Environment) { current.UID = "replacement-uid" }},
+		{name: "execution generation", want: ErrExecutionGenerationChanged, mutate: func(current *platformv1alpha1.Environment) { current.Status.ExecutionGeneration++ }},
+		{name: "lifecycle epoch", want: ErrLifecycleEpochChanged, mutate: func(current *platformv1alpha1.Environment) { current.Status.Lifecycle.Epoch++ }},
+		{name: "hold revision", want: ErrHoldPolicyChanged, mutate: func(current *platformv1alpha1.Environment) { current.Spec.Lifecycle.Hold.Revision++ }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			current := environment.DeepCopy()
+			test.mutate(current)
+			scheme := runtime.NewScheme()
+			if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+				t.Fatal(err)
+			}
+			reader := fake.NewClientBuilder().WithScheme(scheme).WithObjects(current).Build()
+			if _, err := fence.Revalidate(context.Background(), reader); !errors.Is(err, test.want) {
+				t.Fatalf("Revalidate() error = %v, want %v", err, test.want)
+			}
+		})
+	}
+}
+
+func TestExecutionFenceRevalidateReturnsCurrentEnvironment(t *testing.T) {
+	environment := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "environment", Namespace: "project", UID: "env-uid"},
+		Status:     platformv1alpha1.EnvironmentStatus{ExecutionGeneration: 1},
+	}
+	scheme := runtime.NewScheme()
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	reader := fake.NewClientBuilder().WithScheme(scheme).WithObjects(environment).Build()
+	current, err := CaptureExecutionFence(environment).Revalidate(context.Background(), reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current.UID != environment.UID {
+		t.Fatalf("revalidated UID = %q, want %q", current.UID, environment.UID)
+	}
+}

--- a/internal/lifecycle/intent.go
+++ b/internal/lifecycle/intent.go
@@ -77,13 +77,13 @@ func RequestSuspend(ctx context.Context, kube client.Client, key types.Namespace
 // RecordActivity publishes one source's latest activity intent. Activity uses
 // fixed metadata slots so heartbeats are durable without advancing generation;
 // only execution-contract changes make Environment status stale.
-func RecordActivity(ctx context.Context, kube client.Client, key types.NamespacedName, expectedUID types.UID, executionGeneration, policyRevision int64, source platformv1alpha1.EnvironmentActivitySource, requestID string) error {
+func RecordActivity(ctx context.Context, kube client.Client, fence ExecutionFence, source platformv1alpha1.EnvironmentActivitySource, requestID string) error {
 	request := platformv1alpha1.EnvironmentActivityRequest{
 		Source: source,
 		EnvironmentLifecycleRequest: platformv1alpha1.EnvironmentLifecycleRequest{
-			ID: requestID, EnvironmentUID: expectedUID, HoldPolicyRevision: policyRevision,
+			ID: requestID, EnvironmentUID: fence.EnvironmentUID(), HoldPolicyRevision: fence.HoldPolicyRevision(),
 		},
-		ExecutionGeneration: executionGeneration,
+		ExecutionGeneration: fence.ExecutionGeneration(),
 	}
 	if err := validateActivityRequest(request); err != nil {
 		return err
@@ -92,7 +92,7 @@ func RecordActivity(ctx context.Context, kube client.Client, key types.Namespace
 	if err != nil {
 		return fmt.Errorf("encode activity request: %w", err)
 	}
-	return patchActivityIntent(ctx, kube, key, expectedUID, executionGeneration, policyRevision, func(environment *platformv1alpha1.Environment) {
+	return patchActivityIntent(ctx, kube, fence, func(environment *platformv1alpha1.Environment) {
 		if environment.Annotations == nil {
 			environment.Annotations = make(map[string]string)
 		}
@@ -193,20 +193,14 @@ func patchIntent(ctx context.Context, kube client.Client, key types.NamespacedNa
 	})
 }
 
-func patchActivityIntent(ctx context.Context, kube client.Client, key types.NamespacedName, expectedUID types.UID, expectedExecutionGeneration, expectedPolicyRevision int64, mutate func(*platformv1alpha1.Environment)) error {
+func patchActivityIntent(ctx context.Context, kube client.Client, fence ExecutionFence, mutate func(*platformv1alpha1.Environment)) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		var environment platformv1alpha1.Environment
-		if err := kube.Get(ctx, key, &environment); err != nil {
+		if err := kube.Get(ctx, fence.key, &environment); err != nil {
 			return err
 		}
-		if environment.UID != expectedUID {
-			return ErrEnvironmentIncarnationChanged
-		}
-		if expectedExecutionGeneration < 1 || environment.Status.ExecutionGeneration != expectedExecutionGeneration {
-			return ErrExecutionGenerationChanged
-		}
-		if HoldPolicyRevision(&environment) != expectedPolicyRevision {
-			return ErrHoldPolicyChanged
+		if err := fence.Validate(&environment); err != nil {
+			return err
 		}
 		before := environment.DeepCopy()
 		mutate(&environment)

--- a/internal/lifecycle/intent_test.go
+++ b/internal/lifecycle/intent_test.go
@@ -27,13 +27,14 @@ func TestRecordActivityIsSourceBoundedAndFenced(t *testing.T) {
 	environment.Spec.Lifecycle.Hold = &platformv1alpha1.EnvironmentHoldPolicy{Revision: 3}
 	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(environment).Build()
 	key := client.ObjectKeyFromObject(environment)
+	fence := CaptureExecutionFence(environment)
 
 	for _, requestID := range []string{"terminal-1", "terminal-1", "terminal-2"} {
-		if err := RecordActivity(context.Background(), kubeClient, key, environment.UID, 4, 3, platformv1alpha1.EnvironmentActivitySourceTerminal, requestID); err != nil {
+		if err := RecordActivity(context.Background(), kubeClient, fence, platformv1alpha1.EnvironmentActivitySourceTerminal, requestID); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := RecordActivity(context.Background(), kubeClient, key, environment.UID, 4, 3, platformv1alpha1.EnvironmentActivitySourcePortal, "portal-1"); err != nil {
+	if err := RecordActivity(context.Background(), kubeClient, fence, platformv1alpha1.EnvironmentActivitySourcePortal, "portal-1"); err != nil {
 		t.Fatal(err)
 	}
 	var updated platformv1alpha1.Environment
@@ -47,7 +48,9 @@ func TestRecordActivityIsSourceBoundedAndFenced(t *testing.T) {
 	if updated.Generation != environment.Generation || len(updated.Spec.Lifecycle.Activity) != 0 {
 		t.Fatalf("activity changed execution spec: generation=%d spec=%#v", updated.Generation, updated.Spec.Lifecycle)
 	}
-	if err := RecordActivity(context.Background(), kubeClient, key, types.UID("replacement"), 4, 3, platformv1alpha1.EnvironmentActivitySourceInbox, "stale"); err == nil {
+	replacement := environment.DeepCopy()
+	replacement.UID = types.UID("replacement")
+	if err := RecordActivity(context.Background(), kubeClient, CaptureExecutionFence(replacement), platformv1alpha1.EnvironmentActivitySourceInbox, "stale"); err == nil {
 		t.Fatal("replacement UID activity was accepted")
 	}
 }
@@ -81,7 +84,13 @@ func TestRecordActivityRejectsMalformedRequests(t *testing.T) {
 		{name: "negative revision", uid: environment.UID, executionGeneration: 4, revision: -1, source: platformv1alpha1.EnvironmentActivitySourceTerminal, id: "request"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			if err := RecordActivity(context.Background(), kubeClient, key, test.uid, test.executionGeneration, test.revision, test.source, test.id); err == nil {
+			candidate := environment.DeepCopy()
+			candidate.UID = test.uid
+			candidate.Status.ExecutionGeneration = test.executionGeneration
+			if test.revision != 0 {
+				candidate.Spec.Lifecycle.Hold = &platformv1alpha1.EnvironmentHoldPolicy{Revision: test.revision}
+			}
+			if err := RecordActivity(context.Background(), kubeClient, CaptureExecutionFence(candidate), test.source, test.id); err == nil {
 				t.Fatal("RecordActivity() accepted malformed request")
 			}
 		})
@@ -297,7 +306,7 @@ func TestRecordActivityAtomicallyRejectsExecutionTransition(t *testing.T) {
 		},
 	})
 
-	err := RecordActivity(context.Background(), kubeClient, client.ObjectKeyFromObject(environment), environment.UID, 1, 0, platformv1alpha1.EnvironmentActivitySourceTerminal, "stale-terminal")
+	err := RecordActivity(context.Background(), kubeClient, CaptureExecutionFence(environment), platformv1alpha1.EnvironmentActivitySourceTerminal, "stale-terminal")
 	if !errors.Is(err, ErrExecutionGenerationChanged) {
 		t.Fatalf("RecordActivity() error = %v, want execution-generation fence", err)
 	}

--- a/internal/sandboxclient/process.go
+++ b/internal/sandboxclient/process.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
+	"github.com/Chris-Cullins/swe-platform/internal/lifecycle"
 	sandboxdauth "github.com/Chris-Cullins/swe-platform/sandboxd/auth"
 	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
 )
@@ -49,8 +50,8 @@ type TerminalExecution = Execution
 
 // DialTerminal resolves the current ready Environment incarnation and returns
 // terminal and health clients sharing one authenticated, pod-pinned connection.
-func (c Connector) DialTerminal(ctx context.Context, namespace, environment string, environmentUID types.UID) (sandboxdv1.TerminalServiceClient, sandboxdv1.HealthServiceClient, TerminalExecution, func() error, error) {
-	env, pod, err := c.resolvePod(ctx, namespace, environment, environmentUID, nil, nil)
+func (c Connector) DialTerminal(ctx context.Context, fence lifecycle.ExecutionFence) (sandboxdv1.TerminalServiceClient, sandboxdv1.HealthServiceClient, TerminalExecution, func() error, error) {
+	env, pod, err := c.resolvePod(ctx, fence)
 	if err != nil {
 		return nil, nil, TerminalExecution{}, nil, err
 	}
@@ -66,7 +67,7 @@ func (c Connector) DialTerminal(ctx context.Context, namespace, environment stri
 	// Re-read after pinning the endpoint and credentials. A lifecycle transition
 	// or same-name Pod replacement racing the dial must not produce an attachment
 	// whose independent activity heartbeat can outlive that execution.
-	currentEnvironment, currentPod, err := c.resolvePod(ctx, namespace, environment, environmentUID, &execution.executionGeneration, &execution.lifecycleEpoch)
+	currentEnvironment, currentPod, err := c.resolvePod(ctx, fence)
 	if err != nil || executionForPod(currentEnvironment, currentPod) != execution {
 		_ = conn.Close()
 		if err != nil {
@@ -79,8 +80,8 @@ func (c Connector) DialTerminal(ctx context.Context, namespace, environment stri
 
 // ResolveExecution non-dialingly proves that an Environment generation maps to
 // one exact live backend execution and returns its opaque connector identity.
-func (c Connector) ResolveExecution(ctx context.Context, namespace, environment string, environmentUID types.UID, executionGeneration, lifecycleEpoch int64) (Execution, error) {
-	env, pod, err := c.resolvePod(ctx, namespace, environment, environmentUID, &executionGeneration, &lifecycleEpoch)
+func (c Connector) ResolveExecution(ctx context.Context, fence lifecycle.ExecutionFence) (Execution, error) {
+	env, pod, err := c.resolvePod(ctx, fence)
 	if err != nil {
 		return Execution{}, err
 	}
@@ -88,28 +89,30 @@ func (c Connector) ResolveExecution(ctx context.Context, namespace, environment 
 }
 
 // ExecutionCurrent reports whether execution is still the exact active live
-// backend execution. NotFound is a stale result rather than an operational
-// error; all other API read failures remain retryable by callers.
-func (c Connector) ExecutionCurrent(ctx context.Context, namespace, environment string, execution Execution) (bool, error) {
-	var env platformv1alpha1.Environment
-	if err := c.Reader.Get(ctx, types.NamespacedName{Namespace: namespace, Name: environment}, &env); apierrors.IsNotFound(err) {
+// backend execution. NotFound is a stale result; a changed fence is returned
+// as lifecycle.ErrExecutionFenceChanged so each consumer can either discard a
+// delayed result or distinguish a retryable hold-policy transition. Other API
+// read failures remain retryable by callers.
+func (c Connector) ExecutionCurrent(ctx context.Context, fence lifecycle.ExecutionFence, execution Execution) (bool, error) {
+	env, err := fence.Revalidate(ctx, c.Reader)
+	if apierrors.IsNotFound(err) {
 		return false, nil
 	} else if err != nil {
 		return false, err
 	}
 	if env.UID != execution.environmentUID || env.Status.ExecutionGeneration != execution.executionGeneration ||
 		env.Status.Lifecycle.Epoch != execution.lifecycleEpoch || env.Spec.Paused || env.Status.Lifecycle.Suspended ||
-		!platformv1alpha1.IsEnvironmentReady(&env) || env.Status.PodName != execution.podName || env.Status.Endpoints.Sandboxd == "" {
+		!platformv1alpha1.IsEnvironmentReady(env) || env.Status.PodName != execution.podName || env.Status.Endpoints.Sandboxd == "" {
 		return false, nil
 	}
 	var pod corev1.Pod
-	if err := c.Reader.Get(ctx, types.NamespacedName{Namespace: namespace, Name: execution.podName}, &pod); apierrors.IsNotFound(err) {
+	if err := c.Reader.Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: execution.podName}, &pod); apierrors.IsNotFound(err) {
 		return false, nil
 	} else if err != nil {
 		return false, err
 	}
 	podGeneration, generationValid := parseExecutionGeneration(&pod)
-	return exactEnvironmentOwner(&pod, &env) && pod.UID == execution.podUID && pod.DeletionTimestamp.IsZero() &&
+	return exactEnvironmentOwner(&pod, env) && pod.UID == execution.podUID && pod.DeletionTimestamp.IsZero() &&
 		pod.Spec.RestartPolicy == corev1.RestartPolicyNever && processPodReady(&pod) && pod.Status.PodIP != "" &&
 		env.Status.Endpoints.Sandboxd == net.JoinHostPort(pod.Status.PodIP, sandboxdPort) && generationValid &&
 		podGeneration == execution.executionGeneration, nil
@@ -122,26 +125,10 @@ func executionForPod(env *platformv1alpha1.Environment, pod *corev1.Pod) Executi
 	}
 }
 
-// DialProcess resolves the exact Environment UID immediately before dialing
-// and returns a process-only sandboxd client.
-func (c Connector) DialProcess(ctx context.Context, namespace, environment string, environmentUID types.UID) (sandboxdv1.ProcessServiceClient, func() error, error) {
-	return c.dialProcess(ctx, namespace, environment, environmentUID, nil, nil)
-}
-
-// DialProcessForEpoch resolves a process client only when the current
-// Environment lifecycle epoch matches the caller's accepted execution epoch.
-func (c Connector) DialProcessForEpoch(ctx context.Context, namespace, environment string, environmentUID types.UID, expectedEpoch int64) (sandboxdv1.ProcessServiceClient, func() error, error) {
-	return c.dialProcess(ctx, namespace, environment, environmentUID, nil, &expectedEpoch)
-}
-
-// DialProcessForExecution resolves a process client only for the exact accepted
-// backend execution and lifecycle epoch.
-func (c Connector) DialProcessForExecution(ctx context.Context, namespace, environment string, environmentUID types.UID, expectedExecutionGeneration, expectedEpoch int64) (sandboxdv1.ProcessServiceClient, func() error, error) {
-	return c.dialProcess(ctx, namespace, environment, environmentUID, &expectedExecutionGeneration, &expectedEpoch)
-}
-
-func (c Connector) dialProcess(ctx context.Context, namespace, environment string, environmentUID types.UID, expectedExecutionGeneration, expectedEpoch *int64) (sandboxdv1.ProcessServiceClient, func() error, error) {
-	env, pod, err := c.resolvePod(ctx, namespace, environment, environmentUID, expectedExecutionGeneration, expectedEpoch)
+// DialProcess resolves only the complete captured execution fence and returns
+// a process-only sandboxd client.
+func (c Connector) DialProcess(ctx context.Context, fence lifecycle.ExecutionFence) (sandboxdv1.ProcessServiceClient, func() error, error) {
+	env, pod, err := c.resolvePod(ctx, fence)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -151,7 +138,7 @@ func (c Connector) dialProcess(ctx context.Context, namespace, environment strin
 		return nil, nil, fmt.Errorf("sandboxd endpoint does not identify its credential")
 	}
 	var secret corev1.Secret
-	if err := c.Reader.Get(ctx, types.NamespacedName{Namespace: namespace, Name: secretName}, &secret); err != nil {
+	if err := c.Reader.Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: secretName}, &secret); err != nil {
 		return nil, nil, err
 	}
 	identity := pod.Annotations[sandboxdauth.IdentityAnnotation]
@@ -172,54 +159,43 @@ func (c Connector) dialProcess(ctx context.Context, namespace, environment strin
 	if err != nil {
 		return nil, nil, err
 	}
-	if expectedExecutionGeneration != nil || expectedEpoch != nil {
-		// Re-read after pinning the endpoint, TLS identity, and token. If an
-		// epoch transition raced resolution, reject this client; if transition
-		// starts after this check, the old credentials cannot authenticate to
-		// the replacement pod.
-		var current platformv1alpha1.Environment
-		if err := c.Reader.Get(ctx, types.NamespacedName{Namespace: namespace, Name: environment}, &current); err != nil {
-			_ = conn.Close()
-			return nil, nil, err
+	// Re-read after pinning the endpoint, TLS identity, and token. If an
+	// execution-fence transition raced resolution, reject this client; if a
+	// transition starts after this check, the old credentials cannot
+	// authenticate to the replacement backend execution.
+	current, err := fence.Revalidate(ctx, c.Reader)
+	if err != nil || current.Spec.Paused || current.Status.Lifecycle.Suspended || !platformv1alpha1.IsEnvironmentReady(current) ||
+		current.Status.PodName != env.Status.PodName || current.Status.Endpoints.Sandboxd != env.Status.Endpoints.Sandboxd {
+		_ = conn.Close()
+		if err != nil {
+			return nil, nil, fmt.Errorf("environment execution changed while resolving process endpoint: %w", err)
 		}
-		if current.UID != environmentUID || expectedExecutionGeneration != nil && current.Status.ExecutionGeneration != *expectedExecutionGeneration ||
-			expectedEpoch != nil && current.Status.Lifecycle.Epoch != *expectedEpoch ||
-			current.Spec.Paused || current.Status.Lifecycle.Suspended || !platformv1alpha1.IsEnvironmentReady(&current) ||
-			current.Status.PodName != env.Status.PodName || current.Status.Endpoints.Sandboxd != env.Status.Endpoints.Sandboxd {
-			_ = conn.Close()
-			return nil, nil, fmt.Errorf("environment execution changed while resolving process endpoint")
-		}
+		return nil, nil, fmt.Errorf("environment execution changed while resolving process endpoint")
 	}
 	return sandboxdv1.NewProcessServiceClient(conn), conn.Close, nil
 }
 
-func (c Connector) resolvePod(ctx context.Context, namespace, environment string, environmentUID types.UID, expectedExecutionGeneration, expectedEpoch *int64) (*platformv1alpha1.Environment, *corev1.Pod, error) {
-	var env platformv1alpha1.Environment
-	if err := c.Reader.Get(ctx, types.NamespacedName{Namespace: namespace, Name: environment}, &env); err != nil {
+func (c Connector) resolvePod(ctx context.Context, fence lifecycle.ExecutionFence) (*platformv1alpha1.Environment, *corev1.Pod, error) {
+	env, err := fence.Revalidate(ctx, c.Reader)
+	if err != nil {
 		return nil, nil, err
 	}
-	if environmentUID != "" && env.UID != environmentUID || env.Status.ExecutionGeneration < 1 || env.Spec.Paused || env.Status.Lifecycle.Suspended || !platformv1alpha1.IsEnvironmentReady(&env) || env.Status.PodName == "" || env.Status.Endpoints.Sandboxd == "" {
+	if env.Spec.Paused || env.Status.Lifecycle.Suspended || !platformv1alpha1.IsEnvironmentReady(env) || env.Status.PodName == "" || env.Status.Endpoints.Sandboxd == "" {
 		return nil, nil, fmt.Errorf("environment is not the current reachable incarnation")
 	}
-	if expectedExecutionGeneration != nil && env.Status.ExecutionGeneration != *expectedExecutionGeneration {
-		return nil, nil, fmt.Errorf("environment execution generation changed: expected %d, got %d", *expectedExecutionGeneration, env.Status.ExecutionGeneration)
-	}
-	if expectedEpoch != nil && env.Status.Lifecycle.Epoch != *expectedEpoch {
-		return nil, nil, fmt.Errorf("environment lifecycle epoch changed: expected %d, got %d", *expectedEpoch, env.Status.Lifecycle.Epoch)
-	}
 	var template platformv1alpha1.EnvironmentTemplate
-	if err := c.Reader.Get(ctx, types.NamespacedName{Namespace: namespace, Name: env.Spec.TemplateRef}, &template); err != nil {
+	if err := c.Reader.Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: env.Spec.TemplateRef}, &template); err != nil {
 		return nil, nil, fmt.Errorf("get environment template: %w", err)
 	}
-	if backend := platformv1alpha1.EffectiveEnvironmentBackend(&env, &template); backend != platformv1alpha1.EnvironmentBackendPod {
+	if backend := platformv1alpha1.EffectiveEnvironmentBackend(env, &template); backend != platformv1alpha1.EnvironmentBackendPod {
 		return nil, nil, fmt.Errorf("environment backend %q is not supported", backend)
 	}
 	var pod corev1.Pod
-	if err := c.Reader.Get(ctx, types.NamespacedName{Namespace: namespace, Name: env.Status.PodName}, &pod); err != nil {
+	if err := c.Reader.Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: env.Status.PodName}, &pod); err != nil {
 		return nil, nil, err
 	}
 	wantEndpoint := net.JoinHostPort(pod.Status.PodIP, sandboxdPort)
-	if !exactEnvironmentOwner(&pod, &env) {
+	if !exactEnvironmentOwner(&pod, env) {
 		return nil, nil, fmt.Errorf("environment pod is not owned by the current environment")
 	}
 	if pod.UID == "" || !pod.DeletionTimestamp.IsZero() || !processPodReady(&pod) || pod.Status.PodIP == "" || env.Status.Endpoints.Sandboxd != wantEndpoint {
@@ -232,7 +208,7 @@ func (c Connector) resolvePod(ctx context.Context, namespace, environment string
 	if !generationValid || podGeneration != env.Status.ExecutionGeneration {
 		return nil, nil, fmt.Errorf("environment pod does not identify the current execution generation")
 	}
-	return &env, &pod, nil
+	return env, &pod, nil
 }
 
 func parseExecutionGeneration(pod *corev1.Pod) (int64, bool) {

--- a/internal/sandboxclient/process_test.go
+++ b/internal/sandboxclient/process_test.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
+	"github.com/Chris-Cullins/swe-platform/internal/lifecycle"
 	sandboxdauth "github.com/Chris-Cullins/swe-platform/sandboxd/auth"
 )
 
@@ -73,7 +74,7 @@ func TestDialTerminalBindsExactExecutionAfterFinalRead(t *testing.T) {
 		return fake.NewClientBuilder().WithScheme(scheme).WithObjects(environment.DeepCopy(), template.DeepCopy(), pod.DeepCopy()).Build()
 	}
 
-	terminal, health, execution, closeConnection, err := (Connector{Reader: newClient()}).DialTerminal(context.Background(), environment.Namespace, environment.Name, environment.UID)
+	terminal, health, execution, closeConnection, err := (Connector{Reader: newClient()}).DialTerminal(context.Background(), lifecycle.CaptureExecutionFence(environment))
 	if err != nil || terminal == nil || health == nil || closeConnection == nil {
 		t.Fatalf("valid terminal dial: terminal nil=%t, health nil=%t, close nil=%t, error=%v", terminal == nil, health == nil, closeConnection == nil, err)
 	}
@@ -88,14 +89,14 @@ func TestDialTerminalBindsExactExecutionAfterFinalRead(t *testing.T) {
 		current.Status.Lifecycle.Epoch++
 		current.Status.Lifecycle.Suspended = true
 	}}
-	terminal, health, execution, closeConnection, err = (Connector{Reader: epochRace}).DialTerminal(context.Background(), environment.Namespace, environment.Name, environment.UID)
+	terminal, health, execution, closeConnection, err = (Connector{Reader: epochRace}).DialTerminal(context.Background(), lifecycle.CaptureExecutionFence(environment))
 	if err == nil || !strings.Contains(err.Error(), "execution changed while resolving terminal endpoint") || epochRace.environmentGets != 2 || terminal != nil || health != nil || closeConnection != nil || execution != (TerminalExecution{}) {
 		t.Fatalf("post-dial lifecycle race: terminal nil=%t, health nil=%t, execution=%#v, close nil=%t, error=%v, Environment reads=%d", terminal == nil, health == nil, execution, closeConnection == nil, err, epochRace.environmentGets)
 	}
 	executionRace := &environmentChangingReader{Reader: newClient(), mutate: func(current *platformv1alpha1.Environment) {
 		current.Status.ExecutionGeneration++
 	}}
-	terminal, health, execution, closeConnection, err = (Connector{Reader: executionRace}).DialTerminal(context.Background(), environment.Namespace, environment.Name, environment.UID)
+	terminal, health, execution, closeConnection, err = (Connector{Reader: executionRace}).DialTerminal(context.Background(), lifecycle.CaptureExecutionFence(environment))
 	if err == nil || !strings.Contains(err.Error(), "execution changed while resolving terminal endpoint") || executionRace.environmentGets != 2 || terminal != nil || health != nil || closeConnection != nil || execution != (TerminalExecution{}) {
 		t.Fatalf("post-dial execution-generation race: terminal nil=%t, health nil=%t, execution=%#v, close nil=%t, error=%v, Environment reads=%d", terminal == nil, health == nil, execution, closeConnection == nil, err, executionRace.environmentGets)
 	}
@@ -103,7 +104,7 @@ func TestDialTerminalBindsExactExecutionAfterFinalRead(t *testing.T) {
 	podRace := &podChangingReader{Reader: newClient(), mutate: func(current *corev1.Pod) {
 		current.UID = "pod-uid-2"
 	}}
-	terminal, health, execution, closeConnection, err = (Connector{Reader: podRace}).DialTerminal(context.Background(), environment.Namespace, environment.Name, environment.UID)
+	terminal, health, execution, closeConnection, err = (Connector{Reader: podRace}).DialTerminal(context.Background(), lifecycle.CaptureExecutionFence(environment))
 	if err == nil || !strings.Contains(err.Error(), "execution changed while resolving terminal endpoint") || podRace.podGets != 2 || terminal != nil || health != nil || closeConnection != nil || execution != (TerminalExecution{}) {
 		t.Fatalf("post-dial same-name Pod race: terminal nil=%t, health nil=%t, execution=%#v, close nil=%t, error=%v, Pod reads=%d", terminal == nil, health == nil, execution, closeConnection == nil, err, podRace.podGets)
 	}
@@ -140,7 +141,7 @@ func TestDialProcessValidatesCurrentEnvironmentPodAndCredentialIncarnation(t *te
 		return fake.NewClientBuilder().WithScheme(scheme).WithObjects(append(objects, template.DeepCopy())...).Build()
 	}
 
-	process, closeConnection, err := (Connector{Reader: newClient(env.DeepCopy(), pod.DeepCopy(), secret.DeepCopy())}).DialProcess(context.Background(), env.Namespace, env.Name, env.UID)
+	process, closeConnection, err := (Connector{Reader: newClient(env.DeepCopy(), pod.DeepCopy(), secret.DeepCopy())}).DialProcess(context.Background(), lifecycle.CaptureExecutionFence(env))
 	if err != nil || process == nil || closeConnection == nil {
 		t.Fatalf("valid process dial handle: process nil=%t, close nil=%t, error=%v", process == nil, closeConnection == nil, err)
 	}
@@ -149,35 +150,37 @@ func TestDialProcessValidatesCurrentEnvironmentPodAndCredentialIncarnation(t *te
 	}
 	freshEpoch := env.DeepCopy()
 	freshEpoch.Status.Lifecycle.Epoch = 1
-	if _, _, err := (Connector{Reader: newClient(freshEpoch, pod.DeepCopy(), secret.DeepCopy())}).DialProcessForEpoch(context.Background(), env.Namespace, env.Name, env.UID, 0); err == nil || !strings.Contains(err.Error(), "lifecycle epoch changed") {
+	if _, _, err := (Connector{Reader: newClient(freshEpoch, pod.DeepCopy(), secret.DeepCopy())}).DialProcess(context.Background(), lifecycle.CaptureExecutionFence(env)); err == nil || !strings.Contains(err.Error(), "lifecycle epoch changed") {
 		t.Fatalf("stale lifecycle epoch error = %v", err)
 	}
-	if _, _, err := (Connector{Reader: newClient(env.DeepCopy(), pod.DeepCopy(), secret.DeepCopy())}).DialProcessForExecution(context.Background(), env.Namespace, env.Name, env.UID, 2, 0); err == nil || !strings.Contains(err.Error(), "execution generation changed") {
+	staleGeneration := env.DeepCopy()
+	staleGeneration.Status.ExecutionGeneration = 2
+	if _, _, err := (Connector{Reader: newClient(env.DeepCopy(), pod.DeepCopy(), secret.DeepCopy())}).DialProcess(context.Background(), lifecycle.CaptureExecutionFence(staleGeneration)); err == nil || !strings.Contains(err.Error(), "execution generation changed") {
 		t.Fatalf("stale execution generation error = %v", err)
 	}
 	for _, policy := range []corev1.RestartPolicy{corev1.RestartPolicyAlways, corev1.RestartPolicyOnFailure, ""} {
 		restartable := pod.DeepCopy()
 		restartable.Spec.RestartPolicy = policy
-		if _, _, err := (Connector{Reader: newClient(env.DeepCopy(), restartable, secret.DeepCopy())}).DialProcess(context.Background(), env.Namespace, env.Name, env.UID); err == nil || !strings.Contains(err.Error(), "restart policy") {
+		if _, _, err := (Connector{Reader: newClient(env.DeepCopy(), restartable, secret.DeepCopy())}).DialProcess(context.Background(), lifecycle.CaptureExecutionFence(env)); err == nil || !strings.Contains(err.Error(), "restart policy") {
 			t.Fatalf("restart policy %q error = %v", policy, err)
 		}
 	}
 	for _, annotation := range []string{"", "0", "01", "malformed", "2"} {
 		malformed := pod.DeepCopy()
 		malformed.Annotations[executionGenerationAnnotation] = annotation
-		if _, _, err := (Connector{Reader: newClient(env.DeepCopy(), malformed, secret.DeepCopy())}).DialProcess(context.Background(), env.Namespace, env.Name, env.UID); err == nil || !strings.Contains(err.Error(), "execution generation") {
+		if _, _, err := (Connector{Reader: newClient(env.DeepCopy(), malformed, secret.DeepCopy())}).DialProcess(context.Background(), lifecycle.CaptureExecutionFence(env)); err == nil || !strings.Contains(err.Error(), "execution generation") {
 			t.Fatalf("execution annotation %q error = %v", annotation, err)
 		}
 	}
 	legacy := env.DeepCopy()
 	legacy.Status.ExecutionGeneration = 0
-	if _, _, err := (Connector{Reader: newClient(legacy, pod.DeepCopy(), secret.DeepCopy())}).DialProcess(context.Background(), env.Namespace, env.Name, env.UID); err == nil || !strings.Contains(err.Error(), "current reachable incarnation") {
+	if _, _, err := (Connector{Reader: newClient(legacy, pod.DeepCopy(), secret.DeepCopy())}).DialProcess(context.Background(), lifecycle.CaptureExecutionFence(legacy)); err == nil || !strings.Contains(err.Error(), "execution generation changed") {
 		t.Fatalf("legacy generation zero error = %v", err)
 	}
 	activityReader := &environmentChangingReader{Reader: newClient(env.DeepCopy(), pod.DeepCopy(), secret.DeepCopy()), mutate: func(environment *platformv1alpha1.Environment) {
 		environment.Annotations = map[string]string{"lifecycle.swe.dev/activity-terminal": `{"id":"activity"}`}
 	}}
-	_, closeActivity, err := (Connector{Reader: activityReader}).DialProcessForEpoch(context.Background(), env.Namespace, env.Name, env.UID, 0)
+	_, closeActivity, err := (Connector{Reader: activityReader}).DialProcess(context.Background(), lifecycle.CaptureExecutionFence(env))
 	if err != nil || closeActivity == nil || activityReader.environmentGets != 2 {
 		t.Fatalf("metadata-only activity dial: close nil=%t, error=%v, Environment reads=%d", closeActivity == nil, err, activityReader.environmentGets)
 	}
@@ -203,7 +206,7 @@ func TestDialProcessValidatesCurrentEnvironmentPodAndCredentialIncarnation(t *te
 	} {
 		t.Run("final read "+test.name, func(t *testing.T) {
 			reader := &environmentChangingReader{Reader: newClient(env.DeepCopy(), pod.DeepCopy(), secret.DeepCopy()), mutate: test.mutate}
-			if _, _, err := (Connector{Reader: reader}).DialProcessForEpoch(context.Background(), env.Namespace, env.Name, env.UID, 0); err == nil || !strings.Contains(err.Error(), "execution changed while resolving") || reader.environmentGets != 2 {
+			if _, _, err := (Connector{Reader: reader}).DialProcess(context.Background(), lifecycle.CaptureExecutionFence(env)); err == nil || !strings.Contains(err.Error(), "execution changed while resolving") || reader.environmentGets != 2 {
 				t.Fatalf("racing execution error = %v, Environment reads = %d", err, reader.environmentGets)
 			}
 		})
@@ -211,7 +214,7 @@ func TestDialProcessValidatesCurrentEnvironmentPodAndCredentialIncarnation(t *te
 	suspended := env.DeepCopy()
 	suspended.Status.Lifecycle.Suspended = true
 	suspended.Status.Lifecycle.SuspensionReason = platformv1alpha1.EnvironmentSuspensionReasonIdle
-	if _, _, err := (Connector{Reader: newClient(suspended, pod.DeepCopy(), secret.DeepCopy())}).DialProcess(context.Background(), env.Namespace, env.Name, env.UID); err == nil || !strings.Contains(err.Error(), "current reachable incarnation") {
+	if _, _, err := (Connector{Reader: newClient(suspended, pod.DeepCopy(), secret.DeepCopy())}).DialProcess(context.Background(), lifecycle.CaptureExecutionFence(suspended)); err == nil || !strings.Contains(err.Error(), "current reachable incarnation") {
 		t.Fatalf("suspended environment error = %v", err)
 	}
 	longNameEnv := env.DeepCopy()
@@ -222,7 +225,7 @@ func TestDialProcessValidatesCurrentEnvironmentPodAndCredentialIncarnation(t *te
 	longNameSecret := secret.DeepCopy()
 	longNameSecret.Name = "bounded-credential-name"
 	longNameSecret.OwnerReferences[0].Name = longNameEnv.Name
-	_, closeLongName, err := (Connector{Reader: newClient(longNameEnv, longNamePod, longNameSecret)}).DialProcess(context.Background(), longNameEnv.Namespace, longNameEnv.Name, longNameEnv.UID)
+	_, closeLongName, err := (Connector{Reader: newClient(longNameEnv, longNamePod, longNameSecret)}).DialProcess(context.Background(), lifecycle.CaptureExecutionFence(longNameEnv))
 	if err != nil {
 		t.Fatalf("long-name Environment credential lookup: %v", err)
 	}
@@ -232,27 +235,29 @@ func TestDialProcessValidatesCurrentEnvironmentPodAndCredentialIncarnation(t *te
 
 	wrongOwner := pod.DeepCopy()
 	wrongOwner.OwnerReferences[0].Name = "other-environment"
-	if _, _, err := (Connector{Reader: newClient(env.DeepCopy(), wrongOwner, secret.DeepCopy())}).DialProcess(context.Background(), env.Namespace, env.Name, env.UID); err == nil || !strings.Contains(err.Error(), "not owned") {
+	if _, _, err := (Connector{Reader: newClient(env.DeepCopy(), wrongOwner, secret.DeepCopy())}).DialProcess(context.Background(), lifecycle.CaptureExecutionFence(env)); err == nil || !strings.Contains(err.Error(), "not owned") {
 		t.Fatalf("wrong pod owner error = %v", err)
 	}
 
 	staleCredential := secret.DeepCopy()
 	staleCredential.Annotations[sandboxdauth.PodUIDAnnotation] = "replaced-pod"
-	if _, _, err := (Connector{Reader: newClient(env.DeepCopy(), pod.DeepCopy(), staleCredential)}).DialProcess(context.Background(), env.Namespace, env.Name, env.UID); err == nil || !strings.Contains(err.Error(), "current environment pod") {
+	if _, _, err := (Connector{Reader: newClient(env.DeepCopy(), pod.DeepCopy(), staleCredential)}).DialProcess(context.Background(), lifecycle.CaptureExecutionFence(env)); err == nil || !strings.Contains(err.Error(), "current environment pod") {
 		t.Fatalf("stale credential error = %v", err)
 	}
 	replacementSecret := secret.DeepCopy()
 	replacementSecret.UID = "replacement-secret-uid"
-	if _, _, err := (Connector{Reader: newClient(env.DeepCopy(), pod.DeepCopy(), replacementSecret)}).DialProcess(context.Background(), env.Namespace, env.Name, env.UID); err == nil || !strings.Contains(err.Error(), "current environment pod") {
+	if _, _, err := (Connector{Reader: newClient(env.DeepCopy(), pod.DeepCopy(), replacementSecret)}).DialProcess(context.Background(), lifecycle.CaptureExecutionFence(env)); err == nil || !strings.Contains(err.Error(), "current environment pod") {
 		t.Fatalf("replacement Secret error = %v", err)
 	}
 	wrongSecretOwner := secret.DeepCopy()
 	wrongSecretOwner.OwnerReferences[0].Kind = "Run"
-	if _, _, err := (Connector{Reader: newClient(env.DeepCopy(), pod.DeepCopy(), wrongSecretOwner)}).DialProcess(context.Background(), env.Namespace, env.Name, env.UID); err == nil || !strings.Contains(err.Error(), "current environment pod") {
+	if _, _, err := (Connector{Reader: newClient(env.DeepCopy(), pod.DeepCopy(), wrongSecretOwner)}).DialProcess(context.Background(), lifecycle.CaptureExecutionFence(env)); err == nil || !strings.Contains(err.Error(), "current environment pod") {
 		t.Fatalf("wrong Secret owner kind error = %v", err)
 	}
 
-	if _, _, err := (Connector{Reader: newClient(env.DeepCopy())}).DialProcess(context.Background(), env.Namespace, env.Name, types.UID("replaced-environment")); err == nil || !strings.Contains(err.Error(), "current reachable incarnation") {
+	replacedEnvironment := env.DeepCopy()
+	replacedEnvironment.UID = types.UID("replaced-environment")
+	if _, _, err := (Connector{Reader: newClient(env.DeepCopy())}).DialProcess(context.Background(), lifecycle.CaptureExecutionFence(replacedEnvironment)); err == nil || !strings.Contains(err.Error(), "incarnation changed") {
 		t.Fatalf("stale environment UID error = %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- add an opaque `lifecycle.ExecutionFence` that captures Environment UID, execution generation, lifecycle epoch, and hold-policy revision as one mandatory value
- migrate Run adapter calls, terminal activity/currentness checks, lifecycle activity publication, and sandboxclient resolution to capture/revalidate the complete fence
- remove sandboxclient's UID-only, epoch-only, and optional generation/epoch process boundaries while keeping backend Pod identity connector-private
- document the fence as mandatory for future service observation, portal, and egress identity consumers

## Safety and behavior

- Run post-call/current-identity proofs continue to use the uncached API reader and discard stale adapter results
- terminal heartbeats retain newer disabled hold-revision adoption, revoke changed bound executions, and revalidate the opaque backend handle during hold refresh
- disclosure-safe association checks and backend-neutral connector ownership are unchanged

## Tests

- `go test ./internal/lifecycle ./internal/sandboxclient ./internal/controllers ./internal/controlplane`
- `go test ./internal/controlplane -run 'TestTerminal(PolicyRetriesDisabledHoldRevisionRacingExecutionProof|HoldRefreshRevalidatesBoundExecution)' -count=10`
- `make test`
- `make vet`
- `git diff --check`

Closes #142
