### PR TITLE
Test sandboxd ingress policy on an enforcing CNI

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -37,6 +37,33 @@ jobs:
       - uses: helm/kind-action@v1
         with:
           cluster_name: swe-e2e
+          config: hack/kind-calico.yaml
+          # Nodes remain NotReady until the pinned CNI is installed below.
+          wait: 0s
+
+      - name: Install enforcing CNI
+        run: |
+          kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.32.1/manifests/calico.yaml
+          kubectl -n kube-system rollout status daemonset/calico-node --timeout=3m
+          kubectl -n kube-system rollout status deployment/calico-kube-controllers --timeout=3m
+          kubectl wait --for=condition=Ready nodes --all --timeout=2m
+          echo "E2E_EXPECTED_CLUSTER_UID=$(kubectl get namespace kube-system -o jsonpath='{.metadata.uid}')" >> "$GITHUB_ENV"
+
+      - name: Install kind acceptance prerequisites
+        env:
+          KIND_CLUSTER: swe-e2e
+        run: |
+          ./hack/kind-up.sh
+          test "$(kubectl get namespace kube-system -o jsonpath='{.metadata.uid}')" = "$E2E_EXPECTED_CLUSTER_UID"
+          echo "Reused Calico cluster fixture $E2E_EXPECTED_CLUSTER_UID for gVisor/CSI bootstrap"
+          kubectl -n kube-system rollout status daemonset/calico-node --timeout=3m
+          kubectl -n kube-system rollout status deployment/calico-kube-controllers --timeout=3m
 
       - name: Run e2e acceptance
+        env:
+          # Enables the narrow ingress dataplane assertion. This is evidence
+          # for this pinned CI fixture, not production CNI attestation.
+          E2E_USE_EXISTING_CLUSTER: "true"
+          E2E_RUNTIME_CLASS: gvisor
+          E2E_ENFORCING_CNI: calico-v3.32.1
         run: ./hack/e2e.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,8 @@ runs both via `make` targets:
 - **Regenerate protobuf:** `make proto` (requires `protoc`; plugins install locally)
 - **Dev cluster:** `make kind-up` creates/reuses `swe-dev`, installs the pinned gVisor
   `gvisor` RuntimeClass plus the CSI hostpath driver and VolumeSnapshot controller, and
-  verifies both with smoke resources. Build/load the images, then install
+  configures the fixture driver's `fsGroupPolicy: File` and verifies non-root group-writable
+  snapshot/restore behavior with smoke resources. Build/load the images, then install
   `charts/swe-platform` with `values-kind.yaml` and the gVisor override printed by the
   script. Run the full acceptance suite against it with
   `KIND_CLUSTER=swe-dev E2E_USE_EXISTING_CLUSTER=true E2E_RUNTIME_CLASS=gvisor ./hack/e2e.sh`.
@@ -169,6 +170,9 @@ runs both via `make` targets:
   system-namespace installation plus CLI onboarding of a distinct scoped Project namespace,
   exact claims, managed catalog copies, explicit baseline quota/RBAC/policy, scoped denial,
   same-named two-release isolation, and retained offboarding,
+  sandboxd ingress NetworkPolicy allow/deny behavior on CI's exact-UID-pinned, fully bootstrapped
+  Calico kind fixture, including group-writable fresh and retained CSI workspaces under gVisor
+  (without claiming production CNI, CSI, or runtime attestation),
   control-plane TokenReview/SAR scoping, memory and durable encrypted PostgreSQL browser session
   exchange/logout/revocation, capacity and CSRF,
   the embedded console entry point/SPA fallback/static assets, typed Run

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -186,6 +186,21 @@ missing named RuntimeClass fails before child creation. PVC expansion is not sup
 requested storage remains the snapshotted `diskSize`; changing a Template cannot resize an
 existing workspace, and a larger disk requires a new Environment.
 
+`/workspace` must be writable by the Environment image's execution identity before sandboxd is
+usable and after every pause/resume. The Linux Pod backend supplies fixed supplementary group
+10001 with `fsGroupChangePolicy: OnRootMismatch`; it does not override the image's UID or primary
+GID. The storage implementation must grant that supplementary group access, whether through
+kubelet ownership changes (`fsGroupPolicy: File`, or `ReadWriteOnceWithFSType` when its access-mode
+and filesystem conditions hold), correct CSI `VOLUME_MOUNT_GROUP` delegation, or equivalent
+non-CSI volume behavior. `OnRootMismatch` controls only kubelet-side ownership changes and is not
+applied when CSI performs the delegation. Drivers that declare `None` without effective delegated
+mount-group handling, root-squashed storage that cannot grant the group, and non-POSIX storage
+without an equivalent access mechanism are unsupported. This is a required storage contract, not
+runtime or CSI capability attestation. Other backends, including a future Windows backend, must
+provide equivalent ACL or workspace preparation semantics rather than reproducing a numeric GID.
+Security revision 5 replaces older Environment Pods to apply this contract while retaining the
+exact workspace PVC and frozen provisioning inputs.
+
 ### Tenancy and Project namespace lifecycle
 
 The chart installs one empty-spec `Installation` in its system namespace. The object's

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -92,6 +92,10 @@ while protocol authentication remains the durable boundary on clusters without N
 enforcement. Environment pods do not receive a Kubernetes service-account token by default.
 NetworkPolicies are additive, destination-node traffic may be exempt, and Kubernetes API
 port-forwarding is governed by `pods/portforward` RBAC rather than this policy.
+CI verifies this ingress rule's allow and deny dataplane behavior only on its pinned Calico
+kind fixture, with an allowed connection as a positive control. The operator does not attest
+that a production cluster's CNI enforces NetworkPolicy, and Environment status does not claim
+effective CNI enforcement.
 
 Default-deny egress and the per-project egress proxy are not implemented. The
 `Project.spec.egressAllowlist` field is reserved for that future contract; the operator rejects
@@ -129,6 +133,20 @@ intentionally uses the cluster default runtime.
    from the prior incarnation.
 4. **Storage:** credentials are held in a Kubernetes Secret volume, never the retained workspace
    PVC. Pausing retains `/workspace` but removes the credential source and pod.
+
+The workspace itself has a separate availability and access contract: it must be writable by the
+Environment image's execution identity before sandboxd becomes usable and remain writable across
+pause/resume. Linux Environment Pods receive supplementary group 10001 with
+`fsGroupChangePolicy: OnRootMismatch`; the platform does not force the image's UID or primary GID,
+and keeps seccomp RuntimeDefault, dropped capabilities, and no-privilege-escalation controls.
+Production storage must grant that group access through kubelet ownership changes (CSI
+`fsGroupPolicy: File`, or `ReadWriteOnceWithFSType` when its conditions hold), correct CSI
+`VOLUME_MOUNT_GROUP` delegation, or equivalent non-CSI volume behavior. `OnRootMismatch` applies
+only to kubelet-side ownership changes, not delegated CSI mounts. `None` without effective
+delegated mount-group handling, root-squashed storage that cannot grant the group, and storage
+without equivalent POSIX access are unsupported. The operator does not attest that a driver or
+runtime honors this contract. A future Windows or non-Pod backend must establish equivalent
+ACL/preparation behavior without assuming a Unix GID.
 
 Certificates are valid for one year to avoid expiring a continuously running pod; normal pod
 recreation rotates them much earlier. Operators should recreate any pod approaching that limit.

--- a/charts/swe-platform/BYOC.md
+++ b/charts/swe-platform/BYOC.md
@@ -96,10 +96,13 @@ workload readiness; it never reads or prints the App private key.
 
 ## Provider runbooks
 
-All providers require a default `ReadWriteOnce` StorageClass, an enforcing CNI for the chart's
-ingress NetworkPolicies, outbound access to GHCR for image pulls, and workload outbound access
-needed by Git, setup/package managers, and the selected agent provider. That outbound access is
-not constrained by the platform today.
+All providers require a default `ReadWriteOnce` StorageClass whose volume implementation grants
+supplementary group 10001 write access to the mounted workspace. This can use kubelet ownership
+changes (`fsGroupPolicy: File`, or `ReadWriteOnceWithFSType` when its conditions hold), correct CSI
+`VOLUME_MOUNT_GROUP` delegation, or equivalent non-CSI behavior. They also require an enforcing
+CNI for the chart's ingress NetworkPolicies, outbound access to GHCR for image pulls, and workload
+outbound access needed by Git, setup/package managers, and the selected agent provider. That
+outbound access is not constrained by the platform today.
 
 ### k3s
 
@@ -186,7 +189,8 @@ keyring disclosure can recover encrypted browser bearer credentials.
 `preflight` reads Secret keys only to confirm that non-empty data exists; it never prints or
 decodes their values. It checks Kubernetes version, the NetworkPolicy API, a default
 StorageClass, and GKE's named RuntimeClass. It cannot prove that a CNI or runtime enforces the
-advertised isolation.
+advertised isolation, or that the storage implementation applies the required filesystem-group
+access. Validate all three behaviors independently before admitting untrusted workloads.
 
 ```sh
 ./hack/validate-byoc.sh preflight "$PROVIDER"

--- a/charts/swe-platform/README.md
+++ b/charts/swe-platform/README.md
@@ -431,6 +431,19 @@ recover. RuntimeClass identity is pinned by UID, so the first operator upgrade c
 check also replaces existing pods that use a named RuntimeClass; their workspace PVCs are
 retained. The chart does not create or manage provider RuntimeClasses.
 
+Every Linux Environment Pod also receives supplementary workspace access group `10001` with
+`fsGroupChangePolicy: OnRootMismatch`. This makes `/workspace` writable without overriding the
+image's UID or primary GID and remains in force after pause/resume. The selected StorageClass and
+volume implementation must grant that group access using kubelet ownership changes (CSI
+`fsGroupPolicy: File`, or `ReadWriteOnceWithFSType` when its conditions hold), correct CSI
+`VOLUME_MOUNT_GROUP` delegation, or equivalent non-CSI behavior. `OnRootMismatch` applies only to
+kubelet-side ownership changes, not delegated CSI mounts. Drivers declaring `None` without
+effective delegated mount-group handling, root-squashed volumes that cannot grant the group, and
+non-POSIX volumes without equivalent access semantics are unsupported. The chart cannot attest
+this behavior; operators must validate it for their production storage and runtime. Future
+Windows or non-Pod backends require equivalent ACL/preparation semantics rather than the numeric
+Linux GID.
+
 This existence check does not prove that the runtime handler works or that eligible nodes can
 run it. Cluster operators must still install and test the handler on every eligible environment
 node; unsupported scheduling or handler failures may leave pods Pending. `make kind-up` performs
@@ -442,7 +455,9 @@ environment's sandboxd port only from this release's control-plane- and operator
 in the configured control-plane namespace. The cluster CNI must enforce
 Kubernetes NetworkPolicy for this defense in depth; TLS identity and capability authorization
 remain mandatory regardless. See [the security model](../../SECURITY.md) for credential
-lifecycle and backend requirements.
+lifecycle and backend requirements. CI exercises the allow and deny paths on its pinned Calico
+kind fixture, but the operator does not detect or attest production CNI enforcement and
+Environment status does not report it as effective isolation.
 
 The chart does not install default-deny egress or an egress allowlist proxy. Project
 `egressAllowlist` values are reserved and rejected when non-empty; empty or omitted values leave

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -7,9 +7,12 @@
 #
 # Prerequisites: go, docker, kind, kubectl, helm.
 # Env: KIND_CLUSTER (default swe-e2e), KEEP_CLUSTER=true to skip teardown,
-# E2E_USE_EXISTING_CLUSTER=true to test a bootstrapped cluster, and
-# E2E_RUNTIME_CLASS (for example gvisor) to select its environment runtime. Existing
-# cluster mode expects a fresh `make kind-up` cluster without an installed platform.
+# E2E_USE_EXISTING_CLUSTER=true to test a bootstrapped cluster,
+# E2E_RUNTIME_CLASS (for example gvisor) to select its environment runtime, and
+# E2E_ENFORCING_CNI to assert the sandboxd ingress policy on a separately installed,
+# known-enforcing CNI. CNI assertions also require E2E_EXPECTED_CLUSTER_UID to bind
+# acceptance to that exact cluster. Existing cluster mode expects a fresh `make
+# kind-up` cluster without an installed platform.
 set -euo pipefail
 
 CLUSTER="${KIND_CLUSTER:-swe-e2e}"
@@ -100,6 +103,9 @@ cleanup() {
 	if [[ -n "$E2E_SESSION_FIXTURE" ]]; then
 		rm -rf "$E2E_SESSION_FIXTURE"
 	fi
+	kubectl -n "$SYSTEM_NAMESPACE" delete pod swe-ingress-allowed --ignore-not-found --wait=false >/dev/null 2>&1 || true
+	kubectl -n "$SYSTEM_NAMESPACE" delete pod swe-sandboxd-relay --ignore-not-found --wait=false >/dev/null 2>&1 || true
+	kubectl -n "$PROJECT_NAMESPACE" delete pod swe-ingress-denied --ignore-not-found --wait=false >/dev/null 2>&1 || true
 	rm -f /tmp/swe-platform-sandboxd-cert-"$$" /tmp/swe-platform-sandboxd-token-"$$" \
 		/tmp/swe-platform-observation-cert-"$$" /tmp/swe-platform-observation-process-token-"$$"
 	if [[ "${KEEP_CLUSTER:-false}" != "true" && "${E2E_USE_EXISTING_CLUSTER:-false}" != "true" ]]; then
@@ -185,25 +191,52 @@ check_sandboxd_process() {
 	local pod_name="$1"
 	local run_uid="$2"
 	local expected_key="$3"
-	local secret_name identity
+	local secret_name identity checked=false forward_namespace="$PROJECT_NAMESPACE" forward_pod="$pod_name"
 	secret_name=$(kubectl -n "$PROJECT_NAMESPACE" get pod "$pod_name" -o jsonpath='{.metadata.annotations.swe\.dev/sandboxd-secret-name}')
 	identity=$(kubectl -n "$PROJECT_NAMESPACE" get pod "$pod_name" -o jsonpath='{.metadata.annotations.swe\.dev/sandboxd-identity}')
 	kubectl -n "$PROJECT_NAMESPACE" get secret "$secret_name" -o jsonpath='{.data.tls\.crt}' | base64 --decode > /tmp/swe-platform-sandboxd-cert-"$$"
 	kubectl -n "$PROJECT_NAMESPACE" get secret "$secret_name" -o jsonpath='{.data.process-token}' | base64 --decode > /tmp/swe-platform-sandboxd-token-"$$"
-	kubectl -n "$PROJECT_NAMESPACE" port-forward pod/"$pod_name" 15051:50051 >/tmp/swe-platform-sandboxd-port-forward.log 2>&1 &
-	SANDBOXD_PORT_FORWARD_PID=$!
-	for _ in $(seq 1 30); do
-		if grep -q 'Forwarding from' /tmp/swe-platform-sandboxd-port-forward.log; then
-			break
+	if [[ -n "${E2E_ENFORCING_CNI:-}" ]]; then
+		# Exercise the exact authenticated RPC through the policy-authorized path;
+		# a runner-to-Environment port-forward is correctly denied by Calico.
+		local pod_ip
+		pod_ip=$(kubectl -n "$PROJECT_NAMESPACE" get pod "$pod_name" -o jsonpath='{.status.podIP}')
+		kubectl -n "$SYSTEM_NAMESPACE" delete pod swe-sandboxd-relay --ignore-not-found --wait=true >/dev/null
+		kubectl -n "$SYSTEM_NAMESPACE" run swe-sandboxd-relay \
+			--image=busybox:1.36.1 --restart=Never \
+			--labels='app.kubernetes.io/name=swe-platform,app.kubernetes.io/instance=swe-platform,app.kubernetes.io/component=control-plane' \
+			-- sh -c "exec nc -ll -p 50051 -e nc '$pod_ip' 50051"
+		kubectl -n "$SYSTEM_NAMESPACE" wait --for=condition=Ready pod/swe-sandboxd-relay --timeout=30s
+		forward_namespace="$SYSTEM_NAMESPACE"
+		forward_pod="swe-sandboxd-relay"
+	fi
+	for _ in $(seq 1 5); do
+		: > /tmp/swe-platform-sandboxd-port-forward.log
+		kubectl -n "$forward_namespace" port-forward pod/"$forward_pod" 15051:50051 >/tmp/swe-platform-sandboxd-port-forward.log 2>&1 &
+		SANDBOXD_PORT_FORWARD_PID=$!
+		for _ in $(seq 1 30); do
+			if kill -0 "$SANDBOXD_PORT_FORWARD_PID" >/dev/null 2>&1 && \
+				grep -q 'Forwarding from' /tmp/swe-platform-sandboxd-port-forward.log; then
+				break
+			fi
+			sleep 1
+		done
+		if kill -0 "$SANDBOXD_PORT_FORWARD_PID" >/dev/null 2>&1 && \
+			printf '%s' "$expected_key" | go run ./hack/e2e-process-check \
+			127.0.0.1:15051 "$identity" /tmp/swe-platform-sandboxd-cert-"$$" /tmp/swe-platform-sandboxd-token-"$$" "$run_uid"; then
+			checked=true
 		fi
+		kill "$SANDBOXD_PORT_FORWARD_PID" >/dev/null 2>&1 || true
+		wait "$SANDBOXD_PORT_FORWARD_PID" >/dev/null 2>&1 || true
+		SANDBOXD_PORT_FORWARD_PID=""
+		[[ "$checked" == "true" ]] && break
 		sleep 1
 	done
-	printf '%s' "$expected_key" | go run ./hack/e2e-process-check \
-		127.0.0.1:15051 "$identity" /tmp/swe-platform-sandboxd-cert-"$$" /tmp/swe-platform-sandboxd-token-"$$" "$run_uid"
-	kill "$SANDBOXD_PORT_FORWARD_PID" >/dev/null 2>&1 || true
-	wait "$SANDBOXD_PORT_FORWARD_PID" >/dev/null 2>&1 || true
-	SANDBOXD_PORT_FORWARD_PID=""
 	rm -f /tmp/swe-platform-sandboxd-cert-"$$" /tmp/swe-platform-sandboxd-token-"$$"
+	if [[ -n "${E2E_ENFORCING_CNI:-}" ]]; then
+		kubectl -n "$SYSTEM_NAMESPACE" delete pod swe-sandboxd-relay --ignore-not-found --wait=true >/dev/null
+	fi
+	[[ "$checked" == "true" ]]
 }
 
 manage_observation_listener() {
@@ -212,12 +245,24 @@ manage_observation_listener() {
 	local owner="$3"
 	local role="$4"
 	local port="${5:-}"
-	local secret_name identity
+	local secret_name identity forward_namespace="$PROJECT_NAMESPACE" forward_pod="$pod_name"
 	secret_name=$(kubectl -n "$PROJECT_NAMESPACE" get pod "$pod_name" -o jsonpath='{.metadata.annotations.swe\.dev/sandboxd-secret-name}')
 	identity=$(kubectl -n "$PROJECT_NAMESPACE" get pod "$pod_name" -o jsonpath='{.metadata.annotations.swe\.dev/sandboxd-identity}')
 	kubectl -n "$PROJECT_NAMESPACE" get secret "$secret_name" -o jsonpath='{.data.tls\.crt}' | base64 --decode > /tmp/swe-platform-observation-cert-"$$"
 	kubectl -n "$PROJECT_NAMESPACE" get secret "$secret_name" -o jsonpath='{.data.process-token}' | base64 --decode > /tmp/swe-platform-observation-process-token-"$$"
-	kubectl -n "$PROJECT_NAMESPACE" port-forward pod/"$pod_name" 15052:50051 >/tmp/swe-platform-observation-port-forward.log 2>&1 &
+	if [[ -n "${E2E_ENFORCING_CNI:-}" ]]; then
+		local pod_ip
+		pod_ip=$(kubectl -n "$PROJECT_NAMESPACE" get pod "$pod_name" -o jsonpath='{.status.podIP}')
+		kubectl -n "$SYSTEM_NAMESPACE" delete pod swe-sandboxd-relay --ignore-not-found --wait=true >/dev/null
+		kubectl -n "$SYSTEM_NAMESPACE" run swe-sandboxd-relay \
+			--image=busybox:1.36.1 --restart=Never \
+			--labels='app.kubernetes.io/name=swe-platform,app.kubernetes.io/instance=swe-platform,app.kubernetes.io/component=control-plane' \
+			-- sh -c "exec nc -ll -p 50051 -e nc '$pod_ip' 50051"
+		kubectl -n "$SYSTEM_NAMESPACE" wait --for=condition=Ready pod/swe-sandboxd-relay --timeout=30s
+		forward_namespace="$SYSTEM_NAMESPACE"
+		forward_pod="swe-sandboxd-relay"
+	fi
+	kubectl -n "$forward_namespace" port-forward pod/"$forward_pod" 15052:50051 >/tmp/swe-platform-observation-port-forward.log 2>&1 &
 	SANDBOXD_PORT_FORWARD_PID=$!
 	for _ in $(seq 1 30); do
 		if grep -q 'Forwarding from' /tmp/swe-platform-observation-port-forward.log; then
@@ -239,6 +284,9 @@ manage_observation_listener() {
 	wait "$SANDBOXD_PORT_FORWARD_PID" >/dev/null 2>&1 || true
 	SANDBOXD_PORT_FORWARD_PID=""
 	rm -f /tmp/swe-platform-observation-cert-"$$" /tmp/swe-platform-observation-process-token-"$$"
+	if [[ -n "${E2E_ENFORCING_CNI:-}" ]]; then
+		kubectl -n "$SYSTEM_NAMESPACE" delete pod swe-sandboxd-relay --ignore-not-found --wait=true >/dev/null
+	fi
 }
 
 wait_service_observation() {
@@ -284,6 +332,35 @@ else
 	echo "==> creating kind cluster '$CLUSTER'"
 	kind delete cluster --name "$CLUSTER" >/dev/null 2>&1 || true
 	kind create cluster --name "$CLUSTER"
+fi
+if [[ -n "${E2E_ENFORCING_CNI:-}" && -z "${E2E_EXPECTED_CLUSTER_UID:-}" ]]; then
+	echo "FAIL: E2E_ENFORCING_CNI requires E2E_EXPECTED_CLUSTER_UID to prevent testing a replacement cluster" >&2
+	exit 1
+fi
+if [[ -n "${E2E_EXPECTED_CLUSTER_UID:-}" ]]; then
+	ACTUAL_CLUSTER_UID=$(kubectl get namespace kube-system -o jsonpath='{.metadata.uid}')
+	if [[ "$ACTUAL_CLUSTER_UID" != "$E2E_EXPECTED_CLUSTER_UID" ]]; then
+		echo "FAIL: selected cluster UID '$ACTUAL_CLUSTER_UID' differs from expected fixture '$E2E_EXPECTED_CLUSTER_UID'" >&2
+		exit 1
+	fi
+	echo "==> verified existing cluster fixture UID $ACTUAL_CLUSTER_UID"
+fi
+if [[ -n "${E2E_ENFORCING_CNI:-}" ]]; then
+	case "$E2E_ENFORCING_CNI" in
+	calico-v3.32.1)
+		if ! kubectl -n kube-system get daemonset calico-node -o json | jq -e '
+			.status.desiredNumberScheduled > 0 and
+			.status.numberReady == .status.desiredNumberScheduled and
+			any(.spec.template.spec.containers[]; .name == "calico-node" and (.image | endswith("/calico/node:v3.32.1")))' >/dev/null; then
+			echo "FAIL: selected cluster does not have the ready pinned Calico v3.32.1 fixture" >&2
+			exit 1
+		fi
+		;;
+	*)
+		echo "FAIL: unsupported E2E_ENFORCING_CNI fixture '$E2E_ENFORCING_CNI'" >&2
+		exit 1
+		;;
+	esac
 fi
 
 echo "==> building platform images"
@@ -883,6 +960,8 @@ metadata:
   name: env-$legacy_env
   labels:
     swe.dev/environment: $legacy_env
+  annotations:
+    swe.dev/sandboxd-security-revision: "4"
   ownerReferences:
   - apiVersion: swe.dev/v1alpha1
     kind: Environment
@@ -894,7 +973,8 @@ spec:
   containers:
   - name: environment
     image: $E2E_ENV_IMAGE
-    command: [sh, -c, 'git -C /workspace init -q; git -C /workspace config --local swe.setup-complete true; printf "%s\\n" "$legacy_env" > /workspace/pre-164-marker; exec sleep 3600']
+    command: [sh, -ec, 'chmod 0750 /workspace; git -C /workspace init -q; git -C /workspace config --local swe.setup-complete true; printf "%s\\n" "$legacy_env" > /workspace/pre-164-marker; exec sleep 3600']
+    securityContext: {runAsUser: 0}
     resources:
       requests: {cpu: 100m, memory: 128Mi}
     volumeMounts:
@@ -906,7 +986,14 @@ EOF
 	kubectl -n "$PROJECT_NAMESPACE" annotate environment "$legacy_env" \
 		swe.dev/e2e-legacy-pvc-uid="$(kubectl -n "$PROJECT_NAMESPACE" get pvc "env-$legacy_env" -o jsonpath='{.metadata.uid}')" \
 		swe.dev/e2e-legacy-policy-uid="$(kubectl -n "$PROJECT_NAMESPACE" get networkpolicy "env-$legacy_env-sandboxd" -o jsonpath='{.metadata.uid}')" >/dev/null
-	kubectl -n "$PROJECT_NAMESPACE" wait --for=condition=Ready pod/"env-$legacy_env" --timeout=2m
+	if ! kubectl -n "$PROJECT_NAMESPACE" wait --for=condition=Ready pod/"env-$legacy_env" --timeout=2m; then
+		echo "FAIL: legacy fixture $legacy_env did not become Ready" >&2
+		kubectl -n "$PROJECT_NAMESPACE" get pod "env-$legacy_env" -o yaml >&2 || true
+		kubectl -n "$PROJECT_NAMESPACE" logs "env-$legacy_env" --all-containers=true >&2 || true
+		exit 1
+	fi
+	kubectl -n "$PROJECT_NAMESPACE" exec "env-$legacy_env" -- sh -ec \
+		"test \"\$(git -C /workspace config --local swe.setup-complete)\" = true; grep -qx '$legacy_env' /workspace/pre-164-marker; setpriv --reuid=10001 --regid=10001 --clear-groups sh -ec 'test ! -w /workspace'"
 	kubectl -n "$PROJECT_NAMESPACE" patch environment "$legacy_env" --subresource=status --type=merge \
 		-p "{\"status\":{\"phase\":\"Ready\",\"executionGeneration\":1,\"podName\":\"env-${legacy_env}\"}}" >/dev/null
 done
@@ -1066,20 +1153,52 @@ for legacy_env in "$LEGACY_ACTIVE" "$LEGACY_HELD"; do
 		exit 1
 	}
 done
-kubectl wait --for=jsonpath='{.status.phase}'=Ready environment/"$LEGACY_ACTIVE" --timeout=2m
+if ! kubectl wait --for=jsonpath='{.status.phase}'=Ready environment/"$LEGACY_ACTIVE" --timeout=2m; then
+	echo "FAIL: active legacy Environment did not become Ready" >&2
+	kubectl get environment "$LEGACY_ACTIVE" -o yaml >&2 || true
+	kubectl get pod "env-$LEGACY_ACTIVE" -o yaml >&2 || true
+	kubectl get events --sort-by=.lastTimestamp >&2 || true
+	kubectl -n "$SYSTEM_NAMESPACE" logs deployment/"$INSTALLATION_NAME" --tail=200 >&2 || true
+	exit 1
+fi
 kubectl wait --for=condition=Ready pod/"env-$LEGACY_ACTIVE" --timeout=2m
 if [[ "$(kubectl get pod "env-$LEGACY_ACTIVE" -o jsonpath='{.metadata.creationTimestamp}')" == "" ]] || \
 	! kubectl exec "env-$LEGACY_ACTIVE" -- grep -qx "$LEGACY_ACTIVE" /workspace/pre-164-marker; then
 	echo "FAIL: active legacy Environment did not resume on its durable workspace"
 	exit 1
 fi
+kubectl exec "env-$LEGACY_ACTIVE" -- sh -ec \
+	'test "$(id -u)" -ne 0; test -w /workspace; printf "%s\n" group-writable > /workspace/revision-5-write; grep -qx group-writable /workspace/revision-5-write'
 if [[ "$(kubectl get environment "$LEGACY_HELD" -o jsonpath='{.status.phase}')" != "Paused" ]] || \
 	kubectl get pod "env-$LEGACY_HELD" >/dev/null 2>&1; then
 	echo "FAIL: held legacy Environment did not remain Paused and podless after migration"
 	exit 1
 fi
+if [[ -n "${E2E_ENFORCING_CNI:-}" ]]; then
+	# Calico and the full CSI/snapshot stack share one kind node with the warm
+	# pool. The active migration path is proven above; pause it before releasing
+	# the held fixture so this assertion tests migration rather than node size.
+	bin/swe --namespace "$PROJECT_NAMESPACE" environment hold "$LEGACY_ACTIVE"
+	kubectl wait --for=jsonpath='{.status.phase}'=Paused environment/"$LEGACY_ACTIVE" --timeout=2m
+	for _ in $(seq 1 120); do
+		if ! kubectl get pod "env-$LEGACY_ACTIVE" >/dev/null 2>&1; then
+			break
+		fi
+		sleep 1
+	done
+	if kubectl get pod "env-$LEGACY_ACTIVE" >/dev/null 2>&1; then
+		echo "FAIL: active legacy Environment did not free enforcing-CNI fixture capacity" >&2
+		exit 1
+	fi
+fi
 bin/swe --namespace "$PROJECT_NAMESPACE" environment release "$LEGACY_HELD"
-kubectl wait --for=jsonpath='{.status.phase}'=Ready environment/"$LEGACY_HELD" --timeout=2m
+if ! kubectl wait --for=jsonpath='{.status.phase}'=Ready environment/"$LEGACY_HELD" --timeout=2m; then
+	echo "FAIL: held legacy Environment did not become Ready after release" >&2
+	kubectl get environment "$LEGACY_HELD" -o yaml >&2 || true
+	kubectl get pod "env-$LEGACY_HELD" -o yaml >&2 || true
+	kubectl get events --sort-by=.lastTimestamp >&2 || true
+	exit 1
+fi
 kubectl wait --for=condition=Ready pod/"env-$LEGACY_HELD" --timeout=2m
 if ! kubectl exec "env-$LEGACY_HELD" -- grep -qx "$LEGACY_HELD" /workspace/pre-164-marker; then
 	echo "FAIL: released legacy Environment did not retain its durable workspace marker"
@@ -1108,6 +1227,17 @@ if [[ "$(kubectl get pod "env-${WARM_ENV_NAME}" -o jsonpath='{.spec.serviceAccou
 	echo "FAIL: Environment pod did not use the tokenless onboarding ServiceAccount"
 	exit 1
 fi
+if ! kubectl get pod "env-${WARM_ENV_NAME}" -o json | jq -e '
+	.spec.securityContext.fsGroup == 10001 and
+	.spec.securityContext.fsGroupChangePolicy == "OnRootMismatch" and
+	.spec.securityContext.runAsUser == null and .spec.securityContext.runAsGroup == null and
+	.spec.securityContext.seccompProfile.type == "RuntimeDefault" and
+	.metadata.annotations["swe.dev/sandboxd-security-revision"] == "5" and
+	(.spec.containers[] | select(.name == "environment") |
+		.securityContext.allowPrivilegeEscalation == false and .securityContext.capabilities.drop == ["ALL"])' >/dev/null; then
+	echo "FAIL: Environment pod did not apply revision 5 supplementary workspace access without forcing image identity" >&2
+	exit 1
+fi
 if [[ -n "${E2E_RUNTIME_CLASS:-}" ]]; then
 	WARM_RUNTIME_CLASS=$(kubectl get pod "env-${WARM_ENV_NAME}" -o jsonpath='{.spec.runtimeClassName}')
 	if [[ "$WARM_RUNTIME_CLASS" != "$E2E_RUNTIME_CLASS" ]]; then
@@ -1120,6 +1250,52 @@ if [[ -n "${E2E_RUNTIME_CLASS:-}" ]]; then
 		echo "FAIL: warm Environment pins RuntimeClass UID '$WARM_RUNTIME_CLASS_UID', expected '$EXPECTED_RUNTIME_CLASS_UID'"
 		exit 1
 	fi
+fi
+if [[ -n "${E2E_ENFORCING_CNI:-}" ]]; then
+	echo "==> verifying sandboxd ingress policy on $E2E_ENFORCING_CNI"
+	WARM_POD_IP=$(kubectl get pod "env-${WARM_ENV_NAME}" -o jsonpath='{.status.podIP}')
+	if [[ -z "$WARM_POD_IP" ]]; then
+		echo "FAIL: warm Environment has no Pod IP for ingress policy verification"
+		exit 1
+	fi
+	# The successful connection is a positive control: the denied probe cannot
+	# pass merely because sandboxd is absent or the target is unreachable.
+	cat <<EOF | kubectl -n "$SYSTEM_NAMESPACE" create -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: swe-ingress-allowed
+  labels:
+    app.kubernetes.io/name: swe-platform
+    app.kubernetes.io/instance: swe-platform
+    app.kubernetes.io/component: control-plane
+spec:
+  restartPolicy: Never
+  containers:
+    - name: probe
+      image: busybox:1.36.1
+      command: [sh, -c, "nc -w 5 '$WARM_POD_IP' 50051 </dev/null"]
+      resources:
+        requests: {cpu: 10m, memory: 16Mi}
+EOF
+	kubectl -n "$SYSTEM_NAMESPACE" wait --for=jsonpath='{.status.phase}'=Succeeded pod/swe-ingress-allowed --timeout=30s
+	cat <<EOF | kubectl -n "$PROJECT_NAMESPACE" create -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: swe-ingress-denied
+spec:
+  restartPolicy: Never
+  containers:
+    - name: probe
+      image: busybox:1.36.1
+      command: [sh, -c, "if nc -w 5 '$WARM_POD_IP' 50051 </dev/null; then echo 'unexpected sandboxd access' >&2; exit 1; fi"]
+      resources:
+        requests: {cpu: 10m, memory: 16Mi}
+EOF
+	kubectl -n "$PROJECT_NAMESPACE" wait --for=jsonpath='{.status.phase}'=Succeeded pod/swe-ingress-denied --timeout=30s
+	kubectl -n "$SYSTEM_NAMESPACE" delete pod swe-ingress-allowed --wait=true >/dev/null
+	kubectl -n "$PROJECT_NAMESPACE" delete pod swe-ingress-denied --wait=true >/dev/null
 fi
 if [[ "${E2E_USE_EXISTING_CLUSTER:-false}" == "true" ]]; then
 	WARM_PVC_NAME=$(kubectl get pod "env-${WARM_ENV_NAME}" -o jsonpath='{.spec.volumes[?(@.name=="workspace")].persistentVolumeClaim.claimName}')
@@ -1333,7 +1509,14 @@ echo "==> creating project environment + run intent via swe"
 printf '%s' "$E2E_AGENT_API_KEY" | bin/swe --namespace "$PROJECT_NAMESPACE" credentials create e2e-claude --agent claude-code --api-key-stdin
 bin/swe --namespace "$PROJECT_NAMESPACE" run "end-to-end smoke test" --project "$PROJECT_NAME" --credential-profile e2e-claude --wait=false
 RUN_NAME=$(kubectl get runs -o jsonpath='{.items[0].metadata.name}')
-kubectl wait --for=jsonpath='{.status.state}'=Running run/"$RUN_NAME" --timeout=3m
+if ! kubectl wait --for=jsonpath='{.status.state}'=Running run/"$RUN_NAME" --timeout=3m; then
+	echo "FAIL: Run did not reach Running" >&2
+	kubectl get run "$RUN_NAME" -o yaml >&2 || true
+	kubectl get environments,pods -o wide >&2 || true
+	kubectl get events --sort-by=.lastTimestamp >&2 || true
+	kubectl -n "$SYSTEM_NAMESPACE" logs deployment/"$INSTALLATION_NAME" --tail=200 >&2 || true
+	exit 1
+fi
 kubectl wait --for=jsonpath='{.status.state}'=Succeeded run/"$RUN_NAME" --timeout=3m
 RUN_UID=$(kubectl get run "$RUN_NAME" -o jsonpath='{.metadata.uid}')
 PROFILE_UID=$(kubectl get agentcredentialprofile e2e-claude -o jsonpath='{.metadata.uid}')
@@ -2205,6 +2388,51 @@ if [[ "$PROVISIONING_SNAPSHOT" == "null" ]] || ! jq -e \
 	kubectl get environment "$ENV_NAME" -o yaml >&2
 	exit 1
 fi
+if ! kubectl exec "$POD_NAME" -- sh -c 'test ! -e /workspace/resume-result'; then
+	echo "FAIL: project promotion ran the resume hook before active Pod recreation" >&2
+	kubectl exec "$POD_NAME" -- sh -c 'wc -l /workspace/resume-result; cat /workspace/resume-result' >&2 || true
+	echo "--- project-hooks resume marker ---" >&2
+	kubectl get pod "$POD_NAME" -o json | jq -r '.spec.initContainers[] | select(.name == "project-hooks") | [.env[]? | select(.name == "SWE_RESUMING") | "\(.name)=\(.value)"] | if length == 0 then "<absent>" else .[] end' >&2 || true
+	kubectl get environment "$ENV_NAME" -o yaml >&2 || true
+	kubectl -n "$SYSTEM_NAMESPACE" logs deployment/"$INSTALLATION_NAME" --tail=300 >&2 || true
+	exit 1
+fi
+
+if [[ -n "${E2E_ENFORCING_CNI:-}" ]]; then
+	# The pinned Calico + CSI + gVisor fixture has already proven warm-pool
+	# replenishment above, but its single node cannot schedule both that standby
+	# and this active replacement. Drain only the unclaimed pool before testing
+	# recreation; this is explicit fixture capacity management, not a longer
+	# readiness timeout or a relaxation of the replacement contract.
+	if [[ -n "$(kubectl get environment "$ENV_NAME" -o jsonpath='{.metadata.labels.swe\.dev/warm-pool}')" ]]; then
+		echo "FAIL: claimed active Environment still has the warm-pool label; refusing fixture drain" >&2
+		exit 1
+	fi
+	kubectl patch environmenttemplate small --type=merge -p '{"spec":{"warmPool":{"min":0}}}' >/dev/null
+	for _ in $(seq 1 60); do
+		DRAIN_WARM_MEMBERS=$(kubectl get environments -l swe.dev/warm-pool=small -o json)
+		if [[ "$(jq '.items | length' <<<"$DRAIN_WARM_MEMBERS")" == "0" ]]; then
+			break
+		fi
+		while IFS=$'\t' read -r warm_env warm_uid; do
+			if [[ "$warm_env" == "$ENV_NAME" || "$(kubectl get environment "$warm_env" -o jsonpath='{.metadata.uid}')" != "$warm_uid" ]]; then
+				echo "FAIL: warm fixture drain crossed active or UID identity boundary for $warm_env" >&2
+				exit 1
+			fi
+			kubectl delete environment "$warm_env" --wait=true --timeout=2m >/dev/null
+			if kubectl get pod "env-$warm_env" >/dev/null 2>&1; then
+				echo "FAIL: deleted warm Environment $warm_env retained its Pod" >&2
+				exit 1
+			fi
+		done < <(jq -r '.items[] | [.metadata.name, .metadata.uid] | @tsv' <<<"$DRAIN_WARM_MEMBERS")
+		sleep 1
+	done
+	if [[ -n "$(kubectl get environments -l swe.dev/warm-pool=small -o name)" ]]; then
+		echo "FAIL: enforcing-CNI fixture did not drain unclaimed warm capacity" >&2
+		kubectl get environments,pods -o wide >&2 || true
+		exit 1
+	fi
+fi
 
 echo "==> verifying setup runs only once when the pod is recreated"
 kubectl delete pod "$POD_NAME" --wait=true >/dev/null
@@ -2214,23 +2442,45 @@ for _ in $(seq 1 30); do
 	fi
 	sleep 1
 done
-kubectl wait --for=condition=Ready pod/"$POD_NAME" --timeout=2m
+if ! kubectl wait --for=condition=Ready pod/"$POD_NAME" --timeout=2m; then
+	echo "FAIL: recreated Environment pod did not become Ready" >&2
+	kubectl get environment "$ENV_NAME" -o yaml >&2 || true
+	kubectl get pod "$POD_NAME" -o yaml >&2 || true
+	kubectl describe pod "$POD_NAME" >&2 || true
+	for container in repository-clone project-hooks environment; do
+		echo "--- $POD_NAME/$container logs ---" >&2
+		kubectl logs "$POD_NAME" -c "$container" >&2 || true
+	done
+	kubectl get events --sort-by=.lastTimestamp >&2 || true
+	kubectl -n "$SYSTEM_NAMESPACE" logs deployment/"$INSTALLATION_NAME" --tail=300 >&2 || true
+	exit 1
+fi
 if [[ "$(kubectl get environment "$ENV_NAME" -o json | jq -cS '.status.provisioning')" != "$PROVISIONING_SNAPSHOT" ]]; then
 	echo "FAIL: active Pod recreation changed the provisioning snapshot"
 	exit 1
 fi
 RECREATED_POD=$(kubectl get pod "$POD_NAME" -o json)
 if ! jq -e --argjson snapshot "$PROVISIONING_SNAPSHOT" '
+	(.spec.securityContext.fsGroup == 10001 and
+	 .spec.securityContext.fsGroupChangePolicy == "OnRootMismatch" and
+	 .spec.securityContext.runAsUser == null and .spec.securityContext.runAsGroup == null) and
 	([.spec.containers[] | select(.name == "environment")] | length == 1 and
 	 .[0].image == $snapshot.image and .[0].resources.requests == $snapshot.resources and
-	 .[0].resources.limits == $snapshot.resources) and
+	 .[0].resources.limits == $snapshot.resources and
+	 ([.[0].env[]? | select(.name == "SWE_REPOSITORY_TOKEN")] | length) == 0) and
 	([.spec.initContainers[] | select(.name == "repository-clone")] | length == 1 and
 	 .[0].image == $snapshot.image and .[0].resources.requests == $snapshot.resources and
 	 .[0].resources.limits == $snapshot.resources and
-	 ([.[0].env[] | select(.name == "SWE_REPOSITORY") | .value] | first) == $snapshot.project.repository) and
+	 .[0].securityContext.runAsUser == null and .[0].securityContext.runAsGroup == null and
+	 .[0].securityContext.allowPrivilegeEscalation == false and .[0].securityContext.capabilities.drop == ["ALL"] and
+	 ([.[0].env[] | select(.name == "SWE_REPOSITORY") | .value] | first) == $snapshot.project.repository and
+	 ([.[0].env[] | select(.name == "SWE_REPOSITORY_TOKEN")] | length) == 0) and
 	([.spec.initContainers[] | select(.name == "project-hooks")] | length == 1 and
 	 .[0].image == $snapshot.image and .[0].resources.requests == $snapshot.resources and
 	 .[0].resources.limits == $snapshot.resources and
+	 .[0].securityContext.runAsUser == null and .[0].securityContext.runAsGroup == null and
+	 .[0].securityContext.allowPrivilegeEscalation == false and .[0].securityContext.capabilities.drop == ["ALL"] and
+	 ([.[0].env[] | select(.name == "SWE_RESUMING") | .value] | first) == "true" and
 	 ([.[0].env[] | select(.name == "SWE_REPOSITORY_TOKEN")] | length) == 0)' <<<"$RECREATED_POD" >/dev/null ||
 	[[ "$(jq -r '.spec.runtimeClassName // ""' <<<"$RECREATED_POD")" != "$(jq -r '.runtimeClassName' <<<"$PROVISIONING_SNAPSHOT")" ]]; then
 	echo "FAIL: recreated Pod does not match the provisioning image/runtime/resources/repository"
@@ -2242,9 +2492,17 @@ if ! kubectl exec "$POD_NAME" -- sh -c 'test "$(wc -l < /workspace/setup-result)
 fi
 if ! kubectl exec "$POD_NAME" -- sh -c \
 	'test "$(wc -l < /workspace/resume-result)" -eq 1 && ! grep -vx credential-absent /workspace/resume-result'; then
-	echo "FAIL: active Pod recreation did not run exactly one credential-free resume hook"
+	echo "FAIL: active Pod recreation did not run exactly one credential-free resume hook" >&2
+	echo "--- project-hooks resume marker ---" >&2
+	jq -r '.spec.initContainers[] | select(.name == "project-hooks") | [.env[]? | select(.name == "SWE_RESUMING") | "\(.name)=\(.value)"] | if length == 0 then "<absent>" else .[] end' <<<"$RECREATED_POD" >&2
+	echo "--- /workspace/resume-result ---" >&2
+	kubectl exec "$POD_NAME" -- sh -c 'if [ -e /workspace/resume-result ]; then wc -l /workspace/resume-result; cat /workspace/resume-result; else echo "<absent>"; fi' >&2 || true
+	kubectl logs "$POD_NAME" -c project-hooks >&2 || true
+	kubectl get environment "$ENV_NAME" -o yaml >&2 || true
+	kubectl -n "$SYSTEM_NAMESPACE" logs deployment/"$INSTALLATION_NAME" --tail=300 >&2 || true
 	exit 1
 fi
+echo "verified active Pod recreation ran one resume hook for its retained-workspace episode"
 
 echo "==> verifying repository service ingestion, supervision, and authenticated portal"
 bin/swe --namespace "$PROJECT_NAMESPACE" environment services declare "$ENV_NAME" manual-api --target-port 3999

--- a/hack/kind-calico.yaml
+++ b/hack/kind-calico.yaml
@@ -1,0 +1,9 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  # The e2e workflow installs its pinned Calico release after kind creates the
+  # control plane. kindnet does not enforce Kubernetes NetworkPolicy.
+  disableDefaultCNI: true
+  podSubnet: 192.168.0.0/16
+nodes:
+  - role: control-plane

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -83,8 +83,7 @@ done
 
 for node in "${NODES[@]}"; do
 	for binary in runsc containerd-shim-runsc-v1; do
-		docker cp "$TMP_DIR/$binary" "$node:/tmp/$binary"
-		docker exec "$node" install -m 0755 "/tmp/$binary" "/usr/local/bin/$binary"
+		docker exec -i "$node" sh -c "cat > '/usr/local/bin/$binary' && chmod 0755 '/usr/local/bin/$binary'" < "$TMP_DIR/$binary"
 	done
 	if ! docker exec "$node" grep -Fq 'containerd.runtimes.runsc]' /etc/containerd/config.toml; then
 		if docker exec "$node" grep -Eq '^[[:space:]]*version[[:space:]]*=[[:space:]]*2[[:space:]]*$' /etc/containerd/config.toml; then
@@ -159,6 +158,9 @@ export REAL_KUBECTL KUBE_CONTEXT="$CONTEXT"
 PATH="$TMP_DIR/bin:$PATH" "$TMP_DIR/csi-driver-host-path/deploy/$HOSTPATH_DEPLOYMENT/deploy.sh"
 kubectl --context "$CONTEXT" apply -f "$TMP_DIR/csi-driver-host-path/examples/csi-storageclass.yaml"
 kubectl --context "$CONTEXT" rollout status statefulset/csi-hostpathplugin --timeout=3m
+kubectl --context "$CONTEXT" patch csidriver hostpath.csi.k8s.io --type=merge \
+	-p '{"spec":{"fsGroupPolicy":"File"}}' >/dev/null
+[[ "$(kubectl --context "$CONTEXT" get csidriver hostpath.csi.k8s.io -o jsonpath='{.spec.fsGroupPolicy}')" == "File" ]]
 kubectl --context "$CONTEXT" annotate storageclass standard \
 	storageclass.kubernetes.io/is-default-class- --overwrite >/dev/null
 kubectl --context "$CONTEXT" annotate storageclass csi-hostpath-sc \
@@ -185,10 +187,17 @@ metadata:
   namespace: $SMOKE_NAMESPACE
 spec:
   restartPolicy: Never
+  securityContext:
+    fsGroup: 10001
+    fsGroupChangePolicy: OnRootMismatch
   containers:
     - name: writer
       image: busybox:1.36.1
       command: [sh, -c, "echo snapshot-ready > /data/marker && sleep 300"]
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
       volumeMounts:
         - name: data
           mountPath: /data
@@ -236,10 +245,17 @@ metadata:
   namespace: $SMOKE_NAMESPACE
 spec:
   restartPolicy: Never
+  securityContext:
+    fsGroup: 10001
+    fsGroupChangePolicy: OnRootMismatch
   containers:
     - name: reader
       image: busybox:1.36.1
-      command: [sh, -c, "grep -qx snapshot-ready /data/marker"]
+      command: [sh, -c, "grep -qx snapshot-ready /data/marker && echo restore-writable > /data/restored-marker && grep -qx restore-writable /data/restored-marker"]
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
       volumeMounts:
         - name: data
           mountPath: /data

--- a/internal/controllers/environment_controller.go
+++ b/internal/controllers/environment_controller.go
@@ -125,9 +125,10 @@ func terminalEnvironment(err error) error {
 
 const (
 	sandboxdCredentialMount    = "/var/run/swe-platform/sandboxd"
-	sandboxdSecurityRevision   = "4"
+	sandboxdSecurityRevision   = "5"
 	sandboxdRevisionAnnotation = "swe.dev/sandboxd-security-revision"
 	environmentFinalizer       = "swe.dev/environment-security"
+	workspaceAccessGroup       = int64(10001)
 )
 
 const hookRunnerScript = `set -eu
@@ -934,14 +935,51 @@ func (r *EnvironmentReconciler) backendCreationSourcesCurrent(ctx context.Contex
 	return true, nil
 }
 
+func isResumeReplacement(env *platformv1alpha1.Environment) bool {
+	if !projectProvisioningCurrent(env) {
+		return false
+	}
+	if env.Status.Phase == platformv1alpha1.EnvironmentPhaseResuming {
+		return true
+	}
+	if env.Status.Phase == platformv1alpha1.EnvironmentPhaseCreating && env.Status.PodName != "" && env.Status.LastActiveAt != nil {
+		return true
+	}
+	if env.Status.PodName == "" || env.Status.Endpoints.Sandboxd == "" {
+		return false
+	}
+	switch env.Status.Phase {
+	case platformv1alpha1.EnvironmentPhaseReady, platformv1alpha1.EnvironmentPhaseRunning, platformv1alpha1.EnvironmentPhaseIdle:
+		return true
+	default:
+		return false
+	}
+}
+
+func projectProvisioningCurrent(env *platformv1alpha1.Environment) bool {
+	if env.Spec.ProjectRef == "" {
+		return env.Status.Provisioning == nil || env.Status.Provisioning.Project == nil
+	}
+	return env.Status.Provisioning != nil && env.Status.Provisioning.Project != nil &&
+		env.Status.Provisioning.Project.Name == env.Spec.ProjectRef && env.Status.Provisioning.ProjectVerified
+}
+
+func projectSetupPending(env *platformv1alpha1.Environment) bool {
+	return env.Spec.ProjectRef != "" && !projectProvisioningCurrent(env)
+}
+
 func (r *EnvironmentReconciler) ensurePodForProject(ctx context.Context, env *platformv1alpha1.Environment, tmpl *platformv1alpha1.EnvironmentTemplate, project *platformv1alpha1.Project, runtimeClassUID types.UID, claim tenancy.Claim) (*corev1.Pod, error) {
 	podName := envPodName(env)
 	resuming := env.Status.Phase == platformv1alpha1.EnvironmentPhaseResuming
+	resumeReplacement := isResumeReplacement(env)
+	projectSetup := projectSetupPending(env)
 	var pod corev1.Pod
 	err := r.apiReader().Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: podName}, &pod)
 	if err == nil {
+		resumeReplacement = resumeReplacement || podIsResume(&pod)
 		if metav1.IsControlledBy(&pod, env) && !pod.DeletionTimestamp.IsZero() {
-			if pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodSucceeded {
+			projectSetup = projectSetup || pod.Annotations[projectAnnotation] != env.Spec.ProjectRef
+			if !projectSetup && (pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodSucceeded) {
 				secure, err := r.currentSandboxdPod(ctx, env, &pod)
 				if err != nil {
 					return nil, err
@@ -953,7 +991,13 @@ func (r *EnvironmentReconciler) ensurePodForProject(ctx context.Context, env *pl
 			if err := r.clearRepositoryProvisioning(ctx, env); err != nil {
 				return nil, err
 			}
-			if err := r.setEnvironmentStatus(ctx, env, platformv1alpha1.EnvironmentPhaseCreating, "", "", "PodTerminating", "the previous environment pod is terminating"); err != nil {
+			phase := platformv1alpha1.EnvironmentPhaseCreating
+			if projectSetup {
+				phase = platformv1alpha1.EnvironmentPhaseSetup
+			} else if resumeReplacement {
+				phase = platformv1alpha1.EnvironmentPhaseResuming
+			}
+			if err := r.setEnvironmentStatus(ctx, env, phase, "", "", "PodTerminating", "the previous environment pod is terminating"); err != nil {
 				return nil, err
 			}
 			if env.Status.PodName != "" || env.Status.Endpoints.Sandboxd != "" {
@@ -995,7 +1039,11 @@ func (r *EnvironmentReconciler) ensurePodForProject(ctx context.Context, env *pl
 		if !metav1.IsControlledBy(&pod, env) {
 			return nil, &childOwnershipCollisionError{kind: "Pod", name: podName}
 		}
-		if err := r.setEnvironmentStatus(ctx, env, platformv1alpha1.EnvironmentPhaseCreating, "", "", "PodReplacing", "the environment pod is being replaced before readiness can be restored"); err != nil {
+		phase := platformv1alpha1.EnvironmentPhaseCreating
+		if resumeReplacement {
+			phase = platformv1alpha1.EnvironmentPhaseResuming
+		}
+		if err := r.setEnvironmentStatus(ctx, env, phase, "", "", "PodReplacing", "the environment pod is being replaced before readiness can be restored"); err != nil {
 			return nil, err
 		}
 		if env.Status.PodName != "" || env.Status.Endpoints.Sandboxd != "" {
@@ -1011,6 +1059,24 @@ func (r *EnvironmentReconciler) ensurePodForProject(ctx context.Context, env *pl
 	}
 	if !errors.IsNotFound(err) {
 		return nil, err
+	}
+	if projectSetup {
+		if env.Status.Phase != platformv1alpha1.EnvironmentPhaseSetup || env.Status.PodName != "" || env.Status.Endpoints.Sandboxd != "" {
+			if err := r.setPhase(ctx, env, platformv1alpha1.EnvironmentPhaseSetup, "", ""); err != nil {
+				return nil, err
+			}
+		}
+		return nil, errPodReplacing
+	}
+	// A previously published Pod disappearing is a backend restart over the
+	// retained workspace, not a fresh creation. Persist resume intent before
+	// reserving the replacement execution so Project resume hooks cannot be
+	// skipped if creation races another reconcile or controller restart.
+	if resumeReplacement && !resuming {
+		if err := r.setEnvironmentStatus(ctx, env, platformv1alpha1.EnvironmentPhaseResuming, "", "", "PodMissing", "the environment pod disappeared and is being resumed on its retained workspace"); err != nil {
+			return nil, err
+		}
+		return nil, errPodReplacing
 	}
 	// A persisted provisioning record means this exact execution may already
 	// have created a Pod and exposed the repository token. Without that Pod's
@@ -1141,7 +1207,9 @@ func (r *EnvironmentReconciler) ensurePodForProject(ctx context.Context, env *pl
 			AutomountServiceAccountToken: ptr(false),
 			ServiceAccountName:           r.EnvironmentServiceAccountName,
 			SecurityContext: &corev1.PodSecurityContext{
-				SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+				FSGroup:             ptr(workspaceAccessGroup),
+				FSGroupChangePolicy: ptr(corev1.FSGroupChangeOnRootMismatch),
+				SeccompProfile:      &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
 			},
 			Containers: []corev1.Container{{
 				Name:            "environment",

--- a/internal/controllers/environment_lifecycle_test.go
+++ b/internal/controllers/environment_lifecycle_test.go
@@ -158,6 +158,58 @@ func TestSyncStatusRejectsReadyObservationAfterExecutionChanges(t *testing.T) {
 	}
 }
 
+func TestSyncStatusCannotRepublishWarmPodAfterProjectPromotion(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	lastActive := metav1.Now()
+	stored := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "warm", Namespace: "default", UID: "environment-uid", Generation: 2},
+		Spec:       platformv1alpha1.EnvironmentSpec{ProjectRef: "project"},
+		Status: platformv1alpha1.EnvironmentStatus{
+			ExecutionGeneration: 2,
+			Phase:               platformv1alpha1.EnvironmentPhaseSetup,
+			LastActiveAt:        &lastActive,
+		},
+	}
+	stale := stored.DeepCopy()
+	stale.Spec.ProjectRef = ""
+	stale.Status.Phase = platformv1alpha1.EnvironmentPhaseReady
+	stale.Status.PodName = "env-warm"
+	stale.Status.Endpoints.Sandboxd = "10.0.0.2:50051"
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "env-warm", Namespace: "default",
+			Annotations: map[string]string{executionGenerationAnnotation: "2", projectAnnotation: ""},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning, PodIP: "10.0.0.2",
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}},
+		},
+	}
+	reconciler := &EnvironmentReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(stored).WithObjects(stored).Build(),
+		Scheme: scheme,
+	}
+
+	if err := reconciler.syncStatus(context.Background(), stale, pod); !stderrors.Is(err, errEnvironmentExecutionChanged) {
+		t.Fatalf("stale warm-pod observation error = %v, want requeue", err)
+	}
+	var retained platformv1alpha1.Environment
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(stored), &retained); err != nil {
+		t.Fatal(err)
+	}
+	ready := apimeta.FindStatusCondition(retained.Status.Conditions, platformv1alpha1.EnvironmentConditionReady)
+	if retained.Status.Phase != platformv1alpha1.EnvironmentPhaseSetup || retained.Status.PodName != "" || retained.Status.Endpoints.Sandboxd != "" ||
+		ready == nil || ready.Status != metav1.ConditionFalse || ready.Reason != "SetupInProgress" || retained.Status.LastActiveAt == nil {
+		t.Fatalf("stale warm Pod republished after promotion: %#v", retained.Status)
+	}
+}
+
 func TestEnvironmentPodStateSurfacesReadinessFailures(t *testing.T) {
 	waiting := func(reason, message string) corev1.ContainerState {
 		return corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: reason, Message: message}}
@@ -202,7 +254,7 @@ func TestEnvironmentPodStateSurfacesReadinessFailures(t *testing.T) {
 					Name: "project-setup", State: waiting("CrashLoopBackOff", "retrying"), LastTerminationState: terminated(124, ""),
 				}}},
 			},
-			wantPhase: platformv1alpha1.EnvironmentPhaseFailed, wantReason: "ResumeHookTimedOut",
+			wantPhase: platformv1alpha1.EnvironmentPhaseResuming, wantReason: "ResumeHookTimedOut",
 		},
 		{
 			name: "image pull",
@@ -314,6 +366,7 @@ func TestEnsurePodMarksProjectInitializationAsResume(t *testing.T) {
 	tmpl := &platformv1alpha1.EnvironmentTemplate{
 		Spec: platformv1alpha1.EnvironmentTemplateSpec{Image: "example/environment:latest", Size: "small"},
 	}
+	setTestProvisioningSnapshot(env, tmpl, project)
 
 	pod, err := reconciler.ensurePod(context.Background(), env, tmpl)
 	if err != nil {

--- a/internal/controllers/environment_provisioning_test.go
+++ b/internal/controllers/environment_provisioning_test.go
@@ -180,22 +180,49 @@ func TestProvisioningSnapshotAtomicPublicationAndFailClosedInputs(t *testing.T) 
 		scheme, env, tmpl := fixture(t)
 		c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env, tmpl).Build()
 		r := &EnvironmentReconciler{Client: c, Scheme: scheme}
-		for i := 0; i < 2; i++ {
+		var warmPod corev1.Pod
+		for i := 0; i < 20; i++ {
 			if _, err := r.Reconcile(context.Background(), provisioningRequest(env)); err != nil {
 				t.Fatal(err)
 			}
+			if err := c.Get(context.Background(), client.ObjectKey{Namespace: env.Namespace, Name: envPodName(env)}, &warmPod); err == nil {
+				break
+			} else if !apierrors.IsNotFound(err) {
+				t.Fatal(err)
+			}
+		}
+		if warmPod.Name == "" || warmPod.Annotations[projectAnnotation] != "" {
+			t.Fatalf("generic warm Pod = %#v", warmPod)
 		}
 		var promoted platformv1alpha1.Environment
 		if err := c.Get(context.Background(), client.ObjectKeyFromObject(env), &promoted); err != nil {
 			t.Fatal(err)
 		}
+		if promoted.Status.ExecutionGeneration <= 0 {
+			t.Fatalf("generic warm execution generation = %d", promoted.Status.ExecutionGeneration)
+		}
+		for _, child := range []client.Object{
+			&corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: envPVCName(env), Namespace: env.Namespace}},
+			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: envCredentialName(env), Namespace: env.Namespace}},
+		} {
+			if err := c.Get(context.Background(), client.ObjectKeyFromObject(child), child); err != nil {
+				t.Fatalf("get warm %T: %v", child, err)
+			}
+		}
 		original := promoted.Status.Provisioning.DeepCopy()
+		applyEnvironmentStatus(&promoted, platformv1alpha1.EnvironmentPhaseReady, warmPod.Name, "10.0.0.1:50051", "SandboxdReady", "generic warm environment is ready", nil)
+		if err := c.Status().Update(context.Background(), &promoted); err != nil {
+			t.Fatal(err)
+		}
 		promoted.Spec.ProjectRef = "project"
 		if err := c.Update(context.Background(), &promoted); err != nil {
 			t.Fatal(err)
 		}
 		project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "project", Namespace: env.Namespace, UID: "project-uid", Generation: 1}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://example.test/repository"}}}
 		if err := c.Create(context.Background(), project); err != nil {
+			t.Fatal(err)
+		}
+		if err := c.Delete(context.Background(), &warmPod); err != nil {
 			t.Fatal(err)
 		}
 		if _, err := r.Reconcile(context.Background(), provisioningRequest(env)); err != nil {
@@ -207,8 +234,60 @@ func TestProvisioningSnapshotAtomicPublicationAndFailClosedInputs(t *testing.T) 
 		if promoted.Status.Provisioning.Project == nil || !equality.Semantic.DeepEqual(promoted.Status.Provisioning.Template, original.Template) {
 			t.Fatalf("promotion changed template snapshot or omitted project: before=%#v after=%#v", original, promoted.Status.Provisioning)
 		}
+		if promoted.Status.Phase != platformv1alpha1.EnvironmentPhaseSetup || promoted.Status.PodName != "" || promoted.Status.Endpoints.Sandboxd != "" {
+			t.Fatalf("promotion retained stale published warm status: %#v", promoted.Status)
+		}
 		if err := c.Get(context.Background(), client.ObjectKey{Namespace: env.Namespace, Name: envPodName(env)}, &corev1.Pod{}); !apierrors.IsNotFound(err) {
 			t.Fatalf("project Pod existed before project snapshot extension: %v", err)
+		}
+
+		var setupPod corev1.Pod
+		for i := 0; i < 20; i++ {
+			if _, err := r.Reconcile(context.Background(), provisioningRequest(env)); err != nil {
+				t.Fatalf("project setup reconcile %d: %v", i+1, err)
+			}
+			if err := c.Get(context.Background(), client.ObjectKey{Namespace: env.Namespace, Name: envPodName(env)}, &setupPod); err == nil {
+				break
+			} else if !apierrors.IsNotFound(err) {
+				t.Fatal(err)
+			}
+		}
+		if setupPod.Name == "" || podIsResume(&setupPod) {
+			t.Fatalf("promoted Project setup Pod = %#v, want no resume marker", setupPod)
+		}
+		setupGeneration := setupPod.Annotations[executionGenerationAnnotation]
+		setupIdentity := setupPod.Annotations[sandboxdauth.IdentityAnnotation]
+
+		if err := c.Get(context.Background(), client.ObjectKeyFromObject(env), &promoted); err != nil {
+			t.Fatal(err)
+		}
+		applyEnvironmentStatus(&promoted, platformv1alpha1.EnvironmentPhaseReady, setupPod.Name, "10.0.0.2:50051", "SandboxdReady", "project environment is ready", nil)
+		if err := c.Status().Update(context.Background(), &promoted); err != nil {
+			t.Fatal(err)
+		}
+		if err := c.Delete(context.Background(), &setupPod); err != nil {
+			t.Fatal(err)
+		}
+		var replacement corev1.Pod
+		observedResuming := false
+		for i := 0; i < 20; i++ {
+			if _, err := r.Reconcile(context.Background(), provisioningRequest(env)); err != nil {
+				t.Fatalf("resume reconcile %d: %v", i+1, err)
+			}
+			if err := c.Get(context.Background(), client.ObjectKeyFromObject(env), &promoted); err != nil {
+				t.Fatal(err)
+			}
+			observedResuming = observedResuming || promoted.Status.Phase == platformv1alpha1.EnvironmentPhaseResuming
+			if err := c.Get(context.Background(), client.ObjectKey{Namespace: env.Namespace, Name: envPodName(env)}, &replacement); err == nil {
+				break
+			} else if !apierrors.IsNotFound(err) {
+				t.Fatal(err)
+			}
+		}
+		if replacement.Name == "" || !observedResuming || !podIsResume(&replacement) ||
+			replacement.Annotations[executionGenerationAnnotation] == setupGeneration ||
+			replacement.Annotations[sandboxdauth.IdentityAnnotation] == setupIdentity {
+			t.Fatalf("established Project replacement = %#v, status = %#v", replacement, promoted.Status)
 		}
 	})
 

--- a/internal/controllers/environment_reconcile.go
+++ b/internal/controllers/environment_reconcile.go
@@ -207,7 +207,12 @@ func reconcileEnvironmentProvisioningFenceGate(r *EnvironmentReconciler, ctx con
 func reconcileEnvironmentLegacyProvisioningMigrationGate(r *EnvironmentReconciler, ctx context.Context, state *environmentReconcileState) environmentPhaseOutcome {
 	env := &state.env
 	if env.Status.Provisioning != nil && env.Status.Provisioning.TemplateVerified &&
-		(env.Status.Provisioning.Project == nil || env.Status.Provisioning.ProjectVerified) {
+		(env.Status.Provisioning.Project == nil || env.Status.Provisioning.ProjectVerified ||
+			env.Status.Phase == platformv1alpha1.EnvironmentPhaseSetup && env.Status.Provisioning.Project.Name == env.Spec.ProjectRef) {
+		// Setup with an exact pending Project snapshot is the modern warm-pool
+		// promotion handshake. The Template gate verifies that captured Project
+		// before provisioning continues; it is not a pre-snapshot execution that
+		// needs legacy teardown merely because its execution generation is positive.
 		return phaseContinue()
 	}
 	// Recovery deadlines and exhaustion were persisted by an earlier controller
@@ -370,6 +375,12 @@ func (r *EnvironmentReconciler) publishProvisioningSnapshot(ctx context.Context,
 		}
 		before := env.DeepCopy()
 		env.Status.Provisioning = next
+		// Binding a Project changes generic warm-pool initialization into Project
+		// setup. Withdraw any stale published warm execution in the same status
+		// write that freezes the Project identity, so a reconcile between the Run
+		// spec patch and its best-effort Setup status update cannot classify a
+		// missing generic Pod as a Project resume.
+		applyEnvironmentStatus(env, platformv1alpha1.EnvironmentPhaseSetup, "", "", "SetupInProgress", "warm environment is being configured for its project", env.Status.LastActiveAt)
 		if err := r.Status().Patch(ctx, env, client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{})); err != nil {
 			if errors.IsConflict(err) {
 				return true, nil

--- a/internal/controllers/environment_recovery.go
+++ b/internal/controllers/environment_recovery.go
@@ -86,7 +86,7 @@ func (r *EnvironmentReconciler) reconcilePendingPodRecovery(ctx context.Context,
 	if now.Before(nextAttemptAt.Time) {
 		if ready == nil || ready.ObservedGeneration != env.Generation || ready.Status != metav1.ConditionFalse || ready.Reason != "PodRecoveryPending" {
 			message := fmt.Sprintf("terminal pod recovery attempt %d of %d is scheduled for %s", recovery.Attempts+1, podRecoveryLimit, nextAttemptAt.Time.UTC().Format(time.RFC3339))
-			if err := r.setEnvironmentStatus(ctx, env, platformv1alpha1.EnvironmentPhaseCreating, "", "", "PodRecoveryPending", message); err != nil {
+			if err := r.setEnvironmentStatus(ctx, env, podRecoveryPhase(env, nil), "", "", "PodRecoveryPending", message); err != nil {
 				return ctrl.Result{}, true, err
 			}
 		}
@@ -96,7 +96,7 @@ func (r *EnvironmentReconciler) reconcilePendingPodRecovery(ctx context.Context,
 	attempts := recovery.Attempts + 1
 	message := fmt.Sprintf("replacing terminal environment pod (recovery attempt %d of %d)", attempts, podRecoveryLimit)
 	if err := r.updatePodRecoveryStatus(ctx, env, func(current *platformv1alpha1.Environment) {
-		applyEnvironmentStatus(current, platformv1alpha1.EnvironmentPhaseCreating, "", "", "PodRecovering", message, env.Status.LastActiveAt)
+		applyEnvironmentStatus(current, podRecoveryPhase(current, nil), "", "", "PodRecovering", message, env.Status.LastActiveAt)
 		current.Status.Recovery.Attempts = attempts
 		current.Status.Recovery.ExecutionGeneration = recovery.ExecutionGeneration
 		current.Status.Recovery.NextAttemptAt = nil
@@ -152,7 +152,7 @@ func (r *EnvironmentReconciler) reconcileTerminalPod(ctx context.Context, env *p
 		next := metav1.NewTime(now.Add(podRecoveryBackoff(attempts)))
 		message := fmt.Sprintf("environment pod %s; recovery attempt %d of %d is scheduled for %s", strings.ToLower(string(pod.Status.Phase)), attempts+1, podRecoveryLimit, next.Time.UTC().Format(time.RFC3339))
 		if err := r.updatePodRecoveryStatus(ctx, env, func(current *platformv1alpha1.Environment) {
-			applyEnvironmentStatus(current, platformv1alpha1.EnvironmentPhaseCreating, "", "", "PodRecoveryPending", message, env.Status.LastActiveAt)
+			applyEnvironmentStatus(current, podRecoveryPhase(current, pod), "", "", "PodRecoveryPending", message, env.Status.LastActiveAt)
 			current.Status.Recovery.Attempts = attempts
 			current.Status.Recovery.Exhausted = false
 			current.Status.Recovery.ExecutionGeneration = executionGeneration
@@ -179,6 +179,13 @@ func (r *EnvironmentReconciler) reconcileTerminalPod(ctx context.Context, env *p
 	}
 	log.FromContext(ctx).Info("replacing terminal environment pod", "environment", env.Name, "pod", pod.Name, "attempt", attempts, "maxAttempts", podRecoveryLimit)
 	return ctrl.Result{Requeue: true}, nil
+}
+
+func podRecoveryPhase(env *platformv1alpha1.Environment, pod *corev1.Pod) platformv1alpha1.EnvironmentPhase {
+	if isResumeReplacement(env) || pod != nil && podIsResume(pod) {
+		return platformv1alpha1.EnvironmentPhaseResuming
+	}
+	return platformv1alpha1.EnvironmentPhaseCreating
 }
 
 func podRecoveryBackoff(attempts int32) time.Duration {

--- a/internal/controllers/environment_resources_test.go
+++ b/internal/controllers/environment_resources_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -280,12 +281,14 @@ func TestEnsurePodUsesOnlyNonSecretProjectValues(t *testing.T) {
 			TemplateRef: "small",
 		},
 	}
-	reconciler := &EnvironmentReconciler{
-		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(project, env).Build(),
-		Scheme: scheme,
-	}
 	tmpl := &platformv1alpha1.EnvironmentTemplate{
-		Spec: platformv1alpha1.EnvironmentTemplateSpec{Image: "example/environment:latest", Size: "small"},
+		ObjectMeta: metav1.ObjectMeta{Name: env.Spec.TemplateRef, Namespace: env.Namespace},
+		Spec:       platformv1alpha1.EnvironmentTemplateSpec{Image: "example/environment:latest", Size: "small"},
+	}
+	setTestProvisioningSnapshot(env, tmpl, project)
+	reconciler := &EnvironmentReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(project, env, tmpl).Build(),
+		Scheme: scheme,
 	}
 
 	pod, err := reconciler.ensurePod(context.Background(), env, tmpl)
@@ -311,6 +314,13 @@ func TestEnsurePodUsesOnlyNonSecretProjectValues(t *testing.T) {
 	clone, setup := pod.Spec.InitContainers[0], pod.Spec.InitContainers[1]
 	if clone.Name != "repository-clone" || setup.Name != "project-hooks" {
 		t.Errorf("init container order = %q, %q", clone.Name, setup.Name)
+	}
+	for _, init := range []corev1.Container{clone, setup} {
+		if init.SecurityContext == nil || init.SecurityContext.AllowPrivilegeEscalation == nil || *init.SecurityContext.AllowPrivilegeEscalation ||
+			init.SecurityContext.Capabilities == nil || len(init.SecurityContext.Capabilities.Drop) != 1 || init.SecurityContext.Capabilities.Drop[0] != "ALL" ||
+			init.SecurityContext.RunAsUser != nil || init.SecurityContext.RunAsGroup != nil {
+			t.Errorf("%s security context = %#v, want image identity, no escalation, and drop ALL", init.Name, init.SecurityContext)
+		}
 	}
 	envValues := make(map[string]string, len(clone.Env))
 	for _, envVar := range clone.Env {
@@ -430,13 +440,17 @@ func TestEnsurePodCreatesAndRotatesEphemeralSandboxdCredentials(t *testing.T) {
 	}
 	env := &platformv1alpha1.Environment{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "environment-uid"},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small", ProjectRef: "project"},
 	}
-	reconciler := &EnvironmentReconciler{
-		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env).Build(),
-		Scheme: scheme,
-	}
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "project", Namespace: env.Namespace}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/example/repo"}}}
 	tmpl := &platformv1alpha1.EnvironmentTemplate{
-		Spec: platformv1alpha1.EnvironmentTemplateSpec{Image: "example/environment:latest", Size: "small"},
+		ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: env.Namespace},
+		Spec:       platformv1alpha1.EnvironmentTemplateSpec{Image: "example/environment:latest", Size: "small"},
+	}
+	setTestProvisioningSnapshot(env, tmpl, project)
+	reconciler := &EnvironmentReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env, project, tmpl).Build(),
+		Scheme: scheme,
 	}
 
 	pod, err := reconciler.ensurePod(context.Background(), env, tmpl)
@@ -450,7 +464,21 @@ func TestEnsurePodCreatesAndRotatesEphemeralSandboxdCredentials(t *testing.T) {
 	if pod.Spec.AutomountServiceAccountToken == nil || *pod.Spec.AutomountServiceAccountToken {
 		t.Fatal("environment pod must not mount a Kubernetes service account token")
 	}
+	if pod.Spec.SecurityContext == nil || pod.Spec.SecurityContext.FSGroup == nil || *pod.Spec.SecurityContext.FSGroup != workspaceAccessGroup ||
+		pod.Spec.SecurityContext.FSGroupChangePolicy == nil || *pod.Spec.SecurityContext.FSGroupChangePolicy != corev1.FSGroupChangeOnRootMismatch {
+		t.Fatalf("pod workspace access security context = %#v", pod.Spec.SecurityContext)
+	}
+	if pod.Spec.SecurityContext.RunAsUser != nil || pod.Spec.SecurityContext.RunAsGroup != nil {
+		t.Fatalf("pod forces image identity: runAsUser=%v runAsGroup=%v", pod.Spec.SecurityContext.RunAsUser, pod.Spec.SecurityContext.RunAsGroup)
+	}
+	if pod.Spec.SecurityContext.SeccompProfile == nil || pod.Spec.SecurityContext.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+		t.Fatalf("pod seccomp profile = %#v, want RuntimeDefault", pod.Spec.SecurityContext.SeccompProfile)
+	}
 	container := pod.Spec.Containers[0]
+	if container.SecurityContext == nil || container.SecurityContext.AllowPrivilegeEscalation == nil || *container.SecurityContext.AllowPrivilegeEscalation ||
+		container.SecurityContext.Capabilities == nil || len(container.SecurityContext.Capabilities.Drop) != 1 || container.SecurityContext.Capabilities.Drop[0] != "ALL" {
+		t.Fatalf("sandboxd security context = %#v, want no escalation and drop ALL", container.SecurityContext)
+	}
 	for name, probe := range map[string]*corev1.Probe{"startup": container.StartupProbe, "readiness": container.ReadinessProbe, "liveness": container.LivenessProbe} {
 		if probe == nil || probe.Exec == nil || len(probe.Exec.Command) < 2 || probe.Exec.Command[1] != "healthcheck" {
 			t.Errorf("%s probe = %#v, want authenticated sandboxd health RPC", name, probe)
@@ -541,10 +569,41 @@ func TestEnsurePodCreatesAndRotatesEphemeralSandboxdCredentials(t *testing.T) {
 		t.Fatal("pod specification or metadata exposes a raw operator token")
 	}
 
+	var readyEnv platformv1alpha1.Environment
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(env), &readyEnv); err != nil {
+		t.Fatal(err)
+	}
+	readyEnv.Status.Phase = platformv1alpha1.EnvironmentPhaseReady
+	readyEnv.Status.PodName = pod.Name
+	readyEnv.Status.Endpoints.Sandboxd = "10.0.0.1:50051"
+	if err := reconciler.Status().Update(context.Background(), &readyEnv); err != nil {
+		t.Fatal(err)
+	}
+	pod.Finalizers = []string{"test/hold"}
+	if err := reconciler.Update(context.Background(), pod); err != nil {
+		t.Fatal(err)
+	}
 	if err := reconciler.Delete(context.Background(), pod); err != nil {
 		t.Fatal(err)
 	}
-	recreated, err := reconciler.ensurePod(context.Background(), env, tmpl)
+	if recreated, err := reconciler.ensurePod(context.Background(), &readyEnv, tmpl); recreated != nil || err != nil {
+		t.Fatalf("begin terminating Pod resume = (%#v, %v)", recreated, err)
+	}
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(env), &readyEnv); err != nil {
+		t.Fatal(err)
+	}
+	if readyEnv.Status.Phase != platformv1alpha1.EnvironmentPhaseResuming || readyEnv.Status.PodName != "" {
+		t.Fatalf("terminating Pod status = %#v, want unpublished Resuming", readyEnv.Status)
+	}
+	var terminating corev1.Pod
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(pod), &terminating); err != nil {
+		t.Fatal(err)
+	}
+	terminating.Finalizers = nil
+	if err := reconciler.Update(context.Background(), &terminating); err != nil {
+		t.Fatal(err)
+	}
+	recreated, err := reconciler.ensurePod(context.Background(), &readyEnv, tmpl)
 	if err != nil {
 		t.Fatalf("recreate ensurePod() error = %v", err)
 	}
@@ -557,6 +616,11 @@ func TestEnsurePodCreatesAndRotatesEphemeralSandboxdCredentials(t *testing.T) {
 	}
 	if recreated.Annotations[sandboxdauth.TokenAnnotation] == firstToken {
 		t.Fatal("pod recreation did not rotate terminal capability")
+	}
+	if len(recreated.Spec.InitContainers) != 2 || !slices.ContainsFunc(recreated.Spec.InitContainers[1].Env, func(variable corev1.EnvVar) bool {
+		return variable.Name == "SWE_RESUMING" && variable.Value == "true"
+	}) {
+		t.Fatalf("replacement project hooks = %#v, want SWE_RESUMING=true", recreated.Spec.InitContainers)
 	}
 }
 
@@ -608,7 +672,10 @@ func TestFailedPodCreateLeavesGenerationGap(t *testing.T) {
 		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small", ProjectRef: "project"},
 		Status:     platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhaseResuming},
 	}
-	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env).Build()
+	template := &platformv1alpha1.EnvironmentTemplate{Spec: platformv1alpha1.EnvironmentTemplateSpec{Image: "example/environment:latest", Size: "small"}}
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "project", Namespace: env.Namespace}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/example/repo"}}}
+	setTestProvisioningSnapshot(env, template, project)
+	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env, template, project).Build()
 	failCreate := true
 	transientErr := stderrors.New("transient Pod create failure")
 	intercepted := interceptor.NewClient(baseClient, interceptor.Funcs{
@@ -621,8 +688,6 @@ func TestFailedPodCreateLeavesGenerationGap(t *testing.T) {
 		},
 	})
 	reconciler := &EnvironmentReconciler{Client: intercepted, Scheme: scheme}
-	template := &platformv1alpha1.EnvironmentTemplate{Spec: platformv1alpha1.EnvironmentTemplateSpec{Image: "example/environment:latest", Size: "small"}}
-	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "project", Namespace: env.Namespace}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/example/repo"}}}
 
 	if pod, err := reconciler.ensurePodForProject(context.Background(), env, template, project, "", tenancy.Claim{}); pod != nil || !stderrors.Is(err, transientErr) {
 		t.Fatalf("first create = (%#v, %v), want transient error", pod, err)
@@ -678,7 +743,7 @@ func TestCurrentSandboxdPodRejectsRestartableLegacyPod(t *testing.T) {
 	}
 }
 
-func TestEnsurePodReplacesLegacyOnFailureExecution(t *testing.T) {
+func TestEnsurePodReplacesRevision4AndRetainsWorkspace(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := corev1.AddToScheme(scheme); err != nil {
 		t.Fatal(err)
@@ -691,26 +756,41 @@ func TestEnsurePodReplacesLegacyOnFailureExecution(t *testing.T) {
 		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small"},
 		Status:     platformv1alpha1.EnvironmentStatus{ExecutionGeneration: 1},
 	}
+	template := &platformv1alpha1.EnvironmentTemplate{Spec: platformv1alpha1.EnvironmentTemplateSpec{Image: "example/environment:latest", Size: "small"}}
+	setTestProvisioningSnapshot(env, template, nil)
+	originalSnapshot := env.Status.Provisioning.DeepCopy()
 	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: envPodName(env), Namespace: env.Namespace, UID: "legacy-pod", Annotations: map[string]string{executionGenerationAnnotation: "1"}},
-		Spec:       corev1.PodSpec{RestartPolicy: corev1.RestartPolicyOnFailure},
+		ObjectMeta: metav1.ObjectMeta{Name: envPodName(env), Namespace: env.Namespace, UID: "legacy-pod", Annotations: map[string]string{
+			executionGenerationAnnotation: "1", sandboxdRevisionAnnotation: "4",
+		}},
+		Spec: corev1.PodSpec{RestartPolicy: corev1.RestartPolicyNever},
 	}
 	if err := controllerutil.SetControllerReference(env, pod, scheme); err != nil {
 		t.Fatal(err)
 	}
-	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env, pod).Build()
+	pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: envPVCName(env), Namespace: env.Namespace, UID: "retained-pvc"}}
+	if err := controllerutil.SetControllerReference(env, pvc, scheme); err != nil {
+		t.Fatal(err)
+	}
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env, template, pod, pvc).Build()
 	reconciler := &EnvironmentReconciler{Client: kubeClient, Scheme: scheme}
-	template := &platformv1alpha1.EnvironmentTemplate{Spec: platformv1alpha1.EnvironmentTemplateSpec{Image: "example/environment:latest", Size: "small"}}
 
 	if current, err := reconciler.ensurePod(context.Background(), env, template); err != nil || current != nil {
 		t.Fatalf("legacy replacement step = (%#v, %v)", current, err)
 	}
 	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(pod), &corev1.Pod{}); !apierrors.IsNotFound(err) {
-		t.Fatalf("legacy OnFailure Pod remains: %v", err)
+		t.Fatalf("revision 4 Pod remains: %v", err)
+	}
+	var retainedPVC corev1.PersistentVolumeClaim
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(pvc), &retainedPVC); err != nil || retainedPVC.UID != pvc.UID {
+		t.Fatalf("revision replacement changed retained PVC: uid=%q err=%v", retainedPVC.UID, err)
 	}
 	var replacing platformv1alpha1.Environment
 	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(env), &replacing); err != nil {
 		t.Fatal(err)
+	}
+	if !platformv1alpha1.ProvisioningSnapshotsEqual(replacing.Status.Provisioning, originalSnapshot) {
+		t.Fatalf("revision replacement changed frozen provisioning inputs: %#v", replacing.Status.Provisioning)
 	}
 	replacement, err := reconciler.ensurePod(context.Background(), &replacing, template)
 	if err != nil {
@@ -718,6 +798,9 @@ func TestEnsurePodReplacesLegacyOnFailureExecution(t *testing.T) {
 	}
 	if replacement.Spec.RestartPolicy != corev1.RestartPolicyNever || replacement.Annotations[executionGenerationAnnotation] != "2" {
 		t.Fatalf("replacement execution = restart %q, generation %q", replacement.Spec.RestartPolicy, replacement.Annotations[executionGenerationAnnotation])
+	}
+	if replacement.Spec.SecurityContext == nil || replacement.Spec.SecurityContext.FSGroup == nil || *replacement.Spec.SecurityContext.FSGroup != workspaceAccessGroup {
+		t.Fatalf("replacement workspace access = %#v", replacement.Spec.SecurityContext)
 	}
 }
 
@@ -813,6 +896,7 @@ func TestEnsurePodRetainsCurrentPodWhenSecretReadFails(t *testing.T) {
 		Name: envPodName(env), Namespace: env.Namespace,
 		Annotations: map[string]string{
 			executionGenerationAnnotation:     "1",
+			projectAnnotation:                 env.Spec.ProjectRef,
 			sandboxdRevisionAnnotation:        sandboxdSecurityRevision,
 			sandboxdauth.IdentityAnnotation:   "current.sandboxd.swe.dev",
 			sandboxdauth.TrustAnnotation:      "public trust bundle",
@@ -1217,21 +1301,22 @@ func TestTerminatingFailedPodPersistsRecoveryBeforeReplacement(t *testing.T) {
 	deletedAt := metav1.NewTime(now.Add(-time.Second))
 	env := &platformv1alpha1.Environment{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "env-uid", Generation: 2, Finalizers: []string{environmentFinalizer}},
-		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small"},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small", ProjectRef: "project"},
 		Status: platformv1alpha1.EnvironmentStatus{
-			ObservedGeneration: 1, ExecutionGeneration: 1, Phase: platformv1alpha1.EnvironmentPhaseReady, PodName: "env-test",
-			Endpoints: platformv1alpha1.EnvironmentEndpoints{Sandboxd: "10.0.0.1:50051"},
-			Conditions: []metav1.Condition{{Type: platformv1alpha1.EnvironmentConditionReady, Status: metav1.ConditionTrue,
-				ObservedGeneration: 1, Reason: "SandboxdReady", Message: "sandboxd is ready"}},
+			ObservedGeneration: 1, ExecutionGeneration: 1, Phase: platformv1alpha1.EnvironmentPhaseCreating, PodName: "env-test",
+			Conditions: []metav1.Condition{{Type: platformv1alpha1.EnvironmentConditionReady, Status: metav1.ConditionFalse,
+				ObservedGeneration: 1, Reason: "ResumeHookTimedOut", Message: "resume hook failed before readiness"}},
 		},
 	}
-	template := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: env.Namespace}}
-	setTestProvisioningSnapshot(env, template, nil)
+	template := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: env.Namespace}, Spec: platformv1alpha1.EnvironmentTemplateSpec{Image: "example/environment:latest", Size: "small"}}
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "project", Namespace: env.Namespace, UID: "project-uid"}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/example/repo"}}}
+	setTestProvisioningSnapshot(env, template, project)
 	pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: envPVCName(env), Namespace: env.Namespace, UID: "workspace-pvc"}}
 	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 		Name: envPodName(env), Namespace: env.Namespace, UID: "dead-pod", DeletionTimestamp: &deletedAt, Finalizers: []string{"test/hold"},
 		Annotations: map[string]string{
 			executionGenerationAnnotation:     "1",
+			projectAnnotation:                 env.Spec.ProjectRef,
 			sandboxdRevisionAnnotation:        sandboxdSecurityRevision,
 			sandboxdauth.IdentityAnnotation:   "sandboxd.test",
 			sandboxdauth.TrustAnnotation:      "trust",
@@ -1239,7 +1324,7 @@ func TestTerminatingFailedPodPersistsRecoveryBeforeReplacement(t *testing.T) {
 			sandboxdauth.SecretNameAnnotation: envCredentialName(env),
 			sandboxdauth.SecretUIDAnnotation:  "secret-uid",
 		},
-	}, Spec: corev1.PodSpec{RestartPolicy: corev1.RestartPolicyNever}, Status: corev1.PodStatus{Phase: corev1.PodFailed}}
+	}, Spec: corev1.PodSpec{RestartPolicy: corev1.RestartPolicyNever, InitContainers: []corev1.Container{{Name: "project-hooks", Env: []corev1.EnvVar{{Name: "SWE_RESUMING", Value: "true"}}}}}, Status: corev1.PodStatus{Phase: corev1.PodFailed}}
 	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
 		Name: envCredentialName(env), Namespace: env.Namespace, UID: "secret-uid",
 		Annotations: map[string]string{sandboxdauth.IdentityAnnotation: "sandboxd.test", sandboxdauth.PodUIDAnnotation: string(pod.UID)},
@@ -1253,7 +1338,7 @@ func TestTerminatingFailedPodPersistsRecoveryBeforeReplacement(t *testing.T) {
 		}
 	}
 	reconciler := &EnvironmentReconciler{
-		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env, template, pvc, pod, secret).Build(),
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env, template, project, pvc, pod, secret).Build(),
 		Scheme: scheme, Now: func() time.Time { return now },
 	}
 	request := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(env)}
@@ -1268,6 +1353,9 @@ func TestTerminatingFailedPodPersistsRecoveryBeforeReplacement(t *testing.T) {
 	}
 	if pending.Status.Recovery.ExecutionGeneration != 1 || pending.Status.Recovery.NextAttemptAt == nil || pending.Status.PodName != "" || pending.Status.Endpoints.Sandboxd != "" {
 		t.Fatalf("terminating failed Pod recovery status = %#v", pending.Status)
+	}
+	if pending.Status.Phase != platformv1alpha1.EnvironmentPhaseResuming {
+		t.Fatalf("terminating failed Pod phase = %q, want Resuming", pending.Status.Phase)
 	}
 	var disappearing corev1.Pod
 	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(pod), &disappearing); err != nil {
@@ -1305,6 +1393,85 @@ func TestTerminatingFailedPodPersistsRecoveryBeforeReplacement(t *testing.T) {
 	}
 	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(pod), &corev1.Pod{}); !apierrors.IsNotFound(err) {
 		t.Fatalf("replacement Pod created in the same reconcile as attempt persistence: %v", err)
+	}
+	replacement, err := reconciler.ensurePodForProject(context.Background(), &due, template, project, "", tenancy.Claim{})
+	if err != nil {
+		t.Fatalf("create recovery replacement: %v", err)
+	}
+	if due.Status.ExecutionGeneration != 2 || replacement.Annotations[executionGenerationAnnotation] != "2" {
+		t.Fatalf("replacement generation = status %d pod %q, want exactly 2", due.Status.ExecutionGeneration, replacement.Annotations[executionGenerationAnnotation])
+	}
+	if replacement.Annotations[sandboxdauth.IdentityAnnotation] == pod.Annotations[sandboxdauth.IdentityAnnotation] || replacement.Annotations[sandboxdauth.TokenAnnotation] == pod.Annotations[sandboxdauth.TokenAnnotation] {
+		t.Fatal("terminal recovery replacement did not rotate sandboxd credentials")
+	}
+	if len(replacement.Spec.InitContainers) != 2 || !slices.ContainsFunc(replacement.Spec.InitContainers[1].Env, func(variable corev1.EnvVar) bool {
+		return variable.Name == "SWE_RESUMING" && variable.Value == "true"
+	}) {
+		t.Fatalf("terminal recovery project hooks = %#v, want SWE_RESUMING=true", replacement.Spec.InitContainers)
+	}
+}
+
+func TestTerminatingWarmPodPreservesProjectSetupBeforeReplacement(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	deletedAt := metav1.Now()
+	env := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "warm", Namespace: "default", UID: "env-uid", Generation: 2},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small", ProjectRef: "project"},
+		Status: platformv1alpha1.EnvironmentStatus{
+			ExecutionGeneration: 1, Phase: platformv1alpha1.EnvironmentPhaseReady, PodName: "env-warm",
+			Endpoints: platformv1alpha1.EnvironmentEndpoints{Sandboxd: "10.0.0.1:50051"},
+		},
+	}
+	template := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: env.Namespace, UID: "template-uid", Generation: 1}, Spec: platformv1alpha1.EnvironmentTemplateSpec{Image: "example/environment:latest", Size: "small"}}
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "project", Namespace: env.Namespace, UID: "project-uid", Generation: 1}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/example/repo"}}}
+	setTestProvisioningSnapshot(env, template, project)
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: envPodName(env), Namespace: env.Namespace, UID: "warm-pod", DeletionTimestamp: &deletedAt, Finalizers: []string{"test/hold"},
+		Annotations: map[string]string{executionGenerationAnnotation: "1", projectAnnotation: ""},
+	}, Spec: corev1.PodSpec{RestartPolicy: corev1.RestartPolicyNever}, Status: corev1.PodStatus{Phase: corev1.PodFailed}}
+	if err := controllerutil.SetControllerReference(env, pod, scheme); err != nil {
+		t.Fatal(err)
+	}
+	reconciler := &EnvironmentReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env, template, project, pod).Build(),
+		Scheme: scheme,
+	}
+
+	created, err := reconciler.ensurePodForProject(context.Background(), env, template, project, "", tenancy.Claim{})
+	if err != nil || created != nil {
+		t.Fatalf("terminating warm Pod = (%#v, %v), want setup barrier", created, err)
+	}
+	var setup platformv1alpha1.Environment
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(env), &setup); err != nil {
+		t.Fatal(err)
+	}
+	if setup.Status.Phase != platformv1alpha1.EnvironmentPhaseSetup || setup.Status.PodName != "" || setup.Status.Endpoints.Sandboxd != "" || nestedRecoveryMeaningful(setup.Status.Recovery) {
+		t.Fatalf("terminating warm Pod status = %#v, want unpublished Setup without recovery", setup.Status)
+	}
+	var terminating corev1.Pod
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(pod), &terminating); err != nil {
+		t.Fatal(err)
+	}
+	terminating.Finalizers = nil
+	if err := reconciler.Update(context.Background(), &terminating); err != nil && !apierrors.IsNotFound(err) {
+		t.Fatal(err)
+	}
+	if err := reconciler.Get(context.Background(), client.ObjectKeyFromObject(env), &setup); err != nil {
+		t.Fatal(err)
+	}
+	replacement, err := reconciler.ensurePodForProject(context.Background(), &setup, template, project, "", tenancy.Claim{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replacement.Annotations[executionGenerationAnnotation] != "2" || len(replacement.Spec.InitContainers) != 2 ||
+		slices.ContainsFunc(replacement.Spec.InitContainers[1].Env, func(variable corev1.EnvVar) bool { return variable.Name == "SWE_RESUMING" }) {
+		t.Fatalf("project setup replacement = %#v, want generation 2 without resume hook", replacement)
 	}
 }
 
@@ -2172,43 +2339,81 @@ func TestOperationalFailureRetriesAndRecoversReadiness(t *testing.T) {
 	}
 	env := &platformv1alpha1.Environment{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "environment-uid", Generation: 2, Finalizers: []string{environmentFinalizer}},
-		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small"},
-		Status:     platformv1alpha1.EnvironmentStatus{ExecutionGeneration: 1},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small", ProjectRef: "project"},
+		Status:     platformv1alpha1.EnvironmentStatus{ExecutionGeneration: 1, Phase: platformv1alpha1.EnvironmentPhaseResuming},
 	}
-	template := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: "default"}}
-	setTestProvisioningSnapshot(env, template, nil)
-	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env, template).Build()
-	transient := apierrors.NewServiceUnavailable("temporary template API failure")
-	failTemplateGet := true
+	template := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: "default", UID: "template-uid", Generation: 1}, Spec: platformv1alpha1.EnvironmentTemplateSpec{Image: "example/environment:test", Size: "small"}}
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "project", Namespace: env.Namespace, UID: "project-uid", Generation: 1}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/example/repo"}}}
+	setTestProvisioningSnapshot(env, template, project)
+	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env, template, project).Build()
+	transient := apierrors.NewServiceUnavailable("temporary Pod create failure")
+	failPodCreate := true
 	interceptedClient := interceptor.NewClient(baseClient, interceptor.Funcs{
-		Get: func(ctx context.Context, underlying client.WithWatch, key client.ObjectKey, object client.Object, options ...client.GetOption) error {
-			if failTemplateGet && key == client.ObjectKeyFromObject(template) {
-				failTemplateGet = false
+		Create: func(ctx context.Context, underlying client.WithWatch, object client.Object, options ...client.CreateOption) error {
+			if _, ok := object.(*corev1.Pod); ok && failPodCreate {
+				failPodCreate = false
 				return transient
 			}
-			return underlying.Get(ctx, key, object, options...)
+			return underlying.Create(ctx, object, options...)
 		},
 	})
 	reconciler := &EnvironmentReconciler{Client: interceptedClient, Scheme: scheme}
 	request := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(env)}
-	if _, err := reconciler.Reconcile(context.Background(), request); !stderrors.Is(err, transient) {
-		t.Fatalf("Reconcile() error = %v, want transient retry", err)
+	observedTransient := false
+	for i := 0; i < 20; i++ {
+		if _, err := reconciler.Reconcile(context.Background(), request); stderrors.Is(err, transient) {
+			observedTransient = true
+			break
+		} else if err != nil {
+			t.Fatalf("initial Reconcile() %d: %v", i+1, err)
+		}
+	}
+	if !observedTransient {
+		t.Fatal("top-level reconciliation did not reach transient Pod create failure")
 	}
 	var retrying platformv1alpha1.Environment
 	if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(env), &retrying); err != nil {
 		t.Fatal(err)
 	}
 	condition := apimeta.FindStatusCondition(retrying.Status.Conditions, platformv1alpha1.EnvironmentConditionReady)
-	if retrying.Status.Phase != platformv1alpha1.EnvironmentPhaseCreating || condition == nil || condition.Status != metav1.ConditionFalse || condition.Reason != "OperationalError" {
+	if retrying.Status.Phase != platformv1alpha1.EnvironmentPhaseResuming || condition == nil || condition.Status != metav1.ConditionFalse || condition.Reason != "OperationalError" {
 		t.Fatalf("transient failure status = phase %q, condition %#v", retrying.Status.Phase, condition)
 	}
-	if result, err := reconciler.Reconcile(context.Background(), request); err != nil {
-		t.Fatalf("recovery Reconcile() = (%#v, %v), want provisioning to resume", result, err)
+	var failedCreateCredentials corev1.Secret
+	if err := baseClient.Get(context.Background(), client.ObjectKey{Namespace: env.Namespace, Name: envCredentialName(env)}, &failedCreateCredentials); err != nil {
+		t.Fatal(err)
+	}
+	var replacement corev1.Pod
+	for i := 0; i < 20; i++ {
+		if _, err := reconciler.Reconcile(context.Background(), request); err != nil {
+			t.Fatalf("recovery Reconcile() %d: %v", i+1, err)
+		}
+		if err := baseClient.Get(context.Background(), client.ObjectKey{Namespace: env.Namespace, Name: envPodName(env)}, &replacement); err == nil {
+			break
+		} else if !apierrors.IsNotFound(err) {
+			t.Fatal(err)
+		}
 	}
 	if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(env), &retrying); err != nil {
 		t.Fatal(err)
 	}
-	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Annotations: map[string]string{executionGenerationAnnotation: strconv.FormatInt(retrying.Status.ExecutionGeneration, 10)}}, Status: corev1.PodStatus{
+	if replacement.Name == "" || retrying.Status.ExecutionGeneration != 3 || replacement.Annotations[executionGenerationAnnotation] != "3" ||
+		len(replacement.Spec.InitContainers) != 2 || !slices.ContainsFunc(replacement.Spec.InitContainers[1].Env, func(variable corev1.EnvVar) bool {
+		return variable.Name == "SWE_RESUMING" && variable.Value == "true"
+	}) {
+		t.Fatalf("replacement = %#v, status = %#v", replacement, retrying.Status)
+	}
+	var replacementCredentials corev1.Secret
+	if err := baseClient.Get(context.Background(), client.ObjectKey{Namespace: env.Namespace, Name: envCredentialName(env)}, &replacementCredentials); err != nil {
+		t.Fatal(err)
+	}
+	if replacementCredentials.Annotations[sandboxdauth.IdentityAnnotation] == failedCreateCredentials.Annotations[sandboxdauth.IdentityAnnotation] ||
+		string(replacementCredentials.Data[sandboxdauth.ProcessTokenKey]) == string(failedCreateCredentials.Data[sandboxdauth.ProcessTokenKey]) {
+		t.Fatal("retry after transient Pod create failure did not rotate sandboxd credentials")
+	}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Annotations: map[string]string{
+		executionGenerationAnnotation: strconv.FormatInt(retrying.Status.ExecutionGeneration, 10), projectAnnotation: env.Spec.ProjectRef,
+	}}, Status: corev1.PodStatus{
 		Phase: corev1.PodRunning,
 		PodIP: "10.0.0.1",
 		Conditions: []corev1.PodCondition{{
@@ -2224,6 +2429,108 @@ func TestOperationalFailureRetriesAndRecoversReadiness(t *testing.T) {
 	condition = apimeta.FindStatusCondition(retrying.Status.Conditions, platformv1alpha1.EnvironmentConditionReady)
 	if !platformv1alpha1.IsEnvironmentReady(&retrying) || condition == nil || condition.Reason != "SandboxdReady" {
 		t.Fatalf("recovered status = %#v", retrying.Status)
+	}
+}
+
+func TestPublishedPodAbsencePreservesResumeAcrossPrePodGateFailure(t *testing.T) {
+	scheme := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{corev1.AddToScheme, networkingv1.AddToScheme, platformv1alpha1.AddToScheme} {
+		if err := add(scheme); err != nil {
+			t.Fatal(err)
+		}
+	}
+	lastActive := metav1.NewTime(time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC))
+	env := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default", UID: "environment-uid", Generation: 2, Finalizers: []string{environmentFinalizer}},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "small", ProjectRef: "project"},
+		Status: platformv1alpha1.EnvironmentStatus{ExecutionGeneration: 1, Phase: platformv1alpha1.EnvironmentPhaseReady, PodName: "env-test",
+			Endpoints: platformv1alpha1.EnvironmentEndpoints{Sandboxd: "10.0.0.1:50051"}, LastActiveAt: &lastActive},
+	}
+	template := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: env.Namespace, UID: "template-uid", Generation: 1}, Spec: platformv1alpha1.EnvironmentTemplateSpec{Image: "example/environment:test", Size: "small"}}
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "project", Namespace: env.Namespace, UID: "project-uid", Generation: 1}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/example/repo"}}}
+	setTestProvisioningSnapshot(env, template, project)
+	oldCredentials := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: envCredentialName(env), Namespace: env.Namespace, UID: "old-secret", Annotations: map[string]string{sandboxdauth.IdentityAnnotation: "old.sandboxd.swe.dev"}}, Data: map[string][]byte{sandboxdauth.ProcessTokenKey: []byte("old-process-token")}}
+	if err := controllerutil.SetControllerReference(env, oldCredentials, scheme); err != nil {
+		t.Fatal(err)
+	}
+	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(env, template, project, oldCredentials).Build()
+	transient := apierrors.NewServiceUnavailable("temporary Template gate failure")
+	failTemplateGet := true
+	intercepted := interceptor.NewClient(baseClient, interceptor.Funcs{Get: func(ctx context.Context, underlying client.WithWatch, key client.ObjectKey, object client.Object, options ...client.GetOption) error {
+		if failTemplateGet && key == client.ObjectKeyFromObject(template) {
+			failTemplateGet = false
+			return transient
+		}
+		return underlying.Get(ctx, key, object, options...)
+	}})
+	reconciler := &EnvironmentReconciler{Client: intercepted, Scheme: scheme}
+	request := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(env)}
+	degradedPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: envPodName(env), Namespace: env.Namespace, Annotations: map[string]string{executionGenerationAnnotation: "1", projectAnnotation: env.Spec.ProjectRef}}, Status: corev1.PodStatus{
+		Phase: corev1.PodRunning, PodIP: "10.0.0.1", Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionFalse}},
+	}}
+	if err := reconciler.syncStatus(context.Background(), env, degradedPod); err != nil {
+		t.Fatal(err)
+	}
+	var current platformv1alpha1.Environment
+	if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(env), &current); err != nil {
+		t.Fatal(err)
+	}
+	if current.Status.Phase != platformv1alpha1.EnvironmentPhaseCreating || current.Status.PodName != envPodName(env) || current.Status.Endpoints.Sandboxd != "" || current.Status.LastActiveAt == nil {
+		t.Fatalf("degraded established execution status = %#v", current.Status)
+	}
+	if _, err := reconciler.Reconcile(context.Background(), request); !stderrors.Is(err, transient) {
+		t.Fatalf("pre-Pod gate Reconcile() error = %v, want transient", err)
+	}
+	if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(env), &current); err != nil {
+		t.Fatal(err)
+	}
+	if current.Status.Phase != platformv1alpha1.EnvironmentPhaseResuming || current.Status.PodName != "" || current.Status.Endpoints.Sandboxd != "" {
+		t.Fatalf("pre-Pod gate failure status = %#v, want unpublished Resuming", current.Status)
+	}
+	var replacement corev1.Pod
+	for i := 0; i < 20; i++ {
+		if _, err := reconciler.Reconcile(context.Background(), request); err != nil {
+			t.Fatalf("replacement Reconcile() %d: %v", i+1, err)
+		}
+		if err := baseClient.Get(context.Background(), client.ObjectKey{Namespace: env.Namespace, Name: envPodName(env)}, &replacement); err == nil {
+			break
+		} else if !apierrors.IsNotFound(err) {
+			t.Fatal(err)
+		}
+	}
+	if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(env), &current); err != nil {
+		t.Fatal(err)
+	}
+	var rotated corev1.Secret
+	if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(oldCredentials), &rotated); err != nil {
+		t.Fatal(err)
+	}
+	if replacement.Name == "" || current.Status.ExecutionGeneration != 2 || replacement.Annotations[executionGenerationAnnotation] != "2" ||
+		len(replacement.Spec.InitContainers) != 2 || !slices.ContainsFunc(replacement.Spec.InitContainers[1].Env, func(variable corev1.EnvVar) bool { return variable.Name == "SWE_RESUMING" && variable.Value == "true" }) ||
+		rotated.Annotations[sandboxdauth.IdentityAnnotation] == oldCredentials.Annotations[sandboxdauth.IdentityAnnotation] || string(rotated.Data[sandboxdauth.ProcessTokenKey]) == "old-process-token" {
+		t.Fatalf("replacement = %#v, status = %#v, credentials = %#v", replacement, current.Status, rotated.ObjectMeta)
+	}
+}
+
+func TestResumeReplacementRequiresEstablishedActiveExecution(t *testing.T) {
+	lastActive := metav1.Now()
+	for _, test := range []struct {
+		name  string
+		phase platformv1alpha1.EnvironmentPhase
+		pod   string
+		last  *metav1.Time
+		want  bool
+	}{
+		{name: "degraded established execution", phase: platformv1alpha1.EnvironmentPhaseCreating, pod: "env-test", last: &lastActive, want: true},
+		{name: "never ready creating", phase: platformv1alpha1.EnvironmentPhaseCreating, pod: "env-test"},
+		{name: "project promotion setup", phase: platformv1alpha1.EnvironmentPhaseSetup, pod: "env-test", last: &lastActive},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			env := &platformv1alpha1.Environment{Status: platformv1alpha1.EnvironmentStatus{Phase: test.phase, PodName: test.pod, LastActiveAt: test.last}}
+			if got := isResumeReplacement(env); got != test.want {
+				t.Fatalf("isResumeReplacement() = %t, want %t", got, test.want)
+			}
+		})
 	}
 }
 

--- a/internal/controllers/environment_status.go
+++ b/internal/controllers/environment_status.go
@@ -32,9 +32,17 @@ func (r *EnvironmentReconciler) syncStatus(ctx context.Context, env *platformv1a
 		}
 	}
 	executionChanged := false
+	projectChanged := false
 	err := r.updateEnvironmentStatus(ctx, env, func(current *platformv1alpha1.Environment) {
 		if current.Status.ExecutionGeneration != executionGeneration {
 			executionChanged = true
+			return
+		}
+		if pod.Annotations[projectAnnotation] != current.Spec.ProjectRef {
+			projectChanged = true
+			reason, message := phaseReadiness(platformv1alpha1.EnvironmentPhaseSetup)
+			applyEnvironmentStatus(current, platformv1alpha1.EnvironmentPhaseSetup, "", "", reason, message, current.Status.LastActiveAt)
+			clearChildOwnershipCollision(current)
 			return
 		}
 		applyEnvironmentStatus(current, phase, pod.Name, sandboxdEndpoint, reason, message, env.Status.LastActiveAt)
@@ -51,7 +59,7 @@ func (r *EnvironmentReconciler) syncStatus(ctx context.Context, env *platformv1a
 	if err != nil {
 		return err
 	}
-	if executionChanged {
+	if executionChanged || projectChanged {
 		return errEnvironmentExecutionChanged
 	}
 	return nil
@@ -66,8 +74,13 @@ func environmentImageID(pod *corev1.Pod) string {
 	return ""
 }
 
-func environmentPodState(env *platformv1alpha1.Environment, pod *corev1.Pod) (platformv1alpha1.EnvironmentPhase, string, string) {
+func environmentPodState(env *platformv1alpha1.Environment, pod *corev1.Pod) (phase platformv1alpha1.EnvironmentPhase, reason, message string) {
 	resuming := podIsResume(pod) || env.Status.Phase == platformv1alpha1.EnvironmentPhaseResuming
+	defer func() {
+		if resuming && phase != platformv1alpha1.EnvironmentPhaseReady {
+			phase = platformv1alpha1.EnvironmentPhaseResuming
+		}
+	}()
 	for _, condition := range pod.Status.Conditions {
 		if condition.Type == corev1.PodScheduled && condition.Status == corev1.ConditionFalse && condition.Reason == corev1.PodReasonUnschedulable {
 			return platformv1alpha1.EnvironmentPhaseCreating, "Unschedulable", messageOr(condition.Message, "the scheduler cannot currently place the environment pod")
@@ -201,7 +214,11 @@ func (r *EnvironmentReconciler) fail(ctx context.Context, env *platformv1alpha1.
 		reason = "ResourceCollision"
 	}
 	statusErr := r.updateEnvironmentStatus(ctx, env, func(current *platformv1alpha1.Environment) {
-		applyEnvironmentStatus(current, phase, "", "", reason, err.Error(), env.Status.LastActiveAt)
+		currentPhase := phase
+		if reason == "OperationalError" && isResumeReplacement(current) {
+			currentPhase = platformv1alpha1.EnvironmentPhaseResuming
+		}
+		applyEnvironmentStatus(current, currentPhase, "", "", reason, err.Error(), env.Status.LastActiveAt)
 		if stderrors.As(err, &collision) {
 			apimeta.SetStatusCondition(&current.Status.Conditions, metav1.Condition{
 				Type:               "ChildOwnershipConflict",


### PR DESCRIPTION
## Summary

- run e2e on kind with pinned Calico instead of non-enforcing kindnet
- prove the existing sandboxd ingress NetworkPolicy allows the exact system-component identity and denies a Project-namespace pod, with a successful connection as the positive control
- document that this fixture is narrow CI evidence, not production CNI attestation or effective-isolation status

This is a non-overlapping #10 slice. It does not implement #68's default-deny egress/proxy path, does not change `egressAllowlist` handling, and does not claim RuntimeClass or production CNI enforcement.

## Validation

- `make test`
- `make vet`
- `bash -n hack/e2e.sh`
- `git diff --check`
- `helm lint charts/swe-platform --values charts/swe-platform/values-kind.yaml`
- `helm template swe-platform charts/swe-platform --namespace swe-platform-system --values charts/swe-platform/values-kind.yaml`
- `actionlint .github/workflows/e2e.yaml`

The live Calico/kind dataplane path requires Docker and is exercised by this PR's e2e workflow; Docker is unavailable in the development orb.

Refs #10. Related #68.
