### PR TITLE
refactor: extract agent adapter contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,8 @@ Pi deliberately supports no credential profiles or credential injection.
 
 - **Language:** Go for control plane, operator, `sandboxd`, and CLI.
 - **Layout:** kubebuilder conventions — `api/v1alpha1/` for types,
-  `internal/controllers/`, `cmd/{operator,swe}`. Shared fenced Environment intent
+  `internal/controllers/`, `cmd/{operator,swe}`. The exact adapter contract boundary is
+  `internal/agent/`. Shared fenced Environment intent
   publication and validation belongs in `internal/lifecycle/`; controllers remain
   the sole owners of observed lifecycle transitions. `sandboxd/` is a **separate Go
   module** with its own `go.mod`: keep its dependencies minimal so it stays portable and

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -274,10 +274,10 @@ in this declaration-only API.
 
 ### Adapters, processes, and transcripts
 
-The agent layer is adapters. Platform code supplies an immutable Run UID/task, an ephemeral
-credential, a backend-neutral sandboxd process dialer, and an opaque event sink. Adapters own
-agent command/protocol details and event payload meaning; the platform does not impose a shared
-transcript schema.
+The agent layer is adapters. `internal/agent` is the exact adapter contract boundary. Platform
+code supplies an immutable Run UID/task, an ephemeral credential, a backend-neutral sandboxd
+process dialer, and an opaque event sink. Adapters own agent command/protocol details and event
+payload meaning; the platform does not impose a shared transcript schema.
 
 The registered `claude-code` (default), `amp`, `codex`, and `pi` adapters each run a foreground
 CLI through sandboxd's keyed managed-process service. Starts are duplicate-safe within one

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -274,10 +274,11 @@ in this declaration-only API.
 
 ### Adapters, processes, and transcripts
 
-The agent layer is adapters. `internal/agent` is the exact adapter contract boundary. Platform
-code supplies an immutable Run UID/task, an ephemeral credential, a backend-neutral sandboxd
-process dialer, and an opaque event sink. Adapters own agent command/protocol details and event
-payload meaning; the platform does not impose a shared transcript schema.
+The agent layer is adapters. `internal/agent` is the exact adapter contract boundary, including
+an agent-owned string type for immutable Environment identity that does not expose a backend API
+type. Platform code supplies an immutable Run UID/task, an ephemeral credential, a backend-neutral
+sandboxd process dialer, and an opaque event sink. Adapters own agent command/protocol details and
+event payload meaning; the platform does not impose a shared transcript schema.
 
 The registered `claude-code` (default), `amp`, `codex`, and `pi` adapters each run a foreground
 CLI through sandboxd's keyed managed-process service. Starts are duplicate-safe within one

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Chris-Cullins/swe-platform/internal/adapters/claudecode"
 	"github.com/Chris-Cullins/swe-platform/internal/adapters/codex"
 	"github.com/Chris-Cullins/swe-platform/internal/adapters/pi"
+	"github.com/Chris-Cullins/swe-platform/internal/agent"
 	"github.com/Chris-Cullins/swe-platform/internal/controllers"
 	"github.com/Chris-Cullins/swe-platform/internal/sandboxclient"
 	"github.com/Chris-Cullins/swe-platform/internal/tenancy"
@@ -174,7 +175,7 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	var eventSink controllers.AdapterEventSink
+	var eventSink agent.AdapterEventSink
 	if transcriptURL != "" {
 		if transcriptTokenFile == "" {
 			setupLog.Error(nil, "transcript-token-file is required when transcript-url is set")
@@ -243,8 +244,8 @@ func installationLeaderElectionID(uid types.UID) string {
 	return fmt.Sprintf("swe-platform-operator-%x", sum[:16])
 }
 
-func registeredAdapters() map[string]controllers.AdapterLifecycle {
-	return map[string]controllers.AdapterLifecycle{
+func registeredAdapters() map[string]agent.AdapterLifecycle {
+	return map[string]agent.AdapterLifecycle{
 		"amp":         &amp.Adapter{},
 		"claude-code": &claudecode.Adapter{},
 		"codex":       &codex.Adapter{},

--- a/internal/adapters/amp/adapter.go
+++ b/internal/adapters/amp/adapter.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
-	"github.com/Chris-Cullins/swe-platform/internal/controllers"
+	"github.com/Chris-Cullins/swe-platform/internal/agent"
 	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
 )
 
@@ -31,8 +31,10 @@ type Adapter struct {
 	pending    map[cursor]pendingEvent
 }
 
+var _ agent.AdapterLifecycle = (*Adapter)(nil)
+
 type pendingEvent struct {
-	event      controllers.AdapterEvent
+	event      agent.AdapterEvent
 	nextOffset uint64
 }
 
@@ -67,11 +69,11 @@ func (a *Adapter) executable() string {
 	return "amp"
 }
 
-func key(task controllers.AdapterTask) *sandboxdv1.ProcessKey {
+func key(task agent.AdapterTask) *sandboxdv1.ProcessKey {
 	return &sandboxdv1.ProcessKey{OwnerId: task.ID, Role: processRole}
 }
 
-func (a *Adapter) spec(task controllers.AdapterTask) *sandboxdv1.ProcessSpec {
+func (a *Adapter) spec(task agent.AdapterTask) *sandboxdv1.ProcessSpec {
 	// --execute=<prompt> is deliberately one argv element. The pinned CLI does
 	// not treat "--" after --execute as a flag terminator for a flag-like prompt.
 	return &sandboxdv1.ProcessSpec{
@@ -81,9 +83,9 @@ func (a *Adapter) spec(task controllers.AdapterTask) *sandboxdv1.ProcessSpec {
 }
 
 // EnsureAccepted duplicate-safely starts (or recovers) the Run-keyed process.
-func (a *Adapter) EnsureAccepted(ctx context.Context, task controllers.AdapterTask, sandbox controllers.AdapterSandbox, credential *controllers.AdapterCredential) error {
+func (a *Adapter) EnsureAccepted(ctx context.Context, task agent.AdapterTask, sandbox agent.AdapterSandbox, credential *agent.AdapterCredential) error {
 	if credential != nil && credential.Type != platformv1alpha1.AgentCredentialTypeAPIKey {
-		return fmt.Errorf("%w: unsupported credential type %q", controllers.ErrAdapterTaskRejected, credential.Type)
+		return fmt.Errorf("%w: unsupported credential type %q", agent.ErrAdapterTaskRejected, credential.Type)
 	}
 	client, closeConnection, err := sandbox.DialProcess(ctx)
 	if err != nil {
@@ -104,7 +106,7 @@ func (a *Adapter) EnsureAccepted(ctx context.Context, task controllers.AdapterTa
 }
 
 // Observe forwards bounded process output and maps Amp's terminal result event.
-func (a *Adapter) Observe(ctx context.Context, task controllers.AdapterTask, sandbox controllers.AdapterSandbox) (controllers.AdapterObservation, string, error) {
+func (a *Adapter) Observe(ctx context.Context, task agent.AdapterTask, sandbox agent.AdapterSandbox) (agent.AdapterObservation, string, error) {
 	client, closeConnection, err := sandbox.DialProcess(ctx)
 	if err != nil {
 		return "", "", err
@@ -113,58 +115,58 @@ func (a *Adapter) Observe(ctx context.Context, task controllers.AdapterTask, san
 	process, err := client.Get(ctx, &sandboxdv1.GetProcessRequest{Key: key(task)})
 	if err != nil {
 		if status.Code(err) == codes.NotFound {
-			return controllers.AdapterObservationFailed, "Amp execution is absent in the current sandbox epoch", nil
+			return agent.AdapterObservationFailed, "Amp execution is absent in the current sandbox epoch", nil
 		}
 		return "", "", err
 	}
 	if err := a.forward(ctx, client, task, sandbox, process); err != nil {
-		if errors.Is(err, controllers.ErrAdapterEventRejected) {
-			return controllers.AdapterObservationFailed, "Amp transcript output was permanently rejected", nil
+		if errors.Is(err, agent.ErrAdapterEventRejected) {
+			return agent.AdapterObservationFailed, "Amp transcript output was permanently rejected", nil
 		}
 		return "", "", err
 	}
 	switch process.State {
 	case sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, sandboxdv1.ProcessState_PROCESS_STATE_STOPPING:
-		return controllers.AdapterObservationRunning, "Amp is running", nil
+		return agent.AdapterObservationRunning, "Amp is running", nil
 	case sandboxdv1.ProcessState_PROCESS_STATE_FAILED:
-		return controllers.AdapterObservationFailed, message("Amp failed to start", process.Error), nil
+		return agent.AdapterObservationFailed, message("Amp failed to start", process.Error), nil
 	case sandboxdv1.ProcessState_PROCESS_STATE_EXITED:
 		if process.ExitCode == nil {
-			return controllers.AdapterObservationFailed, "Amp exited without an exit code", nil
+			return agent.AdapterObservationFailed, "Amp exited without an exit code", nil
 		}
 		if process.GetExitCode() != 0 {
-			return controllers.AdapterObservationFailed, fmt.Sprintf("Amp exited with code %d", process.GetExitCode()), nil
+			return agent.AdapterObservationFailed, fmt.Sprintf("Amp exited with code %d", process.GetExitCode()), nil
 		}
 		output, err := readOutput(ctx, client, key(task), process.ExecutionId)
 		if err != nil {
 			var truncated *outputTruncatedError
 			if errors.As(err, &truncated) {
-				return controllers.AdapterObservationFailed, message("Amp stdout was truncated before terminal validation", truncated.Error()), nil
+				return agent.AdapterObservationFailed, message("Amp stdout was truncated before terminal validation", truncated.Error()), nil
 			}
 			return "", "", err
 		}
 		result, ok := finalResult(output)
 		if !ok {
-			return controllers.AdapterObservationFailed, "Amp exited without a valid result event", nil
+			return agent.AdapterObservationFailed, "Amp exited without a valid result event", nil
 		}
 		if result.IsError == nil {
-			return controllers.AdapterObservationFailed, "Amp result is missing is_error", nil
+			return agent.AdapterObservationFailed, "Amp result is missing is_error", nil
 		}
 		if *result.IsError || result.Subtype != "success" {
 			detail := result.Result
 			if detail == "" {
 				detail = errorDetail(result.Error)
 			}
-			return controllers.AdapterObservationFailed, message("Amp reported "+result.Subtype, detail), nil
+			return agent.AdapterObservationFailed, message("Amp reported "+result.Subtype, detail), nil
 		}
-		return controllers.AdapterObservationSucceeded, message("Amp completed", result.Result), nil
+		return agent.AdapterObservationSucceeded, message("Amp completed", result.Result), nil
 	default:
-		return controllers.AdapterObservationFailed, fmt.Sprintf("Amp returned invalid process state %s", process.State), nil
+		return agent.AdapterObservationFailed, fmt.Sprintf("Amp returned invalid process state %s", process.State), nil
 	}
 }
 
 // Cancel idempotently stops only this Run UID's managed process tree.
-func (a *Adapter) Cancel(ctx context.Context, task controllers.AdapterTask, sandbox controllers.AdapterSandbox) error {
+func (a *Adapter) Cancel(ctx context.Context, task agent.AdapterTask, sandbox agent.AdapterSandbox) error {
 	client, closeConnection, err := sandbox.DialProcess(ctx)
 	if err != nil {
 		return err
@@ -176,10 +178,10 @@ func (a *Adapter) Cancel(ctx context.Context, task controllers.AdapterTask, sand
 	}
 	switch process.State {
 	case sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, sandboxdv1.ProcessState_PROCESS_STATE_STOPPING:
-		return controllers.ErrAdapterCancellationPending
+		return agent.ErrAdapterCancellationPending
 	case sandboxdv1.ProcessState_PROCESS_STATE_EXITED, sandboxdv1.ProcessState_PROCESS_STATE_FAILED:
 		err := a.forward(ctx, client, task, sandbox, process)
-		if errors.Is(err, controllers.ErrAdapterEventRejected) {
+		if errors.Is(err, agent.ErrAdapterEventRejected) {
 			return nil
 		}
 		return err
@@ -188,7 +190,7 @@ func (a *Adapter) Cancel(ctx context.Context, task controllers.AdapterTask, sand
 	}
 }
 
-func (a *Adapter) forward(ctx context.Context, client sandboxdv1.ProcessServiceClient, task controllers.AdapterTask, sandbox controllers.AdapterSandbox, process *sandboxdv1.Process) error {
+func (a *Adapter) forward(ctx context.Context, client sandboxdv1.ProcessServiceClient, task agent.AdapterTask, sandbox agent.AdapterSandbox, process *sandboxdv1.Process) error {
 	if sandbox.EmitEvent == nil || process.ExecutionId == "" {
 		return nil
 	}
@@ -216,7 +218,7 @@ func (a *Adapter) forward(ctx context.Context, client sandboxdv1.ProcessServiceC
 				return err
 			}
 			digest := sha256.Sum256(payload)
-			event := controllers.AdapterEvent{Source: "amp", IdempotencyKey: fmt.Sprintf("v1:%s:%x", streamName(stream), digest), Type: "amp.process-output", Data: payload}
+			event := agent.AdapterEvent{Source: "amp", IdempotencyKey: fmt.Sprintf("v1:%s:%x", streamName(stream), digest), Type: "amp.process-output", Data: payload}
 			a.setPending(c, pendingEvent{event: event, nextOffset: response.NextOffset})
 			if err := sandbox.EmitEvent(ctx, event); err != nil {
 				return err

--- a/internal/adapters/amp/adapter_test.go
+++ b/internal/adapters/amp/adapter_test.go
@@ -122,7 +122,7 @@ func TestOutputIncludesGapMetadata(t *testing.T) {
 }
 
 func testSandbox(client sandboxdv1.ProcessServiceClient) agent.AdapterSandbox {
-	return agent.AdapterSandbox{EnvironmentUID: "epoch", DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
+	return agent.AdapterSandbox{EnvironmentUID: agent.EnvironmentUID("epoch"), DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
 		return client, func() error { return nil }, nil
 	}}
 }

--- a/internal/adapters/amp/adapter_test.go
+++ b/internal/adapters/amp/adapter_test.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
-	"github.com/Chris-Cullins/swe-platform/internal/controllers"
+	"github.com/Chris-Cullins/swe-platform/internal/agent"
 	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
 )
 
@@ -109,10 +109,10 @@ func (f *fakeClient) ReadOutput(_ context.Context, request *sandboxdv1.ReadOutpu
 
 func TestOutputIncludesGapMetadata(t *testing.T) {
 	client := &fakeClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"}, stdout: []byte("kept"), retainedFrom: 9}
-	var event controllers.AdapterEvent
+	var event agent.AdapterEvent
 	sandbox := testSandbox(client)
-	sandbox.EmitEvent = func(_ context.Context, got controllers.AdapterEvent) error { event = got; return nil }
-	if _, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err != nil {
+	sandbox.EmitEvent = func(_ context.Context, got agent.AdapterEvent) error { event = got; return nil }
+	if _, _, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox); err != nil {
 		t.Fatal(err)
 	}
 	var output outputEvent
@@ -121,8 +121,8 @@ func TestOutputIncludesGapMetadata(t *testing.T) {
 	}
 }
 
-func testSandbox(client sandboxdv1.ProcessServiceClient) controllers.AdapterSandbox {
-	return controllers.AdapterSandbox{EnvironmentUID: "epoch", DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
+func testSandbox(client sandboxdv1.ProcessServiceClient) agent.AdapterSandbox {
+	return agent.AdapterSandbox{EnvironmentUID: "epoch", DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
 		return client, func() error { return nil }, nil
 	}}
 }
@@ -133,18 +133,18 @@ func TestTerminalValidationFailsOnRetainedOutputGap(t *testing.T) {
 	// offset; the retained tail still contains a valid-looking success event,
 	// but the transport-reported gap makes the terminal result untrustworthy.
 	client := &fakeClient{
-		process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "execution", ExitCode: &exit0},
-		stdout:  []byte(`{"type":"result","subtype":"success","is_error":false,"result":"done"}` + "\n"),
+		process:      &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "execution", ExitCode: &exit0},
+		stdout:       []byte(`{"type":"result","subtype":"success","is_error":false,"result":"done"}` + "\n"),
 		retainedFrom: 1024,
 	}
-	got, detail, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, testSandbox(client))
-	if err != nil || got != controllers.AdapterObservationFailed || !strings.Contains(detail, "truncated before terminal validation") || !strings.Contains(detail, "retained from offset 1024") {
+	got, detail, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, testSandbox(client))
+	if err != nil || got != agent.AdapterObservationFailed || !strings.Contains(detail, "truncated before terminal validation") || !strings.Contains(detail, "retained from offset 1024") {
 		t.Fatalf("Observe = %q, %q, %v", got, detail, err)
 	}
 }
 
 func TestAcceptanceIsDuplicateSafePromptSafeAndFreshEpoch(t *testing.T) {
-	task := controllers.AdapterTask{ID: "run-uid", Prompt: "--version\nsecond line"}
+	task := agent.AdapterTask{ID: "run-uid", Prompt: "--version\nsecond line"}
 	adapter := &Adapter{Executable: "fake-amp"}
 	first := &fakeClient{}
 	for range 2 {
@@ -171,8 +171,8 @@ func TestAcceptanceIsDuplicateSafePromptSafeAndFreshEpoch(t *testing.T) {
 func TestAPIKeyUsesLaunchMaterialOnlyAndClearsTemporaryCopy(t *testing.T) {
 	client := &fakeClient{}
 	key := []byte("!!AMP-API-KEY-FIXTURE!!")
-	credential := &controllers.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: key}
-	if err := (&Adapter{}).EnsureAccepted(context.Background(), controllers.AdapterTask{ID: "run", Prompt: "task"}, testSandbox(client), credential); err != nil {
+	credential := &agent.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: key}
+	if err := (&Adapter{}).EnsureAccepted(context.Background(), agent.AdapterTask{ID: "run", Prompt: "task"}, testSandbox(client), credential); err != nil {
 		t.Fatal(err)
 	}
 	if client.launchCalls != 1 || client.starts != 0 || string(client.launchValue) != string(key) || string(credential.APIKey) != string(key) {
@@ -191,12 +191,12 @@ func TestAPIKeyUsesLaunchMaterialOnlyAndClearsTemporaryCopy(t *testing.T) {
 
 func TestUnsupportedCredentialTypeFailsBeforeDial(t *testing.T) {
 	dials := 0
-	sandbox := controllers.AdapterSandbox{DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
+	sandbox := agent.AdapterSandbox{DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
 		dials++
 		return nil, nil, nil
 	}}
-	err := (&Adapter{}).EnsureAccepted(context.Background(), controllers.AdapterTask{}, sandbox, &controllers.AdapterCredential{Type: "OAuth", APIKey: []byte("!!UNUSED-KEY-FIXTURE!!")})
-	if !errors.Is(err, controllers.ErrAdapterTaskRejected) || dials != 0 {
+	err := (&Adapter{}).EnsureAccepted(context.Background(), agent.AdapterTask{}, sandbox, &agent.AdapterCredential{Type: "OAuth", APIKey: []byte("!!UNUSED-KEY-FIXTURE!!")})
+	if !errors.Is(err, agent.ErrAdapterTaskRejected) || dials != 0 {
 		t.Fatalf("error/dials = %v/%d", err, dials)
 	}
 }
@@ -204,18 +204,18 @@ func TestUnsupportedCredentialTypeFailsBeforeDial(t *testing.T) {
 func TestLaunchMaterialFailureDoesNotFallbackOrExposeKey(t *testing.T) {
 	key := []byte("!!AMP-FAILURE-KEY-FIXTURE!!")
 	client := &fakeClient{beforeLaunchErr: status.Error(codes.Unimplemented, "old sandboxd")}
-	err := (&Adapter{}).EnsureAccepted(context.Background(), controllers.AdapterTask{ID: "run", Prompt: "task"}, testSandbox(client), &controllers.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: key})
+	err := (&Adapter{}).EnsureAccepted(context.Background(), agent.AdapterTask{ID: "run", Prompt: "task"}, testSandbox(client), &agent.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: key})
 	if status.Code(err) != codes.Unimplemented || client.starts != 0 || client.launchCalls != 1 || client.launches != 0 || strings.Contains(err.Error(), string(key)) {
 		t.Fatalf("error/start/calls/launches = %v/%d/%d/%d", err, client.starts, client.launchCalls, client.launches)
 	}
 }
 
 func TestKeyedAcceptancePreservesDuplicateRotationAndFreshEpochSemantics(t *testing.T) {
-	task := controllers.AdapterTask{ID: "run-uid", Prompt: "task"}
+	task := agent.AdapterTask{ID: "run-uid", Prompt: "task"}
 	adapter := &Adapter{}
 	first := &fakeClient{}
 	for _, value := range []string{"first-key", "rotated-key"} {
-		credential := &controllers.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: []byte(value)}
+		credential := &agent.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: []byte(value)}
 		if err := adapter.EnsureAccepted(context.Background(), task, testSandbox(first), credential); err != nil {
 			t.Fatal(err)
 		}
@@ -224,7 +224,7 @@ func TestKeyedAcceptancePreservesDuplicateRotationAndFreshEpochSemantics(t *test
 		t.Fatalf("duplicate calls/launches/launched/submitted/key = %d/%d/%q/%q/%#v", first.launchCalls, first.launches, first.launchValue, first.submittedValue, first.startedKey)
 	}
 	second := &fakeClient{}
-	credential := &controllers.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: []byte("current-key")}
+	credential := &agent.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: []byte("current-key")}
 	if err := adapter.EnsureAccepted(context.Background(), task, testSandbox(second), credential); err != nil {
 		t.Fatal(err)
 	}
@@ -235,8 +235,8 @@ func TestKeyedAcceptancePreservesDuplicateRotationAndFreshEpochSemantics(t *test
 
 func TestUncertainKeyedStartRetryDoesNotUsePlainStart(t *testing.T) {
 	client := &fakeClient{afterLaunchErr: status.Error(codes.Unavailable, "response lost")}
-	credential := &controllers.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: []byte("first-key")}
-	task := controllers.AdapterTask{ID: "run", Prompt: "task"}
+	credential := &agent.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: []byte("first-key")}
+	task := agent.AdapterTask{ID: "run", Prompt: "task"}
 	if err := (&Adapter{}).EnsureAccepted(context.Background(), task, testSandbox(client), credential); status.Code(err) != codes.Unavailable {
 		t.Fatalf("first start error = %v", err)
 	}
@@ -256,43 +256,43 @@ func TestObservationOutcomes(t *testing.T) {
 		name    string
 		process *sandboxdv1.Process
 		output  string
-		want    controllers.AdapterObservation
+		want    agent.AdapterObservation
 	}{
-		{"running", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "e"}, "", controllers.AdapterObservationRunning},
-		{"success", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, `{"type":"result","subtype":"success","is_error":false,"result":"done"}` + "\n", controllers.AdapterObservationSucceeded},
-		{"truncated prefix then success", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, "{truncated\n" + `{"type":"result","subtype":"success","is_error":false,"result":"done"}`, controllers.AdapterObservationSucceeded},
-		{"success then assistant", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, `{"type":"result","subtype":"success","is_error":false}` + "\n" + `{"type":"assistant"}`, controllers.AdapterObservationFailed},
-		{"success then malformed", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, `{"type":"result","subtype":"success","is_error":false}` + "\ntruncated", controllers.AdapterObservationFailed},
-		{"failed result", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, `{"type":"result","subtype":"error_during_execution","is_error":true}` + "\n", controllers.AdapterObservationFailed},
-		{"malformed", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, "not json\n", controllers.AdapterObservationFailed},
-		{"missing terminal", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, `{"type":"assistant"}` + "\n", controllers.AdapterObservationFailed},
-		{"nonzero", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit1, ExecutionId: "e"}, `{"type":"result","subtype":"success","is_error":false}` + "\n", controllers.AdapterObservationFailed},
+		{"running", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "e"}, "", agent.AdapterObservationRunning},
+		{"success", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, `{"type":"result","subtype":"success","is_error":false,"result":"done"}` + "\n", agent.AdapterObservationSucceeded},
+		{"truncated prefix then success", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, "{truncated\n" + `{"type":"result","subtype":"success","is_error":false,"result":"done"}`, agent.AdapterObservationSucceeded},
+		{"success then assistant", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, `{"type":"result","subtype":"success","is_error":false}` + "\n" + `{"type":"assistant"}`, agent.AdapterObservationFailed},
+		{"success then malformed", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, `{"type":"result","subtype":"success","is_error":false}` + "\ntruncated", agent.AdapterObservationFailed},
+		{"failed result", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, `{"type":"result","subtype":"error_during_execution","is_error":true}` + "\n", agent.AdapterObservationFailed},
+		{"malformed", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, "not json\n", agent.AdapterObservationFailed},
+		{"missing terminal", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, `{"type":"assistant"}` + "\n", agent.AdapterObservationFailed},
+		{"nonzero", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit1, ExecutionId: "e"}, `{"type":"result","subtype":"success","is_error":false}` + "\n", agent.AdapterObservationFailed},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, testSandbox(&fakeClient{process: test.process, stdout: []byte(test.output)}))
+			got, _, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, testSandbox(&fakeClient{process: test.process, stdout: []byte(test.output)}))
 			if err != nil || got != test.want {
 				t.Fatalf("Observe = %q, %v", got, err)
 			}
 		})
 	}
-	absent, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, testSandbox(&fakeClient{getErr: status.Error(codes.NotFound, "gone")}))
-	if err != nil || absent != controllers.AdapterObservationFailed {
+	absent, _, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, testSandbox(&fakeClient{getErr: status.Error(codes.NotFound, "gone")}))
+	if err != nil || absent != agent.AdapterObservationFailed {
 		t.Fatalf("absent = %q, %v", absent, err)
 	}
 }
 
 func TestCancellationAndBoundedIdempotentOutput(t *testing.T) {
 	client := &fakeClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"}, stdout: []byte("stdout"), stderr: []byte("stderr")}
-	var events []controllers.AdapterEvent
+	var events []agent.AdapterEvent
 	sandbox := testSandbox(client)
-	sandbox.EmitEvent = func(_ context.Context, event controllers.AdapterEvent) error {
+	sandbox.EmitEvent = func(_ context.Context, event agent.AdapterEvent) error {
 		events = append(events, event)
 		return nil
 	}
 	adapter := &Adapter{}
 	for range 2 {
-		if _, _, err := adapter.Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err != nil {
+		if _, _, err := adapter.Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -307,17 +307,17 @@ func TestCancellationAndBoundedIdempotentOutput(t *testing.T) {
 	if client.readRequests[0].MaxBytes != pageMax {
 		t.Fatalf("read max = %d", client.readRequests[0].MaxBytes)
 	}
-	err := adapter.Cancel(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox)
-	if !errors.Is(err, controllers.ErrAdapterCancellationPending) || client.stoppedKey.OwnerId != "run" {
+	err := adapter.Cancel(context.Background(), agent.AdapterTask{ID: "run"}, sandbox)
+	if !errors.Is(err, agent.ErrAdapterCancellationPending) || client.stoppedKey.OwnerId != "run" {
 		t.Fatalf("cancel = %v/%#v", err, client.stoppedKey)
 	}
 }
 
 func TestOutputRetryUsesStableKey(t *testing.T) {
 	client := &fakeClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"}, stdout: []byte("output")}
-	var events []controllers.AdapterEvent
+	var events []agent.AdapterEvent
 	sandbox := testSandbox(client)
-	sandbox.EmitEvent = func(_ context.Context, event controllers.AdapterEvent) error {
+	sandbox.EmitEvent = func(_ context.Context, event agent.AdapterEvent) error {
 		events = append(events, event)
 		if len(events) == 1 {
 			return errors.New("retry")
@@ -325,11 +325,11 @@ func TestOutputRetryUsesStableKey(t *testing.T) {
 		return nil
 	}
 	adapter := &Adapter{}
-	if _, _, err := adapter.Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err == nil {
+	if _, _, err := adapter.Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox); err == nil {
 		t.Fatal("wanted transient error")
 	}
 	client.stdout = []byte("output appended")
-	if _, _, err := adapter.Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err != nil {
+	if _, _, err := adapter.Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox); err != nil {
 		t.Fatal(err)
 	}
 	if len(events) != 3 || !reflect.DeepEqual(events[0], events[1]) {
@@ -347,26 +347,26 @@ func TestRestartChangesKeyWhenSnapshotMetadataChanges(t *testing.T) {
 		process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"},
 		stdout:  bytes.Repeat([]byte("x"), pageMax+1),
 	}
-	var first controllers.AdapterEvent
+	var first agent.AdapterEvent
 	sandbox := testSandbox(client)
-	sandbox.EmitEvent = func(_ context.Context, event controllers.AdapterEvent) error {
+	sandbox.EmitEvent = func(_ context.Context, event agent.AdapterEvent) error {
 		if first.Data == nil {
 			first = event
 			return errors.New("uncertain append")
 		}
 		return nil
 	}
-	if _, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err == nil {
+	if _, _, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox); err == nil {
 		t.Fatal("wanted uncertain append error")
 	}
 
 	client.stdout = append(client.stdout, 'y')
-	var replay controllers.AdapterEvent
-	sandbox.EmitEvent = func(_ context.Context, event controllers.AdapterEvent) error {
+	var replay agent.AdapterEvent
+	sandbox.EmitEvent = func(_ context.Context, event agent.AdapterEvent) error {
 		replay = event
 		return errors.New("stop after replay")
 	}
-	if _, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err == nil {
+	if _, _, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox); err == nil {
 		t.Fatal("wanted replay stop error")
 	}
 	if first.IdempotencyKey == replay.IdempotencyKey || bytes.Equal(first.Data, replay.Data) {

--- a/internal/adapters/claudecode/adapter.go
+++ b/internal/adapters/claudecode/adapter.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
-	"github.com/Chris-Cullins/swe-platform/internal/controllers"
+	"github.com/Chris-Cullins/swe-platform/internal/agent"
 	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
 )
 
@@ -30,6 +30,8 @@ type Adapter struct {
 	mu      sync.Mutex
 	cursors map[outputCursor]uint64
 }
+
+var _ agent.AdapterLifecycle = (*Adapter)(nil)
 
 type outputCursor struct {
 	environment string
@@ -64,11 +66,11 @@ func (a *Adapter) executable() string {
 	return "claude"
 }
 
-func processKey(task controllers.AdapterTask) *sandboxdv1.ProcessKey {
+func processKey(task agent.AdapterTask) *sandboxdv1.ProcessKey {
 	return &sandboxdv1.ProcessKey{OwnerId: task.ID, Role: processRole}
 }
 
-func (a *Adapter) processSpec(task controllers.AdapterTask) *sandboxdv1.ProcessSpec {
+func (a *Adapter) processSpec(task agent.AdapterTask) *sandboxdv1.ProcessSpec {
 	return &sandboxdv1.ProcessSpec{
 		Argv: []string{
 			a.executable(),
@@ -85,7 +87,7 @@ func (a *Adapter) processSpec(task controllers.AdapterTask) *sandboxdv1.ProcessS
 }
 
 // EnsureAccepted duplicate-safely starts (or recovers) the Run-keyed process.
-func (a *Adapter) EnsureAccepted(ctx context.Context, task controllers.AdapterTask, sandbox controllers.AdapterSandbox, credential *controllers.AdapterCredential) error {
+func (a *Adapter) EnsureAccepted(ctx context.Context, task agent.AdapterTask, sandbox agent.AdapterSandbox, credential *agent.AdapterCredential) error {
 	if credential != nil && credential.Type != platformv1alpha1.AgentCredentialTypeAPIKey {
 		return fmt.Errorf("unsupported credential type %q", credential.Type)
 	}
@@ -109,7 +111,7 @@ func (a *Adapter) EnsureAccepted(ctx context.Context, task controllers.AdapterTa
 
 // Observe forwards bounded process output and maps Claude's terminal result to
 // the adapter-neutral Run lifecycle.
-func (a *Adapter) Observe(ctx context.Context, task controllers.AdapterTask, sandbox controllers.AdapterSandbox) (controllers.AdapterObservation, string, error) {
+func (a *Adapter) Observe(ctx context.Context, task agent.AdapterTask, sandbox agent.AdapterSandbox) (agent.AdapterObservation, string, error) {
 	client, closeConnection, err := sandbox.DialProcess(ctx)
 	if err != nil {
 		return "", "", err
@@ -118,55 +120,55 @@ func (a *Adapter) Observe(ctx context.Context, task controllers.AdapterTask, san
 	process, err := client.Get(ctx, &sandboxdv1.GetProcessRequest{Key: processKey(task)})
 	if err != nil {
 		if status.Code(err) == codes.NotFound {
-			return controllers.AdapterObservationFailed, "Claude Code execution is absent in the current sandbox epoch", nil
+			return agent.AdapterObservationFailed, "Claude Code execution is absent in the current sandbox epoch", nil
 		}
 		return "", "", err
 	}
 	if err := a.forwardOutput(ctx, client, task, sandbox, process); err != nil {
-		if errors.Is(err, controllers.ErrAdapterEventRejected) {
-			return controllers.AdapterObservationFailed, "Claude Code transcript output was permanently rejected", nil
+		if errors.Is(err, agent.ErrAdapterEventRejected) {
+			return agent.AdapterObservationFailed, "Claude Code transcript output was permanently rejected", nil
 		}
 		return "", "", err
 	}
 
 	switch process.State {
 	case sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, sandboxdv1.ProcessState_PROCESS_STATE_STOPPING:
-		return controllers.AdapterObservationRunning, "Claude Code is running", nil
+		return agent.AdapterObservationRunning, "Claude Code is running", nil
 	case sandboxdv1.ProcessState_PROCESS_STATE_FAILED:
-		return controllers.AdapterObservationFailed, processMessage("Claude Code failed to start", process.Error), nil
+		return agent.AdapterObservationFailed, processMessage("Claude Code failed to start", process.Error), nil
 	case sandboxdv1.ProcessState_PROCESS_STATE_EXITED:
 		if process.ExitCode == nil {
-			return controllers.AdapterObservationFailed, "Claude Code exited without an exit code", nil
+			return agent.AdapterObservationFailed, "Claude Code exited without an exit code", nil
 		}
 		if process.GetExitCode() != 0 {
-			return controllers.AdapterObservationFailed, fmt.Sprintf("Claude Code exited with code %d", process.GetExitCode()), nil
+			return agent.AdapterObservationFailed, fmt.Sprintf("Claude Code exited with code %d", process.GetExitCode()), nil
 		}
 		output, err := readRetainedOutput(ctx, client, processKey(task), process.ExecutionId, sandboxdv1.OutputStream_OUTPUT_STREAM_STDOUT)
 		if err != nil {
 			var truncated *outputTruncatedError
 			if errors.As(err, &truncated) {
-				return controllers.AdapterObservationFailed, processMessage("Claude Code stdout was truncated before terminal validation", truncated.Error()), nil
+				return agent.AdapterObservationFailed, processMessage("Claude Code stdout was truncated before terminal validation", truncated.Error()), nil
 			}
 			return "", "", err
 		}
 		result, ok := finalResult(output)
 		if !ok {
-			return controllers.AdapterObservationFailed, "Claude Code exited without a valid result event", nil
+			return agent.AdapterObservationFailed, "Claude Code exited without a valid result event", nil
 		}
 		if result.IsError == nil {
-			return controllers.AdapterObservationFailed, "Claude Code result is missing is_error", nil
+			return agent.AdapterObservationFailed, "Claude Code result is missing is_error", nil
 		}
 		if *result.IsError || result.Subtype != "success" {
-			return controllers.AdapterObservationFailed, processMessage("Claude Code reported "+result.Subtype, result.Result), nil
+			return agent.AdapterObservationFailed, processMessage("Claude Code reported "+result.Subtype, result.Result), nil
 		}
-		return controllers.AdapterObservationSucceeded, processMessage("Claude Code completed", result.Result), nil
+		return agent.AdapterObservationSucceeded, processMessage("Claude Code completed", result.Result), nil
 	default:
-		return controllers.AdapterObservationFailed, fmt.Sprintf("Claude Code returned invalid process state %s", process.State), nil
+		return agent.AdapterObservationFailed, fmt.Sprintf("Claude Code returned invalid process state %s", process.State), nil
 	}
 }
 
 // Cancel idempotently stops only this Run UID's managed process tree.
-func (a *Adapter) Cancel(ctx context.Context, task controllers.AdapterTask, sandbox controllers.AdapterSandbox) error {
+func (a *Adapter) Cancel(ctx context.Context, task agent.AdapterTask, sandbox agent.AdapterSandbox) error {
 	client, closeConnection, err := sandbox.DialProcess(ctx)
 	if err != nil {
 		return err
@@ -182,10 +184,10 @@ func (a *Adapter) Cancel(ctx context.Context, task controllers.AdapterTask, sand
 	}
 	switch process.State {
 	case sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, sandboxdv1.ProcessState_PROCESS_STATE_STOPPING:
-		return controllers.ErrAdapterCancellationPending
+		return agent.ErrAdapterCancellationPending
 	case sandboxdv1.ProcessState_PROCESS_STATE_EXITED, sandboxdv1.ProcessState_PROCESS_STATE_FAILED:
 		err := a.forwardOutput(ctx, client, task, sandbox, process)
-		if errors.Is(err, controllers.ErrAdapterEventRejected) {
+		if errors.Is(err, agent.ErrAdapterEventRejected) {
 			return nil
 		}
 		return err
@@ -194,7 +196,7 @@ func (a *Adapter) Cancel(ctx context.Context, task controllers.AdapterTask, sand
 	}
 }
 
-func (a *Adapter) forwardOutput(ctx context.Context, client sandboxdv1.ProcessServiceClient, task controllers.AdapterTask, sandbox controllers.AdapterSandbox, process *sandboxdv1.Process) error {
+func (a *Adapter) forwardOutput(ctx context.Context, client sandboxdv1.ProcessServiceClient, task agent.AdapterTask, sandbox agent.AdapterSandbox, process *sandboxdv1.Process) error {
 	if sandbox.EmitEvent == nil || process.ExecutionId == "" {
 		return nil
 	}
@@ -219,7 +221,7 @@ func (a *Adapter) forwardOutput(ctx context.Context, client sandboxdv1.ProcessSe
 			}
 			digest := sha256.Sum256(payload)
 			key := fmt.Sprintf("v1:%s:%x", streamName(stream), digest)
-			if err := sandbox.EmitEvent(ctx, controllers.AdapterEvent{Source: "claude-code", IdempotencyKey: key, Type: "claude-code.process-output", Data: payload}); err != nil {
+			if err := sandbox.EmitEvent(ctx, agent.AdapterEvent{Source: "claude-code", IdempotencyKey: key, Type: "claude-code.process-output", Data: payload}); err != nil {
 				return err
 			}
 			offset = response.NextOffset

--- a/internal/adapters/claudecode/adapter_test.go
+++ b/internal/adapters/claudecode/adapter_test.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
-	"github.com/Chris-Cullins/swe-platform/internal/controllers"
+	"github.com/Chris-Cullins/swe-platform/internal/agent"
 	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
 )
 
@@ -97,8 +97,8 @@ func (f *fakeProcessClient) ReadOutput(_ context.Context, request *sandboxdv1.Re
 	return &sandboxdv1.ReadOutputResponse{Data: append([]byte(nil), data[start:end]...), Offset: offset, NextOffset: retainedFrom + uint64(end), GapBytes: gapBytes, RetainedStart: retainedFrom, ProducedEnd: producedEnd, Eof: end == len(data)}, nil
 }
 
-func sandboxFor(client sandboxdv1.ProcessServiceClient) controllers.AdapterSandbox {
-	return controllers.AdapterSandbox{
+func sandboxFor(client sandboxdv1.ProcessServiceClient) agent.AdapterSandbox {
+	return agent.AdapterSandbox{
 		EnvironmentName: "environment",
 		EnvironmentUID:  "environment-uid",
 		DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
@@ -108,7 +108,7 @@ func sandboxFor(client sandboxdv1.ProcessServiceClient) controllers.AdapterSandb
 }
 
 func TestAcceptanceIsDuplicateSafeAndResumeKeepsTaskIdentity(t *testing.T) {
-	task := controllers.AdapterTask{ID: "run-uid", Prompt: "fix the test"}
+	task := agent.AdapterTask{ID: "run-uid", Prompt: "fix the test"}
 	adapter := &Adapter{Executable: "fake-claude"}
 	firstEpoch := &fakeProcessClient{}
 	for range 2 {
@@ -136,7 +136,7 @@ func TestAcceptanceIsDuplicateSafeAndResumeKeepsTaskIdentity(t *testing.T) {
 }
 
 func TestPromptIsSeparatedFromClaudeFlags(t *testing.T) {
-	spec := (&Adapter{}).processSpec(controllers.AdapterTask{Prompt: "--version"})
+	spec := (&Adapter{}).processSpec(agent.AdapterTask{Prompt: "--version"})
 	if got := spec.Argv[len(spec.Argv)-2:]; !reflect.DeepEqual(got, []string{"--", "--version"}) {
 		t.Fatalf("argv suffix = %#v, want flag terminator and prompt", got)
 	}
@@ -145,7 +145,7 @@ func TestPromptIsSeparatedFromClaudeFlags(t *testing.T) {
 func TestAPIKeyUsesLaunchMaterialOnly(t *testing.T) {
 	client := &fakeProcessClient{}
 	key := []byte("!!CLAUDE-API-KEY-FIXTURE!!")
-	err := (&Adapter{}).EnsureAccepted(context.Background(), controllers.AdapterTask{ID: "run", Prompt: "task"}, sandboxFor(client), &controllers.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: key})
+	err := (&Adapter{}).EnsureAccepted(context.Background(), agent.AdapterTask{ID: "run", Prompt: "task"}, sandboxFor(client), &agent.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: key})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -162,7 +162,7 @@ func TestAPIKeyUsesLaunchMaterialOnly(t *testing.T) {
 
 func TestLaunchMaterialUnimplementedDoesNotFallback(t *testing.T) {
 	client := &fakeProcessClient{launchErr: status.Error(codes.Unimplemented, "old sandboxd")}
-	err := (&Adapter{}).EnsureAccepted(context.Background(), controllers.AdapterTask{ID: "run"}, sandboxFor(client), &controllers.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: []byte("key")})
+	err := (&Adapter{}).EnsureAccepted(context.Background(), agent.AdapterTask{ID: "run"}, sandboxFor(client), &agent.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: []byte("key")})
 	if status.Code(err) != codes.Unimplemented || client.startCalls != 0 {
 		t.Fatalf("error/start calls = %v/%d", err, client.startCalls)
 	}
@@ -170,11 +170,11 @@ func TestLaunchMaterialUnimplementedDoesNotFallback(t *testing.T) {
 
 func TestUnsupportedCredentialTypeFailsBeforeDial(t *testing.T) {
 	dials := 0
-	sandbox := controllers.AdapterSandbox{DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
+	sandbox := agent.AdapterSandbox{DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
 		dials++
 		return &fakeProcessClient{}, func() error { return nil }, nil
 	}}
-	err := (&Adapter{}).EnsureAccepted(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox, &controllers.AdapterCredential{Type: "FutureType", APIKey: []byte("!!UNUSED-KEY-FIXTURE!!")})
+	err := (&Adapter{}).EnsureAccepted(context.Background(), agent.AdapterTask{ID: "run"}, sandbox, &agent.AdapterCredential{Type: "FutureType", APIKey: []byte("!!UNUSED-KEY-FIXTURE!!")})
 	if err == nil || dials != 0 {
 		t.Fatalf("unsupported credential = error %v, dials %d", err, dials)
 	}
@@ -182,7 +182,7 @@ func TestUnsupportedCredentialTypeFailsBeforeDial(t *testing.T) {
 
 func TestCancelStopsOnlyRunOwnedProcessTree(t *testing.T) {
 	client := &fakeProcessClient{}
-	task := controllers.AdapterTask{ID: "run-uid"}
+	task := agent.AdapterTask{ID: "run-uid"}
 	if err := (&Adapter{}).Cancel(context.Background(), task, sandboxFor(client)); err != nil {
 		t.Fatal(err)
 	}
@@ -193,8 +193,8 @@ func TestCancelStopsOnlyRunOwnedProcessTree(t *testing.T) {
 
 func TestCancelWaitsForProcessTreeToBecomeTerminal(t *testing.T) {
 	client := &fakeProcessClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_STOPPING, ExecutionId: "execution"}}
-	err := (&Adapter{}).Cancel(context.Background(), controllers.AdapterTask{ID: "run-uid"}, sandboxFor(client))
-	if !errors.Is(err, controllers.ErrAdapterCancellationPending) {
+	err := (&Adapter{}).Cancel(context.Background(), agent.AdapterTask{ID: "run-uid"}, sandboxFor(client))
+	if !errors.Is(err, agent.ErrAdapterCancellationPending) {
 		t.Fatalf("Cancel() error = %v, want cancellation pending", err)
 	}
 }
@@ -205,23 +205,23 @@ func TestObservationMapping(t *testing.T) {
 		name    string
 		process *sandboxdv1.Process
 		stdout  string
-		want    controllers.AdapterObservation
+		want    agent.AdapterObservation
 	}{
-		{name: "running", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "e"}, want: controllers.AdapterObservationRunning},
-		{name: "start failure", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_FAILED, Error: "executable not found", ExecutionId: "e"}, want: controllers.AdapterObservationFailed},
-		{name: "nonzero exit", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit1, ExecutionId: "e"}, want: controllers.AdapterObservationFailed},
-		{name: "success", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"result\":\"done\"}\n", want: controllers.AdapterObservationSucceeded},
-		{name: "success with historical denial", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"permission_denials\":[{\"tool\":\"Bash\"}]}\n", want: controllers.AdapterObservationSucceeded},
-		{name: "reported error", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"result\",\"subtype\":\"error_max_turns\",\"is_error\":true}\n", want: controllers.AdapterObservationFailed},
-		{name: "error with denial", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"result\",\"subtype\":\"error_during_execution\",\"is_error\":true,\"permission_denials\":[{}]}\n", want: controllers.AdapterObservationFailed},
-		{name: "missing error marker", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"result\",\"subtype\":\"success\"}\n", want: controllers.AdapterObservationFailed},
-		{name: "malformed result", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "not-json\n", want: controllers.AdapterObservationFailed},
-		{name: "missing exit code", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e"}, want: controllers.AdapterObservationFailed},
+		{name: "running", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "e"}, want: agent.AdapterObservationRunning},
+		{name: "start failure", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_FAILED, Error: "executable not found", ExecutionId: "e"}, want: agent.AdapterObservationFailed},
+		{name: "nonzero exit", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit1, ExecutionId: "e"}, want: agent.AdapterObservationFailed},
+		{name: "success", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"result\":\"done\"}\n", want: agent.AdapterObservationSucceeded},
+		{name: "success with historical denial", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"permission_denials\":[{\"tool\":\"Bash\"}]}\n", want: agent.AdapterObservationSucceeded},
+		{name: "reported error", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"result\",\"subtype\":\"error_max_turns\",\"is_error\":true}\n", want: agent.AdapterObservationFailed},
+		{name: "error with denial", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"result\",\"subtype\":\"error_during_execution\",\"is_error\":true,\"permission_denials\":[{}]}\n", want: agent.AdapterObservationFailed},
+		{name: "missing error marker", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "{\"type\":\"result\",\"subtype\":\"success\"}\n", want: agent.AdapterObservationFailed},
+		{name: "malformed result", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: "not-json\n", want: agent.AdapterObservationFailed},
+		{name: "missing exit code", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e"}, want: agent.AdapterObservationFailed},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			client := &fakeProcessClient{process: test.process, stdout: []byte(test.stdout)}
-			got, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandboxFor(client))
+			got, _, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandboxFor(client))
 			if err != nil || got != test.want {
 				t.Fatalf("Observe() = (%q, %v), want %q", got, err, test.want)
 			}
@@ -231,15 +231,15 @@ func TestObservationMapping(t *testing.T) {
 
 func TestUnavailableAndAbsentExecution(t *testing.T) {
 	dialError := errors.New("sandbox unavailable")
-	sandbox := controllers.AdapterSandbox{DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
+	sandbox := agent.AdapterSandbox{DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
 		return nil, nil, dialError
 	}}
-	if err := (&Adapter{}).EnsureAccepted(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox, nil); !errors.Is(err, dialError) {
+	if err := (&Adapter{}).EnsureAccepted(context.Background(), agent.AdapterTask{ID: "run"}, sandbox, nil); !errors.Is(err, dialError) {
 		t.Fatalf("EnsureAccepted() error = %v", err)
 	}
 	client := &fakeProcessClient{getErr: status.Error(codes.NotFound, "absent")}
-	got, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandboxFor(client))
-	if err != nil || got != controllers.AdapterObservationFailed {
+	got, _, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandboxFor(client))
+	if err != nil || got != agent.AdapterObservationFailed {
 		t.Fatalf("Observe(absent) = (%q, %v)", got, err)
 	}
 }
@@ -249,15 +249,15 @@ func TestOutputForwardingIsBoundedCursorBasedAndAdapterOwned(t *testing.T) {
 		process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"},
 		stdout:  []byte("stdout"), stderr: []byte("stderr"),
 	}
-	var events []controllers.AdapterEvent
+	var events []agent.AdapterEvent
 	sandbox := sandboxFor(client)
-	sandbox.EmitEvent = func(_ context.Context, event controllers.AdapterEvent) error {
+	sandbox.EmitEvent = func(_ context.Context, event agent.AdapterEvent) error {
 		events = append(events, event)
 		return nil
 	}
 	adapter := &Adapter{}
 	for range 2 {
-		if _, _, err := adapter.Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err != nil {
+		if _, _, err := adapter.Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -275,15 +275,15 @@ func TestOutputRetryAfterRestartUsesContentAddressedKeys(t *testing.T) {
 	client := &fakeProcessClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"}, stdout: []byte("first")}
 	var keys []string
 	sandbox := sandboxFor(client)
-	sandbox.EmitEvent = func(_ context.Context, event controllers.AdapterEvent) error {
+	sandbox.EmitEvent = func(_ context.Context, event agent.AdapterEvent) error {
 		keys = append(keys, event.IdempotencyKey)
 		return nil
 	}
-	if _, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err != nil {
+	if _, _, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox); err != nil {
 		t.Fatal(err)
 	}
 	client.stdout = []byte("first-second")
-	if _, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err != nil {
+	if _, _, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox); err != nil {
 		t.Fatal(err)
 	}
 	if len(keys) != 2 || keys[0] == keys[1] {
@@ -296,7 +296,7 @@ func TestTransientOutputFailureRetriesSameEvent(t *testing.T) {
 	transient := errors.New("temporary transcript outage")
 	var keys []string
 	sandbox := sandboxFor(client)
-	sandbox.EmitEvent = func(_ context.Context, event controllers.AdapterEvent) error {
+	sandbox.EmitEvent = func(_ context.Context, event agent.AdapterEvent) error {
 		keys = append(keys, event.IdempotencyKey)
 		if len(keys) == 1 {
 			return transient
@@ -304,11 +304,11 @@ func TestTransientOutputFailureRetriesSameEvent(t *testing.T) {
 		return nil
 	}
 	adapter := &Adapter{}
-	if _, _, err := adapter.Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); !errors.Is(err, transient) {
+	if _, _, err := adapter.Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox); !errors.Is(err, transient) {
 		t.Fatalf("first Observe() error = %v, want transient error", err)
 	}
-	got, _, err := adapter.Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox)
-	if err != nil || got != controllers.AdapterObservationRunning {
+	got, _, err := adapter.Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox)
+	if err != nil || got != agent.AdapterObservationRunning {
 		t.Fatalf("retry Observe() = (%q, %v)", got, err)
 	}
 	if len(keys) != 2 || keys[0] != keys[1] {
@@ -319,11 +319,11 @@ func TestTransientOutputFailureRetriesSameEvent(t *testing.T) {
 func TestPermanentOutputRejectionFailsObservation(t *testing.T) {
 	client := &fakeProcessClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"}, stdout: []byte("output")}
 	sandbox := sandboxFor(client)
-	sandbox.EmitEvent = func(context.Context, controllers.AdapterEvent) error {
-		return controllers.ErrAdapterEventRejected
+	sandbox.EmitEvent = func(context.Context, agent.AdapterEvent) error {
+		return agent.ErrAdapterEventRejected
 	}
-	got, message, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox)
-	if err != nil || got != controllers.AdapterObservationFailed || !strings.Contains(message, "permanently rejected") {
+	got, message, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox)
+	if err != nil || got != agent.AdapterObservationFailed || !strings.Contains(message, "permanently rejected") {
 		t.Fatalf("Observe() = (%q, %q, %v)", got, message, err)
 	}
 }
@@ -338,8 +338,8 @@ func TestTerminalValidationFailsOnRetainedOutputGap(t *testing.T) {
 		stdout:       []byte(`{"type":"result","subtype":"success","is_error":false,"result":"done"}` + "\n"),
 		retainedFrom: 512,
 	}
-	got, detail, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandboxFor(client))
-	if err != nil || got != controllers.AdapterObservationFailed || !strings.Contains(detail, "truncated before terminal validation") || !strings.Contains(detail, "retained from offset 512") {
+	got, detail, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandboxFor(client))
+	if err != nil || got != agent.AdapterObservationFailed || !strings.Contains(detail, "truncated before terminal validation") || !strings.Contains(detail, "retained from offset 512") {
 		t.Fatalf("Observe() = (%q, %q, %v)", got, detail, err)
 	}
 }
@@ -348,10 +348,10 @@ func TestTerminalCancellationIgnoresPermanentOutputRejection(t *testing.T) {
 	exitCode := int32(0)
 	client := &fakeProcessClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "execution", ExitCode: &exitCode}, stdout: []byte("output")}
 	sandbox := sandboxFor(client)
-	sandbox.EmitEvent = func(context.Context, controllers.AdapterEvent) error {
-		return controllers.ErrAdapterEventRejected
+	sandbox.EmitEvent = func(context.Context, agent.AdapterEvent) error {
+		return agent.ErrAdapterEventRejected
 	}
-	if err := (&Adapter{}).Cancel(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err != nil {
+	if err := (&Adapter{}).Cancel(context.Background(), agent.AdapterTask{ID: "run"}, sandbox); err != nil {
 		t.Fatalf("Cancel() error = %v", err)
 	}
 }

--- a/internal/adapters/claudecode/adapter_test.go
+++ b/internal/adapters/claudecode/adapter_test.go
@@ -100,7 +100,7 @@ func (f *fakeProcessClient) ReadOutput(_ context.Context, request *sandboxdv1.Re
 func sandboxFor(client sandboxdv1.ProcessServiceClient) agent.AdapterSandbox {
 	return agent.AdapterSandbox{
 		EnvironmentName: "environment",
-		EnvironmentUID:  "environment-uid",
+		EnvironmentUID:  agent.EnvironmentUID("environment-uid"),
 		DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
 			return client, func() error { return nil }, nil
 		},

--- a/internal/adapters/codex/adapter.go
+++ b/internal/adapters/codex/adapter.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
-	"github.com/Chris-Cullins/swe-platform/internal/controllers"
+	"github.com/Chris-Cullins/swe-platform/internal/agent"
 	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
 )
 
@@ -29,12 +29,15 @@ type Adapter struct {
 	cursors    map[cursor]uint64
 	pending    map[cursor]pendingEvent
 }
+
+var _ agent.AdapterLifecycle = (*Adapter)(nil)
+
 type cursor struct {
 	environment, owner, execution string
 	stream                        sandboxdv1.OutputStream
 }
 type pendingEvent struct {
-	event      controllers.AdapterEvent
+	event      agent.AdapterEvent
 	nextOffset uint64
 }
 type outputEvent struct {
@@ -72,19 +75,19 @@ func (a *Adapter) executable() string {
 	}
 	return "codex"
 }
-func key(t controllers.AdapterTask) *sandboxdv1.ProcessKey {
+func key(t agent.AdapterTask) *sandboxdv1.ProcessKey {
 	return &sandboxdv1.ProcessKey{OwnerId: t.ID, Role: processRole}
 }
-func (a *Adapter) spec(t controllers.AdapterTask) *sandboxdv1.ProcessSpec {
+func (a *Adapter) spec(t agent.AdapterTask) *sandboxdv1.ProcessSpec {
 	return &sandboxdv1.ProcessSpec{Argv: []string{a.executable(), "exec", "--json", "--ephemeral", "--ignore-user-config", "--ignore-rules", "--sandbox", "workspace-write", "--color", "never", "--skip-git-repo-check", "--", t.Prompt}, EnvMode: sandboxdv1.EnvironmentMode_ENVIRONMENT_MODE_INHERIT}
 }
 
-func (a *Adapter) EnsureAccepted(ctx context.Context, task controllers.AdapterTask, sandbox controllers.AdapterSandbox, credential *controllers.AdapterCredential) error {
+func (a *Adapter) EnsureAccepted(ctx context.Context, task agent.AdapterTask, sandbox agent.AdapterSandbox, credential *agent.AdapterCredential) error {
 	if task.Prompt == "-" {
-		return fmt.Errorf("%w: Codex prompt '-' requires managed stdin", controllers.ErrAdapterTaskRejected)
+		return fmt.Errorf("%w: Codex prompt '-' requires managed stdin", agent.ErrAdapterTaskRejected)
 	}
 	if credential != nil && credential.Type != platformv1alpha1.AgentCredentialTypeAPIKey {
-		return fmt.Errorf("%w: unsupported credential type %q", controllers.ErrAdapterTaskRejected, credential.Type)
+		return fmt.Errorf("%w: unsupported credential type %q", agent.ErrAdapterTaskRejected, credential.Type)
 	}
 	client, closeConnection, err := sandbox.DialProcess(ctx)
 	if err != nil {
@@ -101,7 +104,7 @@ func (a *Adapter) EnsureAccepted(ctx context.Context, task controllers.AdapterTa
 	return err
 }
 
-func (a *Adapter) Observe(ctx context.Context, task controllers.AdapterTask, sandbox controllers.AdapterSandbox) (controllers.AdapterObservation, string, error) {
+func (a *Adapter) Observe(ctx context.Context, task agent.AdapterTask, sandbox agent.AdapterSandbox) (agent.AdapterObservation, string, error) {
 	client, closeConnection, err := sandbox.DialProcess(ctx)
 	if err != nil {
 		return "", "", err
@@ -110,43 +113,43 @@ func (a *Adapter) Observe(ctx context.Context, task controllers.AdapterTask, san
 	p, err := client.Get(ctx, &sandboxdv1.GetProcessRequest{Key: key(task)})
 	if err != nil {
 		if status.Code(err) == codes.NotFound {
-			return controllers.AdapterObservationFailed, "Codex execution is absent in the current sandbox epoch", nil
+			return agent.AdapterObservationFailed, "Codex execution is absent in the current sandbox epoch", nil
 		}
 		return "", "", err
 	}
 	if err = a.forward(ctx, client, task, sandbox, p); err != nil {
-		if errors.Is(err, controllers.ErrAdapterEventRejected) {
-			return controllers.AdapterObservationFailed, "Codex transcript output was permanently rejected", nil
+		if errors.Is(err, agent.ErrAdapterEventRejected) {
+			return agent.AdapterObservationFailed, "Codex transcript output was permanently rejected", nil
 		}
 		return "", "", err
 	}
 	switch p.State {
 	case sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, sandboxdv1.ProcessState_PROCESS_STATE_STOPPING:
-		return controllers.AdapterObservationRunning, "Codex is running", nil
+		return agent.AdapterObservationRunning, "Codex is running", nil
 	case sandboxdv1.ProcessState_PROCESS_STATE_FAILED:
-		return controllers.AdapterObservationFailed, message("Codex failed to start", p.Error), nil
+		return agent.AdapterObservationFailed, message("Codex failed to start", p.Error), nil
 	case sandboxdv1.ProcessState_PROCESS_STATE_EXITED:
 		if p.ExitCode == nil {
-			return controllers.AdapterObservationFailed, "Codex exited without an exit code", nil
+			return agent.AdapterObservationFailed, "Codex exited without an exit code", nil
 		}
 		if p.GetExitCode() != 0 {
-			return controllers.AdapterObservationFailed, fmt.Sprintf("Codex exited with code %d", p.GetExitCode()), nil
+			return agent.AdapterObservationFailed, fmt.Sprintf("Codex exited with code %d", p.GetExitCode()), nil
 		}
 		out, e := readOutput(ctx, client, key(task), p.ExecutionId)
 		if e != nil {
 			var truncated *outputTruncatedError
 			if errors.As(e, &truncated) {
-				return controllers.AdapterObservationFailed, message("Codex stdout was truncated before terminal validation", truncated.Error()), nil
+				return agent.AdapterObservationFailed, message("Codex stdout was truncated before terminal validation", truncated.Error()), nil
 			}
 			return "", "", e
 		}
 		thread, detail, ok := terminal(out)
 		if !ok {
-			return controllers.AdapterObservationFailed, message("Codex exited without a coherent completed turn", detail), nil
+			return agent.AdapterObservationFailed, message("Codex exited without a coherent completed turn", detail), nil
 		}
-		return controllers.AdapterObservationSucceeded, "Codex completed thread " + thread, nil
+		return agent.AdapterObservationSucceeded, "Codex completed thread " + thread, nil
 	default:
-		return controllers.AdapterObservationFailed, fmt.Sprintf("Codex returned invalid process state %s", p.State), nil
+		return agent.AdapterObservationFailed, fmt.Sprintf("Codex returned invalid process state %s", p.State), nil
 	}
 }
 
@@ -204,7 +207,7 @@ func terminal(output []byte) (string, string, bool) {
 	return thread, "", true
 }
 
-func (a *Adapter) Cancel(ctx context.Context, task controllers.AdapterTask, sandbox controllers.AdapterSandbox) error {
+func (a *Adapter) Cancel(ctx context.Context, task agent.AdapterTask, sandbox agent.AdapterSandbox) error {
 	client, closeConnection, err := sandbox.DialProcess(ctx)
 	if err != nil {
 		return err
@@ -219,10 +222,10 @@ func (a *Adapter) Cancel(ctx context.Context, task controllers.AdapterTask, sand
 	}
 	switch p.State {
 	case sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, sandboxdv1.ProcessState_PROCESS_STATE_STOPPING:
-		return controllers.ErrAdapterCancellationPending
+		return agent.ErrAdapterCancellationPending
 	case sandboxdv1.ProcessState_PROCESS_STATE_EXITED, sandboxdv1.ProcessState_PROCESS_STATE_FAILED:
 		err = a.forward(ctx, client, task, sandbox, p)
-		if errors.Is(err, controllers.ErrAdapterEventRejected) {
+		if errors.Is(err, agent.ErrAdapterEventRejected) {
 			return nil
 		}
 		return err
@@ -231,7 +234,7 @@ func (a *Adapter) Cancel(ctx context.Context, task controllers.AdapterTask, sand
 	}
 }
 
-func (a *Adapter) forward(ctx context.Context, client sandboxdv1.ProcessServiceClient, task controllers.AdapterTask, sandbox controllers.AdapterSandbox, p *sandboxdv1.Process) error {
+func (a *Adapter) forward(ctx context.Context, client sandboxdv1.ProcessServiceClient, task agent.AdapterTask, sandbox agent.AdapterSandbox, p *sandboxdv1.Process) error {
 	if sandbox.EmitEvent == nil || p.ExecutionId == "" {
 		return nil
 	}
@@ -256,7 +259,7 @@ func (a *Adapter) forward(ctx context.Context, client sandboxdv1.ProcessServiceC
 			}
 			payload, _ := json.Marshal(outputEvent{p.ExecutionId, streamName(stream), r.Offset, r.NextOffset, r.GapBytes, r.RetainedStart, r.ProducedEnd, r.Eof, r.Data})
 			digest := sha256.Sum256(payload)
-			event := controllers.AdapterEvent{Source: "codex", Type: "codex.process-output", IdempotencyKey: fmt.Sprintf("v1:%s:%x", streamName(stream), digest), Data: payload}
+			event := agent.AdapterEvent{Source: "codex", Type: "codex.process-output", IdempotencyKey: fmt.Sprintf("v1:%s:%x", streamName(stream), digest), Data: payload}
 			a.setPending(c, pendingEvent{event, r.NextOffset})
 			if err = sandbox.EmitEvent(ctx, event); err != nil {
 				return err

--- a/internal/adapters/codex/adapter_test.go
+++ b/internal/adapters/codex/adapter_test.go
@@ -48,7 +48,7 @@ func (f *launchClient) StartWithLaunchMaterial(_ context.Context, r *sandboxdv1.
 }
 
 func sandboxFor(c sandboxdv1.ProcessServiceClient, dials *int) agent.AdapterSandbox {
-	return agent.AdapterSandbox{EnvironmentUID: "epoch", DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
+	return agent.AdapterSandbox{EnvironmentUID: agent.EnvironmentUID("epoch"), DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
 		*dials++
 		return c, func() error { return nil }, nil
 	}}
@@ -210,7 +210,7 @@ func (f *fakeProcessClient) ReadOutput(_ context.Context, request *sandboxdv1.Re
 	}, nil
 }
 
-func processSandbox(client sandboxdv1.ProcessServiceClient, epoch string) agent.AdapterSandbox {
+func processSandbox(client sandboxdv1.ProcessServiceClient, epoch agent.EnvironmentUID) agent.AdapterSandbox {
 	return agent.AdapterSandbox{
 		EnvironmentUID: epoch,
 		DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {

--- a/internal/adapters/codex/adapter_test.go
+++ b/internal/adapters/codex/adapter_test.go
@@ -12,10 +12,9 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"k8s.io/apimachinery/pkg/types"
 
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
-	"github.com/Chris-Cullins/swe-platform/internal/controllers"
+	"github.com/Chris-Cullins/swe-platform/internal/agent"
 	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
 )
 
@@ -48,8 +47,8 @@ func (f *launchClient) StartWithLaunchMaterial(_ context.Context, r *sandboxdv1.
 	return &sandboxdv1.Process{}, nil
 }
 
-func sandboxFor(c sandboxdv1.ProcessServiceClient, dials *int) controllers.AdapterSandbox {
-	return controllers.AdapterSandbox{EnvironmentUID: "epoch", DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
+func sandboxFor(c sandboxdv1.ProcessServiceClient, dials *int) agent.AdapterSandbox {
+	return agent.AdapterSandbox{EnvironmentUID: "epoch", DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
 		*dials++
 		return c, func() error { return nil }, nil
 	}}
@@ -59,7 +58,7 @@ func TestAcceptancePromptAndCredentialSafety(t *testing.T) {
 	dials := 0
 	c := &launchClient{}
 	a := &Adapter{Executable: "fake-codex"}
-	task := controllers.AdapterTask{ID: "run-uid", Prompt: "--leading\nline"}
+	task := agent.AdapterTask{ID: "run-uid", Prompt: "--leading\nline"}
 	if err := a.EnsureAccepted(context.Background(), task, sandboxFor(c, &dials), nil); err != nil {
 		t.Fatal(err)
 	}
@@ -67,7 +66,7 @@ func TestAcceptancePromptAndCredentialSafety(t *testing.T) {
 	if !reflect.DeepEqual(c.spec.Argv, want) || c.spec.Env["CODEX_API_KEY"] != "" || c.starts != 1 || c.key.OwnerId != task.ID || c.key.Role != processRole {
 		t.Fatalf("spec/start = %#v/%d", c.spec, c.starts)
 	}
-	credential := &controllers.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: []byte("secret")}
+	credential := &agent.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: []byte("secret")}
 	if err := a.EnsureAccepted(context.Background(), task, sandboxFor(c, &dials), credential); err != nil {
 		t.Fatal(err)
 	}
@@ -79,10 +78,10 @@ func TestAcceptancePromptAndCredentialSafety(t *testing.T) {
 	}
 	before := dials
 	for _, rejected := range []struct {
-		task controllers.AdapterTask
-		cred *controllers.AdapterCredential
-	}{{task: controllers.AdapterTask{Prompt: "-"}}, {task: task, cred: &controllers.AdapterCredential{Type: "OAuth"}}} {
-		if err := a.EnsureAccepted(context.Background(), rejected.task, sandboxFor(c, &dials), rejected.cred); !errors.Is(err, controllers.ErrAdapterTaskRejected) {
+		task agent.AdapterTask
+		cred *agent.AdapterCredential
+	}{{task: agent.AdapterTask{Prompt: "-"}}, {task: task, cred: &agent.AdapterCredential{Type: "OAuth"}}} {
+		if err := a.EnsureAccepted(context.Background(), rejected.task, sandboxFor(c, &dials), rejected.cred); !errors.Is(err, agent.ErrAdapterTaskRejected) {
 			t.Fatalf("rejection = %v", err)
 		}
 	}
@@ -94,14 +93,14 @@ func TestAcceptancePromptAndCredentialSafety(t *testing.T) {
 func TestLaunchMaterialFailureDoesNotFallbackToAmbientStart(t *testing.T) {
 	dials := 0
 	client := &launchClient{launchErr: status.Error(codes.Unimplemented, "old sandboxd")}
-	err := (&Adapter{}).EnsureAccepted(context.Background(), controllers.AdapterTask{ID: "run", Prompt: "task"}, sandboxFor(client, &dials), &controllers.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: []byte("secret")})
+	err := (&Adapter{}).EnsureAccepted(context.Background(), agent.AdapterTask{ID: "run", Prompt: "task"}, sandboxFor(client, &dials), &agent.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: []byte("secret")})
 	if status.Code(err) != codes.Unimplemented || client.starts != 0 || client.launches != 1 {
 		t.Fatalf("EnsureAccepted = %v, starts/launches %d/%d", err, client.starts, client.launches)
 	}
 }
 
 func TestAcceptanceIsDuplicateSafeAndFreshEpoch(t *testing.T) {
-	task := controllers.AdapterTask{ID: "run-uid", Prompt: "task"}
+	task := agent.AdapterTask{ID: "run-uid", Prompt: "task"}
 	adapter := &Adapter{}
 	first := &launchClient{}
 	firstDials := 0
@@ -211,9 +210,9 @@ func (f *fakeProcessClient) ReadOutput(_ context.Context, request *sandboxdv1.Re
 	}, nil
 }
 
-func processSandbox(client sandboxdv1.ProcessServiceClient, epoch string) controllers.AdapterSandbox {
-	return controllers.AdapterSandbox{
-		EnvironmentUID: types.UID(epoch),
+func processSandbox(client sandboxdv1.ProcessServiceClient, epoch string) agent.AdapterSandbox {
+	return agent.AdapterSandbox{
+		EnvironmentUID: epoch,
 		DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
 			return client, func() error { return nil }, nil
 		},
@@ -227,30 +226,30 @@ func TestObservationOutcomes(t *testing.T) {
 		name    string
 		process *sandboxdv1.Process
 		stdout  string
-		want    controllers.AdapterObservation
+		want    agent.AdapterObservation
 	}{
-		{"running", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "e"}, "", controllers.AdapterObservationRunning},
-		{"stopping", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_STOPPING, ExecutionId: "e"}, "", controllers.AdapterObservationRunning},
-		{"start failure", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_FAILED, ExecutionId: "e", Error: "not found"}, "", controllers.AdapterObservationFailed},
-		{"success", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, success, controllers.AdapterObservationSucceeded},
-		{"missing exit", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e"}, success, controllers.AdapterObservationFailed},
-		{"nonzero", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit1}, success, controllers.AdapterObservationFailed},
-		{"malformed", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, "not-json\n", controllers.AdapterObservationFailed},
-		{"missing thread", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, `{"type":"turn.completed","usage":{}}`, controllers.AdapterObservationFailed},
-		{"missing terminal", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, `{"type":"thread.started","thread_id":"t"}`, controllers.AdapterObservationFailed},
-		{"turn failed", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, `{"type":"thread.started","thread_id":"t"}` + "\n" + `{"type":"turn.failed","error":{"message":"failed"}}`, controllers.AdapterObservationFailed},
-		{"error", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, `{"type":"thread.started","thread_id":"t"}` + "\n" + `{"type":"error","message":"failed"}`, controllers.AdapterObservationFailed},
+		{"running", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "e"}, "", agent.AdapterObservationRunning},
+		{"stopping", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_STOPPING, ExecutionId: "e"}, "", agent.AdapterObservationRunning},
+		{"start failure", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_FAILED, ExecutionId: "e", Error: "not found"}, "", agent.AdapterObservationFailed},
+		{"success", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, success, agent.AdapterObservationSucceeded},
+		{"missing exit", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e"}, success, agent.AdapterObservationFailed},
+		{"nonzero", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit1}, success, agent.AdapterObservationFailed},
+		{"malformed", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, "not-json\n", agent.AdapterObservationFailed},
+		{"missing thread", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, `{"type":"turn.completed","usage":{}}`, agent.AdapterObservationFailed},
+		{"missing terminal", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, `{"type":"thread.started","thread_id":"t"}`, agent.AdapterObservationFailed},
+		{"turn failed", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, `{"type":"thread.started","thread_id":"t"}` + "\n" + `{"type":"turn.failed","error":{"message":"failed"}}`, agent.AdapterObservationFailed},
+		{"error", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, `{"type":"thread.started","thread_id":"t"}` + "\n" + `{"type":"error","message":"failed"}`, agent.AdapterObservationFailed},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, processSandbox(&fakeProcessClient{process: test.process, stdout: []byte(test.stdout)}, "epoch"))
+			got, _, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, processSandbox(&fakeProcessClient{process: test.process, stdout: []byte(test.stdout)}, "epoch"))
 			if err != nil || got != test.want {
 				t.Fatalf("Observe = %q, %v; want %q", got, err, test.want)
 			}
 		})
 	}
-	absent, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, processSandbox(&fakeProcessClient{getErr: status.Error(codes.NotFound, "gone")}, "epoch"))
-	if err != nil || absent != controllers.AdapterObservationFailed {
+	absent, _, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, processSandbox(&fakeProcessClient{getErr: status.Error(codes.NotFound, "gone")}, "epoch"))
+	if err != nil || absent != agent.AdapterObservationFailed {
 		t.Fatalf("absent Observe = %q, %v", absent, err)
 	}
 }
@@ -261,27 +260,27 @@ func TestTerminalObservationFailsOnRetainedOutputGap(t *testing.T) {
 		process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "execution", ExitCode: &exit0},
 		stdout:  []byte(`{"type":"turn.completed","usage":{}}`), retainedFrom: 1024,
 	}
-	got, detail, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, processSandbox(client, "epoch"))
-	if err != nil || got != controllers.AdapterObservationFailed || !strings.Contains(detail, "retained from offset 1024") {
+	got, detail, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, processSandbox(client, "epoch"))
+	if err != nil || got != agent.AdapterObservationFailed || !strings.Contains(detail, "retained from offset 1024") {
 		t.Fatalf("Observe = %q, %q, %v", got, detail, err)
 	}
 }
 
 func TestCancellationIsRunFencedAndWaitsForTerminalProcess(t *testing.T) {
 	client := &fakeProcessClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_STOPPING, ExecutionId: "execution"}}
-	err := (&Adapter{}).Cancel(context.Background(), controllers.AdapterTask{ID: "run-uid"}, processSandbox(client, "epoch"))
-	if !errors.Is(err, controllers.ErrAdapterCancellationPending) || client.stoppedKey.OwnerId != "run-uid" || client.stoppedKey.Role != processRole || client.stopMode != sandboxdv1.StopMode_STOP_MODE_GRACEFUL {
+	err := (&Adapter{}).Cancel(context.Background(), agent.AdapterTask{ID: "run-uid"}, processSandbox(client, "epoch"))
+	if !errors.Is(err, agent.ErrAdapterCancellationPending) || client.stoppedKey.OwnerId != "run-uid" || client.stoppedKey.Role != processRole || client.stopMode != sandboxdv1.StopMode_STOP_MODE_GRACEFUL {
 		t.Fatalf("Cancel = %v, key %#v, mode %s", err, client.stoppedKey, client.stopMode)
 	}
 	client.process.State = sandboxdv1.ProcessState_PROCESS_STATE_EXITED
-	if err := (&Adapter{}).Cancel(context.Background(), controllers.AdapterTask{ID: "run-uid"}, processSandbox(client, "epoch")); err != nil {
+	if err := (&Adapter{}).Cancel(context.Background(), agent.AdapterTask{ID: "run-uid"}, processSandbox(client, "epoch")); err != nil {
 		t.Fatalf("terminal Cancel = %v", err)
 	}
 }
 
 func TestCancellationTreatsAbsentProcessAsComplete(t *testing.T) {
 	client := &fakeProcessClient{stopErr: status.Error(codes.NotFound, "absent")}
-	if err := (&Adapter{}).Cancel(context.Background(), controllers.AdapterTask{ID: "run-uid"}, processSandbox(client, "epoch")); err != nil {
+	if err := (&Adapter{}).Cancel(context.Background(), agent.AdapterTask{ID: "run-uid"}, processSandbox(client, "epoch")); err != nil {
 		t.Fatalf("Cancel absent process = %v", err)
 	}
 }
@@ -291,15 +290,15 @@ func TestOutputIsBoundedGapVisibleAndAdapterOwned(t *testing.T) {
 		process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"},
 		stdout:  []byte("stdout"), stderr: []byte("stderr"), gapBytes: 9, retainedFrom: 9,
 	}
-	var events []controllers.AdapterEvent
+	var events []agent.AdapterEvent
 	sandbox := processSandbox(client, "epoch")
-	sandbox.EmitEvent = func(_ context.Context, event controllers.AdapterEvent) error {
+	sandbox.EmitEvent = func(_ context.Context, event agent.AdapterEvent) error {
 		events = append(events, event)
 		return nil
 	}
 	adapter := &Adapter{}
 	for range 2 {
-		if _, _, err := adapter.Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err != nil {
+		if _, _, err := adapter.Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -319,9 +318,9 @@ func TestOutputIsBoundedGapVisibleAndAdapterOwned(t *testing.T) {
 
 func TestTransientOutputFailureRetriesExactEvent(t *testing.T) {
 	client := &fakeProcessClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"}, stdout: []byte("output")}
-	var events []controllers.AdapterEvent
+	var events []agent.AdapterEvent
 	sandbox := processSandbox(client, "epoch")
-	sandbox.EmitEvent = func(_ context.Context, event controllers.AdapterEvent) error {
+	sandbox.EmitEvent = func(_ context.Context, event agent.AdapterEvent) error {
 		events = append(events, event)
 		if len(events) == 1 {
 			return errors.New("retry")
@@ -329,11 +328,11 @@ func TestTransientOutputFailureRetriesExactEvent(t *testing.T) {
 		return nil
 	}
 	adapter := &Adapter{}
-	if _, _, err := adapter.Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err == nil {
+	if _, _, err := adapter.Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox); err == nil {
 		t.Fatal("wanted transient error")
 	}
 	client.stdout = []byte("output appended")
-	if _, _, err := adapter.Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err != nil {
+	if _, _, err := adapter.Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox); err != nil {
 		t.Fatal(err)
 	}
 	if len(events) != 3 || !reflect.DeepEqual(events[0], events[1]) {
@@ -349,13 +348,13 @@ func TestPermanentOutputRejectionFailsObserveButNotTerminalCancel(t *testing.T) 
 	exit0 := int32(0)
 	client := &fakeProcessClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"}, stdout: []byte("output")}
 	sandbox := processSandbox(client, "epoch")
-	sandbox.EmitEvent = func(context.Context, controllers.AdapterEvent) error { return controllers.ErrAdapterEventRejected }
-	got, message, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox)
-	if err != nil || got != controllers.AdapterObservationFailed || !strings.Contains(message, "permanently rejected") {
+	sandbox.EmitEvent = func(context.Context, agent.AdapterEvent) error { return agent.ErrAdapterEventRejected }
+	got, message, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox)
+	if err != nil || got != agent.AdapterObservationFailed || !strings.Contains(message, "permanently rejected") {
 		t.Fatalf("Observe = %q, %q, %v", got, message, err)
 	}
 	client.process.State, client.process.ExitCode = sandboxdv1.ProcessState_PROCESS_STATE_EXITED, &exit0
-	if err := (&Adapter{}).Cancel(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err != nil {
+	if err := (&Adapter{}).Cancel(context.Background(), agent.AdapterTask{ID: "run"}, sandbox); err != nil {
 		t.Fatalf("Cancel = %v", err)
 	}
 }
@@ -365,23 +364,23 @@ func TestEpochAndSnapshotMetadataFenceOutputKeys(t *testing.T) {
 		process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"},
 		stdout:  bytes.Repeat([]byte("x"), pageMax+1),
 	}
-	var first controllers.AdapterEvent
+	var first agent.AdapterEvent
 	firstSandbox := processSandbox(client, "epoch-one")
-	firstSandbox.EmitEvent = func(_ context.Context, event controllers.AdapterEvent) error {
+	firstSandbox.EmitEvent = func(_ context.Context, event agent.AdapterEvent) error {
 		first = event
 		return errors.New("uncertain append")
 	}
-	if _, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, firstSandbox); err == nil {
+	if _, _, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, firstSandbox); err == nil {
 		t.Fatal("wanted uncertain append error")
 	}
 	client.stdout = append(client.stdout, 'y')
-	var changed controllers.AdapterEvent
+	var changed agent.AdapterEvent
 	secondSandbox := processSandbox(client, "epoch-two")
-	secondSandbox.EmitEvent = func(_ context.Context, event controllers.AdapterEvent) error {
+	secondSandbox.EmitEvent = func(_ context.Context, event agent.AdapterEvent) error {
 		changed = event
 		return errors.New("stop")
 	}
-	if _, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, secondSandbox); err == nil {
+	if _, _, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, secondSandbox); err == nil {
 		t.Fatal("wanted replay stop error")
 	}
 	if first.IdempotencyKey == changed.IdempotencyKey || bytes.Equal(first.Data, changed.Data) {

--- a/internal/adapters/pi/adapter.go
+++ b/internal/adapters/pi/adapter.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/Chris-Cullins/swe-platform/internal/controllers"
+	"github.com/Chris-Cullins/swe-platform/internal/agent"
 	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
 )
 
@@ -29,12 +29,18 @@ type Adapter struct {
 	cursors    map[cursor]uint64
 	pending    map[cursor]pendingEvent
 }
+
+var (
+	_ agent.AdapterLifecycle        = (*Adapter)(nil)
+	_ agent.AdapterCredentialPolicy = (*Adapter)(nil)
+)
+
 type cursor struct {
 	environment, owner, execution string
 	stream                        sandboxdv1.OutputStream
 }
 type pendingEvent struct {
-	event      controllers.AdapterEvent
+	event      agent.AdapterEvent
 	nextOffset uint64
 }
 type outputEvent struct {
@@ -69,19 +75,19 @@ func (a *Adapter) executable() string {
 	}
 	return "pi"
 }
-func key(t controllers.AdapterTask) *sandboxdv1.ProcessKey {
+func key(t agent.AdapterTask) *sandboxdv1.ProcessKey {
 	return &sandboxdv1.ProcessKey{OwnerId: t.ID, Role: processRole}
 }
-func (a *Adapter) spec(t controllers.AdapterTask) *sandboxdv1.ProcessSpec {
+func (a *Adapter) spec(t agent.AdapterTask) *sandboxdv1.ProcessSpec {
 	return &sandboxdv1.ProcessSpec{Argv: []string{a.executable(), "--mode", "json", "--no-session", "-p", t.Prompt}, EnvMode: sandboxdv1.EnvironmentMode_ENVIRONMENT_MODE_INHERIT}
 }
 
-func (a *Adapter) EnsureAccepted(ctx context.Context, task controllers.AdapterTask, sandbox controllers.AdapterSandbox, credential *controllers.AdapterCredential) error {
+func (a *Adapter) EnsureAccepted(ctx context.Context, task agent.AdapterTask, sandbox agent.AdapterSandbox, credential *agent.AdapterCredential) error {
 	if credential != nil {
-		return fmt.Errorf("%w: Pi does not support credential profiles", controllers.ErrAdapterTaskRejected)
+		return fmt.Errorf("%w: Pi does not support credential profiles", agent.ErrAdapterTaskRejected)
 	}
 	if strings.HasPrefix(task.Prompt, "-") || strings.HasPrefix(task.Prompt, "@") {
-		return fmt.Errorf("%w: Pi prompt begins with unsupported parser prefix", controllers.ErrAdapterTaskRejected)
+		return fmt.Errorf("%w: Pi prompt begins with unsupported parser prefix", agent.ErrAdapterTaskRejected)
 	}
 	c, close, err := sandbox.DialProcess(ctx)
 	if err != nil {
@@ -91,7 +97,7 @@ func (a *Adapter) EnsureAccepted(ctx context.Context, task controllers.AdapterTa
 	_, err = c.Start(ctx, &sandboxdv1.StartProcessRequest{Key: key(task), Spec: a.spec(task)})
 	return err
 }
-func (a *Adapter) Observe(ctx context.Context, task controllers.AdapterTask, sandbox controllers.AdapterSandbox) (controllers.AdapterObservation, string, error) {
+func (a *Adapter) Observe(ctx context.Context, task agent.AdapterTask, sandbox agent.AdapterSandbox) (agent.AdapterObservation, string, error) {
 	c, close, err := sandbox.DialProcess(ctx)
 	if err != nil {
 		return "", "", err
@@ -100,43 +106,43 @@ func (a *Adapter) Observe(ctx context.Context, task controllers.AdapterTask, san
 	p, err := c.Get(ctx, &sandboxdv1.GetProcessRequest{Key: key(task)})
 	if err != nil {
 		if status.Code(err) == codes.NotFound {
-			return controllers.AdapterObservationFailed, "Pi execution is absent in the current sandbox epoch", nil
+			return agent.AdapterObservationFailed, "Pi execution is absent in the current sandbox epoch", nil
 		}
 		return "", "", err
 	}
 	if err = a.forward(ctx, c, task, sandbox, p); err != nil {
-		if errors.Is(err, controllers.ErrAdapterEventRejected) {
-			return controllers.AdapterObservationFailed, "Pi transcript output was permanently rejected", nil
+		if errors.Is(err, agent.ErrAdapterEventRejected) {
+			return agent.AdapterObservationFailed, "Pi transcript output was permanently rejected", nil
 		}
 		return "", "", err
 	}
 	switch p.State {
 	case sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, sandboxdv1.ProcessState_PROCESS_STATE_STOPPING:
-		return controllers.AdapterObservationRunning, "Pi is running", nil
+		return agent.AdapterObservationRunning, "Pi is running", nil
 	case sandboxdv1.ProcessState_PROCESS_STATE_FAILED:
-		return controllers.AdapterObservationFailed, message("Pi failed to start", p.Error), nil
+		return agent.AdapterObservationFailed, message("Pi failed to start", p.Error), nil
 	case sandboxdv1.ProcessState_PROCESS_STATE_EXITED:
 		if p.ExitCode == nil {
-			return controllers.AdapterObservationFailed, "Pi exited without an exit code", nil
+			return agent.AdapterObservationFailed, "Pi exited without an exit code", nil
 		}
 		if p.GetExitCode() != 0 {
-			return controllers.AdapterObservationFailed, fmt.Sprintf("Pi exited with code %d", p.GetExitCode()), nil
+			return agent.AdapterObservationFailed, fmt.Sprintf("Pi exited with code %d", p.GetExitCode()), nil
 		}
 		out, e := readOutput(ctx, c, key(task), p.ExecutionId)
 		if e != nil {
 			var gap *outputTruncatedError
 			if errors.As(e, &gap) {
-				return controllers.AdapterObservationFailed, message("Pi stdout was truncated before terminal validation", gap.Error()), nil
+				return agent.AdapterObservationFailed, message("Pi stdout was truncated before terminal validation", gap.Error()), nil
 			}
 			return "", "", e
 		}
 		detail, ok := terminal(out)
 		if !ok {
-			return controllers.AdapterObservationFailed, message("Pi exited without a coherent final agent_end", detail), nil
+			return agent.AdapterObservationFailed, message("Pi exited without a coherent final agent_end", detail), nil
 		}
-		return controllers.AdapterObservationSucceeded, "Pi completed", nil
+		return agent.AdapterObservationSucceeded, "Pi completed", nil
 	default:
-		return controllers.AdapterObservationFailed, fmt.Sprintf("Pi returned invalid process state %s", p.State), nil
+		return agent.AdapterObservationFailed, fmt.Sprintf("Pi returned invalid process state %s", p.State), nil
 	}
 }
 func terminal(out []byte) (string, bool) {
@@ -183,7 +189,7 @@ func terminal(out []byte) (string, bool) {
 		return "final assistant has invalid stopReason", false
 	}
 }
-func (a *Adapter) Cancel(ctx context.Context, task controllers.AdapterTask, sandbox controllers.AdapterSandbox) error {
+func (a *Adapter) Cancel(ctx context.Context, task agent.AdapterTask, sandbox agent.AdapterSandbox) error {
 	c, close, err := sandbox.DialProcess(ctx)
 	if err != nil {
 		return err
@@ -198,10 +204,10 @@ func (a *Adapter) Cancel(ctx context.Context, task controllers.AdapterTask, sand
 	}
 	switch p.State {
 	case sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, sandboxdv1.ProcessState_PROCESS_STATE_STOPPING:
-		return controllers.ErrAdapterCancellationPending
+		return agent.ErrAdapterCancellationPending
 	case sandboxdv1.ProcessState_PROCESS_STATE_EXITED, sandboxdv1.ProcessState_PROCESS_STATE_FAILED:
 		err = a.forward(ctx, c, task, sandbox, p)
-		if errors.Is(err, controllers.ErrAdapterEventRejected) {
+		if errors.Is(err, agent.ErrAdapterEventRejected) {
 			return nil
 		}
 		return err
@@ -209,7 +215,7 @@ func (a *Adapter) Cancel(ctx context.Context, task controllers.AdapterTask, sand
 		return fmt.Errorf("Pi cancellation returned invalid process state %s", p.State)
 	}
 }
-func (a *Adapter) forward(ctx context.Context, c sandboxdv1.ProcessServiceClient, task controllers.AdapterTask, s controllers.AdapterSandbox, p *sandboxdv1.Process) error {
+func (a *Adapter) forward(ctx context.Context, c sandboxdv1.ProcessServiceClient, task agent.AdapterTask, s agent.AdapterSandbox, p *sandboxdv1.Process) error {
 	if s.EmitEvent == nil || p.ExecutionId == "" {
 		return nil
 	}
@@ -234,7 +240,7 @@ func (a *Adapter) forward(ctx context.Context, c sandboxdv1.ProcessServiceClient
 			}
 			payload, _ := json.Marshal(outputEvent{p.ExecutionId, streamName(stream), r.Offset, r.NextOffset, r.GapBytes, r.RetainedStart, r.ProducedEnd, r.Eof, r.Data})
 			digest := sha256.Sum256(payload)
-			event := controllers.AdapterEvent{Source: "pi", Type: "pi.process-output", IdempotencyKey: fmt.Sprintf("v1:%s:%x", streamName(stream), digest), Data: payload}
+			event := agent.AdapterEvent{Source: "pi", Type: "pi.process-output", IdempotencyKey: fmt.Sprintf("v1:%s:%x", streamName(stream), digest), Data: payload}
 			a.setPending(k, pendingEvent{event, r.NextOffset})
 			if err = s.EmitEvent(ctx, event); err != nil {
 				return err

--- a/internal/adapters/pi/adapter_test.go
+++ b/internal/adapters/pi/adapter_test.go
@@ -33,7 +33,7 @@ func (c *startClient) StartWithLaunchMaterial(context.Context, *sandboxdv1.Start
 }
 
 func acceptanceSandbox(client sandboxdv1.ProcessServiceClient, dials *int) agent.AdapterSandbox {
-	return agent.AdapterSandbox{EnvironmentUID: "epoch", DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
+	return agent.AdapterSandbox{EnvironmentUID: agent.EnvironmentUID("epoch"), DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
 		*dials++
 		return client, func() error { return nil }, nil
 	}}
@@ -162,7 +162,7 @@ func (c *processClient) ReadOutput(_ context.Context, r *sandboxdv1.ReadOutputRe
 	return &sandboxdv1.ReadOutputResponse{Data: append([]byte(nil), data[start:end]...), Offset: offset, NextOffset: retained + uint64(end), GapBytes: gap, RetainedStart: retained, ProducedEnd: produced, Eof: end == len(data)}, nil
 }
 
-func processSandbox(client sandboxdv1.ProcessServiceClient, epoch string) agent.AdapterSandbox {
+func processSandbox(client sandboxdv1.ProcessServiceClient, epoch agent.EnvironmentUID) agent.AdapterSandbox {
 	return agent.AdapterSandbox{EnvironmentUID: epoch, DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
 		return client, func() error { return nil }, nil
 	}}

--- a/internal/adapters/pi/adapter_test.go
+++ b/internal/adapters/pi/adapter_test.go
@@ -12,9 +12,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/Chris-Cullins/swe-platform/internal/controllers"
+	"github.com/Chris-Cullins/swe-platform/internal/agent"
 	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
 )
 
@@ -33,8 +32,8 @@ func (c *startClient) StartWithLaunchMaterial(context.Context, *sandboxdv1.Start
 	return nil, errors.New("unexpected launch material")
 }
 
-func acceptanceSandbox(client sandboxdv1.ProcessServiceClient, dials *int) controllers.AdapterSandbox {
-	return controllers.AdapterSandbox{EnvironmentUID: "epoch", DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
+func acceptanceSandbox(client sandboxdv1.ProcessServiceClient, dials *int) agent.AdapterSandbox {
+	return agent.AdapterSandbox{EnvironmentUID: "epoch", DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
 		*dials++
 		return client, func() error { return nil }, nil
 	}}
@@ -44,7 +43,7 @@ func TestAcceptanceArgvAndPreDialRejections(t *testing.T) {
 	client := &startClient{}
 	dials := 0
 	sandbox := acceptanceSandbox(client, &dials)
-	task := controllers.AdapterTask{ID: "run-uid", Prompt: "line one\nline two"}
+	task := agent.AdapterTask{ID: "run-uid", Prompt: "line one\nline two"}
 	adapter := &Adapter{Executable: "fake-pi"}
 	if err := adapter.EnsureAccepted(context.Background(), task, sandbox, nil); err != nil {
 		t.Fatal(err)
@@ -55,11 +54,11 @@ func TestAcceptanceArgvAndPreDialRejections(t *testing.T) {
 		t.Fatalf("start request = %#v; launches = %d", request, client.launches)
 	}
 	for _, prompt := range []string{"-", "--flag", "@file"} {
-		if err := adapter.EnsureAccepted(context.Background(), controllers.AdapterTask{Prompt: prompt}, sandbox, nil); !errors.Is(err, controllers.ErrAdapterTaskRejected) {
+		if err := adapter.EnsureAccepted(context.Background(), agent.AdapterTask{Prompt: prompt}, sandbox, nil); !errors.Is(err, agent.ErrAdapterTaskRejected) {
 			t.Fatalf("prompt %q: %v", prompt, err)
 		}
 	}
-	if err := adapter.EnsureAccepted(context.Background(), task, sandbox, &controllers.AdapterCredential{}); !errors.Is(err, controllers.ErrAdapterTaskRejected) {
+	if err := adapter.EnsureAccepted(context.Background(), task, sandbox, &agent.AdapterCredential{}); !errors.Is(err, agent.ErrAdapterTaskRejected) {
 		t.Fatalf("credential rejection = %v", err)
 	}
 	if dials != 1 {
@@ -71,7 +70,7 @@ func TestAcceptanceArgvAndPreDialRejections(t *testing.T) {
 }
 
 func TestAcceptanceIsDuplicateSafeAndRestartsInFreshEpoch(t *testing.T) {
-	task := controllers.AdapterTask{ID: "run-uid", Prompt: "task"}
+	task := agent.AdapterTask{ID: "run-uid", Prompt: "task"}
 	adapter := &Adapter{}
 	first, firstDials := &startClient{}, 0
 	for range 2 {
@@ -163,8 +162,8 @@ func (c *processClient) ReadOutput(_ context.Context, r *sandboxdv1.ReadOutputRe
 	return &sandboxdv1.ReadOutputResponse{Data: append([]byte(nil), data[start:end]...), Offset: offset, NextOffset: retained + uint64(end), GapBytes: gap, RetainedStart: retained, ProducedEnd: produced, Eof: end == len(data)}, nil
 }
 
-func processSandbox(client sandboxdv1.ProcessServiceClient, epoch string) controllers.AdapterSandbox {
-	return controllers.AdapterSandbox{EnvironmentUID: types.UID(epoch), DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
+func processSandbox(client sandboxdv1.ProcessServiceClient, epoch string) agent.AdapterSandbox {
+	return agent.AdapterSandbox{EnvironmentUID: epoch, DialProcess: func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
 		return client, func() error { return nil }, nil
 	}}
 }
@@ -176,29 +175,29 @@ func TestObservationOutcomes(t *testing.T) {
 		name    string
 		process *sandboxdv1.Process
 		stdout  string
-		want    controllers.AdapterObservation
+		want    agent.AdapterObservation
 	}{
-		{"running", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "e"}, "", controllers.AdapterObservationRunning},
-		{"stopping", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_STOPPING, ExecutionId: "e"}, "", controllers.AdapterObservationRunning},
-		{"start failure", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_FAILED, ExecutionId: "e", Error: "missing"}, "", controllers.AdapterObservationFailed},
-		{"success", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, success, controllers.AdapterObservationSucceeded},
-		{"missing exit", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e"}, success, controllers.AdapterObservationFailed},
-		{"nonzero", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit1}, success, controllers.AdapterObservationFailed},
-		{"malformed", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, "not-json\n", controllers.AdapterObservationFailed},
-		{"missing terminal", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, `{"type":"session"}`, controllers.AdapterObservationFailed},
-		{"assistant error despite zero exit", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, `{"type":"agent_end","messages":[{"role":"assistant","stopReason":"error"}]}`, controllers.AdapterObservationFailed},
-		{"assistant aborted despite zero exit", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, `{"type":"agent_end","messages":[{"role":"assistant","stopReason":"aborted"}]}`, controllers.AdapterObservationFailed},
+		{"running", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "e"}, "", agent.AdapterObservationRunning},
+		{"stopping", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_STOPPING, ExecutionId: "e"}, "", agent.AdapterObservationRunning},
+		{"start failure", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_FAILED, ExecutionId: "e", Error: "missing"}, "", agent.AdapterObservationFailed},
+		{"success", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, success, agent.AdapterObservationSucceeded},
+		{"missing exit", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e"}, success, agent.AdapterObservationFailed},
+		{"nonzero", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit1}, success, agent.AdapterObservationFailed},
+		{"malformed", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, "not-json\n", agent.AdapterObservationFailed},
+		{"missing terminal", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, `{"type":"session"}`, agent.AdapterObservationFailed},
+		{"assistant error despite zero exit", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, `{"type":"agent_end","messages":[{"role":"assistant","stopReason":"error"}]}`, agent.AdapterObservationFailed},
+		{"assistant aborted despite zero exit", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, `{"type":"agent_end","messages":[{"role":"assistant","stopReason":"aborted"}]}`, agent.AdapterObservationFailed},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, processSandbox(&processClient{process: tc.process, stdout: []byte(tc.stdout)}, "epoch"))
+			got, _, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, processSandbox(&processClient{process: tc.process, stdout: []byte(tc.stdout)}, "epoch"))
 			if err != nil || got != tc.want {
 				t.Fatalf("Observe = %q, %v; want %q", got, err, tc.want)
 			}
 		})
 	}
-	absent, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, processSandbox(&processClient{getErr: status.Error(codes.NotFound, "gone")}, "epoch"))
-	if err != nil || absent != controllers.AdapterObservationFailed {
+	absent, _, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, processSandbox(&processClient{getErr: status.Error(codes.NotFound, "gone")}, "epoch"))
+	if err != nil || absent != agent.AdapterObservationFailed {
 		t.Fatalf("absent Observe = %q, %v", absent, err)
 	}
 }
@@ -206,39 +205,39 @@ func TestObservationOutcomes(t *testing.T) {
 func TestTerminalValidationFailsOnRetainedOutputGap(t *testing.T) {
 	exit0 := int32(0)
 	client := &processClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, stdout: []byte(`{"type":"agent_end","messages":[]}`), retainedFrom: 41}
-	got, detail, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, processSandbox(client, "epoch"))
-	if err != nil || got != controllers.AdapterObservationFailed || !strings.Contains(detail, "retained from offset 41") {
+	got, detail, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, processSandbox(client, "epoch"))
+	if err != nil || got != agent.AdapterObservationFailed || !strings.Contains(detail, "retained from offset 41") {
 		t.Fatalf("Observe = %q, %q, %v", got, detail, err)
 	}
 }
 
 func TestCancellationIsRunFencedAndAbsentIsComplete(t *testing.T) {
 	client := &processClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_STOPPING, ExecutionId: "e"}}
-	err := (&Adapter{}).Cancel(context.Background(), controllers.AdapterTask{ID: "run-uid"}, processSandbox(client, "epoch"))
-	if !errors.Is(err, controllers.ErrAdapterCancellationPending) || client.stoppedKey.OwnerId != "run-uid" || client.stoppedKey.Role != processRole || client.stopMode != sandboxdv1.StopMode_STOP_MODE_GRACEFUL {
+	err := (&Adapter{}).Cancel(context.Background(), agent.AdapterTask{ID: "run-uid"}, processSandbox(client, "epoch"))
+	if !errors.Is(err, agent.ErrAdapterCancellationPending) || client.stoppedKey.OwnerId != "run-uid" || client.stoppedKey.Role != processRole || client.stopMode != sandboxdv1.StopMode_STOP_MODE_GRACEFUL {
 		t.Fatalf("Cancel = %v, key=%#v, mode=%s", err, client.stoppedKey, client.stopMode)
 	}
 	client.process.State = sandboxdv1.ProcessState_PROCESS_STATE_EXITED
-	if err := (&Adapter{}).Cancel(context.Background(), controllers.AdapterTask{ID: "run-uid"}, processSandbox(client, "epoch")); err != nil {
+	if err := (&Adapter{}).Cancel(context.Background(), agent.AdapterTask{ID: "run-uid"}, processSandbox(client, "epoch")); err != nil {
 		t.Fatal(err)
 	}
 	absent := &processClient{stopErr: status.Error(codes.NotFound, "gone")}
-	if err := (&Adapter{}).Cancel(context.Background(), controllers.AdapterTask{ID: "run-uid"}, processSandbox(absent, "epoch")); err != nil {
+	if err := (&Adapter{}).Cancel(context.Background(), agent.AdapterTask{ID: "run-uid"}, processSandbox(absent, "epoch")); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestOutputIsBoundedGapVisibleAndAdapterOwned(t *testing.T) {
 	client := &processClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"}, stdout: []byte("stdout"), stderr: []byte("stderr"), retainedFrom: 9}
-	var events []controllers.AdapterEvent
+	var events []agent.AdapterEvent
 	sandbox := processSandbox(client, "epoch")
-	sandbox.EmitEvent = func(_ context.Context, event controllers.AdapterEvent) error {
+	sandbox.EmitEvent = func(_ context.Context, event agent.AdapterEvent) error {
 		events = append(events, event)
 		return nil
 	}
 	adapter := &Adapter{}
 	for range 2 {
-		if _, _, err := adapter.Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err != nil {
+		if _, _, err := adapter.Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -258,9 +257,9 @@ func TestOutputIsBoundedGapVisibleAndAdapterOwned(t *testing.T) {
 
 func TestTransientOutputFailureRetriesExactEvent(t *testing.T) {
 	client := &processClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"}, stdout: []byte("output")}
-	var events []controllers.AdapterEvent
+	var events []agent.AdapterEvent
 	sandbox := processSandbox(client, "epoch")
-	sandbox.EmitEvent = func(_ context.Context, event controllers.AdapterEvent) error {
+	sandbox.EmitEvent = func(_ context.Context, event agent.AdapterEvent) error {
 		events = append(events, event)
 		if len(events) == 1 {
 			return errors.New("retry")
@@ -268,11 +267,11 @@ func TestTransientOutputFailureRetriesExactEvent(t *testing.T) {
 		return nil
 	}
 	adapter := &Adapter{}
-	if _, _, err := adapter.Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err == nil {
+	if _, _, err := adapter.Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox); err == nil {
 		t.Fatal("wanted transient error")
 	}
 	client.stdout = []byte("output appended")
-	if _, _, err := adapter.Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err != nil {
+	if _, _, err := adapter.Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox); err != nil {
 		t.Fatal(err)
 	}
 	if len(events) != 3 || !reflect.DeepEqual(events[0], events[1]) {
@@ -288,36 +287,36 @@ func TestPermanentOutputRejectionFailsObserveButNotTerminalCancel(t *testing.T) 
 	exit0 := int32(0)
 	client := &processClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"}, stdout: []byte("output")}
 	sandbox := processSandbox(client, "epoch")
-	sandbox.EmitEvent = func(context.Context, controllers.AdapterEvent) error { return controllers.ErrAdapterEventRejected }
-	got, detail, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox)
-	if err != nil || got != controllers.AdapterObservationFailed || !strings.Contains(detail, "permanently rejected") {
+	sandbox.EmitEvent = func(context.Context, agent.AdapterEvent) error { return agent.ErrAdapterEventRejected }
+	got, detail, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox)
+	if err != nil || got != agent.AdapterObservationFailed || !strings.Contains(detail, "permanently rejected") {
 		t.Fatalf("Observe = %q, %q, %v", got, detail, err)
 	}
 	client.process.State, client.process.ExitCode = sandboxdv1.ProcessState_PROCESS_STATE_EXITED, &exit0
-	if err := (&Adapter{}).Cancel(context.Background(), controllers.AdapterTask{ID: "run"}, sandbox); err != nil {
+	if err := (&Adapter{}).Cancel(context.Background(), agent.AdapterTask{ID: "run"}, sandbox); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestEpochAndSnapshotMetadataFenceOutputKeys(t *testing.T) {
 	client := &processClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"}, stdout: bytes.Repeat([]byte("x"), pageMax+1)}
-	var first controllers.AdapterEvent
+	var first agent.AdapterEvent
 	firstSandbox := processSandbox(client, "epoch-one")
-	firstSandbox.EmitEvent = func(_ context.Context, event controllers.AdapterEvent) error {
+	firstSandbox.EmitEvent = func(_ context.Context, event agent.AdapterEvent) error {
 		first = event
 		return errors.New("uncertain")
 	}
-	if _, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, firstSandbox); err == nil {
+	if _, _, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, firstSandbox); err == nil {
 		t.Fatal("wanted uncertain append")
 	}
 	client.stdout = append(client.stdout, 'y')
-	var second controllers.AdapterEvent
+	var second agent.AdapterEvent
 	secondSandbox := processSandbox(client, "epoch-two")
-	secondSandbox.EmitEvent = func(_ context.Context, event controllers.AdapterEvent) error {
+	secondSandbox.EmitEvent = func(_ context.Context, event agent.AdapterEvent) error {
 		second = event
 		return errors.New("stop")
 	}
-	if _, _, err := (&Adapter{}).Observe(context.Background(), controllers.AdapterTask{ID: "run"}, secondSandbox); err == nil {
+	if _, _, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, secondSandbox); err == nil {
 		t.Fatal("wanted replay stop")
 	}
 	if first.IdempotencyKey == second.IdempotencyKey || bytes.Equal(first.Data, second.Data) {

--- a/internal/agent/adapter.go
+++ b/internal/agent/adapter.go
@@ -65,11 +65,15 @@ type AdapterEventSink interface {
 	Append(context.Context, string, string, string, AdapterEvent) error
 }
 
+// EnvironmentUID is the immutable platform Environment identity. Its string
+// representation keeps the adapter contract independent of any backend API.
+type EnvironmentUID string
+
 // AdapterSandbox is the backend-neutral handle exposed to adapters. Adapters
 // use sandboxd and never inspect pods, containers, VMs, PIDs, or OS signals.
 type AdapterSandbox struct {
 	EnvironmentName string
-	EnvironmentUID  string
+	EnvironmentUID  EnvironmentUID
 	DialProcess     func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error)
 	EmitEvent       func(context.Context, AdapterEvent) error
 }

--- a/internal/agent/adapter.go
+++ b/internal/agent/adapter.go
@@ -1,0 +1,93 @@
+// Package agent defines the adapter contract between agent integrations and the platform.
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
+	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
+)
+
+// ErrAdapterCancellationPending means cancellation was accepted but the
+// adapter-owned execution tree has not reached a terminal state yet.
+var ErrAdapterCancellationPending = errors.New("adapter cancellation is pending")
+
+// ErrAdapterEventRejected means the transcript transport permanently rejected
+// an adapter event. Retrying the same event cannot make progress.
+var ErrAdapterEventRejected = errors.New("adapter event permanently rejected")
+
+// ErrAdapterTaskRejected means an adapter permanently rejected the immutable
+// task intent. Retrying acceptance cannot make progress.
+var ErrAdapterTaskRejected = errors.New("adapter task permanently rejected")
+
+// AdapterObservation is the adapter-neutral state observed for accepted work.
+type AdapterObservation string
+
+const (
+	AdapterObservationAccepted   AdapterObservation = "Accepted"
+	AdapterObservationRunning    AdapterObservation = "Running"
+	AdapterObservationNeedsInput AdapterObservation = "NeedsInput"
+	AdapterObservationSucceeded  AdapterObservation = "Succeeded"
+	AdapterObservationFailed     AdapterObservation = "Failed"
+)
+
+// AdapterTask contains immutable task identity and input. ID is the Run UID
+// and is the adapter's idempotency key across retries and controller restarts.
+type AdapterTask struct {
+	ID     string
+	Prompt string
+}
+
+// AdapterCredential is ephemeral launch-only credential material. Callers must
+// not retain APIKey after EnsureAccepted returns.
+type AdapterCredential struct {
+	Type   platformv1alpha1.AgentCredentialType
+	APIKey []byte
+}
+
+// AdapterEvent is an adapter-owned transcript event carried by the platform's
+// generic transcript transport. Data is opaque to the controller.
+type AdapterEvent struct {
+	Source         string
+	IdempotencyKey string
+	Type           string
+	Data           json.RawMessage
+}
+
+// AdapterEventSink forwards opaque adapter events for one namespaced Run. The
+// runUID is the exact reconciled immutable Run UID; the control plane fences
+// append identity against it so a delete/recreate replacement never receives
+// stale events. Permanent rejection wraps ErrAdapterEventRejected; other
+// errors are retryable.
+type AdapterEventSink interface {
+	Append(context.Context, string, string, string, AdapterEvent) error
+}
+
+// AdapterSandbox is the backend-neutral handle exposed to adapters. Adapters
+// use sandboxd and never inspect pods, containers, VMs, PIDs, or OS signals.
+type AdapterSandbox struct {
+	EnvironmentName string
+	EnvironmentUID  string
+	DialProcess     func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error)
+	EmitEvent       func(context.Context, AdapterEvent) error
+}
+
+// AdapterLifecycle translates one agent's execution model into normalized Run
+// lifecycle events. Every operation must be idempotent. EnsureAccepted may be
+// repeated after an uncertain response or environment resume and may wrap
+// ErrAdapterTaskRejected for permanent intent rejection; Cancel succeeds when
+// work is already absent or terminal and returns
+// ErrAdapterCancellationPending while its execution tree is still stopping.
+type AdapterLifecycle interface {
+	EnsureAccepted(context.Context, AdapterTask, AdapterSandbox, *AdapterCredential) error
+	Observe(context.Context, AdapterTask, AdapterSandbox) (AdapterObservation, string, error)
+	Cancel(context.Context, AdapterTask, AdapterSandbox) error
+}
+
+// AdapterCredentialPolicy is an optional adapter capability. Adapters that
+// return false reject credential profiles before any profile or Secret read.
+type AdapterCredentialPolicy interface {
+	SupportsCredentialProfiles() bool
+}

--- a/internal/controllers/environment_controller_test.go
+++ b/internal/controllers/environment_controller_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
+	"github.com/Chris-Cullins/swe-platform/internal/agent"
 	"github.com/Chris-Cullins/swe-platform/internal/lifecycle"
 	sandboxdauth "github.com/Chris-Cullins/swe-platform/sandboxd/auth"
 )
@@ -4094,7 +4095,7 @@ func TestHoldAcceptsSuspendFenceAndAllowsRunCleanupInEitherOrdering(t *testing.T
 			}
 			kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment, run).WithObjects(environment, run, pod, credentials).Build()
 			environmentReconciler := &EnvironmentReconciler{Client: kubeClient, Scheme: scheme}
-			runReconciler := &RunReconciler{Client: kubeClient, Scheme: scheme, Adapters: map[string]AdapterLifecycle{"test": &scriptedAdapter{}}}
+			runReconciler := &RunReconciler{Client: kubeClient, Scheme: scheme, Adapters: map[string]agent.AdapterLifecycle{"test": &scriptedAdapter{}}}
 			key := client.ObjectKeyFromObject(environment)
 			reconcileEnvironment := func() {
 				t.Helper()

--- a/internal/controllers/operator_metrics.go
+++ b/internal/controllers/operator_metrics.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
+	"github.com/Chris-Cullins/swe-platform/internal/agent"
 	"github.com/Chris-Cullins/swe-platform/internal/lifecycle"
 )
 
@@ -77,7 +78,7 @@ func (r *fenceRejectionRecorder) observe(err error) {
 
 // NewOperatorMetrics registers one process-owned collector set. Tests should
 // pass a fresh registry; the operator passes controller-runtime's registry.
-func NewOperatorMetrics(registerer prometheus.Registerer, adapters map[string]AdapterLifecycle) *OperatorMetrics {
+func NewOperatorMetrics(registerer prometheus.Registerer, adapters map[string]agent.AdapterLifecycle) *OperatorMetrics {
 	m := &OperatorMetrics{
 		registeredAdapters: make(map[string]struct{}, len(adapters)),
 		runAllocations: prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -172,9 +173,9 @@ func (m *OperatorMetrics) observeAdapter(adapter, operation string, started time
 	}
 	outcome := adapterOutcomeSuccess
 	switch {
-	case operation == adapterOperationEnsureAccepted && errors.Is(err, ErrAdapterTaskRejected):
+	case operation == adapterOperationEnsureAccepted && errors.Is(err, agent.ErrAdapterTaskRejected):
 		outcome = adapterOutcomeRejected
-	case operation == adapterOperationCancel && errors.Is(err, ErrAdapterCancellationPending):
+	case operation == adapterOperationCancel && errors.Is(err, agent.ErrAdapterCancellationPending):
 		outcome = adapterOutcomePending
 	case err != nil:
 		outcome = adapterOutcomeError

--- a/internal/controllers/operator_metrics_test.go
+++ b/internal/controllers/operator_metrics_test.go
@@ -19,12 +19,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
+	"github.com/Chris-Cullins/swe-platform/internal/agent"
 )
 
 func testOperatorMetrics(t *testing.T) (*OperatorMetrics, *prometheus.Registry) {
 	t.Helper()
 	registry := prometheus.NewRegistry()
-	metrics := NewOperatorMetrics(registry, map[string]AdapterLifecycle{"test": &scriptedAdapter{}})
+	metrics := NewOperatorMetrics(registry, map[string]agent.AdapterLifecycle{"test": &scriptedAdapter{}})
 	return metrics, registry
 }
 
@@ -32,17 +33,17 @@ type dialAfterMutationAdapter struct {
 	mutate func()
 }
 
-func (a *dialAfterMutationAdapter) EnsureAccepted(ctx context.Context, _ AdapterTask, sandbox AdapterSandbox, _ *AdapterCredential) error {
+func (a *dialAfterMutationAdapter) EnsureAccepted(ctx context.Context, _ agent.AdapterTask, sandbox agent.AdapterSandbox, _ *agent.AdapterCredential) error {
 	a.mutate()
 	_, _, err := sandbox.DialProcess(ctx)
 	return err
 }
 
-func (*dialAfterMutationAdapter) Observe(context.Context, AdapterTask, AdapterSandbox) (AdapterObservation, string, error) {
-	return AdapterObservationRunning, "running", nil
+func (*dialAfterMutationAdapter) Observe(context.Context, agent.AdapterTask, agent.AdapterSandbox) (agent.AdapterObservation, string, error) {
+	return agent.AdapterObservationRunning, "running", nil
 }
 
-func (*dialAfterMutationAdapter) Cancel(context.Context, AdapterTask, AdapterSandbox) error {
+func (*dialAfterMutationAdapter) Cancel(context.Context, agent.AdapterTask, agent.AdapterSandbox) error {
 	return nil
 }
 
@@ -107,22 +108,24 @@ func TestOperatorMetricsObserveAdapterOutcomesOnCalls(t *testing.T) {
 		outcome   string
 	}{
 		{name: "accept success", state: platformv1alpha1.RunStateEnvironmentReady, operation: adapterOperationEnsureAccepted, outcome: adapterOutcomeSuccess},
-		{name: "accept rejected", state: platformv1alpha1.RunStateEnvironmentReady, operation: adapterOperationEnsureAccepted, outcome: adapterOutcomeRejected, configure: func(_ *platformv1alpha1.Run, adapter *scriptedAdapter) { adapter.acceptErr = ErrAdapterTaskRejected }},
+		{name: "accept rejected", state: platformv1alpha1.RunStateEnvironmentReady, operation: adapterOperationEnsureAccepted, outcome: adapterOutcomeRejected, configure: func(_ *platformv1alpha1.Run, adapter *scriptedAdapter) {
+			adapter.acceptErr = agent.ErrAdapterTaskRejected
+		}},
 		{name: "observe error", state: platformv1alpha1.RunStateRunning, operation: adapterOperationObserve, outcome: adapterOutcomeError, configure: func(_ *platformv1alpha1.Run, adapter *scriptedAdapter) {
 			adapter.observeErr = errors.New("rpc unavailable")
 		}},
 		{name: "invalid observation", state: platformv1alpha1.RunStateRunning, operation: adapterOperationObserve, outcome: adapterOutcomeError, configure: func(_ *platformv1alpha1.Run, adapter *scriptedAdapter) {
-			adapter.observations = []AdapterObservation{"Unknown"}
+			adapter.observations = []agent.AdapterObservation{"Unknown"}
 		}},
 		{name: "cancel pending", state: platformv1alpha1.RunStateRunning, operation: adapterOperationCancel, outcome: adapterOutcomePending, configure: func(run *platformv1alpha1.Run, adapter *scriptedAdapter) {
 			run.Spec.Cancel = true
-			adapter.cancelErr = ErrAdapterCancellationPending
+			adapter.cancelErr = agent.ErrAdapterCancellationPending
 		}},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			run, env := adapterRaceObjects(platformv1alpha1.EnvironmentOwnershipOwned, test.state)
-			adapter := &scriptedAdapter{observations: []AdapterObservation{AdapterObservationRunning}}
+			adapter := &scriptedAdapter{observations: []agent.AdapterObservation{agent.AdapterObservationRunning}}
 			if test.state == platformv1alpha1.RunStateEnvironmentReady {
 				setAcceptanceAttempted(run)
 			} else {

--- a/internal/controllers/run_controller.go
+++ b/internal/controllers/run_controller.go
@@ -1151,7 +1151,7 @@ func adapterTask(run *platformv1alpha1.Run) agent.AdapterTask {
 }
 
 func (r *RunReconciler) adapterSandbox(run *platformv1alpha1.Run, env *platformv1alpha1.Environment, fence lifecycle.ExecutionFence, fenceRejections *fenceRejectionRecorder) agent.AdapterSandbox {
-	sandbox := agent.AdapterSandbox{EnvironmentName: env.Name, EnvironmentUID: string(env.UID),
+	sandbox := agent.AdapterSandbox{EnvironmentName: env.Name, EnvironmentUID: agent.EnvironmentUID(env.UID),
 		DialProcess: func(ctx context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
 			reader := r.apiReader()
 			// Mandatory uncached pre-call association proof: a still-current

--- a/internal/controllers/run_controller.go
+++ b/internal/controllers/run_controller.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -24,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
+	"github.com/Chris-Cullins/swe-platform/internal/agent"
 	"github.com/Chris-Cullins/swe-platform/internal/lifecycle"
 	"github.com/Chris-Cullins/swe-platform/internal/sandboxclient"
 	"github.com/Chris-Cullins/swe-platform/internal/tenancy"
@@ -40,94 +40,12 @@ var errExplicitEnvironmentClaimed = errors.New("explicit environment is already 
 var errExplicitEnvironmentHeld = errors.New("explicit environment is held")
 var errExplicitEnvironmentSuspensionNotWakeable = errors.New("explicit environment suspension is not wakeable")
 
-// ErrAdapterCancellationPending means cancellation was accepted but the
-// adapter-owned execution tree has not reached a terminal state yet.
-var ErrAdapterCancellationPending = errors.New("adapter cancellation is pending")
-
-// ErrAdapterEventRejected means the transcript transport permanently rejected
-// an adapter event. Retrying the same event cannot make progress.
-var ErrAdapterEventRejected = errors.New("adapter event permanently rejected")
-
-// ErrAdapterTaskRejected means an adapter permanently rejected the immutable
-// task intent. Retrying acceptance cannot make progress.
-var ErrAdapterTaskRejected = errors.New("adapter task permanently rejected")
-
 const (
 	runConditionEnvironmentReady           = "EnvironmentReady"
 	runConditionCredentialProfileBound     = "CredentialProfileBound"
 	runConditionAdapterAcceptanceAttempted = "AdapterAcceptanceAttempted"
 	runConditionAdapterAccepted            = "AdapterAccepted"
 )
-
-// AdapterObservation is the adapter-neutral state observed for accepted work.
-type AdapterObservation string
-
-const (
-	AdapterObservationAccepted   AdapterObservation = "Accepted"
-	AdapterObservationRunning    AdapterObservation = "Running"
-	AdapterObservationNeedsInput AdapterObservation = "NeedsInput"
-	AdapterObservationSucceeded  AdapterObservation = "Succeeded"
-	AdapterObservationFailed     AdapterObservation = "Failed"
-)
-
-// AdapterTask contains immutable task identity and input. ID is the Run UID
-// and is the adapter's idempotency key across retries and controller restarts.
-type AdapterTask struct {
-	ID     string
-	Prompt string
-}
-
-// AdapterCredential is ephemeral launch-only credential material. Callers must
-// not retain APIKey after EnsureAccepted returns.
-type AdapterCredential struct {
-	Type   platformv1alpha1.AgentCredentialType
-	APIKey []byte
-}
-
-// AdapterEvent is an adapter-owned transcript event carried by the platform's
-// generic transcript transport. Data is opaque to the controller.
-type AdapterEvent struct {
-	Source         string
-	IdempotencyKey string
-	Type           string
-	Data           json.RawMessage
-}
-
-// AdapterEventSink forwards opaque adapter events for one namespaced Run. The
-// runUID is the exact reconciled immutable Run UID; the control plane fences
-// append identity against it so a delete/recreate replacement never receives
-// stale events. Permanent rejection wraps ErrAdapterEventRejected; other
-// errors are retryable.
-type AdapterEventSink interface {
-	Append(context.Context, string, string, string, AdapterEvent) error
-}
-
-// AdapterSandbox is the backend-neutral handle exposed to adapters. Adapters
-// use sandboxd and never inspect pods, containers, VMs, PIDs, or OS signals.
-type AdapterSandbox struct {
-	EnvironmentName string
-	EnvironmentUID  types.UID
-	DialProcess     func(context.Context) (sandboxdv1.ProcessServiceClient, func() error, error)
-	EmitEvent       func(context.Context, AdapterEvent) error
-}
-
-// AdapterLifecycle translates one agent's execution model into normalized Run
-// lifecycle events. Every operation must be idempotent. EnsureAccepted may be
-// repeated after an uncertain response or environment resume and may wrap
-// ErrAdapterTaskRejected for permanent intent rejection; Cancel succeeds when
-// work is already absent or terminal and returns
-// ErrAdapterCancellationPending while its execution tree is still stopping.
-type AdapterLifecycle interface {
-	EnsureAccepted(context.Context, AdapterTask, AdapterSandbox, *AdapterCredential) error
-	Observe(context.Context, AdapterTask, AdapterSandbox) (AdapterObservation, string, error)
-	Cancel(context.Context, AdapterTask, AdapterSandbox) error
-}
-
-// AdapterCredentialPolicy is an optional adapter capability. Adapters that
-// return false reject credential profiles before any profile or Secret read.
-type AdapterCredentialPolicy interface {
-	SupportsCredentialProfiles() bool
-}
 
 // RunReconciler turns a Run intent into one Environment allocation and drives
 // its adapter lifecycle. sandboxd, reached through an adapter, owns all agent
@@ -137,8 +55,8 @@ type RunReconciler struct {
 	APIReader client.Reader
 	Scheme    *runtime.Scheme
 	Scope     *tenancy.ReconcileScope
-	Adapters  map[string]AdapterLifecycle
-	EventSink AdapterEventSink
+	Adapters  map[string]agent.AdapterLifecycle
+	EventSink agent.AdapterEventSink
 	Connector sandboxclient.Connector
 	Metrics   *OperatorMetrics
 }
@@ -218,7 +136,7 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	}
 	if run.Status.EnvironmentRef == nil {
 		if run.Spec.CredentialProfileRef != "" {
-			if policy, ok := r.Adapters[run.Spec.Agent].(AdapterCredentialPolicy); ok && !policy.SupportsCredentialProfiles() {
+			if policy, ok := r.Adapters[run.Spec.Agent].(agent.AdapterCredentialPolicy); ok && !policy.SupportsCredentialProfiles() {
 				return ctrl.Result{}, r.failCredential(ctx, &run, "CredentialProfilesUnsupported", fmt.Sprintf("adapter %q does not support credential profiles", run.Spec.Agent))
 			}
 		}
@@ -311,7 +229,7 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			cancelErr := adapter.Cancel(ctx, adapterTask(&run), r.adapterSandbox(&run, env, executionFence, fenceRejections))
 			r.Metrics.observeAdapter(run.Spec.Agent, adapterOperationCancel, started, cancelErr)
 			if cancelErr != nil {
-				if errors.Is(cancelErr, ErrAdapterCancellationPending) {
+				if errors.Is(cancelErr, agent.ErrAdapterCancellationPending) {
 					return ctrl.Result{RequeueAfter: adapterPollInterval}, nil
 				}
 				return ctrl.Result{}, cancelErr
@@ -403,7 +321,7 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			return ctrl.Result{Requeue: true}, nil
 		}
 		if acceptErr != nil {
-			if errors.Is(acceptErr, ErrAdapterTaskRejected) {
+			if errors.Is(acceptErr, agent.ErrAdapterTaskRejected) {
 				return ctrl.Result{}, r.setRunState(ctx, &run, platformv1alpha1.RunStateFailed, "AdapterRejected", acceptErr.Error(), true)
 			}
 			return ctrl.Result{}, acceptErr
@@ -429,7 +347,7 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	metricErr := err
 	if metricErr == nil {
 		switch observation {
-		case AdapterObservationAccepted, AdapterObservationRunning, AdapterObservationNeedsInput, AdapterObservationSucceeded, AdapterObservationFailed:
+		case agent.AdapterObservationAccepted, agent.AdapterObservationRunning, agent.AdapterObservationNeedsInput, agent.AdapterObservationSucceeded, agent.AdapterObservationFailed:
 		default:
 			metricErr = fmt.Errorf("adapter %q returned unknown observation %q", run.Spec.Agent, observation)
 		}
@@ -447,14 +365,14 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	}
 	state := platformv1alpha1.RunStateAdapterAccepted
 	switch observation {
-	case AdapterObservationAccepted:
-	case AdapterObservationRunning:
+	case agent.AdapterObservationAccepted:
+	case agent.AdapterObservationRunning:
 		state = platformv1alpha1.RunStateRunning
-	case AdapterObservationNeedsInput:
+	case agent.AdapterObservationNeedsInput:
 		state = platformv1alpha1.RunStateNeedsInput
-	case AdapterObservationSucceeded:
+	case agent.AdapterObservationSucceeded:
 		state = platformv1alpha1.RunStateSucceeded
-	case AdapterObservationFailed:
+	case agent.AdapterObservationFailed:
 		state = platformv1alpha1.RunStateFailed
 	default:
 		return ctrl.Result{}, metricErr
@@ -549,7 +467,7 @@ func (r *RunReconciler) failCredential(ctx context.Context, run *platformv1alpha
 	return r.setRunState(ctx, run, platformv1alpha1.RunStateFailed, reason, message, run.Status.EnvironmentRef != nil)
 }
 
-func (r *RunReconciler) resolveCredential(ctx context.Context, run *platformv1alpha1.Run) (*AdapterCredential, string, error) {
+func (r *RunReconciler) resolveCredential(ctx context.Context, run *platformv1alpha1.Run) (*agent.AdapterCredential, string, error) {
 	if run.Spec.CredentialProfileRef == "" {
 		return nil, "", nil
 	}
@@ -606,7 +524,7 @@ func (r *RunReconciler) resolveCredential(ctx context.Context, run *platformv1al
 	if secret.Type != platformv1alpha1.AgentCredentialAPIKeySecretType || len(secret.Data) != 1 || !ok || len(value) == 0 || len(value) > platformv1alpha1.AgentCredentialAPIKeyMaxBytes || !utf8.Valid(value) || bytesContainNUL(value) {
 		return nil, "MalformedSecret", errors.New("credential secret is malformed")
 	}
-	return &AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: append([]byte(nil), value...)}, "", nil
+	return &agent.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: append([]byte(nil), value...)}, "", nil
 }
 
 func exactCredentialSecretOwner(profile *platformv1alpha1.AgentCredentialProfile, object metav1.Object) bool {
@@ -1058,7 +976,7 @@ func (r *RunReconciler) cleanupTerminal(ctx context.Context, run *platformv1alph
 		cancelErr := adapter.Cancel(ctx, adapterTask(run), r.adapterSandbox(run, env, executionFence, fenceRejections))
 		r.Metrics.observeAdapter(run.Spec.Agent, adapterOperationCancel, started, cancelErr)
 		if cancelErr != nil {
-			if errors.Is(cancelErr, ErrAdapterCancellationPending) {
+			if errors.Is(cancelErr, agent.ErrAdapterCancellationPending) {
 				return ctrl.Result{RequeueAfter: adapterPollInterval}, nil
 			}
 			return ctrl.Result{}, cancelErr
@@ -1142,7 +1060,7 @@ func (r *RunReconciler) finalize(ctx context.Context, run *platformv1alpha1.Run)
 				cancelErr := adapter.Cancel(ctx, adapterTask(run), r.adapterSandbox(run, env, executionFence, fenceRejections))
 				r.Metrics.observeAdapter(run.Spec.Agent, adapterOperationCancel, started, cancelErr)
 				if cancelErr != nil {
-					if errors.Is(cancelErr, ErrAdapterCancellationPending) {
+					if errors.Is(cancelErr, agent.ErrAdapterCancellationPending) {
 						return ctrl.Result{RequeueAfter: adapterPollInterval}, nil
 					}
 					return ctrl.Result{}, cancelErr
@@ -1181,7 +1099,7 @@ func (r *RunReconciler) setRunState(ctx context.Context, run *platformv1alpha1.R
 	before := run.Status.DeepCopy()
 	run.Status.State = state
 	run.Status.ObservedGeneration = run.Generation
-	adapterAccepted := runAccepted(run) || state == platformv1alpha1.RunStateAdapterAccepted || state == platformv1alpha1.RunStateRunning || state == platformv1alpha1.RunStateNeedsInput || state == platformv1alpha1.RunStateSucceeded || (state == platformv1alpha1.RunStateFailed && reason == string(AdapterObservationFailed))
+	adapterAccepted := runAccepted(run) || state == platformv1alpha1.RunStateAdapterAccepted || state == platformv1alpha1.RunStateRunning || state == platformv1alpha1.RunStateNeedsInput || state == platformv1alpha1.RunStateSucceeded || (state == platformv1alpha1.RunStateFailed && reason == string(agent.AdapterObservationFailed))
 	if adapterAccepted && run.Status.StartedAt == nil {
 		startedAt := metav1.Now()
 		run.Status.StartedAt = &startedAt
@@ -1228,12 +1146,12 @@ func terminalRunState(state platformv1alpha1.RunState) bool {
 	return state == platformv1alpha1.RunStateSucceeded || state == platformv1alpha1.RunStateFailed || state == platformv1alpha1.RunStateCancelled
 }
 
-func adapterTask(run *platformv1alpha1.Run) AdapterTask {
-	return AdapterTask{ID: string(run.UID), Prompt: run.Spec.Prompt}
+func adapterTask(run *platformv1alpha1.Run) agent.AdapterTask {
+	return agent.AdapterTask{ID: string(run.UID), Prompt: run.Spec.Prompt}
 }
 
-func (r *RunReconciler) adapterSandbox(run *platformv1alpha1.Run, env *platformv1alpha1.Environment, fence lifecycle.ExecutionFence, fenceRejections *fenceRejectionRecorder) AdapterSandbox {
-	sandbox := AdapterSandbox{EnvironmentName: env.Name, EnvironmentUID: env.UID,
+func (r *RunReconciler) adapterSandbox(run *platformv1alpha1.Run, env *platformv1alpha1.Environment, fence lifecycle.ExecutionFence, fenceRejections *fenceRejectionRecorder) agent.AdapterSandbox {
+	sandbox := agent.AdapterSandbox{EnvironmentName: env.Name, EnvironmentUID: string(env.UID),
 		DialProcess: func(ctx context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
 			reader := r.apiReader()
 			// Mandatory uncached pre-call association proof: a still-current
@@ -1257,7 +1175,7 @@ func (r *RunReconciler) adapterSandbox(run *platformv1alpha1.Run, env *platformv
 		}}
 	if r.EventSink != nil {
 		runUID := string(run.UID)
-		sandbox.EmitEvent = func(ctx context.Context, event AdapterEvent) error {
+		sandbox.EmitEvent = func(ctx context.Context, event agent.AdapterEvent) error {
 			return r.EventSink.Append(ctx, run.Namespace, run.Name, runUID, event)
 		}
 	}

--- a/internal/controllers/run_controller_test.go
+++ b/internal/controllers/run_controller_test.go
@@ -24,11 +24,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
+	"github.com/Chris-Cullins/swe-platform/internal/agent"
 	"github.com/Chris-Cullins/swe-platform/internal/lifecycle"
 )
 
 type scriptedAdapter struct {
-	observations          []AdapterObservation
+	observations          []agent.AdapterObservation
 	accepted, observed    int
 	cancelled             int
 	acceptErr             error
@@ -41,22 +42,24 @@ type scriptedAdapter struct {
 }
 
 type blockingObserveAdapter struct {
-	observation AdapterObservation
+	observation agent.AdapterObservation
 	started     chan struct{}
 	release     chan struct{}
 }
 
-func (*blockingObserveAdapter) EnsureAccepted(context.Context, AdapterTask, AdapterSandbox, *AdapterCredential) error {
+func (*blockingObserveAdapter) EnsureAccepted(context.Context, agent.AdapterTask, agent.AdapterSandbox, *agent.AdapterCredential) error {
 	return nil
 }
 
-func (a *blockingObserveAdapter) Observe(context.Context, AdapterTask, AdapterSandbox) (AdapterObservation, string, error) {
+func (a *blockingObserveAdapter) Observe(context.Context, agent.AdapterTask, agent.AdapterSandbox) (agent.AdapterObservation, string, error) {
 	close(a.started)
 	<-a.release
 	return a.observation, string(a.observation), nil
 }
 
-func (*blockingObserveAdapter) Cancel(context.Context, AdapterTask, AdapterSandbox) error { return nil }
+func (*blockingObserveAdapter) Cancel(context.Context, agent.AdapterTask, agent.AdapterSandbox) error {
+	return nil
+}
 
 type failAcceptedStatusClient struct {
 	client.Client
@@ -82,36 +85,38 @@ func (w *failAcceptedStatusWriter) Update(ctx context.Context, object client.Obj
 
 // foregroundAdapter models a CLI agent whose managed process exit is the task
 // outcome.
-type foregroundAdapter struct{ process AdapterObservation }
+type foregroundAdapter struct{ process agent.AdapterObservation }
 
-func (*foregroundAdapter) EnsureAccepted(context.Context, AdapterTask, AdapterSandbox, *AdapterCredential) error {
+func (*foregroundAdapter) EnsureAccepted(context.Context, agent.AdapterTask, agent.AdapterSandbox, *agent.AdapterCredential) error {
 	return nil
 }
-func (a *foregroundAdapter) Observe(context.Context, AdapterTask, AdapterSandbox) (AdapterObservation, string, error) {
+func (a *foregroundAdapter) Observe(context.Context, agent.AdapterTask, agent.AdapterSandbox) (agent.AdapterObservation, string, error) {
 	return a.process, "managed process state", nil
 }
-func (*foregroundAdapter) Cancel(context.Context, AdapterTask, AdapterSandbox) error { return nil }
+func (*foregroundAdapter) Cancel(context.Context, agent.AdapterTask, agent.AdapterSandbox) error {
+	return nil
+}
 
 // serviceAdapter models a long-lived agent service: task events change while
 // the service process remains running, so service exit is not task completion.
 type serviceAdapter struct {
 	serviceRunning bool
-	event          AdapterObservation
+	event          agent.AdapterObservation
 }
 
-func (a *serviceAdapter) EnsureAccepted(context.Context, AdapterTask, AdapterSandbox, *AdapterCredential) error {
+func (a *serviceAdapter) EnsureAccepted(context.Context, agent.AdapterTask, agent.AdapterSandbox, *agent.AdapterCredential) error {
 	a.serviceRunning = true
 	return nil
 }
-func (a *serviceAdapter) Observe(context.Context, AdapterTask, AdapterSandbox) (AdapterObservation, string, error) {
+func (a *serviceAdapter) Observe(context.Context, agent.AdapterTask, agent.AdapterSandbox) (agent.AdapterObservation, string, error) {
 	return a.event, "service task event", nil
 }
-func (a *serviceAdapter) Cancel(context.Context, AdapterTask, AdapterSandbox) error {
+func (a *serviceAdapter) Cancel(context.Context, agent.AdapterTask, agent.AdapterSandbox) error {
 	a.serviceRunning = false
 	return nil
 }
 
-func (a *scriptedAdapter) EnsureAccepted(_ context.Context, _ AdapterTask, _ AdapterSandbox, credential *AdapterCredential) error {
+func (a *scriptedAdapter) EnsureAccepted(_ context.Context, _ agent.AdapterTask, _ agent.AdapterSandbox, credential *agent.AdapterCredential) error {
 	a.accepted++
 	if a.onAccept != nil {
 		a.onAccept()
@@ -124,14 +129,14 @@ func (a *scriptedAdapter) EnsureAccepted(_ context.Context, _ AdapterTask, _ Ada
 	}
 	return a.acceptErr
 }
-func (a *scriptedAdapter) Cancel(context.Context, AdapterTask, AdapterSandbox) error {
+func (a *scriptedAdapter) Cancel(context.Context, agent.AdapterTask, agent.AdapterSandbox) error {
 	a.cancelled++
 	if a.onCancel != nil {
 		a.onCancel()
 	}
 	return a.cancelErr
 }
-func (a *scriptedAdapter) Observe(context.Context, AdapterTask, AdapterSandbox) (AdapterObservation, string, error) {
+func (a *scriptedAdapter) Observe(context.Context, agent.AdapterTask, agent.AdapterSandbox) (agent.AdapterObservation, string, error) {
 	a.observed++
 	if a.observeErr != nil {
 		return "", "", a.observeErr
@@ -155,7 +160,7 @@ func runScheme(t *testing.T) *runtime.Scheme {
 	return s
 }
 
-func reconciler(t *testing.T, adapter AdapterLifecycle, objects ...client.Object) *RunReconciler {
+func reconciler(t *testing.T, adapter agent.AdapterLifecycle, objects ...client.Object) *RunReconciler {
 	t.Helper()
 	s := runScheme(t)
 	templates := make(map[types.NamespacedName]bool)
@@ -213,7 +218,7 @@ func reconciler(t *testing.T, adapter AdapterLifecycle, objects ...client.Object
 		objects = append(objects, runExecutionPod(env, types.UID("pod-"+env.Name), "10.0.0.1"))
 	}
 	c := fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&platformv1alpha1.Run{}, &platformv1alpha1.Environment{}).WithObjects(objects...).Build()
-	return &RunReconciler{Client: c, Scheme: s, Adapters: map[string]AdapterLifecycle{"test": adapter}}
+	return &RunReconciler{Client: c, Scheme: s, Adapters: map[string]agent.AdapterLifecycle{"test": adapter}}
 }
 
 func runExecutionPod(env *platformv1alpha1.Environment, uid types.UID, podIP string) *corev1.Pod {
@@ -699,10 +704,10 @@ func TestAcceptedRunIgnoresActivityWithoutRereadingCredentials(t *testing.T) {
 	for _, test := range []struct {
 		name        string
 		state       platformv1alpha1.RunState
-		observation AdapterObservation
+		observation agent.AdapterObservation
 	}{
-		{name: "running", state: platformv1alpha1.RunStateRunning, observation: AdapterObservationRunning},
-		{name: "needs input", state: platformv1alpha1.RunStateNeedsInput, observation: AdapterObservationNeedsInput},
+		{name: "running", state: platformv1alpha1.RunStateRunning, observation: agent.AdapterObservationRunning},
+		{name: "needs input", state: platformv1alpha1.RunStateNeedsInput, observation: agent.AdapterObservationNeedsInput},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			acceptedEpoch := int64(0)
@@ -722,7 +727,7 @@ func TestAcceptedRunIgnoresActivityWithoutRereadingCredentials(t *testing.T) {
 			environment := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "e", Namespace: "ns", UID: "env-uid", Generation: 1}}
 			environment.Status.ExecutionGeneration = 1
 			applyEnvironmentStatus(environment, platformv1alpha1.EnvironmentPhaseReady, "env-e", "10.0.0.1:50051", "SandboxdReady", "ready", nil)
-			adapter := &scriptedAdapter{observations: []AdapterObservation{test.observation}}
+			adapter := &scriptedAdapter{observations: []agent.AdapterObservation{test.observation}}
 			r := reconciler(t, adapter, run, environment)
 			credentialReads := 0
 			r.APIReader = interceptor.NewClient(r.Client.(client.WithWatch), interceptor.Funcs{Get: func(ctx context.Context, delegate client.WithWatch, key client.ObjectKey, object client.Object, options ...client.GetOption) error {
@@ -872,7 +877,7 @@ func TestTerminalClaimReleaseRemainsReleasedAcrossReconcileAndRestart(t *testing
 				t.Fatal(err)
 			}
 
-			restarted := &RunReconciler{Client: r.Client, Scheme: r.Scheme, Adapters: map[string]AdapterLifecycle{"test": adapter}}
+			restarted := &RunReconciler{Client: r.Client, Scheme: r.Scheme, Adapters: map[string]agent.AdapterLifecycle{"test": adapter}}
 			got := reconcileRun(t, restarted, run.Name)
 			assertTerminalEnvironmentCondition(t, got, state, "EnvironmentReleased", "claimed environment was released")
 			var retainedReplacement platformv1alpha1.Environment
@@ -978,12 +983,12 @@ func assertTerminalEnvironmentCondition(t *testing.T, run platformv1alpha1.Run, 
 func TestAdapterShapesPauseResumeAndStatus(t *testing.T) {
 	for _, tc := range []struct {
 		name         string
-		observations []AdapterObservation
+		observations []agent.AdapterObservation
 		want         []platformv1alpha1.RunState
 	}{
-		{"foreground-process", []AdapterObservation{AdapterObservationRunning, AdapterObservationSucceeded}, []platformv1alpha1.RunState{platformv1alpha1.RunStateRunning, platformv1alpha1.RunStateSucceeded}},
-		{"foreground-process-failure", []AdapterObservation{AdapterObservationFailed}, []platformv1alpha1.RunState{platformv1alpha1.RunStateFailed}},
-		{"service-events", []AdapterObservation{AdapterObservationRunning, AdapterObservationNeedsInput}, []platformv1alpha1.RunState{platformv1alpha1.RunStateRunning, platformv1alpha1.RunStateNeedsInput}},
+		{"foreground-process", []agent.AdapterObservation{agent.AdapterObservationRunning, agent.AdapterObservationSucceeded}, []platformv1alpha1.RunState{platformv1alpha1.RunStateRunning, platformv1alpha1.RunStateSucceeded}},
+		{"foreground-process-failure", []agent.AdapterObservation{agent.AdapterObservationFailed}, []platformv1alpha1.RunState{platformv1alpha1.RunStateFailed}},
+		{"service-events", []agent.AdapterObservation{agent.AdapterObservationRunning, agent.AdapterObservationNeedsInput}, []platformv1alpha1.RunState{platformv1alpha1.RunStateRunning, platformv1alpha1.RunStateNeedsInput}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "uid", Finalizers: []string{runFinalizer}}, Spec: platformv1alpha1.RunSpec{Agent: "test"}, Status: platformv1alpha1.RunStatus{State: platformv1alpha1.RunStateAllocating, EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{Name: "e", UID: "euid", Ownership: platformv1alpha1.EnvironmentOwnershipOwned}}}
@@ -1031,7 +1036,7 @@ func TestPermanentAdapterAcceptanceRejectionFailsRun(t *testing.T) {
 		Conditions:     []metav1.Condition{{Type: runConditionAdapterAcceptanceAttempted, Status: metav1.ConditionTrue}},
 	}}
 	env := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "e", Namespace: "ns", UID: "euid"}, Status: platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhaseReady}}
-	adapter := &scriptedAdapter{acceptErr: fmt.Errorf("%w: unsupported task configuration", ErrAdapterTaskRejected)}
+	adapter := &scriptedAdapter{acceptErr: fmt.Errorf("%w: unsupported task configuration", agent.ErrAdapterTaskRejected)}
 	r := reconciler(t, adapter, run, env)
 	got := reconcileRun(t, r, run.Name)
 	condition := apiMeta.FindStatusCondition(got.Status.Conditions, runConditionAdapterAccepted)
@@ -1049,25 +1054,25 @@ func TestDifferentAdapterShapesDriveSameLifecycleContract(t *testing.T) {
 	}
 
 	foregroundRun := readyRun("foreground")
-	foreground := &foregroundAdapter{process: AdapterObservationRunning}
+	foreground := &foregroundAdapter{process: agent.AdapterObservationRunning}
 	foregroundReconciler := reconciler(t, foreground, foregroundRun, readyEnvironment(foregroundRun))
 	reconcileRun(t, foregroundReconciler, foregroundRun.Name) // acceptance attempt marker
 	reconcileRun(t, foregroundReconciler, foregroundRun.Name) // acceptance
 	if got := reconcileRun(t, foregroundReconciler, foregroundRun.Name); got.Status.State != platformv1alpha1.RunStateRunning {
 		t.Fatalf("foreground state = %s", got.Status.State)
 	}
-	foreground.process = AdapterObservationSucceeded
+	foreground.process = agent.AdapterObservationSucceeded
 	if got := reconcileRun(t, foregroundReconciler, foregroundRun.Name); got.Status.State != platformv1alpha1.RunStateSucceeded {
 		t.Fatalf("foreground terminal state = %s", got.Status.State)
 	}
 
 	serviceRun := readyRun("service")
-	service := &serviceAdapter{event: AdapterObservationRunning}
+	service := &serviceAdapter{event: agent.AdapterObservationRunning}
 	serviceReconciler := reconciler(t, service, serviceRun, readyEnvironment(serviceRun))
 	reconcileRun(t, serviceReconciler, serviceRun.Name) // acceptance attempt marker
 	reconcileRun(t, serviceReconciler, serviceRun.Name) // task acknowledgement
 	reconcileRun(t, serviceReconciler, serviceRun.Name) // running event
-	service.event = AdapterObservationNeedsInput
+	service.event = agent.AdapterObservationNeedsInput
 	if got := reconcileRun(t, serviceReconciler, serviceRun.Name); got.Status.State != platformv1alpha1.RunStateNeedsInput || !service.serviceRunning {
 		t.Fatalf("service state = %s, serviceRunning = %v", got.Status.State, service.serviceRunning)
 	}
@@ -1076,7 +1081,7 @@ func TestDifferentAdapterShapesDriveSameLifecycleContract(t *testing.T) {
 func TestNonterminalAdapterObservationSchedulesPolling(t *testing.T) {
 	run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "uid", Finalizers: []string{runFinalizer}}, Spec: platformv1alpha1.RunSpec{Agent: "test"}, Status: platformv1alpha1.RunStatus{State: platformv1alpha1.RunStateAdapterAccepted, EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{Name: "e", UID: "euid", Ownership: platformv1alpha1.EnvironmentOwnershipOwned}}}
 	env := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "e", Namespace: "ns", UID: "euid"}, Status: platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhaseReady}}
-	r := reconciler(t, &foregroundAdapter{process: AdapterObservationRunning}, run, env)
+	r := reconciler(t, &foregroundAdapter{process: agent.AdapterObservationRunning}, run, env)
 	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)})
 	if err != nil {
 		t.Fatal(err)
@@ -1127,7 +1132,7 @@ func TestEnvironmentReadyConditionIsIndependentFromTaskOutcome(t *testing.T) {
 		name         string
 		runState     platformv1alpha1.RunState
 		envPhase     platformv1alpha1.EnvironmentPhase
-		adapter      AdapterLifecycle
+		adapter      agent.AdapterLifecycle
 		cancel       bool
 		accepted     bool
 		wantReady    metav1.ConditionStatus
@@ -1135,7 +1140,7 @@ func TestEnvironmentReadyConditionIsIndependentFromTaskOutcome(t *testing.T) {
 	}{
 		{
 			name: "adapter failure leaves ready Environment", runState: platformv1alpha1.RunStateAdapterAccepted,
-			envPhase: platformv1alpha1.EnvironmentPhaseReady, adapter: &scriptedAdapter{observations: []AdapterObservation{AdapterObservationFailed}},
+			envPhase: platformv1alpha1.EnvironmentPhaseReady, adapter: &scriptedAdapter{observations: []agent.AdapterObservation{agent.AdapterObservationFailed}},
 			accepted: true, wantReady: metav1.ConditionTrue, wantRunState: platformv1alpha1.RunStateFailed,
 		},
 		{
@@ -1170,7 +1175,7 @@ func TestEnvironmentReadyConditionIsIndependentFromTaskOutcome(t *testing.T) {
 			}
 			r := reconciler(t, tc.adapter, run, env)
 			if tc.adapter == nil {
-				r.Adapters = map[string]AdapterLifecycle{}
+				r.Adapters = map[string]agent.AdapterLifecycle{}
 			}
 			got := reconcileRun(t, r, run.Name)
 			condition := apiMeta.FindStatusCondition(got.Status.Conditions, runConditionEnvironmentReady)
@@ -1459,7 +1464,7 @@ func TestCancellationPendingRetainsRunAndClaim(t *testing.T) {
 		Phase: platformv1alpha1.EnvironmentPhaseReady, PodName: "env-shared", Endpoints: platformv1alpha1.EnvironmentEndpoints{Sandboxd: "10.0.0.1:50051"},
 		ClaimedBy: &platformv1alpha1.RunReference{Name: run.Name, UID: run.UID},
 	}}
-	adapter := &scriptedAdapter{cancelErr: ErrAdapterCancellationPending}
+	adapter := &scriptedAdapter{cancelErr: agent.ErrAdapterCancellationPending}
 	r := reconciler(t, adapter, run, env)
 	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)})
 	if err != nil || result.RequeueAfter != adapterPollInterval {
@@ -1704,7 +1709,7 @@ func TestMissingAdapterCleanupFallsBackToBackendFence(t *testing.T) {
 		ClaimedBy: &platformv1alpha1.RunReference{Name: run.Name, UID: run.UID},
 	}}
 	r := reconciler(t, &scriptedAdapter{}, run, env)
-	r.Adapters = map[string]AdapterLifecycle{}
+	r.Adapters = map[string]agent.AdapterLifecycle{}
 	result, err := r.finalize(context.Background(), run)
 	if err != nil || result.RequeueAfter != adapterPollInterval {
 		t.Fatalf("missing-adapter fence = (%#v, %v)", result, err)
@@ -1861,7 +1866,7 @@ func TestOwnershipMismatchNeverCancelsOrMutatesEnvironment(t *testing.T) {
 	s := runScheme(t)
 	c := fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(&platformv1alpha1.Run{}, &platformv1alpha1.Environment{}).WithObjects(run, env).Build()
 	adapter := &scriptedAdapter{}
-	r := &RunReconciler{Client: c, Scheme: s, Adapters: map[string]AdapterLifecycle{"test": adapter}}
+	r := &RunReconciler{Client: c, Scheme: s, Adapters: map[string]agent.AdapterLifecycle{"test": adapter}}
 	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)}); err != nil {
 		t.Fatal(err)
 	}
@@ -2217,7 +2222,7 @@ func TestCredentialRotationIsRematerializedAfterResumeEpoch(t *testing.T) {
 	}
 	reconcileRun(t, r, run.Name) // Paused -> EnvironmentReady.
 	reconcileRun(t, r, run.Name) // Reaccept in the fresh sandbox epoch.
-	adapter.observations = []AdapterObservation{AdapterObservationAccepted}
+	adapter.observations = []agent.AdapterObservation{agent.AdapterObservationAccepted}
 	reconcileRun(t, r, run.Name) // Observe without accepting the same epoch again.
 	if len(adapter.acceptedCredentials) != 2 || string(adapter.acceptedCredentials[0]) != "!!FIRST-EPOCH-KEY!!" || string(adapter.acceptedCredentials[1]) != "!!SECOND-EPOCH-KEY!!" {
 		t.Fatalf("epoch credentials = %#v", adapter.acceptedCredentials)
@@ -2228,10 +2233,10 @@ func TestMissedPauseTransitionReacceptsFreshEnvironmentEpoch(t *testing.T) {
 	for _, test := range []struct {
 		name        string
 		state       platformv1alpha1.RunState
-		observation AdapterObservation
+		observation agent.AdapterObservation
 	}{
-		{name: "running", state: platformv1alpha1.RunStateRunning, observation: AdapterObservationRunning},
-		{name: "needs input", state: platformv1alpha1.RunStateNeedsInput, observation: AdapterObservationNeedsInput},
+		{name: "running", state: platformv1alpha1.RunStateRunning, observation: agent.AdapterObservationRunning},
+		{name: "needs input", state: platformv1alpha1.RunStateNeedsInput, observation: agent.AdapterObservationNeedsInput},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			epoch0 := int64(0)
@@ -2254,7 +2259,7 @@ func TestMissedPauseTransitionReacceptsFreshEnvironmentEpoch(t *testing.T) {
 			applyEnvironmentStatus(env, platformv1alpha1.EnvironmentPhaseReady, "env-e-0", "10.0.0.1:50051", "SandboxdReady", "ready", nil)
 			profile, staleSecret := credentialProfileAndSecret(run, []byte("!!EPOCH-ZERO-KEY!!"))
 			_, rotatedSecret := credentialProfileAndSecret(run, []byte("!!EPOCH-ONE-KEY!!"))
-			adapter := &scriptedAdapter{observations: []AdapterObservation{test.observation}}
+			adapter := &scriptedAdapter{observations: []agent.AdapterObservation{test.observation}}
 			r := reconciler(t, adapter, run, env, profile, staleSecret)
 
 			// The Environment completes an entire pause/resume while the Run
@@ -2318,7 +2323,7 @@ func TestObserveDiscardsStaleExecutionResults(t *testing.T) {
 		platformv1alpha1.EnvironmentOwnershipOwned,
 		platformv1alpha1.EnvironmentOwnershipClaimed,
 	} {
-		for _, observation := range []AdapterObservation{AdapterObservationNeedsInput, AdapterObservationSucceeded} {
+		for _, observation := range []agent.AdapterObservation{agent.AdapterObservationNeedsInput, agent.AdapterObservationSucceeded} {
 			t.Run(string(ownership)+"/"+string(observation), func(t *testing.T) {
 				epoch := int64(0)
 				executionGeneration := int64(1)
@@ -2386,7 +2391,7 @@ func TestAdapterResultsRequireSameLivePodWithUnchangedStatus(t *testing.T) {
 		platformv1alpha1.EnvironmentOwnershipOwned,
 		platformv1alpha1.EnvironmentOwnershipClaimed,
 	} {
-		for _, acceptErr := range []error{nil, ErrAdapterTaskRejected} {
+		for _, acceptErr := range []error{nil, agent.ErrAdapterTaskRejected} {
 			name := "successful accept"
 			if acceptErr != nil {
 				name = "rejected accept"
@@ -2418,7 +2423,7 @@ func TestAdapterResultsRequireSameLivePodWithUnchangedStatus(t *testing.T) {
 			run.Status.AcceptedEnvironmentEpoch = &epoch
 			run.Status.AcceptedEnvironmentExecutionGeneration = &generation
 			apiMeta.SetStatusCondition(&run.Status.Conditions, metav1.Condition{Type: runConditionAdapterAccepted, Status: metav1.ConditionTrue, Reason: "AdapterAccepted"})
-			adapter := &scriptedAdapter{observations: []AdapterObservation{AdapterObservationSucceeded}}
+			adapter := &scriptedAdapter{observations: []agent.AdapterObservation{agent.AdapterObservationSucceeded}}
 			r := reconciler(t, adapter, run, environment)
 			// scripted Observe is synchronous, so replace the Pod from its
 			// observation hook by using a one-shot wrapper.
@@ -2445,7 +2450,7 @@ type mutatingObserveAdapter struct {
 	mutate func()
 }
 
-func (a *mutatingObserveAdapter) Observe(ctx context.Context, task AdapterTask, sandbox AdapterSandbox) (AdapterObservation, string, error) {
+func (a *mutatingObserveAdapter) Observe(ctx context.Context, task agent.AdapterTask, sandbox agent.AdapterSandbox) (agent.AdapterObservation, string, error) {
 	observation, message, err := a.scriptedAdapter.Observe(ctx, task, sandbox)
 	a.mutate()
 	return observation, message, err
@@ -2661,7 +2666,7 @@ func TestCancellationBeforeAllocationDoesNotReadCredentialProfileOrSecret(t *tes
 func TestLifecycleTimestampsSetOnceAcrossPauseResumeAndTerminal(t *testing.T) {
 	run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "uid", Finalizers: []string{runFinalizer}}, Spec: platformv1alpha1.RunSpec{Agent: "test"}, Status: platformv1alpha1.RunStatus{State: platformv1alpha1.RunStateAllocating, EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{Name: "e", UID: "euid", Ownership: platformv1alpha1.EnvironmentOwnershipOwned}}}
 	env := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "e", Namespace: "ns", UID: "euid"}, Status: platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhaseReady}}
-	r := reconciler(t, &scriptedAdapter{observations: []AdapterObservation{AdapterObservationRunning}}, run, env)
+	r := reconciler(t, &scriptedAdapter{observations: []agent.AdapterObservation{agent.AdapterObservationRunning}}, run, env)
 
 	// Drive through allocation to AdapterAccepted.
 	reconcileRun(t, r, "r")        // EnvironmentReady
@@ -2720,7 +2725,7 @@ func TestLifecycleTimestampsSetOnceAcrossPauseResumeAndTerminal(t *testing.T) {
 
 	// Terminal: FinishedAt is set once, StartedAt unchanged.
 	adapter := r.Adapters["test"].(*scriptedAdapter)
-	adapter.observations = []AdapterObservation{AdapterObservationSucceeded}
+	adapter.observations = []agent.AdapterObservation{agent.AdapterObservationSucceeded}
 	got = reconcileRun(t, r, "r")
 	if got.Status.State != platformv1alpha1.RunStateSucceeded {
 		t.Fatalf("state = %s, want Succeeded", got.Status.State)
@@ -2738,7 +2743,7 @@ func TestLifecycleTimestampsSetOnImmediateTerminalSuccess(t *testing.T) {
 	// Running: the Run goes directly from AdapterAccepted to Succeeded.
 	run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "uid", Finalizers: []string{runFinalizer}}, Spec: platformv1alpha1.RunSpec{Agent: "test"}, Status: platformv1alpha1.RunStatus{State: platformv1alpha1.RunStateAllocating, EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{Name: "e", UID: "euid", Ownership: platformv1alpha1.EnvironmentOwnershipOwned}}}
 	env := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "e", Namespace: "ns", UID: "euid"}, Status: platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhaseReady}}
-	r := reconciler(t, &scriptedAdapter{observations: []AdapterObservation{AdapterObservationSucceeded}}, run, env)
+	r := reconciler(t, &scriptedAdapter{observations: []agent.AdapterObservation{agent.AdapterObservationSucceeded}}, run, env)
 
 	reconcileRun(t, r, "r")        // EnvironmentReady
 	reconcileRun(t, r, "r")        // acceptance attempt marker
@@ -2787,7 +2792,7 @@ func TestLifecycleTimestampsNilForNeverAcceptedFailureAndCancellation(t *testing
 			Conditions:     []metav1.Condition{{Type: runConditionAdapterAcceptanceAttempted, Status: metav1.ConditionTrue}},
 		}}
 		env := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "e", Namespace: "ns", UID: "euid"}, Status: platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhaseReady}}
-		adapter := &scriptedAdapter{acceptErr: fmt.Errorf("%w: unsupported task configuration", ErrAdapterTaskRejected)}
+		adapter := &scriptedAdapter{acceptErr: fmt.Errorf("%w: unsupported task configuration", agent.ErrAdapterTaskRejected)}
 		r := reconciler(t, adapter, run, env)
 
 		got := reconcileRun(t, r, "r")
@@ -2824,7 +2829,7 @@ func TestAdapterSandboxEmitEventSendsExactRunUID(t *testing.T) {
 	env := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "env", Namespace: "ns", UID: "env-uid"}}
 
 	var gotNamespace, gotName, gotUID string
-	sink := eventSinkFunc(func(ctx context.Context, namespace, name, runUID string, event AdapterEvent) error {
+	sink := eventSinkFunc(func(ctx context.Context, namespace, name, runUID string, event agent.AdapterEvent) error {
 		gotNamespace, gotName, gotUID = namespace, name, runUID
 		return nil
 	})
@@ -2833,7 +2838,7 @@ func TestAdapterSandboxEmitEventSendsExactRunUID(t *testing.T) {
 	if sandbox.EmitEvent == nil {
 		t.Fatal("EmitEvent closure was not wired")
 	}
-	if err := sandbox.EmitEvent(context.Background(), AdapterEvent{Source: "adapter", IdempotencyKey: "k", Type: "output", Data: json.RawMessage(`{}`)}); err != nil {
+	if err := sandbox.EmitEvent(context.Background(), agent.AdapterEvent{Source: "adapter", IdempotencyKey: "k", Type: "output", Data: json.RawMessage(`{}`)}); err != nil {
 		t.Fatal(err)
 	}
 	if gotNamespace != "ns" || gotName != "r" || gotUID != "run-uid" {
@@ -2841,8 +2846,8 @@ func TestAdapterSandboxEmitEventSendsExactRunUID(t *testing.T) {
 	}
 }
 
-type eventSinkFunc func(context.Context, string, string, string, AdapterEvent) error
+type eventSinkFunc func(context.Context, string, string, string, agent.AdapterEvent) error
 
-func (f eventSinkFunc) Append(ctx context.Context, namespace, name, runUID string, event AdapterEvent) error {
+func (f eventSinkFunc) Append(ctx context.Context, namespace, name, runUID string, event agent.AdapterEvent) error {
 	return f(ctx, namespace, name, runUID, event)
 }

--- a/internal/transcriptclient/client.go
+++ b/internal/transcriptclient/client.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/Chris-Cullins/swe-platform/internal/controllers"
+	"github.com/Chris-Cullins/swe-platform/internal/agent"
 	"github.com/Chris-Cullins/swe-platform/internal/controlplane"
 )
 
@@ -25,7 +25,9 @@ type Client struct {
 	HTTP      *http.Client
 }
 
-func (c Client) Append(ctx context.Context, namespace, run, runUID string, event controllers.AdapterEvent) error {
+var _ agent.AdapterEventSink = Client{}
+
+func (c Client) Append(ctx context.Context, namespace, run, runUID string, event agent.AdapterEvent) error {
 	token, err := os.ReadFile(c.TokenFile)
 	if err != nil {
 		return fmt.Errorf("read transcript credential: %w", err)
@@ -66,7 +68,7 @@ func (c Client) Append(ctx context.Context, namespace, run, runUID string, event
 		message, _ := io.ReadAll(io.LimitReader(response.Body, 4096))
 		err := fmt.Errorf("append transcript event: control plane returned %s: %s", response.Status, strings.TrimSpace(string(message)))
 		if permanentRejection(response.StatusCode) {
-			return fmt.Errorf("%w: %v", controllers.ErrAdapterEventRejected, err)
+			return fmt.Errorf("%w: %v", agent.ErrAdapterEventRejected, err)
 		}
 		return err
 	}

--- a/internal/transcriptclient/client_test.go
+++ b/internal/transcriptclient/client_test.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Chris-Cullins/swe-platform/internal/controllers"
+	"github.com/Chris-Cullins/swe-platform/internal/agent"
 	"github.com/Chris-Cullins/swe-platform/internal/controlplane"
 )
 
@@ -33,7 +33,7 @@ func TestAppendUsesProjectedCredentialAndOpaqueEvent(t *testing.T) {
 	}))
 	defer server.Close()
 
-	event := controllers.AdapterEvent{Source: "claude-code", IdempotencyKey: "execution:stdout:0", Type: "claude.output", Data: json.RawMessage(`{"adapter":"owned"}`)}
+	event := agent.AdapterEvent{Source: "claude-code", IdempotencyKey: "execution:stdout:0", Type: "claude.output", Data: json.RawMessage(`{"adapter":"owned"}`)}
 	if err := (Client{BaseURL: server.URL, TokenFile: tokenFile, HTTP: server.Client()}).Append(context.Background(), "team", "run-1", "run-1-uid", event); err != nil {
 		t.Fatal(err)
 	}
@@ -77,8 +77,8 @@ func TestAppendClassifiesControlPlaneFailures(t *testing.T) {
 				http.Error(w, "rejected", test.status)
 			}))
 			defer server.Close()
-			err := (Client{BaseURL: server.URL, TokenFile: tokenFile}).Append(context.Background(), "ns", "run", "run-uid", controllers.AdapterEvent{Source: "a", IdempotencyKey: "k", Type: "t", Data: json.RawMessage(`{}`)})
-			if err == nil || errors.Is(err, controllers.ErrAdapterEventRejected) != test.permanent {
+			err := (Client{BaseURL: server.URL, TokenFile: tokenFile}).Append(context.Background(), "ns", "run", "run-uid", agent.AdapterEvent{Source: "a", IdempotencyKey: "k", Type: "t", Data: json.RawMessage(`{}`)})
+			if err == nil || errors.Is(err, agent.ErrAdapterEventRejected) != test.permanent {
 				t.Fatalf("Append() error = %v, permanent = %t", err, test.permanent)
 			}
 		})
@@ -108,7 +108,7 @@ func TestAppendDrainsSuccessfulResponse(t *testing.T) {
 	httpClient := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 		return &http.Response{StatusCode: http.StatusCreated, Status: "201 Created", Body: body, Header: make(http.Header)}, nil
 	})}
-	err := (Client{BaseURL: "http://control-plane", TokenFile: tokenFile, HTTP: httpClient}).Append(context.Background(), "ns", "run", "run-uid", controllers.AdapterEvent{Source: "a", IdempotencyKey: "k", Type: "t", Data: json.RawMessage(`{}`)})
+	err := (Client{BaseURL: "http://control-plane", TokenFile: tokenFile, HTTP: httpClient}).Append(context.Background(), "ns", "run", "run-uid", agent.AdapterEvent{Source: "a", IdempotencyKey: "k", Type: "t", Data: json.RawMessage(`{}`)})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,8 +126,8 @@ func TestAppendTransportFailureIsRetryable(t *testing.T) {
 	httpClient := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 		return nil, transportErr
 	})}
-	err := (Client{BaseURL: "http://control-plane", TokenFile: tokenFile, HTTP: httpClient}).Append(context.Background(), "ns", "run", "run-uid", controllers.AdapterEvent{Source: "a", IdempotencyKey: "k", Type: "t", Data: json.RawMessage(`{}`)})
-	if !errors.Is(err, transportErr) || errors.Is(err, controllers.ErrAdapterEventRejected) {
+	err := (Client{BaseURL: "http://control-plane", TokenFile: tokenFile, HTTP: httpClient}).Append(context.Background(), "ns", "run", "run-uid", agent.AdapterEvent{Source: "a", IdempotencyKey: "k", Type: "t", Data: json.RawMessage(`{}`)})
+	if !errors.Is(err, transportErr) || errors.Is(err, agent.ErrAdapterEventRejected) {
 		t.Fatalf("Append() error = %v, want retryable transport error", err)
 	}
 }


### PR DESCRIPTION
## Summary

- move the adapter lifecycle, sandbox, event, credential, observation, and sentinel-error contract into `internal/agent`
- point controllers, operator registration, all four adapters, and transcript transport at the dedicated contract package
- keep Environment UID opaque at the adapter boundary while preserving controller-owned Kubernetes and ExecutionFence semantics
- document `internal/agent` as the exact adapter boundary

## Behavior preserved

- adapter commands, process lifecycle, transcript payloads/cursors, credentials, cancellation classification, polling, and sandbox transport
- registered-adapter metric allowlist and outcome classification
- CRDs, generated code, charts, and user-visible behavior

## Validation

- `go test ./internal/agent ./internal/adapters/... ./internal/transcriptclient ./internal/controllers ./cmd/operator`
- `make test`
- `make vet`
- `make build`
- `git diff --check`
- scoped dependency/import checks for `internal/agent`, adapters, and transcriptclient

Closes #144