### PR TITLE
Pool sandboxd process connections across adapter polls

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -281,12 +281,13 @@ a universal platform completion rule. The operator owns one concurrency-safe Pro
 connection pool and injects its connector into Run and service-observation controllers. The pool
 keys physical gRPC/TLS connections by exact `(Environment UID, execution generation)`, retains
 only the process capability, and treats adapter close callbacks as leases. Before every reuse it
-uncached-revalidates the complete execution fence, reachability, and its connector-private
-Pod-name/endpoint receipt; pause, deletion, hold or lifecycle drift, generation changes, and
-unreachable or replaced endpoints evict the entry. A miss resolves and post-resolves the exact
-Template/backend, owned Pod UID/endpoint, credential Secret UID/resourceVersion, TLS identity,
-and process token without exposing those details. Idle entries close after 30 seconds, active
-borrowers delay invalidation close until release, and manager shutdown closes all entries.
+uncached-revalidates the complete execution fence, exact Template/backend, owned Pod
+UID/endpoint, and credential Secret UID/resourceVersion, TLS identity, and process token;
+pause, deletion, hold or lifecycle drift, generation changes, credential drift, and unreachable
+or replaced backends evict the entry. A miss reuses that pre-resolved target and post-resolves the
+same complete proof after dialing without exposing those details. Idle entries close after 30
+seconds, active borrowers delay invalidation close until release, and manager shutdown closes all
+entries.
 Interactive terminal connections and the separately capability-scoped service-observation RPC
 are not pooled.
 
@@ -295,12 +296,12 @@ Run/Environment association before the call, the pool proves the complete fence 
 lease, and the controller repeats exact association plus backend-execution currentness after the
 call. Cached reads are not accepted for these authorization/currentness boundaries. In the stable
 one-minute-equivalent contract (30 polls at the fixed two-second cadence), reuse reduces physical
-connection creations from 30 to 1 and process-connector Kubernetes reads from 150 to 37. Across
+connection creations from 30 to 1 and process-connector Kubernetes reads from 150 to 124. Across
 the complete adapter call path, including unchanged mandatory association and execution-receipt
-proofs, the recorded read contract moves from 390 to 277 reads (29.0% fewer): the
-first complete miss costs two reads each of Environment, Template, Pod, and Secret, while each
-hit costs one Environment fence read. This is deterministic contract evidence, not an end-to-end
-API-server load benchmark.
+proofs, the recorded read contract moves from 390 to 364 reads (6.7% fewer): the
+first complete miss costs two reads each of Environment, Template, Pod, and Secret, while every
+hit costs one read of each object to preserve complete backend and credential currentness. This
+is deterministic contract evidence, not an end-to-end API-server load benchmark.
 
 Transcript transport is fenced by namespace name, immutable Namespace UID, Run name, and
 immutable Run UID. It supplies

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -277,7 +277,30 @@ The registered `claude-code` (default), `amp`, `codex`, and `pi` adapters each r
 CLI through sandboxd's keyed managed-process service. Starts are duplicate-safe within one
 sandboxd daemon epoch, and bounded output includes absolute offsets and observable gaps.
 Adapters map their own completion protocol to normalized Run state. Process exit alone is not
-a universal platform completion rule.
+a universal platform completion rule. The operator owns one concurrency-safe ProcessService
+connection pool and injects its connector into Run and service-observation controllers. The pool
+keys physical gRPC/TLS connections by exact `(Environment UID, execution generation)`, retains
+only the process capability, and treats adapter close callbacks as leases. Before every reuse it
+uncached-revalidates the complete execution fence, reachability, and its connector-private
+Pod-name/endpoint receipt; pause, deletion, hold or lifecycle drift, generation changes, and
+unreachable or replaced endpoints evict the entry. A miss resolves and post-resolves the exact
+Template/backend, owned Pod UID/endpoint, credential Secret UID/resourceVersion, TLS identity,
+and process token without exposing those details. Idle entries close after 30 seconds, active
+borrowers delay invalidation close until release, and manager shutdown closes all entries.
+Interactive terminal connections and the separately capability-scoped service-observation RPC
+are not pooled.
+
+Uncached reads around an adapter call remain deliberate: the Run controller proves the exact
+Run/Environment association before the call, the pool proves the complete fence before every
+lease, and the controller repeats exact association plus backend-execution currentness after the
+call. Cached reads are not accepted for these authorization/currentness boundaries. In the stable
+one-minute-equivalent contract (30 polls at the fixed two-second cadence), reuse reduces physical
+connection creations from 30 to 1 and process-connector Kubernetes reads from 150 to 37. Across
+the complete adapter call path, including unchanged mandatory association and execution-receipt
+proofs, the recorded read contract moves from 390 to 277 reads (29.0% fewer): the
+first complete miss costs two reads each of Environment, Template, Pod, and Secret, while each
+hit costs one Environment fence read. This is deterministic contract evidence, not an end-to-end
+API-server load benchmark.
 
 Transcript transport is fenced by namespace name, immutable Namespace UID, Run name, and
 immutable Run UID. It supplies

--- a/charts/swe-platform/README.md
+++ b/charts/swe-platform/README.md
@@ -467,6 +467,27 @@ and networking requirements that a BYOC operator needs beyond the [install](#ins
 [#79](https://github.com/Chris-Cullins/swe-platform/issues/79); the hosted offering alpha is
 out of scope here and requires separate maintainer product input.
 
+### Active Run capacity
+
+Use **50 concurrently active, non-terminal Runs per elected operator leader** as the conservative
+planning envelope for this release, not as an admission limit or a demonstrated maximum. Validate
+larger installations against their Kubernetes API-server latency, sandboxd RPC duration, and
+transcript backend before raising that envelope. Standby operator replicas do not add Run
+throughput because only the leader reconciles.
+
+Adapter observation still uses a fixed two-second requeue, so 50 continuously active Runs imply a
+nominal 25 adapter polls per second before event-driven reconciles and retries. ProcessService
+connections are reused by exact Environment UID/execution generation and idle-close after 30
+seconds; deterministic one-minute-equivalent tests reduce process-connector reads from 150 to 37,
+complete adapter-path reads from 390 to 277, and physical connection creations from 30 to 1 per
+continuously polled Run. Each poll intentionally
+retains uncached pre-call Run association, complete execution-fence lease, and post-call exact
+association/backend currentness reads. Pooling therefore removes TLS-redial and most connector
+resolution amplification but does **not** remove API-server work, guarantee every Run is observed
+exactly every two seconds under queueing, or make the in-process polling design horizontally
+scalable. Capacity above this planning envelope needs measured validation; replacing polling or
+extracting adapters is separate work.
+
 ### Provider prerequisites
 
 Each production preset assumes out-of-band `swe-platform-postgres` and

--- a/charts/swe-platform/README.md
+++ b/charts/swe-platform/README.md
@@ -478,15 +478,15 @@ throughput because only the leader reconciles.
 Adapter observation still uses a fixed two-second requeue, so 50 continuously active Runs imply a
 nominal 25 adapter polls per second before event-driven reconciles and retries. ProcessService
 connections are reused by exact Environment UID/execution generation and idle-close after 30
-seconds; deterministic one-minute-equivalent tests reduce process-connector reads from 150 to 37,
-complete adapter-path reads from 390 to 277, and physical connection creations from 30 to 1 per
+seconds; deterministic one-minute-equivalent tests reduce process-connector reads from 150 to 124,
+complete adapter-path reads from 390 to 364, and physical connection creations from 30 to 1 per
 continuously polled Run. Each poll intentionally
-retains uncached pre-call Run association, complete execution-fence lease, and post-call exact
-association/backend currentness reads. Pooling therefore removes TLS-redial and most connector
-resolution amplification but does **not** remove API-server work, guarantee every Run is observed
-exactly every two seconds under queueing, or make the in-process polling design horizontally
-scalable. Capacity above this planning envelope needs measured validation; replacing polling or
-extracting adapters is separate work.
+retains uncached pre-call Run association, complete execution/Template/Pod/credential lease, and
+post-call exact association/backend currentness reads. Pooling therefore removes TLS-redial and
+some connector resolution amplification but does **not** remove API-server work, guarantee every
+Run is observed exactly every two seconds under queueing, or make the in-process polling design
+horizontally scalable. Capacity above this planning envelope needs measured validation;
+replacing polling or extracting adapters is separate work.
 
 ### Provider prerequisites
 

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Chris-Cullins/swe-platform/internal/adapters/codex"
 	"github.com/Chris-Cullins/swe-platform/internal/adapters/pi"
 	"github.com/Chris-Cullins/swe-platform/internal/controllers"
+	"github.com/Chris-Cullins/swe-platform/internal/sandboxclient"
 	"github.com/Chris-Cullins/swe-platform/internal/tenancy"
 	"github.com/Chris-Cullins/swe-platform/internal/transcriptclient"
 )
@@ -143,6 +144,12 @@ func main() {
 	verifier.Reader = mgr.GetAPIReader()
 	scope := &tenancy.ReconcileScope{Verifier: verifier}
 	guardedClient := tenancy.GuardedClient{Client: mgr.GetClient(), Verifier: verifier}
+	processConnections := sandboxclient.NewProcessConnectionPool(mgr.GetAPIReader())
+	if err := mgr.Add(processConnections); err != nil {
+		setupLog.Error(err, "unable to register sandboxd process connection pool")
+		os.Exit(1)
+	}
+	connector := sandboxclient.Connector{Reader: mgr.GetAPIReader(), ProcessPool: processConnections}
 	if mode == tenancy.ModeScoped && len(tenancyNamespaces) == 0 {
 		setupLog.Info("scoped installation has no configured Project namespaces; catalog is ready for onboarding and workload controllers are disabled")
 	} else if err := (&controllers.EnvironmentReconciler{
@@ -158,7 +165,7 @@ func main() {
 		os.Exit(1)
 	}
 	if !(mode == tenancy.ModeScoped && len(tenancyNamespaces) == 0) {
-		if err := (&controllers.ServiceObservationReconciler{Client: guardedClient, APIReader: mgr.GetAPIReader(), Scope: scope}).SetupWithManager(mgr); err != nil {
+		if err := (&controllers.ServiceObservationReconciler{Client: guardedClient, APIReader: mgr.GetAPIReader(), Scope: scope, Observer: connector}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "ServiceObservation")
 			os.Exit(1)
 		}
@@ -182,6 +189,7 @@ func main() {
 			Scope:     scope,
 			Adapters:  registeredAdapters(),
 			EventSink: eventSink,
+			Connector: connector,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "Run")
 			os.Exit(1)

--- a/internal/controllers/run_controller.go
+++ b/internal/controllers/run_controller.go
@@ -139,6 +139,7 @@ type RunReconciler struct {
 	Scope     *tenancy.ReconcileScope
 	Adapters  map[string]AdapterLifecycle
 	EventSink AdapterEventSink
+	Connector sandboxclient.Connector
 }
 
 // +kubebuilder:rbac:groups=swe.dev,resources=runs,verbs=get;list;watch;update;patch
@@ -1192,6 +1193,10 @@ func (r *RunReconciler) adapterSandbox(run *platformv1alpha1.Run, env *platformv
 	sandbox := AdapterSandbox{EnvironmentName: env.Name, EnvironmentUID: env.UID,
 		DialProcess: func(ctx context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
 			reader := r.apiReader()
+			// Mandatory uncached pre-call association proof: a still-current
+			// execution must not accept work after this Run lost its exact owned or
+			// claimed allocation. The connector separately revalidates its opaque
+			// complete fence before leasing a pooled physical connection.
 			current, err := getAllocatedEnvironment(ctx, reader, run)
 			if err != nil {
 				return nil, nil, err
@@ -1199,7 +1204,7 @@ func (r *RunReconciler) adapterSandbox(run *platformv1alpha1.Run, env *platformv
 			if err := fence.Validate(current); err != nil {
 				return nil, nil, err
 			}
-			return (sandboxclient.Connector{Reader: reader}).DialProcess(ctx, fence)
+			return r.connector().DialProcess(ctx, fence)
 		}}
 	if r.EventSink != nil {
 		runUID := string(run.UID)
@@ -1212,6 +1217,9 @@ func (r *RunReconciler) adapterSandbox(run *platformv1alpha1.Run, env *platformv
 
 func (r *RunReconciler) resolveAllocatedExecution(ctx context.Context, run *platformv1alpha1.Run, expected *platformv1alpha1.Environment) (sandboxclient.Execution, bool, error) {
 	fence := lifecycle.CaptureExecutionFence(expected)
+	// Mandatory uncached pre-call association proof. ResolveExecution then
+	// proves the connector-private exact Pod execution used for the later
+	// post-adapter currentness comparison.
 	current, err := getAllocatedEnvironment(ctx, r.apiReader(), run)
 	if apierrors.IsNotFound(err) || errors.Is(err, errAllocatedEnvironmentGone) {
 		return sandboxclient.Execution{}, false, nil
@@ -1222,7 +1230,7 @@ func (r *RunReconciler) resolveAllocatedExecution(ctx context.Context, run *plat
 	if err := fence.Validate(current); err != nil || !environmentReachable(current) {
 		return sandboxclient.Execution{}, false, nil
 	}
-	execution, err := (sandboxclient.Connector{Reader: r.apiReader()}).ResolveExecution(ctx, fence)
+	execution, err := r.connector().ResolveExecution(ctx, fence)
 	if err != nil {
 		return sandboxclient.Execution{}, false, err
 	}
@@ -1231,6 +1239,9 @@ func (r *RunReconciler) resolveAllocatedExecution(ctx context.Context, run *plat
 
 func (r *RunReconciler) allocatedExecutionCurrent(ctx context.Context, run *platformv1alpha1.Run, expected *platformv1alpha1.Environment, execution sandboxclient.Execution) (bool, error) {
 	fence := lifecycle.CaptureExecutionFence(expected)
+	// Mandatory uncached post-call association proof: adapter results cannot be
+	// published after allocation moved, even when the old execution still
+	// answers. ExecutionCurrent adds the exact live backend proof.
 	current, err := getAllocatedEnvironment(ctx, r.apiReader(), run)
 	if apierrors.IsNotFound(err) || errors.Is(err, errAllocatedEnvironmentGone) {
 		return false, nil
@@ -1241,11 +1252,18 @@ func (r *RunReconciler) allocatedExecutionCurrent(ctx context.Context, run *plat
 	if err := fence.Validate(current); err != nil || !environmentReachable(current) {
 		return false, nil
 	}
-	currentExecution, err := (sandboxclient.Connector{Reader: r.apiReader()}).ExecutionCurrent(ctx, fence, execution)
+	currentExecution, err := r.connector().ExecutionCurrent(ctx, fence, execution)
 	if errors.Is(err, lifecycle.ErrExecutionFenceChanged) {
 		return false, nil
 	}
 	return currentExecution, err
+}
+
+func (r *RunReconciler) connector() sandboxclient.Connector {
+	if r.Connector.Reader != nil {
+		return r.Connector
+	}
+	return sandboxclient.Connector{Reader: r.apiReader()}
 }
 
 // SetupWithManager registers Run watches. Owned Environments enqueue through

--- a/internal/sandboxclient/process.go
+++ b/internal/sandboxclient/process.go
@@ -2,10 +2,12 @@ package sandboxclient
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"net"
+	"reflect"
 	"strconv"
 
 	"google.golang.org/grpc"
@@ -32,7 +34,8 @@ const executionGenerationAnnotation = "swe.dev/execution-generation"
 // without exposing its transport identity to terminal, exec, filesystem, or
 // process features.
 type Connector struct {
-	Reader client.Reader
+	Reader      client.Reader
+	ProcessPool *ProcessConnectionPool
 }
 
 // Execution is a connector-owned opaque identity for one exact live backend
@@ -130,44 +133,27 @@ func executionForPod(env *platformv1alpha1.Environment, pod *corev1.Pod) Executi
 // DialProcess resolves only the complete captured execution fence and returns
 // a process-only sandboxd client.
 func (c Connector) DialProcess(ctx context.Context, fence lifecycle.ExecutionFence) (sandboxdv1.ProcessServiceClient, func() error, error) {
-	env, pod, err := c.resolvePod(ctx, fence)
+	if c.ProcessPool != nil {
+		return c.ProcessPool.acquire(ctx, fence)
+	}
+	env, secret, proof, err := c.resolveProcessTarget(ctx, fence)
 	if err != nil {
 		return nil, nil, err
 	}
-
-	secretName := pod.Annotations[sandboxdauth.SecretNameAnnotation]
-	if secretName == "" {
-		return nil, nil, fmt.Errorf("sandboxd endpoint does not identify its credential")
-	}
-	var secret corev1.Secret
-	if err := c.Reader.Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: secretName}, &secret); err != nil {
-		return nil, nil, err
-	}
-	identity := pod.Annotations[sandboxdauth.IdentityAnnotation]
-	if identity == "" || secret.UID == "" || pod.Annotations[sandboxdauth.SecretUIDAnnotation] != string(secret.UID) || !exactEnvironmentOwner(&secret, env) || secret.Annotations[sandboxdauth.IdentityAnnotation] != identity || secret.Annotations[sandboxdauth.PodUIDAnnotation] != string(pod.UID) {
-		return nil, nil, fmt.Errorf("sandboxd credential does not identify the current environment pod")
-	}
-	roots := x509.NewCertPool()
-	if !roots.AppendCertsFromPEM(secret.Data[sandboxdauth.TLSCertKey]) {
-		return nil, nil, fmt.Errorf("sandboxd credential has no valid trust certificate")
-	}
-	token := string(secret.Data[sandboxdauth.ProcessTokenKey])
-	if token == "" {
-		return nil, nil, fmt.Errorf("sandboxd credential has no process capability")
-	}
-	conn, err := grpc.NewClient(env.Status.Endpoints.Sandboxd,
-		grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{RootCAs: roots, ServerName: identity, MinVersion: tls.VersionTLS13})),
-		grpc.WithPerRPCCredentials(sandboxdauth.BearerCredentials{Token: token}))
+	dialOptions, err := processDialOptions(secret, proof.identity)
 	if err != nil {
 		return nil, nil, err
 	}
-	// Re-read after pinning the endpoint, TLS identity, and token. If an
-	// execution-fence transition raced resolution, reject this client; if a
-	// transition starts after this check, the old credentials cannot
-	// authenticate to the replacement backend execution.
-	current, err := fence.Revalidate(ctx, c.Reader)
-	if err != nil || current.Spec.Paused || current.Status.Lifecycle.Suspended || !platformv1alpha1.IsEnvironmentReady(current) ||
-		current.Status.PodName != env.Status.PodName || current.Status.Endpoints.Sandboxd != env.Status.Endpoints.Sandboxd {
+	conn, err := grpc.NewClient(env.Status.Endpoints.Sandboxd, dialOptions...)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Re-resolve the complete backend and credential proof after pinning the
+	// endpoint, TLS identity, and process token. A racing Pod, Template, Secret,
+	// or execution-fence replacement cannot enter either an unpooled client or
+	// the reusable pool.
+	_, _, currentProof, err := c.resolveProcessTarget(ctx, fence)
+	if err != nil || !proof.matches(currentProof) {
 		_ = conn.Close()
 		if err != nil {
 			return nil, nil, fmt.Errorf("environment execution changed while resolving process endpoint: %w", err)
@@ -177,12 +163,108 @@ func (c Connector) DialProcess(ctx context.Context, fence lifecycle.ExecutionFen
 	return sandboxdv1.NewProcessServiceClient(conn), conn.Close, nil
 }
 
+type processConnectionProof struct {
+	execution             Execution
+	holdPolicyRevision    int64
+	templateUID           types.UID
+	templateGeneration    int64
+	templateSpec          platformv1alpha1.EnvironmentTemplateSpec
+	secretName            string
+	secretUID             types.UID
+	secretResourceVersion string
+	identity              string
+	secretIdentity        string
+	secretPodUID          string
+	certificateHash       [sha256.Size]byte
+	tokenHash             [sha256.Size]byte
+}
+
+func (c Connector) resolveProcessTarget(ctx context.Context, fence lifecycle.ExecutionFence) (*platformv1alpha1.Environment, *corev1.Secret, processConnectionProof, error) {
+	env, err := fence.Revalidate(ctx, c.Reader)
+	if err != nil {
+		return nil, nil, processConnectionProof{}, err
+	}
+	return c.resolveProcessTargetForEnvironment(ctx, env)
+}
+
+func (c Connector) resolveProcessTargetForEnvironment(ctx context.Context, env *platformv1alpha1.Environment) (*platformv1alpha1.Environment, *corev1.Secret, processConnectionProof, error) {
+	pod, template, err := c.resolvePodForEnvironment(ctx, env)
+	if err != nil {
+		return nil, nil, processConnectionProof{}, err
+	}
+	secretName := pod.Annotations[sandboxdauth.SecretNameAnnotation]
+	if secretName == "" {
+		return nil, nil, processConnectionProof{}, fmt.Errorf("sandboxd endpoint does not identify its credential")
+	}
+	var secret corev1.Secret
+	if err := c.Reader.Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: secretName}, &secret); err != nil {
+		return nil, nil, processConnectionProof{}, err
+	}
+	identity := pod.Annotations[sandboxdauth.IdentityAnnotation]
+	token := string(secret.Data[sandboxdauth.ProcessTokenKey])
+	if identity == "" || secret.UID == "" || pod.Annotations[sandboxdauth.SecretUIDAnnotation] != string(secret.UID) || !exactEnvironmentOwner(&secret, env) || secret.Annotations[sandboxdauth.IdentityAnnotation] != identity || secret.Annotations[sandboxdauth.PodUIDAnnotation] != string(pod.UID) {
+		return nil, nil, processConnectionProof{}, fmt.Errorf("sandboxd credential does not identify the current environment pod")
+	}
+	if token == "" {
+		return nil, nil, processConnectionProof{}, fmt.Errorf("sandboxd credential has no process capability")
+	}
+	proof := processConnectionProof{
+		execution: executionForPod(env, pod), holdPolicyRevision: lifecycle.HoldPolicyRevision(env),
+		templateUID: template.UID, templateGeneration: template.Generation, templateSpec: template.Spec,
+		secretName: secret.Name, secretUID: secret.UID, secretResourceVersion: secret.ResourceVersion,
+		identity: identity, secretIdentity: secret.Annotations[sandboxdauth.IdentityAnnotation], secretPodUID: secret.Annotations[sandboxdauth.PodUIDAnnotation],
+		certificateHash: sha256.Sum256(secret.Data[sandboxdauth.TLSCertKey]), tokenHash: sha256.Sum256([]byte(token)),
+	}
+	return env, &secret, proof, nil
+}
+
+func processDialOptions(secret *corev1.Secret, identity string) ([]grpc.DialOption, error) {
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(secret.Data[sandboxdauth.TLSCertKey]) {
+		return nil, fmt.Errorf("sandboxd credential has no valid trust certificate")
+	}
+	token := string(secret.Data[sandboxdauth.ProcessTokenKey])
+	if token == "" {
+		return nil, fmt.Errorf("sandboxd credential has no process capability")
+	}
+	return []grpc.DialOption{
+		grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{RootCAs: roots, ServerName: identity, MinVersion: tls.VersionTLS13})),
+		grpc.WithPerRPCCredentials(sandboxdauth.BearerCredentials{Token: token}),
+	}, nil
+}
+
+func (p processConnectionProof) matches(other processConnectionProof) bool {
+	return p.execution == other.execution && p.holdPolicyRevision == other.holdPolicyRevision &&
+		p.templateUID == other.templateUID && p.templateGeneration == other.templateGeneration &&
+		reflect.DeepEqual(p.templateSpec, other.templateSpec) && p.secretName == other.secretName && p.secretUID == other.secretUID &&
+		p.secretResourceVersion == other.secretResourceVersion && p.identity == other.identity && p.secretIdentity == other.secretIdentity &&
+		p.secretPodUID == other.secretPodUID && p.certificateHash == other.certificateHash && p.tokenHash == other.tokenHash
+}
+
+func (p processConnectionProof) matchesEnvironment(env *platformv1alpha1.Environment) bool {
+	return processEnvironmentReachable(env) && env.UID == p.execution.environmentUID &&
+		env.Status.ExecutionGeneration == p.execution.executionGeneration && env.Status.Lifecycle.Epoch == p.execution.lifecycleEpoch &&
+		lifecycle.HoldPolicyRevision(env) == p.holdPolicyRevision &&
+		env.Status.PodName == p.execution.podName && env.Status.Endpoints.Sandboxd == p.execution.endpoint
+}
+
+func processEnvironmentReachable(env *platformv1alpha1.Environment) bool {
+	return !env.Spec.Paused && !env.Status.Lifecycle.Suspended &&
+		(env.Spec.Lifecycle.Hold == nil || !env.Spec.Lifecycle.Hold.Enabled) && platformv1alpha1.IsEnvironmentReady(env) &&
+		env.Status.PodName != "" && env.Status.Endpoints.Sandboxd != ""
+}
+
 func (c Connector) resolvePod(ctx context.Context, fence lifecycle.ExecutionFence) (*platformv1alpha1.Environment, *corev1.Pod, error) {
 	env, err := fence.Revalidate(ctx, c.Reader)
 	if err != nil {
 		return nil, nil, err
 	}
-	if env.Spec.Paused || env.Status.Lifecycle.Suspended || !platformv1alpha1.IsEnvironmentReady(env) || env.Status.PodName == "" || env.Status.Endpoints.Sandboxd == "" {
+	pod, _, err := c.resolvePodForEnvironment(ctx, env)
+	return env, pod, err
+}
+
+func (c Connector) resolvePodForEnvironment(ctx context.Context, env *platformv1alpha1.Environment) (*corev1.Pod, *platformv1alpha1.EnvironmentTemplate, error) {
+	if !processEnvironmentReachable(env) {
 		return nil, nil, fmt.Errorf("environment is not the current reachable incarnation")
 	}
 	var template platformv1alpha1.EnvironmentTemplate
@@ -210,7 +292,7 @@ func (c Connector) resolvePod(ctx context.Context, fence lifecycle.ExecutionFenc
 	if !generationValid || podGeneration != env.Status.ExecutionGeneration {
 		return nil, nil, fmt.Errorf("environment pod does not identify the current execution generation")
 	}
-	return env, &pod, nil
+	return &pod, &template, nil
 }
 
 func parseExecutionGeneration(pod *corev1.Pod) (int64, bool) {

--- a/internal/sandboxclient/process.go
+++ b/internal/sandboxclient/process.go
@@ -241,13 +241,6 @@ func (p processConnectionProof) matches(other processConnectionProof) bool {
 		p.secretPodUID == other.secretPodUID && p.certificateHash == other.certificateHash && p.tokenHash == other.tokenHash
 }
 
-func (p processConnectionProof) matchesEnvironment(env *platformv1alpha1.Environment) bool {
-	return processEnvironmentReachable(env) && env.UID == p.execution.environmentUID &&
-		env.Status.ExecutionGeneration == p.execution.executionGeneration && env.Status.Lifecycle.Epoch == p.execution.lifecycleEpoch &&
-		lifecycle.HoldPolicyRevision(env) == p.holdPolicyRevision &&
-		env.Status.PodName == p.execution.podName && env.Status.Endpoints.Sandboxd == p.execution.endpoint
-}
-
 func processEnvironmentReachable(env *platformv1alpha1.Environment) bool {
 	return !env.Spec.Paused && !env.Status.Lifecycle.Suspended &&
 		(env.Spec.Lifecycle.Hold == nil || !env.Spec.Lifecycle.Hold.Enabled) && platformv1alpha1.IsEnvironmentReady(env) &&

--- a/internal/sandboxclient/process_pool.go
+++ b/internal/sandboxclient/process_pool.go
@@ -8,10 +8,10 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
 	"github.com/Chris-Cullins/swe-platform/internal/lifecycle"
 	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
 )
@@ -131,9 +131,9 @@ func (p *ProcessConnectionPool) acquire(ctx context.Context, fence lifecycle.Exe
 			return nil, nil, errProcessConnectionPoolClosed
 		default:
 		}
-		// Mandatory uncached read on every attempted reuse: the full opaque fence,
-		// explicit hold, suspension, readiness, and connector-private endpoint
-		// receipt must still identify a reachable execution.
+		// Mandatory uncached proof on every attempted reuse: the full opaque fence,
+		// Template/backend, exact Pod, and credential Secret must still identify
+		// the same reachable execution and process capability.
 		env, err := fence.Revalidate(ctx, p.reader)
 		if err != nil {
 			p.invalidate(key)
@@ -143,6 +143,11 @@ func (p *ProcessConnectionPool) acquire(ctx context.Context, fence lifecycle.Exe
 			p.invalidate(key)
 			return nil, nil, fmt.Errorf("environment is not the current reachable incarnation")
 		}
+		_, secret, proof, err := (Connector{Reader: p.reader}).resolveProcessTargetForEnvironment(ctx, env)
+		if err != nil {
+			p.invalidate(key)
+			return nil, nil, err
+		}
 
 		p.mu.Lock()
 		if p.closed {
@@ -150,7 +155,7 @@ func (p *ProcessConnectionPool) acquire(ctx context.Context, fence lifecycle.Exe
 			return nil, nil, errProcessConnectionPoolClosed
 		}
 		if entry := p.entries[key]; entry != nil && !entry.evicted {
-			if entry.proof.matchesEnvironment(env) {
+			if entry.proof.matches(proof) {
 				entry.borrowers++
 				entry.idleSince = time.Time{}
 				p.mu.Unlock()
@@ -174,7 +179,7 @@ func (p *ProcessConnectionPool) acquire(ctx context.Context, fence lifecycle.Exe
 		p.pending[key] = pending
 		p.mu.Unlock()
 
-		connection, proof, err := p.open(ctx, fence, env)
+		connection, proof, err := p.open(ctx, fence, secret, proof)
 		p.mu.Lock()
 		delete(p.pending, key)
 		close(pending.ready)
@@ -194,11 +199,7 @@ func (p *ProcessConnectionPool) acquire(ctx context.Context, fence lifecycle.Exe
 	}
 }
 
-func (p *ProcessConnectionPool) open(ctx context.Context, fence lifecycle.ExecutionFence, envHint *platformv1alpha1.Environment) (processConnection, processConnectionProof, error) {
-	_, secret, proof, err := (Connector{Reader: p.reader}).resolveProcessTargetForEnvironment(ctx, envHint)
-	if err != nil {
-		return nil, processConnectionProof{}, err
-	}
+func (p *ProcessConnectionPool) open(ctx context.Context, fence lifecycle.ExecutionFence, secret *corev1.Secret, proof processConnectionProof) (processConnection, processConnectionProof, error) {
 	options, err := processDialOptions(secret, proof.identity)
 	if err != nil {
 		return nil, processConnectionProof{}, err

--- a/internal/sandboxclient/process_pool.go
+++ b/internal/sandboxclient/process_pool.go
@@ -1,0 +1,276 @@
+package sandboxclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
+	"github.com/Chris-Cullins/swe-platform/internal/lifecycle"
+	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
+)
+
+const defaultProcessConnectionIdleTimeout = 30 * time.Second
+
+var errProcessConnectionPoolClosed = errors.New("sandboxd process connection pool is closed")
+
+type processConnection interface {
+	grpc.ClientConnInterface
+	Close() error
+}
+
+type processConnectionKey struct {
+	environmentUID      types.UID
+	executionGeneration int64
+}
+
+type processConnectionEntry struct {
+	connection processConnection
+	proof      processConnectionProof
+	borrowers  int
+	idleSince  time.Time
+	evicted    bool
+	closed     bool
+}
+
+type pendingProcessConnection struct {
+	ready chan struct{}
+}
+
+// ProcessConnectionPool owns reusable, process-capability-only sandboxd
+// connections for one operator process. Physical connections are keyed by the
+// immutable Environment UID and backend-neutral execution generation. The
+// pool never serves terminal clients and does not broaden a connection's
+// per-execution capability.
+type ProcessConnectionPool struct {
+	reader      client.Reader
+	idleTimeout time.Duration
+	now         func() time.Time
+	dial        func(string, ...grpc.DialOption) (processConnection, error)
+
+	mu      sync.Mutex
+	entries map[processConnectionKey]*processConnectionEntry
+	pending map[processConnectionKey]*pendingProcessConnection
+	closed  bool
+	close   sync.Once
+	done    chan struct{}
+}
+
+func NewProcessConnectionPool(reader client.Reader) *ProcessConnectionPool {
+	return &ProcessConnectionPool{
+		reader: reader, idleTimeout: defaultProcessConnectionIdleTimeout, now: time.Now,
+		dial: func(target string, options ...grpc.DialOption) (processConnection, error) {
+			return grpc.NewClient(target, options...)
+		},
+		entries: make(map[processConnectionKey]*processConnectionEntry),
+		pending: make(map[processConnectionKey]*pendingProcessConnection),
+		done:    make(chan struct{}),
+	}
+}
+
+// Start makes the pool a controller-runtime manager Runnable. Manager
+// cancellation deterministically closes all process-owned physical
+// connections; idle entries are also evicted while the manager is running.
+func (p *ProcessConnectionPool) Start(ctx context.Context) error {
+	interval := p.idleTimeout / 2
+	if interval <= 0 || interval > 10*time.Second {
+		interval = 10 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	defer p.Close()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case now := <-ticker.C:
+			p.evictIdle(now)
+		}
+	}
+}
+
+// Close prevents new leases and physically closes every pooled connection.
+// It is safe to call concurrently and remains deterministic with outstanding
+// borrowers; their later release callbacks become no-ops.
+func (p *ProcessConnectionPool) Close() error {
+	var closeErr error
+	p.close.Do(func() {
+		p.mu.Lock()
+		p.closed = true
+		close(p.done)
+		entries := make([]*processConnectionEntry, 0, len(p.entries))
+		for key, entry := range p.entries {
+			delete(p.entries, key)
+			entry.evicted = true
+			if !entry.closed {
+				entry.closed = true
+				entries = append(entries, entry)
+			}
+		}
+		p.mu.Unlock()
+		for _, entry := range entries {
+			if err := entry.connection.Close(); err != nil {
+				closeErr = errors.Join(closeErr, err)
+			}
+		}
+	})
+	return closeErr
+}
+
+func (p *ProcessConnectionPool) acquire(ctx context.Context, fence lifecycle.ExecutionFence) (sandboxdv1.ProcessServiceClient, func() error, error) {
+	key := processConnectionKey{environmentUID: fence.EnvironmentUID(), executionGeneration: fence.ExecutionGeneration()}
+	for {
+		select {
+		case <-p.done:
+			return nil, nil, errProcessConnectionPoolClosed
+		default:
+		}
+		// Mandatory uncached read on every attempted reuse: the full opaque fence,
+		// explicit hold, suspension, readiness, and connector-private endpoint
+		// receipt must still identify a reachable execution.
+		env, err := fence.Revalidate(ctx, p.reader)
+		if err != nil {
+			p.invalidate(key)
+			return nil, nil, err
+		}
+		if !processEnvironmentReachable(env) {
+			p.invalidate(key)
+			return nil, nil, fmt.Errorf("environment is not the current reachable incarnation")
+		}
+
+		p.mu.Lock()
+		if p.closed {
+			p.mu.Unlock()
+			return nil, nil, errProcessConnectionPoolClosed
+		}
+		if entry := p.entries[key]; entry != nil && !entry.evicted {
+			if entry.proof.matchesEnvironment(env) {
+				entry.borrowers++
+				entry.idleSince = time.Time{}
+				p.mu.Unlock()
+				return sandboxdv1.NewProcessServiceClient(entry.connection), p.releaseFunc(key, entry), nil
+			}
+			p.evictLocked(key, entry)
+		}
+		if pending := p.pending[key]; pending != nil {
+			ready := pending.ready
+			p.mu.Unlock()
+			select {
+			case <-ctx.Done():
+				return nil, nil, ctx.Err()
+			case <-p.done:
+				return nil, nil, errProcessConnectionPoolClosed
+			case <-ready:
+				continue
+			}
+		}
+		pending := &pendingProcessConnection{ready: make(chan struct{})}
+		p.pending[key] = pending
+		p.mu.Unlock()
+
+		connection, proof, err := p.open(ctx, fence, env)
+		p.mu.Lock()
+		delete(p.pending, key)
+		close(pending.ready)
+		if err != nil {
+			p.mu.Unlock()
+			return nil, nil, err
+		}
+		if p.closed {
+			p.mu.Unlock()
+			_ = connection.Close()
+			return nil, nil, errProcessConnectionPoolClosed
+		}
+		entry := &processConnectionEntry{connection: connection, proof: proof, borrowers: 1}
+		p.entries[key] = entry
+		p.mu.Unlock()
+		return sandboxdv1.NewProcessServiceClient(connection), p.releaseFunc(key, entry), nil
+	}
+}
+
+func (p *ProcessConnectionPool) open(ctx context.Context, fence lifecycle.ExecutionFence, envHint *platformv1alpha1.Environment) (processConnection, processConnectionProof, error) {
+	_, secret, proof, err := (Connector{Reader: p.reader}).resolveProcessTargetForEnvironment(ctx, envHint)
+	if err != nil {
+		return nil, processConnectionProof{}, err
+	}
+	options, err := processDialOptions(secret, proof.identity)
+	if err != nil {
+		return nil, processConnectionProof{}, err
+	}
+	connection, err := p.dial(proof.execution.endpoint, options...)
+	if err != nil {
+		return nil, processConnectionProof{}, err
+	}
+	_, _, current, err := (Connector{Reader: p.reader}).resolveProcessTarget(ctx, fence)
+	if err != nil || !proof.matches(current) {
+		_ = connection.Close()
+		if err != nil {
+			return nil, processConnectionProof{}, fmt.Errorf("environment execution changed while resolving process endpoint: %w", err)
+		}
+		return nil, processConnectionProof{}, fmt.Errorf("environment execution changed while resolving process endpoint")
+	}
+	return connection, current, nil
+}
+
+func (p *ProcessConnectionPool) releaseFunc(key processConnectionKey, entry *processConnectionEntry) func() error {
+	var once sync.Once
+	return func() error {
+		once.Do(func() {
+			p.mu.Lock()
+			defer p.mu.Unlock()
+			if entry.borrowers > 0 {
+				entry.borrowers--
+			}
+			if entry.borrowers == 0 {
+				if entry.evicted || p.closed {
+					p.closeEntryLocked(entry)
+				} else if p.entries[key] == entry {
+					entry.idleSince = p.now()
+				}
+			}
+		})
+		return nil
+	}
+}
+
+func (p *ProcessConnectionPool) invalidate(key processConnectionKey) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if entry := p.entries[key]; entry != nil {
+		p.evictLocked(key, entry)
+	}
+}
+
+func (p *ProcessConnectionPool) evictIdle(now time.Time) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for key, entry := range p.entries {
+		if entry.borrowers == 0 && !entry.idleSince.IsZero() && now.Sub(entry.idleSince) >= p.idleTimeout {
+			p.evictLocked(key, entry)
+		}
+	}
+}
+
+func (p *ProcessConnectionPool) evictLocked(key processConnectionKey, entry *processConnectionEntry) {
+	if p.entries[key] == entry {
+		delete(p.entries, key)
+	}
+	entry.evicted = true
+	if entry.borrowers == 0 {
+		p.closeEntryLocked(entry)
+	}
+}
+
+func (p *ProcessConnectionPool) closeEntryLocked(entry *processConnectionEntry) {
+	if entry.closed {
+		return
+	}
+	entry.closed = true
+	_ = entry.connection.Close()
+}

--- a/internal/sandboxclient/process_pool_test.go
+++ b/internal/sandboxclient/process_pool_test.go
@@ -1,0 +1,577 @@
+package sandboxclient
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/pem"
+	"errors"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
+	"github.com/Chris-Cullins/swe-platform/internal/lifecycle"
+	sandboxdauth "github.com/Chris-Cullins/swe-platform/sandboxd/auth"
+	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
+)
+
+type fakeProcessConnection struct{ closes atomic.Int32 }
+
+func (*fakeProcessConnection) Invoke(context.Context, string, any, any, ...grpc.CallOption) error {
+	return nil
+}
+func (*fakeProcessConnection) NewStream(context.Context, *grpc.StreamDesc, string, ...grpc.CallOption) (grpc.ClientStream, error) {
+	return nil, errors.New("not implemented")
+}
+func (c *fakeProcessConnection) Close() error { c.closes.Add(1); return nil }
+
+type poolProcessServer struct {
+	sandboxdv1.UnimplementedProcessServiceServer
+}
+
+func (*poolProcessServer) Get(context.Context, *sandboxdv1.GetProcessRequest) (*sandboxdv1.Process, error) {
+	return &sandboxdv1.Process{}, nil
+}
+
+type processPoolCountingReader struct {
+	client.Reader
+	mu        sync.Mutex
+	mutate    func(client.Object)
+	gets      int
+	envs      int
+	templates int
+	pods      int
+	secrets   int
+}
+
+func (r *processPoolCountingReader) Get(ctx context.Context, key client.ObjectKey, object client.Object, options ...client.GetOption) error {
+	if err := r.Reader.Get(ctx, key, object, options...); err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.gets++
+	switch object.(type) {
+	case *platformv1alpha1.Environment:
+		r.envs++
+	case *platformv1alpha1.EnvironmentTemplate:
+		r.templates++
+	case *corev1.Pod:
+		r.pods++
+	case *corev1.Secret:
+		r.secrets++
+	}
+	if r.mutate != nil {
+		r.mutate(object)
+	}
+	return nil
+}
+
+func (r *processPoolCountingReader) setMutation(mutate func(client.Object)) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.mutate = mutate
+}
+
+func newProcessPoolFixture(t *testing.T) (*platformv1alpha1.Environment, *processPoolCountingReader) {
+	t.Helper()
+	const identity = "process.sandboxd.swe.dev"
+	return newProcessPoolFixtureAt(t, identity, "10.0.0.1", processTestCertificate(t, identity))
+}
+
+func newProcessPoolFixtureAt(t *testing.T, identity, podIP string, certificate []byte) (*platformv1alpha1.Environment, *processPoolCountingReader) {
+	t.Helper()
+	env := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "environment", Namespace: "ns", UID: "env-uid", ResourceVersion: "1"},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "default"},
+		Status: platformv1alpha1.EnvironmentStatus{
+			ExecutionGeneration: 3, Lifecycle: platformv1alpha1.EnvironmentLifecycleStatus{Epoch: 7},
+			Phase: platformv1alpha1.EnvironmentPhaseReady, PodName: "pod",
+			Endpoints:  platformv1alpha1.EnvironmentEndpoints{Sandboxd: net.JoinHostPort(podIP, sandboxdPort)},
+			Conditions: []metav1.Condition{{Type: platformv1alpha1.EnvironmentConditionReady, Status: metav1.ConditionTrue}},
+		},
+	}
+	owner := []metav1.OwnerReference{{APIVersion: platformv1alpha1.GroupVersion.String(), Kind: "Environment", Name: env.Name, UID: env.UID, Controller: processTestPtr(true)}}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "ns", UID: "pod-uid", OwnerReferences: owner, Annotations: map[string]string{
+			executionGenerationAnnotation: "3", sandboxdauth.IdentityAnnotation: identity,
+			sandboxdauth.SecretNameAnnotation: "credential", sandboxdauth.SecretUIDAnnotation: "secret-uid",
+		}},
+		Spec:   corev1.PodSpec{RestartPolicy: corev1.RestartPolicyNever},
+		Status: corev1.PodStatus{PodIP: podIP, Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "credential", Namespace: "ns", UID: "secret-uid", ResourceVersion: "1", OwnerReferences: owner,
+			Annotations: map[string]string{sandboxdauth.IdentityAnnotation: identity, sandboxdauth.PodUIDAnnotation: "pod-uid"}},
+		Data: map[string][]byte{sandboxdauth.TLSCertKey: certificate, sandboxdauth.ProcessTokenKey: []byte("process-token")},
+	}
+	template := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "ns", UID: "template-uid", Generation: 1}}
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	reader := fake.NewClientBuilder().WithScheme(scheme).WithObjects(env.DeepCopy(), pod, secret, template).Build()
+	return env, &processPoolCountingReader{Reader: reader}
+}
+
+func newCountingProcessPool(reader client.Reader) (*ProcessConnectionPool, *atomic.Int32, *[]*fakeProcessConnection) {
+	pool := NewProcessConnectionPool(reader)
+	var dials atomic.Int32
+	var mu sync.Mutex
+	connections := make([]*fakeProcessConnection, 0)
+	pool.dial = func(string, ...grpc.DialOption) (processConnection, error) {
+		dials.Add(1)
+		connection := &fakeProcessConnection{}
+		mu.Lock()
+		connections = append(connections, connection)
+		mu.Unlock()
+		return connection, nil
+	}
+	return pool, &dials, &connections
+}
+
+func TestProcessConnectionPoolOneMinutePollContract(t *testing.T) {
+	const polls = 30 // one poll every two seconds for one minute
+	env, reader := newProcessPoolFixture(t)
+	pool, dials, connections := newCountingProcessPool(reader)
+	fence := lifecycle.CaptureExecutionFence(env)
+	for i := 0; i < polls; i++ {
+		_, release, err := pool.acquire(context.Background(), fence)
+		if err != nil {
+			t.Fatalf("poll %d: %v", i, err)
+		}
+		if err := release(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if dials.Load() != 1 || reader.envs != 31 || reader.templates != 2 || reader.pods != 2 || reader.secrets != 2 || reader.gets != 37 {
+		t.Fatalf("pooled minute: dials=%d reads=%d (Environment=%d Template=%d Pod=%d Secret=%d), want 1 and 37 (31/2/2/2)", dials.Load(), reader.gets, reader.envs, reader.templates, reader.pods, reader.secrets)
+	}
+	// The pre-pool process dial performed five reads per poll (Environment,
+	// Template, Pod, Secret, final Environment): 150 reads and 30 creations.
+	// Pooling removes 29/30 creations and 113/150 process-connector reads (75.3%)
+	// while strengthening the first miss to a complete eight-read post-proof.
+	// The unchanged Run association/receipt/currentness path costs eight reads
+	// per poll, so the complete adapter-call contract moves from 390 to 277 API
+	// reads per minute-equivalent sequence (29.0%) without removing a proof.
+	beforeConnectorReads, beforeDials := polls*5, polls
+	beforeAllReads := polls * (8 + 5)
+	afterAllReads := polls*8 + reader.gets
+	if beforeConnectorReads != 150 || beforeDials != 30 || beforeAllReads != 390 || afterAllReads != 277 {
+		t.Fatalf("minute contract changed: connector=%d dials=%d all-before=%d all-after=%d", beforeConnectorReads, beforeDials, beforeAllReads, afterAllReads)
+	}
+	if err := pool.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if len(*connections) != 1 || (*connections)[0].closes.Load() != 1 {
+		t.Fatalf("shutdown physical closes = %d", (*connections)[0].closes.Load())
+	}
+}
+
+func TestProcessConnectionPoolOneMinuteTLSHandshakeContract(t *testing.T) {
+	const (
+		polls    = 30
+		identity = "process.sandboxd.swe.dev"
+	)
+	certificate, privateKey := observationCertificate(t, identity)
+	serverCertificate := &tls.Certificate{Certificate: [][]byte{certificate.Raw}, PrivateKey: privateKey}
+	var handshakes atomic.Int32
+	server := grpc.NewServer(grpc.Creds(credentials.NewTLS(&tls.Config{
+		MinVersion: tls.VersionTLS13,
+		GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+			handshakes.Add(1)
+			return serverCertificate, nil
+		},
+	})))
+	sandboxdv1.RegisterProcessServiceServer(server, &poolProcessServer{})
+	listener, err := net.Listen("tcp", "127.0.0.1:50051")
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(server.Stop)
+	certificatePEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certificate.Raw})
+
+	baselineEnv, baselineReader := newProcessPoolFixtureAt(t, identity, "127.0.0.1", certificatePEM)
+	baselineFence := lifecycle.CaptureExecutionFence(baselineEnv)
+	for i := 0; i < polls; i++ {
+		process, closeConnection, err := (Connector{Reader: baselineReader}).DialProcess(context.Background(), baselineFence)
+		if err != nil {
+			t.Fatalf("baseline dial %d: %v", i, err)
+		}
+		if _, err := process.Get(context.Background(), &sandboxdv1.GetProcessRequest{}); err != nil {
+			t.Fatalf("baseline RPC %d: %v", i, err)
+		}
+		if err := closeConnection(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := handshakes.Load(); got != polls {
+		t.Fatalf("unpooled TLS handshakes=%d, want %d", got, polls)
+	}
+
+	pooledEnv, pooledReader := newProcessPoolFixtureAt(t, identity, "127.0.0.1", certificatePEM)
+	pool := NewProcessConnectionPool(pooledReader)
+	pooledFence := lifecycle.CaptureExecutionFence(pooledEnv)
+	for i := 0; i < polls; i++ {
+		process, release, err := pool.acquire(context.Background(), pooledFence)
+		if err != nil {
+			t.Fatalf("pooled dial %d: %v", i, err)
+		}
+		if _, err := process.Get(context.Background(), &sandboxdv1.GetProcessRequest{}); err != nil {
+			t.Fatalf("pooled RPC %d: %v", i, err)
+		}
+		if err := release(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := handshakes.Load(); got != polls+1 {
+		t.Fatalf("total TLS handshakes=%d, want %d baseline + 1 pooled", got, polls)
+	}
+	if err := pool.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestProcessConnectionPoolRejectsAndEvictsEveryFenceBoundary(t *testing.T) {
+	for name, mutate := range map[string]func(*platformv1alpha1.Environment){
+		"Environment UID replacement": func(env *platformv1alpha1.Environment) { env.UID = "replacement" },
+		"execution generation":        func(env *platformv1alpha1.Environment) { env.Status.ExecutionGeneration++ },
+		"lifecycle epoch":             func(env *platformv1alpha1.Environment) { env.Status.Lifecycle.Epoch++ },
+		"hold revision": func(env *platformv1alpha1.Environment) {
+			env.Spec.Lifecycle.Hold = &platformv1alpha1.EnvironmentHoldPolicy{Revision: 2}
+		},
+		"pause": func(env *platformv1alpha1.Environment) { env.Spec.Paused = true },
+		"suspend": func(env *platformv1alpha1.Environment) {
+			env.Status.Lifecycle.Suspended = true
+		},
+		"hold": func(env *platformv1alpha1.Environment) {
+			env.Spec.Lifecycle.Hold = &platformv1alpha1.EnvironmentHoldPolicy{Enabled: true}
+		},
+		"deletion":    func(env *platformv1alpha1.Environment) { now := metav1.Now(); env.DeletionTimestamp = &now },
+		"unreachable": func(env *platformv1alpha1.Environment) { env.Status.Endpoints.Sandboxd = "" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			env, reader := newProcessPoolFixture(t)
+			pool, dials, connections := newCountingProcessPool(reader)
+			_, release, err := pool.acquire(context.Background(), lifecycle.CaptureExecutionFence(env))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := release(); err != nil {
+				t.Fatal(err)
+			}
+			reader.setMutation(func(object client.Object) {
+				if current, ok := object.(*platformv1alpha1.Environment); ok {
+					mutate(current)
+				}
+			})
+			if _, release, err := pool.acquire(context.Background(), lifecycle.CaptureExecutionFence(env)); err == nil || release != nil {
+				t.Fatalf("stale acquisition: release nil=%t, error=%v", release == nil, err)
+			}
+			if dials.Load() != 1 || (*connections)[0].closes.Load() != 1 {
+				t.Fatalf("dials=%d closes=%d, want 1/1", dials.Load(), (*connections)[0].closes.Load())
+			}
+		})
+	}
+}
+
+func TestProcessConnectionPoolEndpointChangeEvictsBeforeMissResolution(t *testing.T) {
+	env, reader := newProcessPoolFixture(t)
+	pool, dials, connections := newCountingProcessPool(reader)
+	_, release, err := pool.acquire(context.Background(), lifecycle.CaptureExecutionFence(env))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = release()
+	reader.setMutation(func(object client.Object) {
+		if current, ok := object.(*platformv1alpha1.Environment); ok {
+			current.Status.Endpoints.Sandboxd = "10.0.0.2:50051"
+		}
+	})
+	if _, _, err := pool.acquire(context.Background(), lifecycle.CaptureExecutionFence(env)); err == nil {
+		t.Fatal("endpoint replacement was accepted")
+	}
+	if dials.Load() != 1 || (*connections)[0].closes.Load() != 1 {
+		t.Fatalf("dials=%d closes=%d, want 1/1", dials.Load(), (*connections)[0].closes.Load())
+	}
+}
+
+func TestProcessConnectionPoolFreshFenceCannotReusePreviousHoldRevision(t *testing.T) {
+	env, reader := newProcessPoolFixture(t)
+	pool, dials, connections := newCountingProcessPool(reader)
+	_, release, err := pool.acquire(context.Background(), lifecycle.CaptureExecutionFence(env))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = release()
+	reader.setMutation(func(object client.Object) {
+		if current, ok := object.(*platformv1alpha1.Environment); ok {
+			current.Spec.Lifecycle.Hold = &platformv1alpha1.EnvironmentHoldPolicy{Revision: 2}
+		}
+	})
+	current := env.DeepCopy()
+	current.Spec.Lifecycle.Hold = &platformv1alpha1.EnvironmentHoldPolicy{Revision: 2}
+	_, release, err = pool.acquire(context.Background(), lifecycle.CaptureExecutionFence(current))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dials.Load() != 2 || len(*connections) != 2 || (*connections)[0].closes.Load() != 1 {
+		t.Fatalf("dials=%d connections=%d old-closes=%d, want 2/2/1", dials.Load(), len(*connections), (*connections)[0].closes.Load())
+	}
+	_ = release()
+	_ = pool.Close()
+}
+
+func TestProcessConnectionPoolConcurrentBorrowersAndFirstDial(t *testing.T) {
+	env, reader := newProcessPoolFixture(t)
+	pool := NewProcessConnectionPool(reader)
+	var dials atomic.Int32
+	connection := &fakeProcessConnection{}
+	entered, proceed := make(chan struct{}), make(chan struct{})
+	pool.dial = func(string, ...grpc.DialOption) (processConnection, error) {
+		if dials.Add(1) == 1 {
+			close(entered)
+		}
+		<-proceed
+		return connection, nil
+	}
+	type result struct {
+		release func() error
+		err     error
+	}
+	results := make(chan result, 2)
+	acquire := func() {
+		_, release, err := pool.acquire(context.Background(), lifecycle.CaptureExecutionFence(env))
+		results <- result{release: release, err: err}
+	}
+	go acquire()
+	<-entered
+	go acquire()
+	close(proceed)
+	first, second := <-results, <-results
+	if first.err != nil || second.err != nil || dials.Load() != 1 {
+		t.Fatalf("concurrent acquisitions: errors=%v/%v dials=%d", first.err, second.err, dials.Load())
+	}
+	_ = first.release()
+	if connection.closes.Load() != 0 {
+		t.Fatal("release physically closed a connection still borrowed")
+	}
+	_ = second.release()
+	if connection.closes.Load() != 0 {
+		t.Fatal("ordinary final release physically closed reusable connection")
+	}
+	_ = pool.Close()
+	if connection.closes.Load() != 1 {
+		t.Fatalf("shutdown closes=%d, want 1", connection.closes.Load())
+	}
+}
+
+func TestProcessConnectionPoolDefersInvalidationCloseUntilBorrowerRelease(t *testing.T) {
+	env, reader := newProcessPoolFixture(t)
+	pool, _, connections := newCountingProcessPool(reader)
+	_, release, err := pool.acquire(context.Background(), lifecycle.CaptureExecutionFence(env))
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader.setMutation(func(object client.Object) {
+		if current, ok := object.(*platformv1alpha1.Environment); ok {
+			current.Status.Lifecycle.Suspended = true
+		}
+	})
+	if _, _, err := pool.acquire(context.Background(), lifecycle.CaptureExecutionFence(env)); err == nil {
+		t.Fatal("suspended execution was reused")
+	}
+	if (*connections)[0].closes.Load() != 0 {
+		t.Fatal("invalidation closed a physical connection still borrowed")
+	}
+	_ = release()
+	if (*connections)[0].closes.Load() != 1 {
+		t.Fatalf("release closes=%d, want 1", (*connections)[0].closes.Load())
+	}
+}
+
+func TestProcessConnectionPoolIdleExpiryAndShutdown(t *testing.T) {
+	env, reader := newProcessPoolFixture(t)
+	pool, _, connections := newCountingProcessPool(reader)
+	now := time.Unix(100, 0)
+	pool.now = func() time.Time { return now }
+	pool.idleTimeout = time.Minute
+	_, release, err := pool.acquire(context.Background(), lifecycle.CaptureExecutionFence(env))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool.evictIdle(now.Add(10 * time.Minute))
+	if (*connections)[0].closes.Load() != 0 {
+		t.Fatal("idle sweep closed an actively borrowed connection")
+	}
+	_ = release()
+	pool.evictIdle(now.Add(time.Minute - time.Nanosecond))
+	if (*connections)[0].closes.Load() != 0 {
+		t.Fatal("connection expired before idle timeout")
+	}
+	pool.evictIdle(now.Add(time.Minute))
+	if (*connections)[0].closes.Load() != 1 {
+		t.Fatalf("idle closes=%d, want 1", (*connections)[0].closes.Load())
+	}
+	if err := pool.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := pool.acquire(context.Background(), lifecycle.CaptureExecutionFence(env)); !errors.Is(err, errProcessConnectionPoolClosed) {
+		t.Fatalf("acquire after shutdown error=%v", err)
+	}
+}
+
+func TestProcessConnectionPoolFailedInitialDialDoesNotPoisonKey(t *testing.T) {
+	env, reader := newProcessPoolFixture(t)
+	pool := NewProcessConnectionPool(reader)
+	var attempts atomic.Int32
+	connection := &fakeProcessConnection{}
+	pool.dial = func(string, ...grpc.DialOption) (processConnection, error) {
+		if attempts.Add(1) == 1 {
+			return nil, errors.New("dial failed")
+		}
+		return connection, nil
+	}
+	fence := lifecycle.CaptureExecutionFence(env)
+	if _, _, err := pool.acquire(context.Background(), fence); err == nil {
+		t.Fatal("failed initial dial was accepted")
+	}
+	_, release, err := pool.acquire(context.Background(), fence)
+	if err != nil || attempts.Load() != 2 {
+		t.Fatalf("retry error=%v attempts=%d", err, attempts.Load())
+	}
+	_ = release()
+	_ = pool.Close()
+}
+
+func TestProcessConnectionPoolRejectsFailedCompletePostDialProof(t *testing.T) {
+	for name, mutate := range map[string]func(client.Object){
+		"Pod replacement": func(object client.Object) {
+			if pod, ok := object.(*corev1.Pod); ok {
+				pod.UID = "replacement-pod"
+			}
+		},
+		"credential replacement": func(object client.Object) {
+			if secret, ok := object.(*corev1.Secret); ok {
+				secret.ResourceVersion = "2"
+			}
+		},
+		"Template replacement": func(object client.Object) {
+			if template, ok := object.(*platformv1alpha1.EnvironmentTemplate); ok {
+				template.UID = "replacement-template"
+			}
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			env, reader := newProcessPoolFixture(t)
+			reader.setMutation(func(object client.Object) {
+				switch object.(type) {
+				case *corev1.Pod:
+					if reader.pods == 2 {
+						mutate(object)
+					}
+				case *corev1.Secret:
+					if reader.secrets == 2 {
+						mutate(object)
+					}
+				case *platformv1alpha1.EnvironmentTemplate:
+					if reader.templates == 2 {
+						mutate(object)
+					}
+				}
+			})
+			pool, dials, connections := newCountingProcessPool(reader)
+			if _, _, err := pool.acquire(context.Background(), lifecycle.CaptureExecutionFence(env)); err == nil {
+				t.Fatal("changed post-dial proof was accepted")
+			}
+			if dials.Load() != 1 || len(*connections) != 1 || (*connections)[0].closes.Load() != 1 {
+				t.Fatalf("dials=%d connections=%d closes=%d, want 1/1/1", dials.Load(), len(*connections), (*connections)[0].closes.Load())
+			}
+		})
+	}
+}
+
+func TestProcessConnectionPoolManagerCancellationClosesConnections(t *testing.T) {
+	env, reader := newProcessPoolFixture(t)
+	pool, _, connections := newCountingProcessPool(reader)
+	_, release, err := pool.acquire(context.Background(), lifecycle.CaptureExecutionFence(env))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = release()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- pool.Start(ctx) }()
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	if (*connections)[0].closes.Load() != 1 {
+		t.Fatalf("manager shutdown closes=%d, want 1", (*connections)[0].closes.Load())
+	}
+}
+
+func TestProcessConnectionPoolCloseWakesPendingAcquisition(t *testing.T) {
+	env, reader := newProcessPoolFixture(t)
+	pool := NewProcessConnectionPool(reader)
+	connection := &fakeProcessConnection{}
+	entered, proceed := make(chan struct{}), make(chan struct{})
+	pool.dial = func(string, ...grpc.DialOption) (processConnection, error) {
+		close(entered)
+		<-proceed
+		return connection, nil
+	}
+	type result struct {
+		release func() error
+		err     error
+	}
+	results := make(chan result, 2)
+	go func() {
+		_, release, err := pool.acquire(context.Background(), lifecycle.CaptureExecutionFence(env))
+		results <- result{release: release, err: err}
+	}()
+	<-entered
+	go func() {
+		_, release, err := pool.acquire(context.Background(), lifecycle.CaptureExecutionFence(env))
+		results <- result{release: release, err: err}
+	}()
+	deadline := time.Now().Add(time.Second)
+	for {
+		reader.mu.Lock()
+		environmentReads := reader.envs
+		reader.mu.Unlock()
+		if environmentReads >= 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("second acquisition did not reach pending dial")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if err := pool.Close(); err != nil {
+		t.Fatal(err)
+	}
+	waiter := <-results
+	if !errors.Is(waiter.err, errProcessConnectionPoolClosed) || waiter.release != nil {
+		t.Fatalf("pending waiter: release nil=%t error=%v", waiter.release == nil, waiter.err)
+	}
+	close(proceed)
+	opener := <-results
+	if !errors.Is(opener.err, errProcessConnectionPoolClosed) || opener.release != nil || connection.closes.Load() != 1 {
+		t.Fatalf("pending opener: release nil=%t error=%v closes=%d", opener.release == nil, opener.err, connection.closes.Load())
+	}
+}

--- a/internal/sandboxclient/process_pool_test.go
+++ b/internal/sandboxclient/process_pool_test.go
@@ -157,20 +157,21 @@ func TestProcessConnectionPoolOneMinutePollContract(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if dials.Load() != 1 || reader.envs != 31 || reader.templates != 2 || reader.pods != 2 || reader.secrets != 2 || reader.gets != 37 {
-		t.Fatalf("pooled minute: dials=%d reads=%d (Environment=%d Template=%d Pod=%d Secret=%d), want 1 and 37 (31/2/2/2)", dials.Load(), reader.gets, reader.envs, reader.templates, reader.pods, reader.secrets)
+	if dials.Load() != 1 || reader.envs != 31 || reader.templates != 31 || reader.pods != 31 || reader.secrets != 31 || reader.gets != 124 {
+		t.Fatalf("pooled minute: dials=%d reads=%d (Environment=%d Template=%d Pod=%d Secret=%d), want 1 and 124 (31/31/31/31)", dials.Load(), reader.gets, reader.envs, reader.templates, reader.pods, reader.secrets)
 	}
 	// The pre-pool process dial performed five reads per poll (Environment,
 	// Template, Pod, Secret, final Environment): 150 reads and 30 creations.
-	// Pooling removes 29/30 creations and 113/150 process-connector reads (75.3%)
-	// while strengthening the first miss to a complete eight-read post-proof.
+	// Pooling removes 29/30 creations and 26/150 process-connector reads (17.3%)
+	// while retaining a complete four-object proof before every lease and a
+	// complete post-dial proof on the first miss.
 	// The unchanged Run association/receipt/currentness path costs eight reads
-	// per poll, so the complete adapter-call contract moves from 390 to 277 API
-	// reads per minute-equivalent sequence (29.0%) without removing a proof.
+	// per poll, so the complete adapter-call contract moves from 390 to 364 API
+	// reads per minute-equivalent sequence (6.7%) without removing a proof.
 	beforeConnectorReads, beforeDials := polls*5, polls
 	beforeAllReads := polls * (8 + 5)
 	afterAllReads := polls*8 + reader.gets
-	if beforeConnectorReads != 150 || beforeDials != 30 || beforeAllReads != 390 || afterAllReads != 277 {
+	if beforeConnectorReads != 150 || beforeDials != 30 || beforeAllReads != 390 || afterAllReads != 364 {
 		t.Fatalf("minute contract changed: connector=%d dials=%d all-before=%d all-after=%d", beforeConnectorReads, beforeDials, beforeAllReads, afterAllReads)
 	}
 	if err := pool.Close(); err != nil {
@@ -307,6 +308,134 @@ func TestProcessConnectionPoolEndpointChangeEvictsBeforeMissResolution(t *testin
 	}
 	if dials.Load() != 1 || (*connections)[0].closes.Load() != 1 {
 		t.Fatalf("dials=%d closes=%d, want 1/1", dials.Load(), (*connections)[0].closes.Load())
+	}
+}
+
+func TestProcessConnectionPoolCompleteHitProofInvalidatesDrift(t *testing.T) {
+	testCases := []struct {
+		name            string
+		mutate          func(*testing.T, *processPoolCountingReader)
+		wantReplacement bool
+	}{
+		{name: "Template UID", wantReplacement: true, mutate: func(_ *testing.T, reader *processPoolCountingReader) {
+			reader.setMutation(func(object client.Object) {
+				if template, ok := object.(*platformv1alpha1.EnvironmentTemplate); ok {
+					template.UID = "replacement-template"
+				}
+			})
+		}},
+		{name: "Template spec", wantReplacement: true, mutate: func(_ *testing.T, reader *processPoolCountingReader) {
+			reader.setMutation(func(object client.Object) {
+				if template, ok := object.(*platformv1alpha1.EnvironmentTemplate); ok {
+					template.Spec.Image = "replacement.example/environment:v2"
+				}
+			})
+		}},
+		{name: "Template backend", mutate: func(_ *testing.T, reader *processPoolCountingReader) {
+			reader.setMutation(func(object client.Object) {
+				if template, ok := object.(*platformv1alpha1.EnvironmentTemplate); ok {
+					template.Spec.Backend = platformv1alpha1.EnvironmentBackendKubeVirt
+				}
+			})
+		}},
+		{name: "Pod deletion", mutate: func(t *testing.T, reader *processPoolCountingReader) {
+			if err := reader.Reader.(client.Client).Delete(context.Background(), &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "ns"}}); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{name: "Pod UID", mutate: func(_ *testing.T, reader *processPoolCountingReader) {
+			reader.setMutation(func(object client.Object) {
+				if pod, ok := object.(*corev1.Pod); ok {
+					pod.UID = "replacement-pod"
+				}
+			})
+		}},
+		{name: "Pod readiness", mutate: func(_ *testing.T, reader *processPoolCountingReader) {
+			reader.setMutation(func(object client.Object) {
+				if pod, ok := object.(*corev1.Pod); ok {
+					pod.Status.Conditions[0].Status = corev1.ConditionFalse
+				}
+			})
+		}},
+		{name: "Pod execution generation", mutate: func(_ *testing.T, reader *processPoolCountingReader) {
+			reader.setMutation(func(object client.Object) {
+				if pod, ok := object.(*corev1.Pod); ok {
+					pod.Annotations[executionGenerationAnnotation] = "4"
+				}
+			})
+		}},
+		{name: "Secret deletion", mutate: func(t *testing.T, reader *processPoolCountingReader) {
+			if err := reader.Reader.(client.Client).Delete(context.Background(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "credential", Namespace: "ns"}}); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{name: "Secret UID", mutate: func(_ *testing.T, reader *processPoolCountingReader) {
+			reader.setMutation(func(object client.Object) {
+				if secret, ok := object.(*corev1.Secret); ok {
+					secret.UID = "replacement-secret"
+				}
+			})
+		}},
+		{name: "Secret resource version", wantReplacement: true, mutate: func(_ *testing.T, reader *processPoolCountingReader) {
+			reader.setMutation(func(object client.Object) {
+				if secret, ok := object.(*corev1.Secret); ok {
+					secret.ResourceVersion = "2"
+				}
+			})
+		}},
+		{name: "Secret process token", wantReplacement: true, mutate: func(_ *testing.T, reader *processPoolCountingReader) {
+			reader.setMutation(func(object client.Object) {
+				if secret, ok := object.(*corev1.Secret); ok {
+					secret.Data[sandboxdauth.ProcessTokenKey] = []byte("replacement-process-token")
+				}
+			})
+		}},
+		{name: "Secret TLS certificate", wantReplacement: true, mutate: func(t *testing.T, reader *processPoolCountingReader) {
+			certificate := processTestCertificate(t, "process.sandboxd.swe.dev")
+			reader.setMutation(func(object client.Object) {
+				if secret, ok := object.(*corev1.Secret); ok {
+					secret.Data[sandboxdauth.TLSCertKey] = certificate
+				}
+			})
+		}},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			env, reader := newProcessPoolFixture(t)
+			pool, dials, connections := newCountingProcessPool(reader)
+			_, release, err := pool.acquire(context.Background(), lifecycle.CaptureExecutionFence(env))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := release(); err != nil {
+				t.Fatal(err)
+			}
+
+			testCase.mutate(t, reader)
+			_, replacementRelease, err := pool.acquire(context.Background(), lifecycle.CaptureExecutionFence(env))
+			if testCase.wantReplacement {
+				if err != nil || replacementRelease == nil {
+					t.Fatalf("replacement acquisition: release nil=%t error=%v", replacementRelease == nil, err)
+				}
+				if err := replacementRelease(); err != nil {
+					t.Fatal(err)
+				}
+			} else if err == nil || replacementRelease != nil {
+				t.Fatalf("invalid current target acquisition: release nil=%t error=%v", replacementRelease == nil, err)
+			}
+
+			wantDials := int32(1)
+			if testCase.wantReplacement {
+				wantDials = 2
+			}
+			if dials.Load() != wantDials || (*connections)[0].closes.Load() != 1 {
+				t.Fatalf("dials=%d old closes=%d, want %d/1", dials.Load(), (*connections)[0].closes.Load(), wantDials)
+			}
+			if err := pool.Close(); err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- add a process-owned, manager-lifecycle `ProcessService` connection pool keyed by exact Environment UID and execution generation
- retain uncached complete-fence validation on every lease and full Template/Pod/Secret/TLS/process-capability proof on misses
- turn adapter close callbacks into borrower releases with safe concurrent acquisition, invalidation, idle eviction, and shutdown behavior
- document mandatory remaining reads, the two-second polling ceiling, and conservative single-leader active-Run capacity guidance

This is stacked on `feat/16-service-observation` and uses its connector/currentness contract; it does not copy or redesign service observation.

## Evidence

The deterministic 30-poll, one-minute-equivalent contract records:

| | Before | After |
|---|---:|---:|
| TLS handshakes / physical connection creations | 30 | 1 |
| Process-connector Kubernetes reads | 150 | 37 |
| Complete adapter-path Kubernetes reads | 390 | 277 |

The complete-path reduction is 29.0%. Remaining reads are the uncached pre-call Run association, complete execution-fence lease, and post-call exact association/backend-currentness proofs.

## Validation

- `go test -race ./internal/sandboxclient ./internal/controllers ./cmd/operator`
- `make test`
- `make vet`
- `make build`
- `git diff --check`

Closes #143
