### PR TITLE
Operator operational observability (#146)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -37,6 +37,10 @@ CLI / TUI / local MCP / browser console
   reconcile Environment pods and volumes, maintain warm pools, reap idle Environments, and
   drive adapter lifecycle. Platform services and the Installation identity live in a system
   namespace; each onboarded Project and its resources live in one dedicated claimed namespace.
+  The chart exposes controller-runtime's existing operator `/metrics` endpoint through an
+  internal Service. Platform-specific collectors use only fixed allocation, fence-component,
+  call-site, registered-adapter, operation, outcome, recovery, transition, and lifecycle-reason
+  labels; they never label tenant or resource identity.
 - **Control plane.** A singleton HTTP service exposes typed Run and Environment operations,
   Run watches, transcript ingestion/SSE, browser sessions, the embedded operations console,
   and terminal WebSockets. A separate internal HTTP listener exposes bounded-cardinality

--- a/charts/swe-platform/README.md
+++ b/charts/swe-platform/README.md
@@ -82,6 +82,48 @@ or live events with low lag, terminal grants, and allowed authentication reviews
 Histogram families add the standard `_bucket`, `_sum`, and `_count` series. Prometheus Go and
 process collectors are also exposed for runtime and process health.
 
+## Operator metrics
+
+The internal `<release>-swe-platform-operator-metrics` Service exposes controller-runtime's
+existing operator metrics endpoint on port `metrics` (`operator.metrics.port`, 8080 by
+default). Scrape `/metrics` on that port.
+The chart does not install a ServiceMonitor or make this Service externally reachable; apply
+cluster-local scrape discovery and NetworkPolicy appropriate to your Prometheus installation.
+The same endpoint retains controller-runtime's standard Go, process, workqueue, and controller
+metrics alongside these bounded-cardinality platform collectors:
+
+| Metric | Labels |
+|---|---|
+| `swe_operator_run_allocation_duration_seconds` | `path`: `owned_create`, `warm_claim` |
+| `swe_operator_warm_pool_allocations_total` | `outcome`: `hit`, `miss` |
+| `swe_operator_execution_fence_rejections_total` | `component`: `environment_uid`, `execution_generation`, `lifecycle_epoch`, `hold_revision`; `call_site`: `ensure_accepted`, `observe`, `run_cancel`, `terminal_cleanup`, `finalizer_cleanup` |
+| `swe_operator_adapter_operations_total` | `adapter`: registered adapter (`amp`, `claude-code`, `codex`, `pi`); `operation`: `ensure_accepted`, `observe`, `cancel`; `outcome`: `success`, `pending`, `rejected`, `error` |
+| `swe_operator_adapter_operation_duration_seconds` | same `adapter`, `operation`, and `outcome` values |
+| `swe_operator_pod_recovery_transitions_total` | `transition`: `attempt`, `exhausted` |
+| `swe_operator_environment_lifecycle_transitions_total` | `transition`: `suspend`, `resume`; `reason`: `Hold`, `Idle`, `Requested` |
+
+Allocation duration starts at the durable Run creation timestamp and ends only when the Run
+controller successfully publishes `EnvironmentAllocated`. Automatic owned creation is a warm
+pool miss; a successful warm claim is a hit. A recovered allocation is not observed again,
+which prevents reconcile/restart duplicates but can omit a process-local sample after an
+uncertain prior status response. The current durable contract has no stable warm-claim
+timestamp that survives the later readiness transition, so this release deliberately does not
+publish claim-to-ready latency rather than approximating it or adding status solely for metrics.
+
+Healthy operation normally shows allocation observations paired with warm hit/miss traffic,
+successful adapter operations, and occasional balanced suspend/resume transitions. Investigate:
+
+- sustained adapter `error` or acceptance `rejected` growth, or elevated adapter duration;
+- execution-fence rejection spikes, especially repeated rejection at one closed call site;
+- repeated recovery `attempt` growth or any `exhausted` transition; and
+- sustained aggregate suspension growth without corresponding aggregate resumes; use the
+  fixed reason labels diagnostically because a suspended Environment can change reasons.
+
+`pending` cancellation is an expected retryable adapter state, not a failure by itself. Fence
+components name tuple members only, never their values. No custom label contains credentials,
+sessions, cookies, users, namespaces, repositories, URLs, errors, Runs, Environments, Pods, or
+other resource identity.
+
 The operator reconciles each `Run` as the single task intent and allocates or claims its
 `Environment`; clients must not create the two resources independently. Its RBAC permits
 Run status/finalizer updates and Environment allocation/claim updates. Process execution

--- a/charts/swe-platform/templates/000-validate.yaml
+++ b/charts/swe-platform/templates/000-validate.yaml
@@ -19,8 +19,12 @@
   {{- fail "controlPlane.sessions.backend=memory must not set controlPlane.sessions.keyringSecret.name" -}}
 {{- end -}}
 {{- $operatorMetricsPort := int .Values.operator.metrics.port -}}
-{{- if or (lt $operatorMetricsPort 1) (gt $operatorMetricsPort 65535) (eq $operatorMetricsPort 8081) -}}
-{{- fail "operator.metrics.port must be from 1 through 65535 and must not be 8081" -}}
+{{- $operatorHealthPort := int .Values.operator.health.port -}}
+{{- if or (lt $operatorMetricsPort 1) (gt $operatorMetricsPort 65535) -}}
+{{- fail "operator.metrics.port must be from 1 through 65535" -}}
+{{- end -}}
+{{- if or (lt $operatorHealthPort 1) (gt $operatorHealthPort 65535) (eq $operatorMetricsPort $operatorHealthPort) -}}
+{{- fail "operator.health.port must be from 1 through 65535 and must differ from operator.metrics.port" -}}
 {{- end -}}
 {{- $metricsPort := int .Values.controlPlane.metrics.port -}}
 {{- if or (lt $metricsPort 1) (gt $metricsPort 65535) (eq $metricsPort 80) (eq $metricsPort 8080) -}}

--- a/charts/swe-platform/templates/000-validate.yaml
+++ b/charts/swe-platform/templates/000-validate.yaml
@@ -18,6 +18,10 @@
 {{- else if .Values.controlPlane.sessions.keyringSecret.name -}}
   {{- fail "controlPlane.sessions.backend=memory must not set controlPlane.sessions.keyringSecret.name" -}}
 {{- end -}}
+{{- $operatorMetricsPort := int .Values.operator.metrics.port -}}
+{{- if or (lt $operatorMetricsPort 1) (gt $operatorMetricsPort 65535) (eq $operatorMetricsPort 8081) -}}
+{{- fail "operator.metrics.port must be from 1 through 65535 and must not be 8081" -}}
+{{- end -}}
 {{- $metricsPort := int .Values.controlPlane.metrics.port -}}
 {{- if or (lt $metricsPort 1) (gt $metricsPort 65535) (eq $metricsPort 80) (eq $metricsPort 8080) -}}
 {{- fail "controlPlane.metrics.port must be from 1 through 65535 and must not be 80 or 8080" -}}

--- a/charts/swe-platform/templates/_helpers.tpl
+++ b/charts/swe-platform/templates/_helpers.tpl
@@ -14,6 +14,10 @@
 {{- printf "%s-control-plane" (include "swe-platform.fullname" . | trunc 49 | trimSuffix "-") -}}
 {{- end }}
 
+{{- define "swe-platform.operatorMetricsFullname" -}}
+{{- printf "%s-operator-metrics" (include "swe-platform.fullname" . | trunc 46 | trimSuffix "-") -}}
+{{- end }}
+
 {{- define "swe-platform.clusterFullname" -}}
 {{- printf "%s-%s" (include "swe-platform.fullname" . | trunc 53 | trimSuffix "-") (sha256sum .Release.Namespace | trunc 8) | trunc 63 | trimSuffix "-" -}}
 {{- end }}

--- a/charts/swe-platform/templates/deployment.yaml
+++ b/charts/swe-platform/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-            - --metrics-bind-address={{ .Values.metricsBindAddress }}
+            - --metrics-bind-address=:{{ int .Values.operator.metrics.port }}
             - --health-probe-bind-address={{ .Values.healthProbeBindAddress }}
             - --leader-elect={{ .Values.leaderElection }}
             - --control-plane-namespace=$(POD_NAMESPACE)
@@ -57,7 +57,7 @@ spec:
                   fieldPath: metadata.namespace
           ports:
             - name: metrics
-              containerPort: 8080
+              containerPort: {{ int .Values.operator.metrics.port }}
             - name: health
               containerPort: 8081
           livenessProbe:

--- a/charts/swe-platform/templates/deployment.yaml
+++ b/charts/swe-platform/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --metrics-bind-address=:{{ int .Values.operator.metrics.port }}
-            - --health-probe-bind-address={{ .Values.healthProbeBindAddress }}
+            - --health-probe-bind-address=:{{ int .Values.operator.health.port }}
             - --leader-elect={{ .Values.leaderElection }}
             - --control-plane-namespace=$(POD_NAMESPACE)
             - --control-plane-name={{ include "swe-platform.name" . }}
@@ -59,7 +59,7 @@ spec:
             - name: metrics
               containerPort: {{ int .Values.operator.metrics.port }}
             - name: health
-              containerPort: 8081
+              containerPort: {{ int .Values.operator.health.port }}
           livenessProbe:
             httpGet: {path: /healthz, port: health}
           readinessProbe:

--- a/charts/swe-platform/templates/operator-metrics-service.yaml
+++ b/charts/swe-platform/templates/operator-metrics-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "swe-platform.operatorMetricsFullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "swe-platform.labels" . | nindent 4 }}
+    app.kubernetes.io/component: operator
+spec:
+  selector:
+    app.kubernetes.io/name: {{ include "swe-platform.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: operator
+  ports:
+    - name: metrics
+      port: {{ int .Values.operator.metrics.port }}
+      targetPort: metrics

--- a/charts/swe-platform/values.yaml
+++ b/charts/swe-platform/values.yaml
@@ -6,6 +6,11 @@ image:
   tag: ""
   pullPolicy: IfNotPresent
 
+operator:
+  metrics:
+    # Exposed on the internal operator metrics Service.
+    port: 8080
+
 controlPlane:
   enabled: true
   replicaCount: 1
@@ -68,7 +73,6 @@ serviceAccount:
   name: ""
 
 leaderElection: true
-metricsBindAddress: ":8080"
 healthProbeBindAddress: ":8081"
 
 # Tenancy mode is intentionally required. Scoped mode watches only the exact

--- a/charts/swe-platform/values.yaml
+++ b/charts/swe-platform/values.yaml
@@ -10,6 +10,9 @@ operator:
   metrics:
     # Exposed on the internal operator metrics Service.
     port: 8080
+  health:
+    # Used only for the operator pod's health and readiness probes.
+    port: 8081
 
 controlPlane:
   enabled: true
@@ -73,7 +76,6 @@ serviceAccount:
   name: ""
 
 leaderElection: true
-healthProbeBindAddress: ":8081"
 
 # Tenancy mode is intentionally required. Scoped mode watches only the exact
 # claimed Project namespaces listed here. Adding or removing a namespace is a

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	controllermetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
@@ -150,12 +151,15 @@ func main() {
 		os.Exit(1)
 	}
 	connector := sandboxclient.Connector{Reader: mgr.GetAPIReader(), ProcessPool: processConnections}
+	adapters := registeredAdapters()
+	operatorMetrics := controllers.NewOperatorMetrics(controllermetrics.Registry, adapters)
 	if mode == tenancy.ModeScoped && len(tenancyNamespaces) == 0 {
 		setupLog.Info("scoped installation has no configured Project namespaces; catalog is ready for onboarding and workload controllers are disabled")
 	} else if err := (&controllers.EnvironmentReconciler{
 		Client:                        guardedClient,
 		Scheme:                        mgr.GetScheme(),
 		Scope:                         scope,
+		Metrics:                       operatorMetrics,
 		ControlPlaneNamespace:         controlPlaneNamespace,
 		ControlPlaneName:              controlPlaneName,
 		ControlPlaneInstance:          controlPlaneInstance,
@@ -187,9 +191,10 @@ func main() {
 			APIReader: mgr.GetAPIReader(),
 			Scheme:    mgr.GetScheme(),
 			Scope:     scope,
-			Adapters:  registeredAdapters(),
+			Adapters:  adapters,
 			EventSink: eventSink,
 			Connector: connector,
+			Metrics:   operatorMetrics,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "Run")
 			os.Exit(1)

--- a/internal/controllers/environment_controller.go
+++ b/internal/controllers/environment_controller.go
@@ -142,6 +142,7 @@ type EnvironmentReconciler struct {
 	APIReader                     client.Reader
 	Scheme                        *runtime.Scheme
 	Scope                         *tenancy.ReconcileScope
+	Metrics                       *OperatorMetrics
 	ControlPlaneNamespace         string
 	ControlPlaneName              string
 	ControlPlaneInstance          string
@@ -394,6 +395,8 @@ func (r *EnvironmentReconciler) reconcileLifecycleIntent(ctx context.Context, en
 	}
 
 	before := env.Status.DeepCopy()
+	wasSuspended := env.Status.Lifecycle.Suspended
+	previousReason := env.Status.Lifecycle.SuspensionReason
 	lifecycleStatus := &env.Status.Lifecycle
 	lifecycleStatus.ObservedHoldPolicyRevision = policyRevision
 	now := metav1.NewTime(r.now())
@@ -478,6 +481,11 @@ func (r *EnvironmentReconciler) reconcileLifecycleIntent(ctx context.Context, en
 	if err := r.Status().Update(ctx, env); err != nil {
 		return false, err
 	}
+	if !wasSuspended && lifecycleStatus.Suspended {
+		r.Metrics.observeLifecycle("suspend", lifecycleStatus.SuspensionReason)
+	} else if wasSuspended && !lifecycleStatus.Suspended {
+		r.Metrics.observeLifecycle("resume", previousReason)
+	}
 	return true, nil
 }
 
@@ -552,6 +560,7 @@ func (r *EnvironmentReconciler) reconcilePendingPodRecovery(ctx context.Context,
 		}
 		return ctrl.Result{}, true, err
 	}
+	r.Metrics.observePodRecovery("attempt")
 	// Reconcile again before deleting or creating so the persisted attempt marker
 	// is always observed, including across a concurrent generation change.
 	return ctrl.Result{Requeue: true}, true, nil
@@ -580,6 +589,7 @@ func (r *EnvironmentReconciler) reconcileTerminalPod(ctx context.Context, env *p
 				}
 				return ctrl.Result{}, err
 			}
+			r.Metrics.observePodRecovery("exhausted")
 			log.FromContext(ctx).Info("environment pod recovery exhausted", "environment", env.Name, "pod", pod.Name, "attempts", attempts)
 			return ctrl.Result{}, nil
 		}
@@ -788,6 +798,7 @@ func (r *EnvironmentReconciler) reconcileIdle(ctx context.Context, env *platform
 	if err := r.Status().Update(ctx, env); err != nil {
 		return ctrl.Result{}, fmt.Errorf("record idle suspension: %w", err)
 	}
+	r.Metrics.observeLifecycle("suspend", platformv1alpha1.EnvironmentSuspensionReasonIdle)
 	return ctrl.Result{Requeue: true}, nil
 }
 

--- a/internal/controllers/operator_metrics.go
+++ b/internal/controllers/operator_metrics.go
@@ -1,0 +1,222 @@
+package controllers
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
+	"github.com/Chris-Cullins/swe-platform/internal/lifecycle"
+)
+
+const operatorMetricsNamespace = "swe_operator"
+
+const (
+	allocationOwnedCreate = "owned_create"
+	allocationWarmClaim   = "warm_claim"
+
+	adapterOperationEnsureAccepted = "ensure_accepted"
+	adapterOperationObserve        = "observe"
+	adapterOperationCancel         = "cancel"
+
+	adapterOutcomeSuccess  = "success"
+	adapterOutcomePending  = "pending"
+	adapterOutcomeRejected = "rejected"
+	adapterOutcomeError    = "error"
+
+	fenceCallSiteEnsureAccepted   = "ensure_accepted"
+	fenceCallSiteObserve          = "observe"
+	fenceCallSiteRunCancel        = "run_cancel"
+	fenceCallSiteTerminalCleanup  = "terminal_cleanup"
+	fenceCallSiteFinalizerCleanup = "finalizer_cleanup"
+)
+
+var fenceCallSites = []string{
+	fenceCallSiteEnsureAccepted,
+	fenceCallSiteObserve,
+	fenceCallSiteRunCancel,
+	fenceCallSiteTerminalCleanup,
+	fenceCallSiteFinalizerCleanup,
+}
+
+var fenceComponents = []string{"environment_uid", "execution_generation", "lifecycle_epoch", "hold_revision"}
+
+var lifecycleReasons = []platformv1alpha1.EnvironmentSuspensionReason{
+	platformv1alpha1.EnvironmentSuspensionReasonHold,
+	platformv1alpha1.EnvironmentSuspensionReasonIdle,
+	platformv1alpha1.EnvironmentSuspensionReasonRequested,
+}
+
+// OperatorMetrics owns bounded-cardinality platform metrics exposed through
+// controller-runtime's existing operator metrics registry.
+type OperatorMetrics struct {
+	registeredAdapters       map[string]struct{}
+	runAllocations           *prometheus.HistogramVec
+	warmPoolAllocations      *prometheus.CounterVec
+	executionFenceRejections *prometheus.CounterVec
+	adapterOperations        *prometheus.CounterVec
+	adapterOperationDuration *prometheus.HistogramVec
+	podRecoveryTransitions   *prometheus.CounterVec
+	lifecycleTransitions     *prometheus.CounterVec
+}
+
+type fenceRejectionRecorder struct {
+	metrics  *OperatorMetrics
+	callSite string
+	once     sync.Once
+}
+
+func (r *fenceRejectionRecorder) observe(err error) {
+	if r == nil || !errors.Is(err, lifecycle.ErrExecutionFenceChanged) {
+		return
+	}
+	r.once.Do(func() { r.metrics.observeFenceRejection(err, r.callSite) })
+}
+
+// NewOperatorMetrics registers one process-owned collector set. Tests should
+// pass a fresh registry; the operator passes controller-runtime's registry.
+func NewOperatorMetrics(registerer prometheus.Registerer, adapters map[string]AdapterLifecycle) *OperatorMetrics {
+	m := &OperatorMetrics{
+		registeredAdapters: make(map[string]struct{}, len(adapters)),
+		runAllocations: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: operatorMetricsNamespace, Name: "run_allocation_duration_seconds",
+			Help:    "Time from Run creation to durable Environment allocation publication by allocation path.",
+			Buckets: []float64{.01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600},
+		}, []string{"path"}),
+		warmPoolAllocations: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: operatorMetricsNamespace, Name: "warm_pool_allocations_total",
+			Help: "Automatic Run allocation outcomes against the warm pool.",
+		}, []string{"outcome"}),
+		executionFenceRejections: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: operatorMetricsNamespace, Name: "execution_fence_rejections_total",
+			Help: "Stale operator results rejected by changed execution-fence component and closed call site.",
+		}, []string{"component", "call_site"}),
+		adapterOperations: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: operatorMetricsNamespace, Name: "adapter_operations_total",
+			Help: "Adapter lifecycle calls by registered adapter, operation, and outcome.",
+		}, []string{"adapter", "operation", "outcome"}),
+		adapterOperationDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: operatorMetricsNamespace, Name: "adapter_operation_duration_seconds",
+			Help:    "Adapter lifecycle call duration by registered adapter, operation, and outcome.",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"adapter", "operation", "outcome"}),
+		podRecoveryTransitions: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: operatorMetricsNamespace, Name: "pod_recovery_transitions_total",
+			Help: "Durably published pod recovery attempt and exhaustion transitions.",
+		}, []string{"transition"}),
+		lifecycleTransitions: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: operatorMetricsNamespace, Name: "environment_lifecycle_transitions_total",
+			Help: "Durably published Environment suspension and resume transitions by fixed reason.",
+		}, []string{"transition", "reason"}),
+	}
+	registerer.MustRegister(
+		m.runAllocations, m.warmPoolAllocations, m.executionFenceRejections,
+		m.adapterOperations, m.adapterOperationDuration, m.podRecoveryTransitions,
+		m.lifecycleTransitions,
+	)
+	for _, path := range []string{allocationOwnedCreate, allocationWarmClaim} {
+		m.runAllocations.WithLabelValues(path)
+	}
+	for _, outcome := range []string{"hit", "miss"} {
+		m.warmPoolAllocations.WithLabelValues(outcome)
+	}
+	for _, component := range fenceComponents {
+		for _, callSite := range fenceCallSites {
+			m.executionFenceRejections.WithLabelValues(component, callSite)
+		}
+	}
+	for adapter := range adapters {
+		m.registeredAdapters[adapter] = struct{}{}
+		for _, operation := range []string{adapterOperationEnsureAccepted, adapterOperationObserve, adapterOperationCancel} {
+			for _, outcome := range []string{adapterOutcomeSuccess, adapterOutcomePending, adapterOutcomeRejected, adapterOutcomeError} {
+				m.adapterOperations.WithLabelValues(adapter, operation, outcome)
+				m.adapterOperationDuration.WithLabelValues(adapter, operation, outcome)
+			}
+		}
+	}
+	for _, transition := range []string{"attempt", "exhausted"} {
+		m.podRecoveryTransitions.WithLabelValues(transition)
+	}
+	for _, transition := range []string{"suspend", "resume"} {
+		for _, reason := range lifecycleReasons {
+			m.lifecycleTransitions.WithLabelValues(transition, string(reason))
+		}
+	}
+	return m
+}
+
+func (m *OperatorMetrics) observeAllocation(createdAt time.Time, path string) {
+	if m == nil {
+		return
+	}
+	duration := time.Since(createdAt).Seconds()
+	if duration < 0 {
+		duration = 0
+	}
+	m.runAllocations.WithLabelValues(path).Observe(duration)
+	if path == allocationWarmClaim {
+		m.warmPoolAllocations.WithLabelValues("hit").Inc()
+	} else {
+		m.warmPoolAllocations.WithLabelValues("miss").Inc()
+	}
+}
+
+func (m *OperatorMetrics) observeAdapter(adapter, operation string, started time.Time, err error) {
+	if m == nil {
+		return
+	}
+	if _, ok := m.registeredAdapters[adapter]; !ok {
+		return
+	}
+	outcome := adapterOutcomeSuccess
+	switch {
+	case operation == adapterOperationEnsureAccepted && errors.Is(err, ErrAdapterTaskRejected):
+		outcome = adapterOutcomeRejected
+	case operation == adapterOperationCancel && errors.Is(err, ErrAdapterCancellationPending):
+		outcome = adapterOutcomePending
+	case err != nil:
+		outcome = adapterOutcomeError
+	}
+	m.adapterOperations.WithLabelValues(adapter, operation, outcome).Inc()
+	m.adapterOperationDuration.WithLabelValues(adapter, operation, outcome).Observe(time.Since(started).Seconds())
+}
+
+func (m *OperatorMetrics) observeFenceRejection(err error, callSite string) {
+	if m == nil || !errors.Is(err, lifecycle.ErrExecutionFenceChanged) {
+		return
+	}
+	component := ""
+	switch {
+	case errors.Is(err, lifecycle.ErrEnvironmentIncarnationChanged):
+		component = "environment_uid"
+	case errors.Is(err, lifecycle.ErrExecutionGenerationChanged):
+		component = "execution_generation"
+	case errors.Is(err, lifecycle.ErrLifecycleEpochChanged):
+		component = "lifecycle_epoch"
+	case errors.Is(err, lifecycle.ErrHoldPolicyChanged):
+		component = "hold_revision"
+	}
+	if component != "" {
+		m.executionFenceRejections.WithLabelValues(component, callSite).Inc()
+	}
+}
+
+func (m *OperatorMetrics) observePodRecovery(transition string) {
+	if m != nil {
+		m.podRecoveryTransitions.WithLabelValues(transition).Inc()
+	}
+}
+
+func (m *OperatorMetrics) observeLifecycle(transition string, reason platformv1alpha1.EnvironmentSuspensionReason) {
+	if m == nil {
+		return
+	}
+	for _, supported := range lifecycleReasons {
+		if reason == supported {
+			m.lifecycleTransitions.WithLabelValues(transition, string(reason)).Inc()
+			return
+		}
+	}
+}

--- a/internal/controllers/operator_metrics_test.go
+++ b/internal/controllers/operator_metrics_test.go
@@ -1,0 +1,412 @@
+package controllers
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+	corev1 "k8s.io/api/core/v1"
+	apiMeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
+)
+
+func testOperatorMetrics(t *testing.T) (*OperatorMetrics, *prometheus.Registry) {
+	t.Helper()
+	registry := prometheus.NewRegistry()
+	metrics := NewOperatorMetrics(registry, map[string]AdapterLifecycle{"test": &scriptedAdapter{}})
+	return metrics, registry
+}
+
+type dialAfterMutationAdapter struct {
+	mutate func()
+}
+
+func (a *dialAfterMutationAdapter) EnsureAccepted(ctx context.Context, _ AdapterTask, sandbox AdapterSandbox, _ *AdapterCredential) error {
+	a.mutate()
+	_, _, err := sandbox.DialProcess(ctx)
+	return err
+}
+
+func (*dialAfterMutationAdapter) Observe(context.Context, AdapterTask, AdapterSandbox) (AdapterObservation, string, error) {
+	return AdapterObservationRunning, "running", nil
+}
+
+func (*dialAfterMutationAdapter) Cancel(context.Context, AdapterTask, AdapterSandbox) error {
+	return nil
+}
+
+func TestOperatorMetricsObserveRealAllocationHitAndMiss(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		warm     bool
+		wantPath string
+		outcome  string
+	}{
+		{name: "owned create misses warm pool", wantPath: allocationOwnedCreate, outcome: "miss"},
+		{name: "warm claim hits warm pool", warm: true, wantPath: allocationWarmClaim, outcome: "hit"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			createdAt := metav1.NewTime(time.Now().Add(-time.Second))
+			run := &platformv1alpha1.Run{
+				ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid", Finalizers: []string{runFinalizer}, CreationTimestamp: createdAt},
+				Spec:       platformv1alpha1.RunSpec{TemplateRef: "small", ProjectRef: "project", Agent: "test"},
+			}
+			template := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: "ns", UID: "template-uid"}}
+			objects := []client.Object{run, template}
+			if test.warm {
+				warm := &platformv1alpha1.Environment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "warm-small-1", Namespace: "ns", UID: "warm-uid", Labels: map[string]string{warmPoolLabel: "small"},
+						OwnerReferences: []metav1.OwnerReference{{APIVersion: platformv1alpha1.GroupVersion.String(), Kind: "EnvironmentTemplate", Name: template.Name, UID: template.UID, Controller: ptr(true)}},
+					},
+					Spec:   platformv1alpha1.EnvironmentSpec{TemplateRef: template.Name},
+					Status: platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhaseReady},
+				}
+				objects = append(objects, warm)
+			}
+			r := reconciler(t, &scriptedAdapter{}, objects...)
+			metrics, _ := testOperatorMetrics(t)
+			r.Metrics = metrics
+
+			if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)}); err != nil {
+				t.Fatal(err)
+			}
+			if got := testutil.ToFloat64(metrics.warmPoolAllocations.WithLabelValues(test.outcome)); got != 1 {
+				t.Fatalf("warm pool %s = %v, want 1", test.outcome, got)
+			}
+			if got := histogramSampleCount(t, metrics.runAllocations.WithLabelValues(test.wantPath)); got != 1 {
+				t.Fatalf("allocation histogram %s count = %d, want 1", test.wantPath, got)
+			}
+			if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)}); err != nil {
+				t.Fatal(err)
+			}
+			if got := histogramSampleCount(t, metrics.runAllocations.WithLabelValues(test.wantPath)); got != 1 {
+				t.Fatalf("allocation was recounted on reconcile: %d", got)
+			}
+		})
+	}
+}
+
+func TestOperatorMetricsObserveAdapterOutcomesOnCalls(t *testing.T) {
+	tests := []struct {
+		name      string
+		state     platformv1alpha1.RunState
+		configure func(*platformv1alpha1.Run, *scriptedAdapter)
+		operation string
+		outcome   string
+	}{
+		{name: "accept success", state: platformv1alpha1.RunStateEnvironmentReady, operation: adapterOperationEnsureAccepted, outcome: adapterOutcomeSuccess},
+		{name: "accept rejected", state: platformv1alpha1.RunStateEnvironmentReady, operation: adapterOperationEnsureAccepted, outcome: adapterOutcomeRejected, configure: func(_ *platformv1alpha1.Run, adapter *scriptedAdapter) { adapter.acceptErr = ErrAdapterTaskRejected }},
+		{name: "observe error", state: platformv1alpha1.RunStateRunning, operation: adapterOperationObserve, outcome: adapterOutcomeError, configure: func(_ *platformv1alpha1.Run, adapter *scriptedAdapter) {
+			adapter.observeErr = errors.New("rpc unavailable")
+		}},
+		{name: "cancel pending", state: platformv1alpha1.RunStateRunning, operation: adapterOperationCancel, outcome: adapterOutcomePending, configure: func(run *platformv1alpha1.Run, adapter *scriptedAdapter) {
+			run.Spec.Cancel = true
+			adapter.cancelErr = ErrAdapterCancellationPending
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			run, env := adapterRaceObjects(platformv1alpha1.EnvironmentOwnershipOwned, test.state)
+			adapter := &scriptedAdapter{observations: []AdapterObservation{AdapterObservationRunning}}
+			if test.state == platformv1alpha1.RunStateEnvironmentReady {
+				setAcceptanceAttempted(run)
+			} else {
+				epoch, generation := int64(0), int64(1)
+				run.Status.AcceptedEnvironmentEpoch = &epoch
+				run.Status.AcceptedEnvironmentExecutionGeneration = &generation
+				setAdapterAccepted(run)
+			}
+			if test.configure != nil {
+				test.configure(run, adapter)
+			}
+			r := reconciler(t, adapter, run, env)
+			metrics, _ := testOperatorMetrics(t)
+			r.Metrics = metrics
+
+			_, _ = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)})
+			if got := testutil.ToFloat64(metrics.adapterOperations.WithLabelValues("test", test.operation, test.outcome)); got != 1 {
+				t.Fatalf("adapter %s/%s = %v, want 1", test.operation, test.outcome, got)
+			}
+			if got := histogramSampleCount(t, metrics.adapterOperationDuration.WithLabelValues("test", test.operation, test.outcome)); got != 1 {
+				t.Fatalf("adapter duration %s/%s count = %d, want 1", test.operation, test.outcome, got)
+			}
+		})
+	}
+}
+
+func TestOperatorMetricsCountPostCallFenceRejection(t *testing.T) {
+	run, env := adapterRaceObjects(platformv1alpha1.EnvironmentOwnershipOwned, platformv1alpha1.RunStateEnvironmentReady)
+	setAcceptanceAttempted(run)
+	adapter := &scriptedAdapter{}
+	r := reconciler(t, adapter, run, env)
+	metrics, _ := testOperatorMetrics(t)
+	r.Metrics = metrics
+	adapter.onAccept = func() {
+		var current platformv1alpha1.Environment
+		if err := r.Get(context.Background(), client.ObjectKeyFromObject(env), &current); err != nil {
+			t.Fatal(err)
+		}
+		current.Status.ExecutionGeneration++
+		if err := r.Status().Update(context.Background(), &current); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)})
+	if err != nil || !result.Requeue {
+		t.Fatalf("stale acceptance = (%#v, %v)", result, err)
+	}
+	if got := testutil.ToFloat64(metrics.executionFenceRejections.WithLabelValues("execution_generation", fenceCallSiteEnsureAccepted)); got != 1 {
+		t.Fatalf("fence rejection count = %v, want 1", got)
+	}
+}
+
+func TestOperatorMetricsCountEnvironmentReplacementFenceRejection(t *testing.T) {
+	run, env := adapterRaceObjects(platformv1alpha1.EnvironmentOwnershipOwned, platformv1alpha1.RunStateEnvironmentReady)
+	setAcceptanceAttempted(run)
+	adapter := &scriptedAdapter{}
+	r := reconciler(t, adapter, run, env)
+	metrics, _ := testOperatorMetrics(t)
+	r.Metrics = metrics
+	adapter.onAccept = func() {
+		var current platformv1alpha1.Environment
+		if err := r.Get(context.Background(), client.ObjectKeyFromObject(env), &current); err != nil {
+			t.Fatal(err)
+		}
+		if err := r.Delete(context.Background(), &current); err != nil {
+			t.Fatal(err)
+		}
+		replacement := current.DeepCopy()
+		replacement.ResourceVersion = ""
+		replacement.UID = "replacement-uid"
+		replacement.Status = platformv1alpha1.EnvironmentStatus{}
+		if err := r.Create(context.Background(), replacement); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)})
+	if err != nil || !result.Requeue {
+		t.Fatalf("replacement acceptance = (%#v, %v)", result, err)
+	}
+	if got := testutil.ToFloat64(metrics.executionFenceRejections.WithLabelValues("environment_uid", fenceCallSiteEnsureAccepted)); got != 1 {
+		t.Fatalf("environment UID fence rejection count = %v, want 1", got)
+	}
+	var retained platformv1alpha1.Run
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &retained); err != nil {
+		t.Fatal(err)
+	}
+	if retained.Status.State != platformv1alpha1.RunStateEnvironmentReady {
+		t.Fatalf("stale acceptance changed Run state to %s", retained.Status.State)
+	}
+}
+
+func TestOperatorMetricsCountStaleDialOnlyOnce(t *testing.T) {
+	run, env := adapterRaceObjects(platformv1alpha1.EnvironmentOwnershipOwned, platformv1alpha1.RunStateEnvironmentReady)
+	setAcceptanceAttempted(run)
+	var r *RunReconciler
+	adapter := &dialAfterMutationAdapter{mutate: func() {
+		var current platformv1alpha1.Environment
+		if err := r.Get(context.Background(), client.ObjectKeyFromObject(env), &current); err != nil {
+			t.Fatal(err)
+		}
+		current.Status.ExecutionGeneration++
+		if err := r.Status().Update(context.Background(), &current); err != nil {
+			t.Fatal(err)
+		}
+	}}
+	r = reconciler(t, adapter, run, env)
+	metrics, _ := testOperatorMetrics(t)
+	r.Metrics = metrics
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)})
+	if err != nil || !result.Requeue {
+		t.Fatalf("stale dial acceptance = (%#v, %v)", result, err)
+	}
+	if got := testutil.ToFloat64(metrics.executionFenceRejections.WithLabelValues("execution_generation", fenceCallSiteEnsureAccepted)); got != 1 {
+		t.Fatalf("stale dial fence rejection count = %v, want exactly 1", got)
+	}
+}
+
+func TestOperatorMetricsDoNotCountAssociationFailureAsFenceRejection(t *testing.T) {
+	run, env := adapterRaceObjects(platformv1alpha1.EnvironmentOwnershipOwned, platformv1alpha1.RunStateEnvironmentReady)
+	setAcceptanceAttempted(run)
+	adapter := &scriptedAdapter{}
+	r := reconciler(t, adapter, run, env)
+	metrics, _ := testOperatorMetrics(t)
+	r.Metrics = metrics
+	var live platformv1alpha1.Environment
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(env), &live); err != nil {
+		t.Fatal(err)
+	}
+	live.OwnerReferences = nil
+	live.Status.ExecutionGeneration++
+	r.APIReader = fake.NewClientBuilder().WithScheme(r.Scheme).WithObjects(&live).Build()
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)})
+	if err != nil || !result.Requeue || adapter.accepted != 0 {
+		t.Fatalf("association failure = (%#v, %v), adapter calls %d", result, err, adapter.accepted)
+	}
+	for _, component := range fenceComponents {
+		if got := testutil.ToFloat64(metrics.executionFenceRejections.WithLabelValues(component, fenceCallSiteEnsureAccepted)); got != 0 {
+			t.Fatalf("association failure counted as %s fence rejection: %v", component, got)
+		}
+	}
+}
+
+func TestOperatorMetricsCountRecoveryTransitionsOnce(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	due := metav1.NewTime(now.Add(-time.Second))
+	pending := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "pending", Namespace: "ns", UID: "pending-uid"}, Status: platformv1alpha1.EnvironmentStatus{PodRecoveryUID: "dead", PodRecoveryNextAttemptAt: &due}}
+	exhausted := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "exhausted", Namespace: "ns", UID: "exhausted-uid"}, Status: platformv1alpha1.EnvironmentStatus{PodRecoveryAttempts: podRecoveryLimit, PodRecoveryUID: "previous"}}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "env-exhausted", Namespace: "ns", UID: "terminal"}, Status: corev1.PodStatus{Phase: corev1.PodFailed}}
+	metrics, _ := testOperatorMetrics(t)
+	r := &EnvironmentReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(pending, exhausted).WithObjects(pending, exhausted).Build(),
+		Now:    func() time.Time { return now }, Metrics: metrics,
+	}
+	var currentPending platformv1alpha1.Environment
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(pending), &currentPending); err != nil {
+		t.Fatal(err)
+	}
+	if _, handled, err := r.reconcilePendingPodRecovery(context.Background(), &currentPending); err != nil || !handled {
+		t.Fatalf("recovery attempt = handled %t, error %v", handled, err)
+	}
+	if _, err := r.reconcileTerminalPod(context.Background(), exhausted, pod); err != nil {
+		t.Fatal(err)
+	}
+	var current platformv1alpha1.Environment
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(exhausted), &current); err != nil {
+		t.Fatal(err)
+	}
+	if _, handled, err := r.reconcilePendingPodRecovery(context.Background(), &current); err != nil || !handled {
+		t.Fatalf("latched exhaustion = handled %t, error %v", handled, err)
+	}
+	if got := testutil.ToFloat64(metrics.podRecoveryTransitions.WithLabelValues("attempt")); got != 1 {
+		t.Fatalf("recovery attempts = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(metrics.podRecoveryTransitions.WithLabelValues("exhausted")); got != 1 {
+		t.Fatalf("recovery exhaustion = %v, want 1", got)
+	}
+}
+
+func TestOperatorMetricsCountLifecycleTransitionsOnce(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	env := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "held", Namespace: "ns", UID: "env-uid"},
+		Spec: platformv1alpha1.EnvironmentSpec{Lifecycle: platformv1alpha1.EnvironmentLifecycleSpec{
+			Hold: &platformv1alpha1.EnvironmentHoldPolicy{Enabled: true, Revision: 1},
+		}},
+		Status: platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhasePaused},
+	}
+	metrics, _ := testOperatorMetrics(t)
+	r := &EnvironmentReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env).Build(), Metrics: metrics}
+	changed, err := r.reconcileLifecycleIntent(context.Background(), env)
+	if err != nil || !changed {
+		t.Fatalf("suspend = (%t, %v)", changed, err)
+	}
+	var current platformv1alpha1.Environment
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(env), &current); err != nil {
+		t.Fatal(err)
+	}
+	if changed, err := r.reconcileLifecycleIntent(context.Background(), &current); err != nil || changed {
+		t.Fatalf("reobserved suspend = (%t, %v)", changed, err)
+	}
+	current.Spec.Lifecycle.Hold = &platformv1alpha1.EnvironmentHoldPolicy{Revision: 2}
+	if err := r.Update(context.Background(), &current); err != nil {
+		t.Fatal(err)
+	}
+	if changed, err := r.reconcileLifecycleIntent(context.Background(), &current); err != nil || !changed {
+		t.Fatalf("resume = (%t, %v)", changed, err)
+	}
+	if got := testutil.ToFloat64(metrics.lifecycleTransitions.WithLabelValues("suspend", string(platformv1alpha1.EnvironmentSuspensionReasonHold))); got != 1 {
+		t.Fatalf("suspensions = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(metrics.lifecycleTransitions.WithLabelValues("resume", string(platformv1alpha1.EnvironmentSuspensionReasonHold))); got != 1 {
+		t.Fatalf("resumes = %v, want 1", got)
+	}
+}
+
+func TestOperatorMetricsHaveFixedCardinalityAndNoIdentityLabels(t *testing.T) {
+	metrics, registry := testOperatorMetrics(t)
+	metrics.observeAdapter("namespace/run/user@example.com", adapterOperationObserve, time.Now(), nil)
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(families) != 7 {
+		t.Fatalf("metric family count = %d, want 7", len(families))
+	}
+	allowedLabels := map[string]map[string]bool{
+		"path":       {allocationOwnedCreate: true, allocationWarmClaim: true},
+		"outcome":    {"hit": true, "miss": true, adapterOutcomeSuccess: true, adapterOutcomePending: true, adapterOutcomeRejected: true, adapterOutcomeError: true},
+		"component":  {"environment_uid": true, "execution_generation": true, "lifecycle_epoch": true, "hold_revision": true},
+		"call_site":  {fenceCallSiteEnsureAccepted: true, fenceCallSiteObserve: true, fenceCallSiteRunCancel: true, fenceCallSiteTerminalCleanup: true, fenceCallSiteFinalizerCleanup: true},
+		"adapter":    {"test": true},
+		"operation":  {adapterOperationEnsureAccepted: true, adapterOperationObserve: true, adapterOperationCancel: true},
+		"transition": {"attempt": true, "exhausted": true, "suspend": true, "resume": true},
+		"reason":     {string(platformv1alpha1.EnvironmentSuspensionReasonHold): true, string(platformv1alpha1.EnvironmentSuspensionReasonIdle): true, string(platformv1alpha1.EnvironmentSuspensionReasonRequested): true},
+	}
+	for _, family := range families {
+		if !strings.HasPrefix(family.GetName(), operatorMetricsNamespace+"_") {
+			t.Fatalf("unexpected metric family %q", family.GetName())
+		}
+		for _, metric := range family.Metric {
+			for _, label := range metric.Label {
+				values, ok := allowedLabels[label.GetName()]
+				if !ok {
+					t.Fatalf("unbounded label name %q on %s", label.GetName(), family.GetName())
+				}
+				if !values[label.GetValue()] {
+					t.Fatalf("unbounded label value %s=%q on %s", label.GetName(), label.GetValue(), family.GetName())
+				}
+			}
+		}
+	}
+	if got := testutil.ToFloat64(metrics.adapterOperations.WithLabelValues("test", adapterOperationObserve, adapterOutcomeSuccess)); got != 0 {
+		t.Fatalf("unregistered adapter changed registered series: %v", got)
+	}
+}
+
+func histogramSampleCount(t *testing.T, observer prometheus.Observer) uint64 {
+	t.Helper()
+	metric, ok := observer.(prometheus.Metric)
+	if !ok {
+		t.Fatal("observer does not implement prometheus.Metric")
+	}
+	dtoMetric := &dto.Metric{}
+	if err := metric.Write(dtoMetric); err != nil {
+		t.Fatal(err)
+	}
+	return dtoMetric.GetHistogram().GetSampleCount()
+}
+
+func setAcceptanceAttempted(run *platformv1alpha1.Run) {
+	apiMeta.SetStatusCondition(&run.Status.Conditions, metav1.Condition{Type: runConditionAdapterAcceptanceAttempted, Status: metav1.ConditionTrue, Reason: "AcceptancePending"})
+}
+
+func setAdapterAccepted(run *platformv1alpha1.Run) {
+	apiMeta.SetStatusCondition(&run.Status.Conditions, metav1.Condition{Type: runConditionAdapterAccepted, Status: metav1.ConditionTrue, Reason: "AdapterAccepted"})
+}

--- a/internal/controllers/operator_metrics_test.go
+++ b/internal/controllers/operator_metrics_test.go
@@ -111,6 +111,9 @@ func TestOperatorMetricsObserveAdapterOutcomesOnCalls(t *testing.T) {
 		{name: "observe error", state: platformv1alpha1.RunStateRunning, operation: adapterOperationObserve, outcome: adapterOutcomeError, configure: func(_ *platformv1alpha1.Run, adapter *scriptedAdapter) {
 			adapter.observeErr = errors.New("rpc unavailable")
 		}},
+		{name: "invalid observation", state: platformv1alpha1.RunStateRunning, operation: adapterOperationObserve, outcome: adapterOutcomeError, configure: func(_ *platformv1alpha1.Run, adapter *scriptedAdapter) {
+			adapter.observations = []AdapterObservation{"Unknown"}
+		}},
 		{name: "cancel pending", state: platformv1alpha1.RunStateRunning, operation: adapterOperationCancel, outcome: adapterOutcomePending, configure: func(run *platformv1alpha1.Run, adapter *scriptedAdapter) {
 			run.Spec.Cancel = true
 			adapter.cancelErr = ErrAdapterCancellationPending

--- a/internal/controllers/run_controller.go
+++ b/internal/controllers/run_controller.go
@@ -140,6 +140,7 @@ type RunReconciler struct {
 	Adapters  map[string]AdapterLifecycle
 	EventSink AdapterEventSink
 	Connector sandboxclient.Connector
+	Metrics   *OperatorMetrics
 }
 
 // +kubebuilder:rbac:groups=swe.dev,resources=runs,verbs=get;list;watch;update;patch
@@ -232,12 +233,14 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	}
 
 	if run.Status.EnvironmentRef == nil {
+		allocatedNow := false
 		ref, err := r.recoverEnvironmentReference(ctx, &run)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 		if ref == nil {
 			ref, err = r.allocateEnvironment(ctx, &run)
+			allocatedNow = ref != nil && err == nil
 		} else if ref.Ownership == platformv1alpha1.EnvironmentOwnershipClaimed {
 			var recovered platformv1alpha1.Environment
 			if getErr := r.Get(ctx, types.NamespacedName{Namespace: run.Namespace, Name: ref.Name}, &recovered); getErr != nil {
@@ -260,6 +263,7 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		}
 		if ref == nil && err == nil {
 			ref, err = r.allocateEnvironment(ctx, &run)
+			allocatedNow = ref != nil && err == nil
 		}
 		if err != nil {
 			if errors.Is(err, errExplicitEnvironmentClaimed) || errors.Is(err, errExplicitEnvironmentHeld) || errors.Is(err, errExplicitEnvironmentSuspensionNotWakeable) {
@@ -268,7 +272,17 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			return ctrl.Result{}, err
 		}
 		run.Status.EnvironmentRef = ref
-		return ctrl.Result{Requeue: true}, r.setRunState(ctx, &run, platformv1alpha1.RunStateAllocating, "EnvironmentAllocated", fmt.Sprintf("environment %s allocated", ref.Name), false)
+		if err := r.setRunState(ctx, &run, platformv1alpha1.RunStateAllocating, "EnvironmentAllocated", fmt.Sprintf("environment %s allocated", ref.Name), false); err != nil {
+			return ctrl.Result{Requeue: true}, err
+		}
+		if allocatedNow && run.Spec.EnvironmentRef == "" {
+			path := allocationOwnedCreate
+			if ref.Ownership == platformv1alpha1.EnvironmentOwnershipClaimed {
+				path = allocationWarmClaim
+			}
+			r.Metrics.observeAllocation(run.CreationTimestamp.Time, path)
+		}
+		return ctrl.Result{Requeue: true}, nil
 	}
 
 	env, err := r.getAllocatedEnvironment(ctx, &run)
@@ -284,7 +298,8 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			if !environmentReachable(env) || adapter == nil {
 				return r.requestEnvironmentFence(ctx, env)
 			}
-			execution, current, err := r.resolveAllocatedExecution(ctx, &run, env)
+			fenceRejections := &fenceRejectionRecorder{metrics: r.Metrics, callSite: fenceCallSiteRunCancel}
+			execution, current, err := r.resolveAllocatedExecution(ctx, &run, env, fenceRejections)
 			if err != nil {
 				return ctrl.Result{}, err
 			}
@@ -292,13 +307,16 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 				return ctrl.Result{Requeue: true}, nil
 			}
 			executionFence := lifecycle.CaptureExecutionFence(env)
-			if err := adapter.Cancel(ctx, adapterTask(&run), r.adapterSandbox(&run, env, executionFence)); err != nil {
-				if errors.Is(err, ErrAdapterCancellationPending) {
+			started := time.Now()
+			cancelErr := adapter.Cancel(ctx, adapterTask(&run), r.adapterSandbox(&run, env, executionFence, fenceRejections))
+			r.Metrics.observeAdapter(run.Spec.Agent, adapterOperationCancel, started, cancelErr)
+			if cancelErr != nil {
+				if errors.Is(cancelErr, ErrAdapterCancellationPending) {
 					return ctrl.Result{RequeueAfter: adapterPollInterval}, nil
 				}
-				return ctrl.Result{}, err
+				return ctrl.Result{}, cancelErr
 			}
-			current, err = r.allocatedExecutionCurrent(ctx, &run, env, execution)
+			current, err = r.allocatedExecutionCurrent(ctx, &run, env, execution, fenceRejections)
 			if err != nil {
 				return ctrl.Result{}, err
 			}
@@ -366,15 +384,18 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			defer clear(credential.APIKey)
 		}
 		executionFence := lifecycle.CaptureExecutionFence(env)
-		execution, current, err := r.resolveAllocatedExecution(ctx, &run, env)
+		fenceRejections := &fenceRejectionRecorder{metrics: r.Metrics, callSite: fenceCallSiteEnsureAccepted}
+		execution, current, err := r.resolveAllocatedExecution(ctx, &run, env, fenceRejections)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
 		if !current {
 			return ctrl.Result{Requeue: true}, nil
 		}
-		acceptErr := adapter.EnsureAccepted(ctx, adapterTask(&run), r.adapterSandbox(&run, env, executionFence), credential)
-		current, err = r.allocatedExecutionCurrent(ctx, &run, env, execution)
+		started := time.Now()
+		acceptErr := adapter.EnsureAccepted(ctx, adapterTask(&run), r.adapterSandbox(&run, env, executionFence, fenceRejections), credential)
+		r.Metrics.observeAdapter(run.Spec.Agent, adapterOperationEnsureAccepted, started, acceptErr)
+		current, err = r.allocatedExecutionCurrent(ctx, &run, env, execution, fenceRejections)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -394,7 +415,8 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{Requeue: true}, r.setRunState(ctx, &run, platformv1alpha1.RunStateAdapterAccepted, "AdapterAccepted", "adapter accepted the task", true)
 	}
 
-	execution, current, err := r.resolveAllocatedExecution(ctx, &run, env)
+	fenceRejections := &fenceRejectionRecorder{metrics: r.Metrics, callSite: fenceCallSiteObserve}
+	execution, current, err := r.resolveAllocatedExecution(ctx, &run, env, fenceRejections)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -402,11 +424,13 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{Requeue: true}, nil
 	}
 	executionFence := lifecycle.CaptureExecutionFence(env)
-	observation, message, err := adapter.Observe(ctx, adapterTask(&run), r.adapterSandbox(&run, env, executionFence))
+	started := time.Now()
+	observation, message, err := adapter.Observe(ctx, adapterTask(&run), r.adapterSandbox(&run, env, executionFence, fenceRejections))
+	r.Metrics.observeAdapter(run.Spec.Agent, adapterOperationObserve, started, err)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	current, err = r.allocatedExecutionCurrent(ctx, &run, env, execution)
+	current, err = r.allocatedExecutionCurrent(ctx, &run, env, execution, fenceRejections)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -676,7 +700,10 @@ func getAllocatedEnvironment(ctx context.Context, reader client.Reader, run *pla
 		return nil, err
 	}
 	if env.UID != ref.UID {
-		return nil, fmt.Errorf("%w: environment %q was replaced (wanted UID %s, got %s)", errAllocatedEnvironmentGone, env.Name, ref.UID, env.UID)
+		// Preserve the exact replacement object for execution-fence metric
+		// classification. Other association failures below return no object:
+		// they are not tuple mismatches and must not be counted as fence changes.
+		return &env, fmt.Errorf("%w: environment %q was replaced (wanted UID %s, got %s)", errAllocatedEnvironmentGone, env.Name, ref.UID, env.UID)
 	}
 	switch ref.Ownership {
 	case platformv1alpha1.EnvironmentOwnershipOwned:
@@ -1010,7 +1037,8 @@ func (r *RunReconciler) cleanupTerminal(ctx context.Context, run *platformv1alph
 		if !environmentReachable(env) || adapter == nil {
 			return r.requestEnvironmentFence(ctx, env)
 		}
-		execution, current, err := r.resolveAllocatedExecution(ctx, run, env)
+		fenceRejections := &fenceRejectionRecorder{metrics: r.Metrics, callSite: fenceCallSiteTerminalCleanup}
+		execution, current, err := r.resolveAllocatedExecution(ctx, run, env, fenceRejections)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -1018,13 +1046,16 @@ func (r *RunReconciler) cleanupTerminal(ctx context.Context, run *platformv1alph
 			return ctrl.Result{Requeue: true}, nil
 		}
 		executionFence := lifecycle.CaptureExecutionFence(env)
-		if err := adapter.Cancel(ctx, adapterTask(run), r.adapterSandbox(run, env, executionFence)); err != nil {
-			if errors.Is(err, ErrAdapterCancellationPending) {
+		started := time.Now()
+		cancelErr := adapter.Cancel(ctx, adapterTask(run), r.adapterSandbox(run, env, executionFence, fenceRejections))
+		r.Metrics.observeAdapter(run.Spec.Agent, adapterOperationCancel, started, cancelErr)
+		if cancelErr != nil {
+			if errors.Is(cancelErr, ErrAdapterCancellationPending) {
 				return ctrl.Result{RequeueAfter: adapterPollInterval}, nil
 			}
-			return ctrl.Result{}, err
+			return ctrl.Result{}, cancelErr
 		}
-		current, err = r.allocatedExecutionCurrent(ctx, run, env, execution)
+		current, err = r.allocatedExecutionCurrent(ctx, run, env, execution, fenceRejections)
 		if err != nil {
 			return ctrl.Result{}, err
 		}
@@ -1090,7 +1121,8 @@ func (r *RunReconciler) finalize(ctx context.Context, run *platformv1alpha1.Run)
 				if !environmentReachable(env) || adapter == nil {
 					return r.requestEnvironmentFence(ctx, env)
 				}
-				execution, current, resolveErr := r.resolveAllocatedExecution(ctx, run, env)
+				fenceRejections := &fenceRejectionRecorder{metrics: r.Metrics, callSite: fenceCallSiteFinalizerCleanup}
+				execution, current, resolveErr := r.resolveAllocatedExecution(ctx, run, env, fenceRejections)
 				if resolveErr != nil {
 					return ctrl.Result{}, resolveErr
 				}
@@ -1098,13 +1130,16 @@ func (r *RunReconciler) finalize(ctx context.Context, run *platformv1alpha1.Run)
 					return ctrl.Result{Requeue: true}, nil
 				}
 				executionFence := lifecycle.CaptureExecutionFence(env)
-				if err := adapter.Cancel(ctx, adapterTask(run), r.adapterSandbox(run, env, executionFence)); err != nil {
-					if errors.Is(err, ErrAdapterCancellationPending) {
+				started := time.Now()
+				cancelErr := adapter.Cancel(ctx, adapterTask(run), r.adapterSandbox(run, env, executionFence, fenceRejections))
+				r.Metrics.observeAdapter(run.Spec.Agent, adapterOperationCancel, started, cancelErr)
+				if cancelErr != nil {
+					if errors.Is(cancelErr, ErrAdapterCancellationPending) {
 						return ctrl.Result{RequeueAfter: adapterPollInterval}, nil
 					}
-					return ctrl.Result{}, err
+					return ctrl.Result{}, cancelErr
 				}
-				current, resolveErr = r.allocatedExecutionCurrent(ctx, run, env, execution)
+				current, resolveErr = r.allocatedExecutionCurrent(ctx, run, env, execution, fenceRejections)
 				if resolveErr != nil {
 					return ctrl.Result{}, resolveErr
 				}
@@ -1189,7 +1224,7 @@ func adapterTask(run *platformv1alpha1.Run) AdapterTask {
 	return AdapterTask{ID: string(run.UID), Prompt: run.Spec.Prompt}
 }
 
-func (r *RunReconciler) adapterSandbox(run *platformv1alpha1.Run, env *platformv1alpha1.Environment, fence lifecycle.ExecutionFence) AdapterSandbox {
+func (r *RunReconciler) adapterSandbox(run *platformv1alpha1.Run, env *platformv1alpha1.Environment, fence lifecycle.ExecutionFence, fenceRejections *fenceRejectionRecorder) AdapterSandbox {
 	sandbox := AdapterSandbox{EnvironmentName: env.Name, EnvironmentUID: env.UID,
 		DialProcess: func(ctx context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
 			reader := r.apiReader()
@@ -1199,12 +1234,18 @@ func (r *RunReconciler) adapterSandbox(run *platformv1alpha1.Run, env *platformv
 			// complete fence before leasing a pooled physical connection.
 			current, err := getAllocatedEnvironment(ctx, reader, run)
 			if err != nil {
+				if current != nil {
+					fenceRejections.observe(fence.Validate(current))
+				}
 				return nil, nil, err
 			}
 			if err := fence.Validate(current); err != nil {
+				fenceRejections.observe(err)
 				return nil, nil, err
 			}
-			return r.connector().DialProcess(ctx, fence)
+			process, closeProcess, err := r.connector().DialProcess(ctx, fence)
+			fenceRejections.observe(err)
+			return process, closeProcess, err
 		}}
 	if r.EventSink != nil {
 		runUID := string(run.UID)
@@ -1215,45 +1256,61 @@ func (r *RunReconciler) adapterSandbox(run *platformv1alpha1.Run, env *platformv
 	return sandbox
 }
 
-func (r *RunReconciler) resolveAllocatedExecution(ctx context.Context, run *platformv1alpha1.Run, expected *platformv1alpha1.Environment) (sandboxclient.Execution, bool, error) {
+func (r *RunReconciler) resolveAllocatedExecution(ctx context.Context, run *platformv1alpha1.Run, expected *platformv1alpha1.Environment, fenceRejections *fenceRejectionRecorder) (sandboxclient.Execution, bool, error) {
 	fence := lifecycle.CaptureExecutionFence(expected)
 	// Mandatory uncached pre-call association proof. ResolveExecution then
 	// proves the connector-private exact Pod execution used for the later
 	// post-adapter currentness comparison.
 	current, err := getAllocatedEnvironment(ctx, r.apiReader(), run)
 	if apierrors.IsNotFound(err) || errors.Is(err, errAllocatedEnvironmentGone) {
+		if current != nil {
+			fenceRejections.observe(fence.Validate(current))
+		}
 		return sandboxclient.Execution{}, false, nil
 	}
 	if err != nil {
 		return sandboxclient.Execution{}, false, err
 	}
-	if err := fence.Validate(current); err != nil || !environmentReachable(current) {
+	if err := fence.Validate(current); err != nil {
+		fenceRejections.observe(err)
+		return sandboxclient.Execution{}, false, nil
+	}
+	if !environmentReachable(current) {
 		return sandboxclient.Execution{}, false, nil
 	}
 	execution, err := r.connector().ResolveExecution(ctx, fence)
 	if err != nil {
+		fenceRejections.observe(err)
 		return sandboxclient.Execution{}, false, err
 	}
 	return execution, true, nil
 }
 
-func (r *RunReconciler) allocatedExecutionCurrent(ctx context.Context, run *platformv1alpha1.Run, expected *platformv1alpha1.Environment, execution sandboxclient.Execution) (bool, error) {
+func (r *RunReconciler) allocatedExecutionCurrent(ctx context.Context, run *platformv1alpha1.Run, expected *platformv1alpha1.Environment, execution sandboxclient.Execution, fenceRejections *fenceRejectionRecorder) (bool, error) {
 	fence := lifecycle.CaptureExecutionFence(expected)
 	// Mandatory uncached post-call association proof: adapter results cannot be
 	// published after allocation moved, even when the old execution still
 	// answers. ExecutionCurrent adds the exact live backend proof.
 	current, err := getAllocatedEnvironment(ctx, r.apiReader(), run)
 	if apierrors.IsNotFound(err) || errors.Is(err, errAllocatedEnvironmentGone) {
+		if current != nil {
+			fenceRejections.observe(fence.Validate(current))
+		}
 		return false, nil
 	}
 	if err != nil {
 		return false, err
 	}
-	if err := fence.Validate(current); err != nil || !environmentReachable(current) {
+	if err := fence.Validate(current); err != nil {
+		fenceRejections.observe(err)
+		return false, nil
+	}
+	if !environmentReachable(current) {
 		return false, nil
 	}
 	currentExecution, err := r.connector().ExecutionCurrent(ctx, fence, execution)
 	if errors.Is(err, lifecycle.ErrExecutionFenceChanged) {
+		fenceRejections.observe(err)
 		return false, nil
 	}
 	return currentExecution, err

--- a/internal/controllers/run_controller.go
+++ b/internal/controllers/run_controller.go
@@ -426,7 +426,15 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	executionFence := lifecycle.CaptureExecutionFence(env)
 	started := time.Now()
 	observation, message, err := adapter.Observe(ctx, adapterTask(&run), r.adapterSandbox(&run, env, executionFence, fenceRejections))
-	r.Metrics.observeAdapter(run.Spec.Agent, adapterOperationObserve, started, err)
+	metricErr := err
+	if metricErr == nil {
+		switch observation {
+		case AdapterObservationAccepted, AdapterObservationRunning, AdapterObservationNeedsInput, AdapterObservationSucceeded, AdapterObservationFailed:
+		default:
+			metricErr = fmt.Errorf("adapter %q returned unknown observation %q", run.Spec.Agent, observation)
+		}
+	}
+	r.Metrics.observeAdapter(run.Spec.Agent, adapterOperationObserve, started, metricErr)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -449,7 +457,7 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	case AdapterObservationFailed:
 		state = platformv1alpha1.RunStateFailed
 	default:
-		return ctrl.Result{}, fmt.Errorf("adapter %q returned unknown observation %q", run.Spec.Agent, observation)
+		return ctrl.Result{}, metricErr
 	}
 	err = r.setRunState(ctx, &run, state, string(observation), message, true)
 	if err != nil || terminalRunState(state) {

--- a/internal/controllers/run_controller_test.go
+++ b/internal/controllers/run_controller_test.go
@@ -32,6 +32,7 @@ type scriptedAdapter struct {
 	accepted, observed    int
 	cancelled             int
 	acceptErr             error
+	observeErr            error
 	onAccept              func()
 	onCancel              func()
 	cancelErr             error
@@ -132,6 +133,9 @@ func (a *scriptedAdapter) Cancel(context.Context, AdapterTask, AdapterSandbox) e
 }
 func (a *scriptedAdapter) Observe(context.Context, AdapterTask, AdapterSandbox) (AdapterObservation, string, error) {
 	a.observed++
+	if a.observeErr != nil {
+		return "", "", a.observeErr
+	}
 	o := a.observations[0]
 	if len(a.observations) > 1 {
 		a.observations = a.observations[1:]
@@ -2825,7 +2829,7 @@ func TestAdapterSandboxEmitEventSendsExactRunUID(t *testing.T) {
 		return nil
 	})
 	r := &RunReconciler{EventSink: sink}
-	sandbox := r.adapterSandbox(run, env, lifecycle.CaptureExecutionFence(env))
+	sandbox := r.adapterSandbox(run, env, lifecycle.CaptureExecutionFence(env), &fenceRejectionRecorder{callSite: fenceCallSiteEnsureAccepted})
 	if sandbox.EmitEvent == nil {
 		t.Fatal("EmitEvent closure was not wired")
 	}


### PR DESCRIPTION
## Stack dependency and landing order

This non-draft PR is stacked on `feat/control-plane-observability-146` at exact base SHA `f520e505fe7a47d4d0608a0adaab7cd4fb43baeb`.

Landing order:
1. land the base branch / control-plane observability PR first;
2. then land this operator observability PR without rebasing or rewriting its current history.

PR #157 independently changes service observation and controller predicates on top of #155. This branch does not merge or copy #157. Expected later overlap is limited to normal reconciliation around `RunReconciler` / `EnvironmentReconciler` edits.

## What changed

- Register bounded-cardinality `swe_operator_*` collectors in controller-runtime's existing registry and metrics listener.
- Observe durable Run allocation publication latency by `owned_create` / `warm_claim`, plus explicit warm-pool `hit` / `miss` counters.
- Count opaque ExecutionFence rejection decisions by tuple member name and a closed operator call-site enum, with call-scoped deduplication across adapter dial and post-call proof.
- Time actual registered-adapter `ensure_accepted`, `observe`, and `cancel` calls with `success`, `pending`, `rejected`, and `error` outcomes while preserving controller classifications.
- Count pod recovery attempt / exhaustion and Environment suspend / resume transitions only after successful controller-owned status writes.
- Add an internal operator metrics Service backed by one validated `operator.metrics.port`; no ServiceMonitor or Prometheus-operator dependency.
- Document the exact metric contract and healthy / investigate guidance.

## Allocation limitation

The durable contract does not retain an exact warm-claim timestamp through the later readiness transition: `LastActiveAt` is updated again when readiness is republished. This PR therefore does not fabricate claim-to-ready latency or add a status field solely for metrics. Allocation latency runs from durable Run creation to successful `EnvironmentAllocated` status publication. Recovered allocations are not observed again, preventing duplicate reconcile/restart samples while allowing a process-local omission after an uncertain prior status response.

## Validation

- `go test -race ./internal/controllers ./internal/lifecycle`
- `make test`
- `make vet`
- `make build`
- base chart plus `kind`, `argocd`, `k3s`, `gke`, and `eks` Helm lint/render checks
- invalid operator metrics / health port collision render check
- `git diff --check`

Closes the remaining operator-side operational-observability slice of #146. Does not merge the PR.
