### PR TITLE
Make sandboxd terminal backend selection OS-specific

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,9 +49,9 @@ jobs:
         with:
           go-version: "1.26"
           cache-dependency-path: sandboxd/go.sum
-      - name: Test Windows process containment and portable filesystem
+      - name: Test Windows process containment, portable filesystem, and terminal selection
         working-directory: sandboxd
-        run: go test ./internal/server -run "^(TestProcessDomainAssignsLeaderToJob|TestProcessServiceForceContainsDescendant|TestExecExplicitAndCloseSendEOFStillPublishOutputAndExit|TestFilesystem.*)$" -count=1
+        run: go test ./internal/server -run "^(TestProcessDomainAssignsLeaderToJob|TestProcessServiceForceContainsDescendant|TestExecExplicitAndCloseSendEOFStillPublishOutputAndExit|TestFilesystem.*|TestPlatformTerminalBackendRejectsMissingConPTY)$" -count=1
 
   build-test:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,8 +125,9 @@ runs both via `make` targets:
   image performs both stages in one multi-stage build. The ESLint flat config deliberately
   enables only `rules-of-hooks` and `exhaustive-deps` from the React Hooks plugin; treat
   enabling that plugin's expanding recommended preset as a lint-policy change.
-- **Windows portability:** CI runs focused sandboxd process, launch-material, Exec, and
-  filesystem tests on `windows-latest`; keep OS-specific tests behind build tags.
+- **Windows portability:** CI runs focused sandboxd process, launch-material, Exec,
+  filesystem, and terminal-backend-selection tests on `windows-latest`; keep OS-specific
+  tests behind build tags. Native terminal selection fails closed until ConPTY is implemented.
 - **Regenerate deepcopy:** `make generate` · **CRDs + RBAC:** `make manifests`
   (`manifests` synchronizes chart CRDs; CI fails on a diff). Use `make check-chart-crds`
   to verify the checked-in Helm CRDs independently.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -246,7 +246,9 @@ Platform consumers receive a backend-neutral connector or adapter sandbox and do
 containers, PIDs, tmux, or OS signals. The protobuf uses logical paths, process owner/role keys,
 portable process controls, and opaque execution IDs. The sandboxd module is separate and has
 Windows coverage for process containment and filesystem behavior; the current shared terminal
-backend is tmux, not ConPTY.
+backend is tmux on non-Windows systems. Windows selects an explicit fail-closed backend rather
+than trying to invoke tmux; native Windows terminal sessions remain blocked on a real ConPTY
+implementation with shared-session and per-attachment semantics.
 
 Only the Kubernetes **Pod backend** is implemented. The connector currently resolves an exact
 owned Pod, Pod IP, Pod UID, execution-generation annotation, restart policy, and per-Pod
@@ -649,7 +651,8 @@ path forcing ship together after Project namespace claims.
 
 Repository service ingestion and process URL injection from authenticated discovery are
 implemented. Portal UI work (#95) remains unimplemented. Other unimplemented areas include inbox and child-run semantics, changes
-publication, transcript garbage collection, additional credential forms, ConPTY, non-Pod
+publication, transcript garbage collection, additional credential forms, ConPTY, Windows
+setup/resume hook semantics and node-pool/provider requirements, non-Pod
 backends, and control-plane HA. Their detailed contracts remain issue work unless and until a
 maintainer decision is recorded. In particular, schema placeholders or portable interfaces do
 not by themselves make these features implemented.

--- a/README.md
+++ b/README.md
@@ -523,6 +523,8 @@ environment is created. If the repository contains `.agents/setup`, the hook run
 after checkout. `swe environment hold ENVIRONMENT` deletes the pod while retaining its
 workspace PVC, and `swe environment release ENVIRONMENT` publishes the next policy revision
 to create a fresh pod; `.agents/resume` runs after the volume is reattached.
+These hooks currently run through `/bin/sh` in the Pod backend; `.ps1` hooks and native Windows
+Environment lifecycle are not implemented.
 Setup and resume hooks receive only the controller's
 non-secret repository and timeout values. They are limited to 30 minutes each. Failed or
 completed environment pods are replaced with bounded exponential

--- a/sandboxd/gen/proto/sandboxd/v1/sandboxd_grpc.pb.go
+++ b/sandboxd/gen/proto/sandboxd/v1/sandboxd_grpc.pb.go
@@ -627,8 +627,9 @@ const (
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 //
 // TerminalService multiplexes the environment's shared terminal session.
-// The agent and the human attach to the same session (tmux on Linux,
-// ConPTY on Windows).
+// The agent and the human attach to the same session. The current backend is
+// tmux on non-Windows systems; a native Windows backend requires ConPTY and is
+// not implemented.
 type TerminalServiceClient interface {
 	Terminal(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[TerminalMessage, TerminalMessage], error)
 }
@@ -659,8 +660,9 @@ type TerminalService_TerminalClient = grpc.BidiStreamingClient[TerminalMessage, 
 // for forward compatibility.
 //
 // TerminalService multiplexes the environment's shared terminal session.
-// The agent and the human attach to the same session (tmux on Linux,
-// ConPTY on Windows).
+// The agent and the human attach to the same session. The current backend is
+// tmux on non-Windows systems; a native Windows backend requires ConPTY and is
+// not implemented.
 type TerminalServiceServer interface {
 	Terminal(grpc.BidiStreamingServer[TerminalMessage, TerminalMessage]) error
 	mustEmbedUnimplementedTerminalServiceServer()

--- a/sandboxd/internal/server/terminal.go
+++ b/sandboxd/internal/server/terminal.go
@@ -51,7 +51,7 @@ type TerminalServer struct {
 
 func NewTerminalServer(workspace string) *TerminalServer {
 	return &TerminalServer{
-		backend: newTmuxTerminalBackend(workspace, defaultTmuxSocket, nil),
+		backend: newPlatformTerminalBackend(workspace),
 	}
 }
 

--- a/sandboxd/internal/server/terminal_platform_nonwindows.go
+++ b/sandboxd/internal/server/terminal_platform_nonwindows.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package server
+
+func newPlatformTerminalBackend(workspace string) terminalBackend {
+	return newTmuxTerminalBackend(workspace, defaultTmuxSocket, nil)
+}

--- a/sandboxd/internal/server/terminal_platform_nonwindows_test.go
+++ b/sandboxd/internal/server/terminal_platform_nonwindows_test.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package server
+
+import "testing"
+
+func TestPlatformTerminalBackendUsesTmux(t *testing.T) {
+	if _, ok := newPlatformTerminalBackend(t.TempDir()).(*tmuxTerminalBackend); !ok {
+		t.Fatal("non-Windows terminal backend is not tmux")
+	}
+}

--- a/sandboxd/internal/server/terminal_platform_windows.go
+++ b/sandboxd/internal/server/terminal_platform_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package server
+
+import (
+	"context"
+	"fmt"
+)
+
+// windowsTerminalBackend fails closed until the shared-session and attachment
+// semantics of TerminalService have a real ConPTY implementation. Falling back
+// to tmux would make a Windows sandboxd binary depend on a Unix compatibility
+// layer and falsely imply native terminal support.
+type windowsTerminalBackend struct{}
+
+func newPlatformTerminalBackend(string) terminalBackend {
+	return windowsTerminalBackend{}
+}
+
+func (windowsTerminalBackend) Open(context.Context, uint32, uint32) (terminalSession, error) {
+	return nil, fmt.Errorf("%w: native Windows terminal requires a ConPTY backend", errTerminalUnavailable)
+}

--- a/sandboxd/internal/server/terminal_platform_windows_test.go
+++ b/sandboxd/internal/server/terminal_platform_windows_test.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package server
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestPlatformTerminalBackendRejectsMissingConPTY(t *testing.T) {
+	backend := newPlatformTerminalBackend(t.TempDir())
+	_, err := backend.Open(context.Background(), 80, 24)
+	if !errors.Is(err, errTerminalUnavailable) {
+		t.Fatalf("open error = %v, want terminal unavailable", err)
+	}
+	if !strings.Contains(err.Error(), "ConPTY") {
+		t.Fatalf("open error = %q, want explicit ConPTY requirement", err)
+	}
+}

--- a/sandboxd/proto/sandboxd/v1/sandboxd.proto
+++ b/sandboxd/proto/sandboxd/v1/sandboxd.proto
@@ -310,8 +310,9 @@ message Entry {
 }
 
 // TerminalService multiplexes the environment's shared terminal session.
-// The agent and the human attach to the same session (tmux on Linux,
-// ConPTY on Windows).
+// The agent and the human attach to the same session. The current backend is
+// tmux on non-Windows systems; a native Windows backend requires ConPTY and is
+// not implemented.
 service TerminalService {
   rpc Terminal(stream TerminalMessage) returns (stream TerminalMessage);
 }


### PR DESCRIPTION
## Summary

- select sandboxd's terminal implementation through an OS-specific factory
- keep tmux as the non-Windows implementation and fail closed on Windows with an explicit ConPTY requirement
- exercise the Windows selection on `windows-latest`
- correct public/protobuf/architecture docs: native Windows environments, ConPTY, and `.ps1` hooks are not implemented

## Why this slice

Issue #77 is relevant, but its full acceptance criteria are not yet implementable without inventing provider and lifecycle contracts. Today the Environment controller and connector are Pod-specific, Windows node-pool scheduling/isolation is undecided, and TerminalService requires shared-session/per-attachment behavior that has no ConPTY implementation. This PR delivers a backend-neutral portability boundary without claiming fake Windows support or introducing Linux assumptions into the Windows path.

## Verification

- `cd sandboxd && go test ./...`
- `cd sandboxd && GOOS=windows GOARCH=amd64 go test -exec=/bin/true ./...`
- focused `windows-latest` test added for the native terminal selection

## Explicit follow-up blockers / sequence

1. Approve the external-runner trust, registration, lease, reachability, credential, workspace persistence, suspend/delete, and failure ownership model.
2. Extract an Environment backend contract around create/fence/currentness/suspend/delete/recovery/status; retain Pod/PVC/Secret/NetworkPolicy details in the Pod implementation.
3. Implement external-runner registration and lifecycle against that contract, then admit `external-runner` in CRD validation only after end-to-end fencing tests pass.
4. Decide supported Kubernetes provider(s), Windows host/image compatibility, node selection/taints, workspace storage, networking, isolation claims, and sandboxd distribution/service lifecycle for a Windows node-pool backend.
5. Define Windows setup/resume semantics (`.ps1`, PowerShell executable/version, execution policy, timeout/cancellation, checkout/path rules) before implementing hooks.
6. Implement a real ConPTY shared terminal backend with durable shared-session and independent attach/detach/resize semantics, then replace the fail-closed Windows backend and add native integration tests.

Closes no acceptance checkbox by itself; contributes a truthful, tested prerequisite to #77.
