### PR TITLE
Add executable BYOC operations runbooks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,6 +107,9 @@ jobs:
       - name: Rendered Helm RBAC boundaries
         run: ./hack/helm-rbac_test.sh
 
+      - name: BYOC preset validation
+        run: ./hack/validate-byoc_test.sh
+
       - name: Generated code is current
         run: |
           make generate manifests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,10 +113,11 @@ runs both via `make` targets:
 - **Local operator:** `make run` requires explicit `RUN_TENANCY_MODE`,
   `RUN_SYSTEM_NAMESPACE`, and `RUN_INSTALLATION_NAME`; scoped mode also takes a
   space-separated `RUN_TENANCY_NAMESPACES` list.
-- **Unit tests:** `make test` (including rendered Helm RBAC and Argo port-forward checks) · **Vet:** `make vet`. PostgreSQL transcript/session integration tests
+- **Unit tests:** `make test` (including rendered Helm RBAC, Argo port-forward, and BYOC
+  production-preset checks) · **Vet:** `make vet`. PostgreSQL transcript/session integration tests
   run when `SWE_TEST_POSTGRES_URL` points to a disposable database; CI supplies PostgreSQL 17.
   The required `build-test` CI job runs the root and sandboxd Go suites plus
-  `./hack/argocd-port-forward_test.sh` and `./hack/helm-rbac_test.sh`, mirroring `make test`.
+  the three shell checks above, mirroring `make test`.
 - **Operations console:** from `ui/`, install with `npm ci`; use `npm run lint`,
   `npm run typecheck`, `npm test -- --run`, and `npm run build`. Start the standalone
   Vite development server with `npm run dev`. Production uses `make ui-build`

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -581,10 +581,13 @@ multi-replica or control-plane HA claim is made.
   `appVersion` images, explicitly select PostgreSQL sessions, require out-of-band PostgreSQL
   and session-keyring Secrets, and default to scoped mode with no Project namespaces. GKE
   selects `gvisor`; k3s and EKS use the cluster default runtime unless explicitly overridden.
+  Each coordinated image also accepts a validated `sha256:` manifest digest that takes
+  precedence over its tag, allowing a publish workflow release manifest to pin exact images.
 
 CI builds, vets, and tests both Go modules, runs PostgreSQL transcript/session integration tests,
 checks UI lint/type/tests/build, exercises focused sandboxd Windows portability, verifies
-generated CRDs/chart copies, and lints/renders every preset. The kind acceptance workflow
+generated CRDs/chart copies, lints/renders every preset, and exercises the BYOC production-preset
+validator's render, preflight, and installed contracts. The kind acceptance workflow
 builds and loads local images and covers CRD upgrade, scoped system/Project topology,
 onboarding claims/catalog/baseline, two-release isolation, retained offboarding,
 Runs/warm pools/lifecycle, adapters and process-scoped credentials, TokenReview/SAR and browser

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ test: ## Run unit tests in both modules
 	cd sandboxd && go test ./...
 	./hack/argocd-port-forward_test.sh
 	./hack/helm-rbac_test.sh
+	./hack/validate-byoc_test.sh
 
 .PHONY: vet
 vet: ## Run go vet in both modules

--- a/charts/swe-platform/BYOC.md
+++ b/charts/swe-platform/BYOC.md
@@ -185,13 +185,7 @@ advertised isolation.
 ./hack/validate-byoc.sh preflight "$PROVIDER"
 
 IMAGE_ARGS=()
-if test -n "${SWE_RELEASE_MANIFEST:-}"; then
-  IMAGE_ARGS=(
-    --set-string "image.digest=$(jq -r '.images.operator.digest' "$SWE_RELEASE_MANIFEST")"
-    --set-string "controlPlane.image.digest=$(jq -r '.images["control-plane"].digest' "$SWE_RELEASE_MANIFEST")"
-    --set-string "environmentImage.digest=$(jq -r '.images["env-base"].digest' "$SWE_RELEASE_MANIFEST")"
-  )
-fi
+mapfile -t IMAGE_ARGS < <(./hack/validate-byoc.sh image-args "$PROVIDER")
 helm upgrade --install "$SWE_RELEASE" ./charts/swe-platform \
   --namespace "$SWE_SYSTEM_NAMESPACE" \
   --values "./charts/swe-platform/values-$PROVIDER.yaml" \
@@ -202,7 +196,8 @@ helm upgrade --install "$SWE_RELEASE" ./charts/swe-platform \
 ```
 
 The first scoped install must keep `tenancy.namespaces: []`. Do not use `trusted-admin` as a
-shortcut.
+shortcut. `image-args` is the single source for both release-manifest digest pins and the
+traceable `SWE_IMAGE_TAG` fallback; do not reconstruct these overrides separately.
 
 ### 3. Onboard and activate a Project
 
@@ -237,7 +232,8 @@ existing multi-Project installation.
 
 1. Record `helm get values "$SWE_RELEASE" -n "$SWE_SYSTEM_NAMESPACE" --all` and the current
    commit/release manifest. Verify the target commit's publish and CI workflows, download its
-   release manifest, reconstruct `IMAGE_ARGS` with the install snippet, and run `render`.
+   release manifest, reconstruct `IMAGE_ARGS` with the `image-args` command above, and run
+   `render`.
 2. Take and verify the PostgreSQL backup below. Confirm the backed-up keyring contains every key
    required by the one-hour session TTL and rollback window.
 3. Review the target preset and all private values. Rerun `project onboard` for each active

--- a/charts/swe-platform/BYOC.md
+++ b/charts/swe-platform/BYOC.md
@@ -1,0 +1,407 @@
+# BYOC operator runbooks
+
+These runbooks operate the current k3s, GKE, and EKS Helm presets in a customer-owned
+Kubernetes cluster. They cover installation, scoped Project onboarding/offboarding, upgrades,
+PostgreSQL backup/restore, and first-response incidents. Commands require a dedicated PostgreSQL
+database (with its own role-owned schema/search path), Bash, and Kubernetes 1.33 or newer.
+
+> **Security status:** these presets are deployable baselines, not a production-security
+> certification or a hosted service. Default-deny egress and its authenticated proxy are not
+> implemented ([#68](https://github.com/Chris-Cullins/swe-platform/issues/68)); the complete
+> credential and fail-closed isolation contracts remain open
+> ([#9](https://github.com/Chris-Cullins/swe-platform/issues/9),
+> [#10](https://github.com/Chris-Cullins/swe-platform/issues/10)). Environment egress is
+> unrestricted unless the customer supplies an independent cluster control, and a non-empty
+> `Project.spec.egressAllowlist` is rejected rather than silently ignored.
+
+The current chart provisions only the Pod backend with the Linux `env-base` image. Native
+Windows Environments, PowerShell `.ps1` setup/resume hooks, and ConPTY terminals are unsupported;
+sandboxd's Windows terminal selection fails closed until a real ConPTY backend exists. These
+runbooks must not be adapted into a Windows-hosted offering by changing node selectors or images.
+
+## Choose and pin an input
+
+The repository does not currently publish a Helm package or GitHub Release. The image workflow
+publishes coordinated `sha-<short SHA>` image tags for each successful main build and stores a
+workflow artifact containing all three image digests. Therefore a latest-main installation must
+use an exact commit checkout and its successful `publish-images` run, never the mutable `latest`
+tag. A tagged release may instead use the chart's `appVersion` defaults.
+
+```sh
+set -euo pipefail
+git clone https://github.com/Chris-Cullins/swe-platform.git
+cd swe-platform
+export TARGET_COMMIT=0123456789abcdef0123456789abcdef01234567 # replace with approved full SHA
+[[ "$TARGET_COMMIT" =~ ^[0-9a-f]{40}$ ]]
+git checkout "$TARGET_COMMIT"
+COMMIT="$(git rev-parse HEAD)"
+RUN_ID="$(gh run list --workflow publish-images.yaml --commit "$COMMIT" \
+  --json databaseId,status,conclusion \
+  --jq '[.[] | select(.status == "completed" and .conclusion == "success")][0].databaseId')"
+test -n "$RUN_ID" -a "$RUN_ID" != null
+CI_RUN_ID="$(gh run list --workflow ci.yaml --commit "$COMMIT" \
+  --json databaseId,status,conclusion \
+  --jq '[.[] | select(.status == "completed" and .conclusion == "success")][0].databaseId')"
+test -n "$CI_RUN_ID" -a "$CI_RUN_ID" != null
+mkdir -p .release
+RELEASE_DIR="$(mktemp -d ".release/${COMMIT}.XXXXXX")"
+gh run download "$RUN_ID" --pattern "swe-platform-release-*-$COMMIT" --dir "$RELEASE_DIR"
+mapfile -t manifests < <(find "$RELEASE_DIR" -name release-manifest.json -type f)
+test "${#manifests[@]}" -eq 1
+export SWE_RELEASE_MANIFEST="${manifests[0]}"
+test -s "$SWE_RELEASE_MANIFEST"
+```
+
+Retain that release manifest with the exact chart checkout and private values; Actions artifacts
+expire. The validator reads all three digests and makes the chart render
+`repository@sha256:...`. The artifact name contains the source ref and full SHA; verify it is the
+exact commit selected above. Also require the exact commit's normal `ci` workflow to be green.
+
+Set common values for every procedure:
+
+```sh
+export PROVIDER=k3s                 # exactly one of: k3s, gke, eks
+export SWE_SYSTEM_NAMESPACE=swe-platform-system
+export SWE_RELEASE=swe-platform
+export PRIVATE_VALUES=/secure/path/swe-platform-values.yaml
+export SWE_PRIVATE_VALUES="$PRIVATE_VALUES"
+export POSTGRES_SECRET=swe-platform-postgres
+export POSTGRES_SECRET_KEY=url
+export KEYRING_SECRET=swe-platform-session-keyring
+export KEYRING_SECRET_KEY=keyring.json
+test -s "$PRIVATE_VALUES"          # persist tenancy.namespaces and local overrides here
+grep -q 'mode: scoped' "$PRIVATE_VALUES"
+make build-cli
+export PATH="$PWD/bin:$PATH"
+./hack/validate-byoc.sh render "$PROVIDER"
+```
+
+Do not store database URLs, session keys, bootstrap tokens, or agent keys in Helm values.
+A runbook installation must not set `nameOverride` or `fullnameOverride`; the recovery commands
+use the chart's default resource names.
+A minimal initial private values file is:
+
+```yaml
+tenancy:
+  mode: scoped
+  namespaces: []
+```
+
+## Provider runbooks
+
+All providers require a default `ReadWriteOnce` StorageClass, an enforcing CNI for the chart's
+ingress NetworkPolicies, outbound access to GHCR for image pulls, and workload outbound access
+needed by Git, setup/package managers, and the selected agent provider. That outbound access is
+not constrained by the platform today.
+
+### k3s
+
+Use `values-k3s.yaml`. Confirm that the installed k3s release supplies Kubernetes 1.33 or newer
+and a default local-path or customer-selected durable StorageClass. k3s does not ship gVisor;
+this preset deliberately runs Environment pods with the cluster's default OCI runtime. Decide
+whether that isolation is acceptable before admitting untrusted repositories.
+
+```sh
+export PROVIDER=k3s
+kubectl get nodes -o wide
+kubectl get storageclass
+```
+
+### GKE
+
+Use `values-gke.yaml` only on a cluster whose Environment nodes have GKE Sandbox enabled. The
+preset names `RuntimeClass/gvisor`; the operator verifies that exact object exists, but cannot
+prove handler installation or runtime isolation. Test GKE Sandbox on eligible nodes separately.
+
+```sh
+export PROVIDER=gke
+kubectl get runtimeclass gvisor
+kubectl get nodes -L cloud.google.com/gke-nodepool
+```
+
+Ensure scheduling configuration places Environment pods on Sandbox-capable nodes if the cluster
+also has ordinary node pools. The checked-in preset does not select a node pool.
+
+### EKS
+
+Use `values-eks.yaml`. Install and operate the EBS CSI driver and mark the intended EBS
+StorageClass as default before onboarding Projects. EKS has no standard gVisor RuntimeClass;
+the preset deliberately uses the cluster default runtime unless the administrator adds a tested
+RuntimeClass to the catalog Template override.
+
+```sh
+export PROVIDER=eks
+kubectl -n kube-system get deployment ebs-csi-controller
+kubectl get storageclass
+```
+
+## Install
+
+### 1. Prepare external state
+
+Create a dedicated PostgreSQL database. Its role needs normal table DML and
+`CREATE`/`ALTER` on its own schema because the control plane applies ordered migrations at
+startup. Configure TLS verification appropriate to the database provider; do not use
+`sslmode=disable` outside disposable tests.
+
+Create the namespace and Secrets without committing their values:
+
+```sh
+kubectl create namespace "$SWE_SYSTEM_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+read -rsp 'PostgreSQL URL: ' SWE_POSTGRES_URL; echo
+printf %s "$SWE_POSTGRES_URL" | kubectl -n "$SWE_SYSTEM_NAMESPACE" create secret generic \
+  "$POSTGRES_SECRET" --from-file="$POSTGRES_SECRET_KEY=/dev/stdin" \
+  --dry-run=client -o yaml | kubectl apply -f -
+unset SWE_POSTGRES_URL
+
+umask 077
+KEYRING_DIR="$(mktemp -d)"
+trap 'rm -rf "$KEYRING_DIR"' EXIT
+KEYRING_FILE="$KEYRING_DIR/keyring.json"
+KEY_ID="initial-$(date -u +%Y%m%dT%H%M%SZ)"
+openssl rand 32 | base64 | tr '+/' '-_' | tr -d '=\n' | \
+  jq -Rs --arg id "$KEY_ID" \
+  '{version:1,activeKeyId:$id,keys:[{id:$id,masterKey:.}]}' >"$KEYRING_FILE"
+kubectl -n "$SWE_SYSTEM_NAMESPACE" create secret generic "$KEYRING_SECRET" \
+  --from-file="$KEYRING_SECRET_KEY=$KEYRING_FILE" --dry-run=client -o yaml | kubectl apply -f -
+# Transfer the keyring into the customer secret backup system before deleting this file.
+rm -rf "$KEYRING_DIR"
+trap - EXIT
+unset KEYRING_DIR KEYRING_FILE KEY_ID
+```
+
+The database and keyring must be backed up under separate access controls. A database-plus-
+keyring disclosure can recover encrypted browser bearer credentials.
+
+### 2. Validate and install the empty scoped release
+
+`preflight` reads Secret keys only to confirm that non-empty data exists; it never prints or
+decodes their values. It checks Kubernetes version, the NetworkPolicy API, a default
+StorageClass, and GKE's named RuntimeClass. It cannot prove that a CNI or runtime enforces the
+advertised isolation.
+
+```sh
+./hack/validate-byoc.sh preflight "$PROVIDER"
+
+IMAGE_ARGS=()
+if test -n "${SWE_RELEASE_MANIFEST:-}"; then
+  IMAGE_ARGS=(
+    --set-string "image.digest=$(jq -r '.images.operator.digest' "$SWE_RELEASE_MANIFEST")"
+    --set-string "controlPlane.image.digest=$(jq -r '.images["control-plane"].digest' "$SWE_RELEASE_MANIFEST")"
+    --set-string "environmentImage.digest=$(jq -r '.images["env-base"].digest' "$SWE_RELEASE_MANIFEST")"
+  )
+fi
+helm upgrade --install "$SWE_RELEASE" ./charts/swe-platform \
+  --namespace "$SWE_SYSTEM_NAMESPACE" \
+  --values "./charts/swe-platform/values-$PROVIDER.yaml" \
+  --values "$PRIVATE_VALUES" \
+  "${IMAGE_ARGS[@]}" \
+  --wait --timeout 10m
+./hack/validate-byoc.sh installed "$PROVIDER"
+```
+
+The first scoped install must keep `tenancy.namespaces: []`. Do not use `trusted-admin` as a
+shortcut.
+
+### 3. Onboard and activate a Project
+
+Choose every quota explicitly, then create or deliberately adopt one dedicated namespace:
+
+```sh
+export PROJECT_NAMESPACE=my-project
+export PROJECT_NAME=my-project
+export INSTALLATION="$SWE_RELEASE-swe-platform"
+
+swe --namespace "$PROJECT_NAMESPACE" project onboard "$PROJECT_NAME" \
+  --system-namespace "$SWE_SYSTEM_NAMESPACE" --installation "$INSTALLATION" \
+  --repository https://github.com/example/project.git \
+  --default-template medium --template medium \
+  --quota-hard requests.cpu=8 \
+  --quota-hard requests.memory=32Gi \
+  --quota-hard requests.storage=200Gi \
+  --quota-hard persistentvolumeclaims=20 \
+  --quota-hard pods=20 \
+  --quota-hard secrets=50 \
+  --quota-hard count/runs.swe.dev=100 \
+  --quota-hard count/environments.swe.dev=20 \
+  --quota-hard count/agentcredentialprofiles.swe.dev=20
+```
+
+Replace the example quotas with approved customer limits. Add the namespace to the complete
+`tenancy.namespaces` list in `$PRIVATE_VALUES`, run the Helm command from step 2 again, and run
+`installed` validation. Never replace the complete list with an ad-hoc one-item `--set` on an
+existing multi-Project installation.
+
+## Upgrade
+
+1. Record `helm get values "$SWE_RELEASE" -n "$SWE_SYSTEM_NAMESPACE" --all` and the current
+   commit/release manifest. Verify the target commit's publish and CI workflows, download its
+   release manifest, reconstruct `IMAGE_ARGS` with the install snippet, and run `render`.
+2. Take and verify the PostgreSQL backup below. Confirm the backed-up keyring contains every key
+   required by the one-hour session TTL and rollback window.
+3. Review the target preset and all private values. Rerun `project onboard` for each active
+   Project when catalog sources changed; that explicitly synchronizes managed Template copies.
+4. Apply CRDs first, then upgrade. Helm does not upgrade files under `crds/`.
+
+```sh
+kubectl apply --server-side --force-conflicts -f ./charts/swe-platform/crds
+helm upgrade "$SWE_RELEASE" ./charts/swe-platform \
+  --namespace "$SWE_SYSTEM_NAMESPACE" \
+  --values "./charts/swe-platform/values-$PROVIDER.yaml" \
+  --values "$PRIVATE_VALUES" \
+  "${IMAGE_ARGS[@]}" \
+  --wait --timeout 10m
+./hack/validate-byoc.sh installed "$PROVIDER"
+```
+
+The operator and singleton control plane use `Recreate`; expect open SSE/WebSocket connections
+to reconnect. PostgreSQL preserves transcripts and browser sessions, but this is not control-
+plane HA. `helm rollback` does not downgrade CRDs or database migrations. Roll forward by
+default. Use Helm rollback only when that specific older release documents compatibility with
+the already-forward CRDs/database and the keyring retains every key it may read.
+
+## PostgreSQL backup and restore
+
+This database contains transcript events, cursor/idempotency metadata, migration records, and
+encrypted browser sessions. Back up the complete dedicated database rather than selecting
+name-only Run rows. PostgreSQL backup does not include Kubernetes CRDs, Namespace claims,
+workspace PVCs, chart values, or secret material.
+
+### Backup and test
+
+```sh
+umask 077
+export BACKUP="swe-platform-$(date -u +%Y%m%dT%H%M%SZ).dump"
+read -rsp 'PostgreSQL URL: ' SWE_POSTGRES_URL; echo
+PGDATABASE="$SWE_POSTGRES_URL" pg_dump --format=custom --no-owner --no-acl \
+  --file="$BACKUP"
+pg_restore --list "$BACKUP" >/dev/null
+sha256sum "$BACKUP" >"$BACKUP.sha256"
+unset SWE_POSTGRES_URL
+```
+
+Copy the dump, checksum, exact chart/commit, private values, and separately protected keyring to
+the customer backup system. A successful `pg_restore --list` checks archive readability, not a
+recovery. Regularly restore into an isolated empty database and run a disposable control plane
+against it; define customer-owned RPO/RTO from that exercise.
+
+### Restore the complete application database
+
+Restore into a new empty dedicated database; do not overwrite a live database. Keep the
+control plane stopped while restoring, then change `swe-platform-postgres` to the recovered URL.
+The operator may remain running, but transcript API calls fail while the control plane is down.
+
+```bash
+(
+set -euo pipefail
+: "${BACKUP:?set BACKUP to the recovered dump}"
+: "${RECOVERY_KEYRING_FILE:?set RECOVERY_KEYRING_FILE to the matching keyring backup}"
+test -s "$BACKUP"
+test -s "$BACKUP.sha256"
+test -s "$RECOVERY_KEYRING_FILE"
+sha256sum --check "$BACKUP.sha256"
+CONTROL_PLANE="$SWE_RELEASE-swe-platform-control-plane"
+kubectl -n "$SWE_SYSTEM_NAMESPACE" scale deployment "$CONTROL_PLANE" --replicas=0
+kubectl -n "$SWE_SYSTEM_NAMESPACE" wait pod \
+  -l "app.kubernetes.io/instance=$SWE_RELEASE,app.kubernetes.io/component=control-plane" \
+  --for=delete --timeout=5m
+read -rsp 'EMPTY recovery PostgreSQL URL: ' RECOVERY_POSTGRES_URL; echo
+relation_count="$(PGDATABASE="$RECOVERY_POSTGRES_URL" psql -XAt -v ON_ERROR_STOP=1 \
+  -c "SELECT count(*) FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname <> 'information_schema' AND n.nspname NOT LIKE 'pg\\_%' ESCAPE '\\';")"
+test "$relation_count" = 0
+PGDATABASE="$RECOVERY_POSTGRES_URL" pg_restore --single-transaction --exit-on-error \
+  --no-owner --no-acl "$BACKUP"
+PGDATABASE="$RECOVERY_POSTGRES_URL" psql -XAt -v ON_ERROR_STOP=1 \
+  -c 'SELECT count(*) FROM transcript_schema_migrations;' >/dev/null
+
+kubectl -n "$SWE_SYSTEM_NAMESPACE" create secret generic "$KEYRING_SECRET" \
+  --from-file="$KEYRING_SECRET_KEY=$RECOVERY_KEYRING_FILE" \
+  --dry-run=client -o yaml | kubectl apply -f -
+printf %s "$RECOVERY_POSTGRES_URL" | kubectl -n "$SWE_SYSTEM_NAMESPACE" create secret generic \
+  "$POSTGRES_SECRET" --from-file="$POSTGRES_SECRET_KEY=/dev/stdin" \
+  --dry-run=client -o yaml | kubectl apply -f -
+unset RECOVERY_POSTGRES_URL
+kubectl -n "$SWE_SYSTEM_NAMESPACE" scale deployment "$CONTROL_PLANE" --replicas=1
+kubectl -n "$SWE_SYSTEM_NAMESPACE" rollout status deployment "$CONTROL_PLANE" --timeout=5m
+./hack/validate-byoc.sh installed "$PROVIDER"
+)
+```
+
+Startup applies any newer embedded migrations. Restore the matching keyring before startup or
+encrypted sessions using absent keys will fail. A database restore does not reconstruct Runs,
+Environments, Namespace claims, or workspaces. There is no tested coordinated cluster-loss
+restore: back up Kubernetes/etcd and PVCs with provider-supported tools and test that procedure
+under the customer's own recovery objectives.
+
+## Offboard without deleting customer data
+
+```sh
+swe --namespace "$PROJECT_NAMESPACE" project offboard "$PROJECT_NAME" \
+  --system-namespace "$SWE_SYSTEM_NAMESPACE" --installation "$INSTALLATION" \
+  --timeout 15m
+```
+
+Verify the Namespace is `fenced`, remove it from the complete `tenancy.namespaces` list, and run
+the normal Helm upgrade. Offboarding intentionally retains the Namespace, CRs, PVCs, credential
+profiles/Secrets, and transcripts. Purge is not implemented; direct Namespace, PVC, Secret, or
+name-only SQL deletion is not a supported platform purge.
+
+## Incident first response
+
+Preserve the exact commit, release manifest, `helm get values`, Kubernetes events, component logs,
+and object UIDs. Never paste Secret data into tickets or logs.
+
+| Symptom | Contain | Diagnose and recover |
+|---|---|---|
+| Control plane crash loop after install/upgrade | Leave it stopped; do not switch to memory sessions/transcripts | Check database reachability, migration errors, Secret key presence, and keyring validity; restore/roll back only under the upgrade constraints above |
+| Suspected agent API-key disclosure | Cancel affected Runs and hold their Environments | Rotate the upstream key, then `swe --namespace <project> credentials rotate <profile> --api-key-stdin`; transcripts are not guaranteed to redact a key |
+| Database-only disclosure | Restrict database access and rotate its credential | Database ciphertext does not alone reveal browser bearers, but treat transcript content as disclosed; update the PostgreSQL Secret and roll the control plane |
+| Database plus keyring or control-plane compromise | Stop/exclude the control plane and revoke underlying Kubernetes credentials | Invalidate browser sessions in the dedicated database, rotate database credentials and the session keyring, update both Secrets, then restart. Preserve evidence before destructive session invalidation |
+| Environment suspected compromised | Cancel its Run and apply an explicit Environment hold | Pod deletion/pause rotates sandboxd credentials but retained PVC and transcripts may contain attacker changes; preserve and investigate them before any customer-approved deletion |
+| Project removal | Run the supported offboard command | Wait for `fenced`, remove it from scoped values, and retain data. Do not improvise purge |
+
+NetworkPolicy API presence is not evidence that the CNI enforces policy. Until #68/#10 ship,
+network containment of an Environment requires customer-owned cluster controls and must not be
+described as a platform production guarantee.
+
+After evidence capture and explicit incident-authority approval, invalidate every browser
+session while the control plane is stopped with:
+
+```sh
+read -rsp 'PostgreSQL incident URL: ' INCIDENT_POSTGRES_URL; echo
+PGDATABASE="$INCIDENT_POSTGRES_URL" psql -X -v ON_ERROR_STOP=1 \
+  -c 'DELETE FROM browser_sessions;'
+unset INCIDENT_POSTGRES_URL
+```
+
+This does not revoke the underlying Kubernetes bearer credentials; revoke those at their issuer
+as a separate containment step. It also does not remove transcript evidence.
+
+## Hosted alpha: decisions required before implementation
+
+Issue #79 cannot safely create a shared hosted environment from the current BYOC chart. A
+maintainer must approve all of the following before infrastructure or customer onboarding:
+
+1. **Product and responsibility boundary:** hosted control plane vs fully hosted execution,
+   target customer/region, alpha limits, data ownership/residency, terms, support channel, and
+   whether untrusted repositories are admitted while #9/#10/#68 remain open.
+2. **Tenant and identity model:** organization/user identity provider, invitation and removal,
+   Kubernetes identity translation, Project ownership, administrator roles, audit requirements,
+   and the supported credential classes. Namespace-per-Project is the approved platform target;
+   no alternate shared-namespace boundary should be invented.
+3. **Infrastructure ownership:** cloud account/project, regions, cluster and node-pool topology,
+   enforcing CNI/runtime, PostgreSQL, DNS/TLS, registry access, secret/KMS ownership, egress
+   enforcement, and customer data separation.
+4. **Commercial controls:** billing owner, metering unit, quotas, abuse/spend limits, admission,
+   suspension, and customer offboarding/retention/deletion policy.
+5. **Operations:** named on-call owner, SLOs, monitoring/audit retention, vulnerability and
+   incident response, backup RPO/RTO with restore evidence, upgrades/rollback, capacity tests,
+   and disaster-recovery ownership.
+6. **Launch gates:** disposition of #9, #10, and #68; external threat/security review; supported
+   agent/Git credential paths; and a tested, exact-UID purge or an explicit alpha retention
+   contract acknowledging that purge is not implemented.
+
+Until those decisions are recorded, the coherent #79 deliverable is these customer-owned
+runbooks and their validator—not speculative shared infrastructure or a production-security
+claim.

--- a/charts/swe-platform/README.md
+++ b/charts/swe-platform/README.md
@@ -294,8 +294,14 @@ The production presets create a `medium` catalog source using the published `env
 onboarding creates each runnable Project-local Template copy. Operator, control-plane, and
 env-base tags default to the chart
 `appVersion`, keeping a released chart on one tested version set and making Helm rollback
-restore that set. Override all three tags with immutable release or SHA tags when testing
-a different coordinated set; `latest` and `dev` are development-only choices.
+restore that set. Override all three tags with a coordinated release or traceable SHA tag when
+testing a different set; `latest` and `dev` are development-only choices. Use digests below when
+the registry reference must be immutable.
+
+For an exact published build, set `image.digest`, `controlPlane.image.digest`, and
+`environmentImage.digest` to the three `sha256:` values in the publish workflow's release
+manifest. A digest takes precedence over its corresponding tag. The
+[`BYOC runbook`](BYOC.md#choose-and-pin-an-input) downloads and validates this artifact.
 
 Each image publish run emits a `swe-platform-release-*` artifact containing the chart
 version, app version, and the registry digest of every image for incident diagnosis and
@@ -583,6 +589,11 @@ and networking requirements that a BYOC operator needs beyond the [install](#ins
 [upgrade](#upgrade) procedures above. The acceptance criteria track
 [#79](https://github.com/Chris-Cullins/swe-platform/issues/79); the hosted offering alpha is
 out of scope here and requires separate maintainer product input.
+
+The executable, provider-specific procedures are in the
+[`BYOC operator runbooks`](BYOC.md). They pin latest-main images to an exact successful publish,
+run the checked-in validator, preserve scoped-tenancy ordering, and cover PostgreSQL backup,
+restore, and incident response without claiming production isolation.
 
 ### Active Run capacity
 

--- a/charts/swe-platform/templates/000-validate.yaml
+++ b/charts/swe-platform/templates/000-validate.yaml
@@ -18,6 +18,11 @@
 {{- else if .Values.controlPlane.sessions.keyringSecret.name -}}
   {{- fail "controlPlane.sessions.backend=memory must not set controlPlane.sessions.keyringSecret.name" -}}
 {{- end -}}
+{{- range $name, $image := dict "image" .Values.image "controlPlane.image" .Values.controlPlane.image "environmentImage" .Values.environmentImage -}}
+  {{- if and $image.digest (not (regexMatch "^sha256:[0-9a-f]{64}$" $image.digest)) -}}
+    {{- fail (printf "%s.digest must be a sha256 digest" $name) -}}
+  {{- end -}}
+{{- end -}}
 {{- $operatorMetricsPort := int .Values.operator.metrics.port -}}
 {{- $operatorHealthPort := int .Values.operator.health.port -}}
 {{- if or (lt $operatorMetricsPort 1) (gt $operatorMetricsPort 65535) -}}

--- a/charts/swe-platform/templates/_helpers.tpl
+++ b/charts/swe-platform/templates/_helpers.tpl
@@ -43,7 +43,11 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{- define "swe-platform.environmentImage" -}}
+{{- if .Values.environmentImage.digest -}}
+{{- printf "%s@%s" .Values.environmentImage.repository .Values.environmentImage.digest -}}
+{{- else -}}
 {{- printf "%s:%s" .Values.environmentImage.repository (.Values.environmentImage.tag | default .Chart.AppVersion) -}}
+{{- end -}}
 {{- end }}
 
 {{- define "swe-platform.tenancyMode" -}}

--- a/charts/swe-platform/templates/control-plane-deployment.yaml
+++ b/charts/swe-platform/templates/control-plane-deployment.yaml
@@ -35,7 +35,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: control-plane
-          image: "{{ .Values.controlPlane.image.repository }}:{{ .Values.controlPlane.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.controlPlane.image.repository }}{{ if .Values.controlPlane.image.digest }}@{{ .Values.controlPlane.image.digest }}{{ else }}:{{ .Values.controlPlane.image.tag | default .Chart.AppVersion }}{{ end }}"
           imagePullPolicy: {{ .Values.controlPlane.image.pullPolicy }}
           args:
             - --listen-address=:8080

--- a/charts/swe-platform/templates/deployment.yaml
+++ b/charts/swe-platform/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: operator
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}{{ if .Values.image.digest }}@{{ .Values.image.digest }}{{ else }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{ end }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --metrics-bind-address=:{{ int .Values.operator.metrics.port }}

--- a/charts/swe-platform/values.yaml
+++ b/charts/swe-platform/values.yaml
@@ -4,6 +4,8 @@ image:
   repository: ghcr.io/chris-cullins/swe-platform/operator
   # Defaults to Chart.appVersion so released charts select their coordinated release.
   tag: ""
+  # When set, takes precedence over tag and pins the exact published manifest.
+  digest: ""
   pullPolicy: IfNotPresent
 
 operator:
@@ -46,6 +48,7 @@ controlPlane:
     repository: ghcr.io/chris-cullins/swe-platform/control-plane
     # Defaults to Chart.appVersion.
     tag: ""
+    digest: ""
     pullPolicy: IfNotPresent
   auth:
     tokenAudience: swe-platform
@@ -121,6 +124,7 @@ affinity: {}
 environmentImage:
   repository: ghcr.io/chris-cullins/swe-platform/env-base
   tag: ""
+  digest: ""
 
 # Inert EnvironmentTemplate catalog sources created in the system/release
 # namespace. `swe project onboard` copies selected sources into a claimed

--- a/hack/validate-byoc.sh
+++ b/hack/validate-byoc.sh
@@ -8,8 +8,9 @@ RELEASE="${SWE_RELEASE:-swe-platform}"
 
 usage() {
 	cat <<'EOF'
-Usage: hack/validate-byoc.sh <render|preflight|installed> <k3s|gke|eks>
+Usage: hack/validate-byoc.sh <image-args|render|preflight|installed> <k3s|gke|eks>
 
+  image-args  print the validated image override arguments, one array element per line
   render      lint and render the selected production preset without a cluster
   preflight   render, then validate the current cluster's supported prerequisites
   installed   preflight, then validate the installed Helm release and workloads
@@ -41,10 +42,25 @@ contracts remain open in issues #68, #9, and #10.
 EOF
 }
 
+deployment_image() {
+	local component="$1"
+	awk -v RS='---' -v component="$component" '
+		/kind: Deployment/ && $0 ~ "app.kubernetes.io/component: " component {
+			for (i = 1; i <= NF; i++) if ($i == "image:") {gsub(/"/, "", $(i + 1)); print $(i + 1)}
+		}
+	'
+}
+
+template_images() {
+	awk -v RS='---' '/kind: EnvironmentTemplate/ {
+		for (i = 1; i <= NF; i++) if ($i == "image:") {gsub(/"/, "", $(i + 1)); print $(i + 1)}
+	}'
+}
+
 mode="${1:-}"
 provider="${2:-}"
 [[ $# -eq 2 ]] || { usage >&2; exit 2; }
-[[ "$mode" =~ ^(render|preflight|installed)$ ]] || fail "unknown mode: $mode"
+[[ "$mode" =~ ^(image-args|render|preflight|installed)$ ]] || fail "unknown mode: $mode"
 [[ "$provider" =~ ^(k3s|gke|eks)$ ]] || fail "unsupported provider preset: $provider"
 
 need helm
@@ -52,6 +68,7 @@ values="$CHART/values-$provider.yaml"
 [[ -r "$values" ]] || fail "preset not found: $values"
 
 helm_args=(--namespace "$SYSTEM_NAMESPACE" --values "$values")
+image_args=()
 if [[ -n "${SWE_PRIVATE_VALUES:-}" ]]; then
 	[[ -r "$SWE_PRIVATE_VALUES" ]] || fail "private values not found: $SWE_PRIVATE_VALUES"
 	helm_args+=(--values "$SWE_PRIVATE_VALUES")
@@ -64,18 +81,23 @@ if [[ -n "${SWE_RELEASE_MANIFEST:-}" ]]; then
 		digest="$(jq -er --arg image "$image" '.images[$image].digest | select(test("^sha256:[0-9a-f]{64}$"))' "$SWE_RELEASE_MANIFEST")" || fail "release manifest has no valid $image digest"
 		[[ "$repository" == "ghcr.io/chris-cullins/swe-platform/$image" ]] || fail "unexpected $image repository in release manifest: $repository"
 		case "$image" in
-		operator) helm_args+=(--set-string "image.digest=$digest") ;;
-		control-plane) helm_args+=(--set-string "controlPlane.image.digest=$digest") ;;
-		env-base) helm_args+=(--set-string "environmentImage.digest=$digest") ;;
+		operator) image_args+=(--set-string "image.digest=$digest") ;;
+		control-plane) image_args+=(--set-string "controlPlane.image.digest=$digest") ;;
+		env-base) image_args+=(--set-string "environmentImage.digest=$digest") ;;
 		esac
 	done
 elif [[ -n "${SWE_IMAGE_TAG:-}" ]]; then
 	[[ "$SWE_IMAGE_TAG" =~ ^sha-[0-9a-f]{7}$ ]] || fail "SWE_IMAGE_TAG must match sha-<7 lowercase hex>; use SWE_RELEASE_MANIFEST for immutable digest pinning"
-	helm_args+=(
+	image_args+=(
 		--set-string "image.tag=$SWE_IMAGE_TAG"
 		--set-string "controlPlane.image.tag=$SWE_IMAGE_TAG"
 		--set-string "environmentImage.tag=$SWE_IMAGE_TAG"
 	)
+fi
+helm_args+=("${image_args[@]}")
+if [[ "$mode" == image-args ]]; then
+	((${#image_args[@]} == 0)) || printf '%s\n' "${image_args[@]}"
+	exit 0
 fi
 
 helm lint "$CHART" --values "$values" >/dev/null
@@ -89,15 +111,26 @@ keyring_secret="$(awk '/secretName:/{gsub(/[" ]/, "", $2); print $2; exit}' <<<"
 keyring_key="$(awk '/secretName:/{found=1; next} found && /key:/{value=($1 == "-" ? $3 : $2); gsub(/[" ]/, "", value); print value; exit}' <<<"$rendered")"
 [[ -n "$postgres_secret" && -n "$postgres_key" && -n "$keyring_secret" && -n "$keyring_key" ]] || fail "cannot resolve effective PostgreSQL/keyring Secret references"
 
-mapfile -t images < <(awk '$1 == "image:" {gsub(/"/, "", $2); print $2}' <<<"$rendered")
-[[ ${#images[@]} -eq 3 ]] || fail "expected exactly three coordinated images, found ${#images[@]}"
-for image in "${images[@]}"; do
+operator_image="$(deployment_image operator <<<"$rendered")"
+control_plane_image="$(deployment_image control-plane <<<"$rendered")"
+[[ -n "$operator_image" && "$operator_image" != *$'\n'* ]] || fail "expected exactly one operator image"
+[[ -n "$control_plane_image" && "$control_plane_image" != *$'\n'* ]] || fail "expected exactly one control-plane image"
+mapfile -t environment_images < <(template_images <<<"$rendered")
+for image in "$operator_image" "$control_plane_image" "${environment_images[@]}"; do
 	[[ "$image" != *:latest && "$image" != *:dev ]] || fail "mutable image rendered: $image"
 done
+if [[ "$provider" == gke ]]; then
+	bad_gke_templates="$(awk -v RS='---' '/kind: EnvironmentTemplate/ && $0 !~ /runtimeClass: gvisor([[:space:]]|$)/ {count++} END {print count+0}' <<<"$rendered")"
+	((bad_gke_templates == 0)) || fail "every effective GKE EnvironmentTemplate must select runtimeClass gvisor"
+fi
 if [[ -n "${SWE_RELEASE_MANIFEST:-}" ]]; then
-	for image in operator control-plane env-base; do
-		digest="$(jq -r --arg image "$image" '.images[$image].digest' "$SWE_RELEASE_MANIFEST")"
-		grep -q "ghcr.io/chris-cullins/swe-platform/$image@$digest" <<<"$rendered" || fail "$image is not pinned to its release-manifest digest"
+	operator_digest="$(jq -r '.images.operator.digest' "$SWE_RELEASE_MANIFEST")"
+	control_plane_digest="$(jq -r '.images["control-plane"].digest' "$SWE_RELEASE_MANIFEST")"
+	environment_digest="$(jq -r '.images["env-base"].digest' "$SWE_RELEASE_MANIFEST")"
+	[[ "$operator_image" == "ghcr.io/chris-cullins/swe-platform/operator@$operator_digest" ]] || fail "operator is not pinned to its release-manifest digest"
+	[[ "$control_plane_image" == "ghcr.io/chris-cullins/swe-platform/control-plane@$control_plane_digest" ]] || fail "control plane is not pinned to its release-manifest digest"
+	for image in "${environment_images[@]}"; do
+		[[ "$image" == "ghcr.io/chris-cullins/swe-platform/env-base@$environment_digest" ]] || fail "EnvironmentTemplate image is not pinned to the env-base release-manifest digest"
 	done
 fi
 
@@ -152,11 +185,14 @@ installed_keyring_secret="$(awk '/secretName:/{gsub(/[" ]/, "", $2); print $2; e
 installed_keyring_key="$(awk '/secretName:/{found=1; next} found && /key:/{value=($1 == "-" ? $3 : $2); gsub(/[" ]/, "", value); print value; exit}' <<<"$installed_manifest")"
 [[ "$installed_postgres_secret:$installed_postgres_key" == "$postgres_secret:$postgres_key" ]] || fail "installed PostgreSQL Secret reference differs from effective values"
 [[ "$installed_keyring_secret:$installed_keyring_key" == "$keyring_secret:$keyring_key" ]] || fail "installed keyring Secret reference differs from effective values"
-for image in "${images[@]}"; do
-	grep -Fq "$image" <<<"$installed_manifest" || fail "installed manifest does not use expected image $image"
-done
+installed_operator_image="$(deployment_image operator <<<"$installed_manifest")"
+installed_control_plane_image="$(deployment_image control-plane <<<"$installed_manifest")"
+mapfile -t installed_environment_images < <(template_images <<<"$installed_manifest")
+[[ "$installed_operator_image" == "$operator_image" ]] || fail "installed operator image differs from effective values"
+[[ "$installed_control_plane_image" == "$control_plane_image" ]] || fail "installed control-plane image differs from effective values"
+[[ "$(printf '%s\n' "${installed_environment_images[@]}" | sort)" == "$(printf '%s\n' "${environment_images[@]}" | sort)" ]] || fail "installed EnvironmentTemplate images differ from effective values"
 live_deployments="$(kubectl -n "$SYSTEM_NAMESPACE" get deployments -l "app.kubernetes.io/instance=$RELEASE" -o json)"
-expected_workload_images="$(printf '%s\n' "${images[@]}" | grep -E '/(operator|control-plane)(@|:)' | sort)"
+expected_workload_images="$(printf '%s\n' "$operator_image" "$control_plane_image" | sort)"
 live_workload_images="$(jq -r '.items[].spec.template.spec.containers[].image' <<<"$live_deployments" | sort)"
 [[ "$live_workload_images" == "$expected_workload_images" ]] || fail "live workload images differ from effective values"
 live_namespaces="$(jq -r '.items[].spec.template.spec.containers[].args[]? | select(startswith("--tenancy-namespace="))' <<<"$live_deployments" | sort)"

--- a/hack/validate-byoc.sh
+++ b/hack/validate-byoc.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CHART="${SWE_CHART:-$ROOT/charts/swe-platform}"
+SYSTEM_NAMESPACE="${SWE_SYSTEM_NAMESPACE:-swe-platform-system}"
+RELEASE="${SWE_RELEASE:-swe-platform}"
+
+usage() {
+	cat <<'EOF'
+Usage: hack/validate-byoc.sh <render|preflight|installed> <k3s|gke|eks>
+
+  render      lint and render the selected production preset without a cluster
+  preflight   render, then validate the current cluster's supported prerequisites
+  installed   preflight, then validate the installed Helm release and workloads
+
+Environment:
+  SWE_CHART             chart directory (default: charts/swe-platform)
+  SWE_SYSTEM_NAMESPACE system namespace (default: swe-platform-system)
+  SWE_RELEASE           Helm release name (default: swe-platform)
+  SWE_PRIVATE_VALUES    persisted site values file
+  SWE_RELEASE_MANIFEST  downloaded release-manifest.json for digest pinning
+  SWE_IMAGE_TAG         coordinated traceable tag fallback, exactly sha-<7 hex>
+EOF
+}
+
+fail() {
+	echo "ERROR: $*" >&2
+	exit 1
+}
+
+need() {
+	command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
+}
+
+warn_security_boundary() {
+	cat >&2 <<'EOF'
+WARNING: this validates deployability, not production isolation. Default-deny
+egress, the authenticated egress proxy, and the complete credential/isolation
+contracts remain open in issues #68, #9, and #10.
+EOF
+}
+
+mode="${1:-}"
+provider="${2:-}"
+[[ $# -eq 2 ]] || { usage >&2; exit 2; }
+[[ "$mode" =~ ^(render|preflight|installed)$ ]] || fail "unknown mode: $mode"
+[[ "$provider" =~ ^(k3s|gke|eks)$ ]] || fail "unsupported provider preset: $provider"
+
+need helm
+values="$CHART/values-$provider.yaml"
+[[ -r "$values" ]] || fail "preset not found: $values"
+
+helm_args=(--namespace "$SYSTEM_NAMESPACE" --values "$values")
+if [[ -n "${SWE_PRIVATE_VALUES:-}" ]]; then
+	[[ -r "$SWE_PRIVATE_VALUES" ]] || fail "private values not found: $SWE_PRIVATE_VALUES"
+	helm_args+=(--values "$SWE_PRIVATE_VALUES")
+fi
+if [[ -n "${SWE_RELEASE_MANIFEST:-}" ]]; then
+	need jq
+	[[ -r "$SWE_RELEASE_MANIFEST" ]] || fail "release manifest not found: $SWE_RELEASE_MANIFEST"
+	for image in operator control-plane env-base; do
+		repository="$(jq -er --arg image "$image" '.images[$image].repository' "$SWE_RELEASE_MANIFEST")" || fail "release manifest has no $image repository"
+		digest="$(jq -er --arg image "$image" '.images[$image].digest | select(test("^sha256:[0-9a-f]{64}$"))' "$SWE_RELEASE_MANIFEST")" || fail "release manifest has no valid $image digest"
+		[[ "$repository" == "ghcr.io/chris-cullins/swe-platform/$image" ]] || fail "unexpected $image repository in release manifest: $repository"
+		case "$image" in
+		operator) helm_args+=(--set-string "image.digest=$digest") ;;
+		control-plane) helm_args+=(--set-string "controlPlane.image.digest=$digest") ;;
+		env-base) helm_args+=(--set-string "environmentImage.digest=$digest") ;;
+		esac
+	done
+elif [[ -n "${SWE_IMAGE_TAG:-}" ]]; then
+	[[ "$SWE_IMAGE_TAG" =~ ^sha-[0-9a-f]{7}$ ]] || fail "SWE_IMAGE_TAG must match sha-<7 lowercase hex>; use SWE_RELEASE_MANIFEST for immutable digest pinning"
+	helm_args+=(
+		--set-string "image.tag=$SWE_IMAGE_TAG"
+		--set-string "controlPlane.image.tag=$SWE_IMAGE_TAG"
+		--set-string "environmentImage.tag=$SWE_IMAGE_TAG"
+	)
+fi
+
+helm lint "$CHART" --values "$values" >/dev/null
+rendered="$(helm template "$RELEASE" "$CHART" "${helm_args[@]}")"
+grep -q -- '--tenancy-mode=scoped' <<<"$rendered" || fail "effective values must use scoped tenancy"
+grep -A1 'name: SWE_SESSION_BACKEND' <<<"$rendered" | grep -q 'value: "postgres"' || fail "preset does not select PostgreSQL sessions"
+grep -A5 'name: SWE_POSTGRES_URL' <<<"$rendered" | grep -q 'secretKeyRef:' || fail "preset does not source PostgreSQL from a Secret"
+postgres_secret="$(awk '/name: SWE_POSTGRES_URL/{found=1; next} found && /name:/{gsub(/[" ]/, "", $2); print $2; exit}' <<<"$rendered")"
+postgres_key="$(awk '/name: SWE_POSTGRES_URL/{found=1; next} found && /key:/{gsub(/[" ]/, "", $2); print $2; exit}' <<<"$rendered")"
+keyring_secret="$(awk '/secretName:/{gsub(/[" ]/, "", $2); print $2; exit}' <<<"$rendered")"
+keyring_key="$(awk '/secretName:/{found=1; next} found && /key:/{value=($1 == "-" ? $3 : $2); gsub(/[" ]/, "", value); print value; exit}' <<<"$rendered")"
+[[ -n "$postgres_secret" && -n "$postgres_key" && -n "$keyring_secret" && -n "$keyring_key" ]] || fail "cannot resolve effective PostgreSQL/keyring Secret references"
+
+mapfile -t images < <(awk '$1 == "image:" {gsub(/"/, "", $2); print $2}' <<<"$rendered")
+[[ ${#images[@]} -eq 3 ]] || fail "expected exactly three coordinated images, found ${#images[@]}"
+for image in "${images[@]}"; do
+	[[ "$image" != *:latest && "$image" != *:dev ]] || fail "mutable image rendered: $image"
+done
+if [[ -n "${SWE_RELEASE_MANIFEST:-}" ]]; then
+	for image in operator control-plane env-base; do
+		digest="$(jq -r --arg image "$image" '.images[$image].digest' "$SWE_RELEASE_MANIFEST")"
+		grep -q "ghcr.io/chris-cullins/swe-platform/$image@$digest" <<<"$rendered" || fail "$image is not pinned to its release-manifest digest"
+	done
+fi
+
+echo "render validation passed for values-$provider.yaml"
+warn_security_boundary
+[[ "$mode" == render ]] && exit 0
+
+need kubectl
+need jq
+context="$(kubectl config current-context)"
+[[ -n "$context" ]] || fail "kubectl has no current context"
+echo "validating current context: $context"
+
+server_version="$(kubectl version -o json | jq -er '.serverVersion | [(.major | tonumber), (.minor | sub("[^0-9].*$"; "") | tonumber)]')" || fail "cannot read Kubernetes server version"
+server_major="$(jq -r '.[0]' <<<"$server_version")"
+server_minor="$(jq -r '.[1]' <<<"$server_version")"
+(( server_major > 1 || (server_major == 1 && server_minor >= 33) )) || fail "Kubernetes 1.33 or newer is required"
+
+kubectl get --raw /apis/networking.k8s.io/v1 | jq -e '.resources[] | select(.name == "networkpolicies")' >/dev/null || fail "NetworkPolicy API is unavailable"
+default_storage_classes="$(kubectl get storageclass -o json | jq '[.items[] | select(.metadata.annotations["storageclass.kubernetes.io/is-default-class"] == "true" or .metadata.annotations["storageclass.beta.kubernetes.io/is-default-class"] == "true")] | length')"
+(( default_storage_classes > 0 )) || fail "no default StorageClass is configured"
+
+if [[ "$provider" == gke ]]; then
+	kubectl get runtimeclass gvisor >/dev/null || fail "the GKE preset requires RuntimeClass gvisor"
+else
+	echo "NOTICE: values-$provider.yaml uses the cluster default runtime; it does not provide a sandbox RuntimeClass" >&2
+fi
+
+kubectl get namespace "$SYSTEM_NAMESPACE" >/dev/null || fail "system namespace $SYSTEM_NAMESPACE does not exist"
+postgres_present="$(kubectl -n "$SYSTEM_NAMESPACE" get secret "$postgres_secret" -o go-template="{{if index .data \"$postgres_key\"}}present{{end}}")" || fail "Secret $postgres_secret with key $postgres_key is required"
+[[ "$postgres_present" == present ]] || fail "Secret $postgres_secret has an empty $postgres_key key"
+keyring_present="$(kubectl -n "$SYSTEM_NAMESPACE" get secret "$keyring_secret" -o go-template="{{if index .data \"$keyring_key\"}}present{{end}}")" || fail "Secret $keyring_secret with key $keyring_key is required"
+[[ "$keyring_present" == present ]] || fail "Secret $keyring_secret has an empty $keyring_key key"
+unset postgres_present keyring_present
+
+echo "cluster preflight passed for values-$provider.yaml"
+[[ "$mode" == preflight ]] && exit 0
+
+helm status "$RELEASE" --namespace "$SYSTEM_NAMESPACE" >/dev/null || fail "Helm release $RELEASE is not installed"
+installed_manifest="$(helm get manifest "$RELEASE" --namespace "$SYSTEM_NAMESPACE")"
+grep -q -- '--tenancy-mode=scoped' <<<"$installed_manifest" || fail "installed release does not use scoped tenancy"
+grep -A1 'name: SWE_SESSION_BACKEND' <<<"$installed_manifest" | grep -q 'value: "postgres"' || fail "installed release does not use PostgreSQL sessions"
+expected_namespaces="$(awk '$2 ~ /^--tenancy-namespace=/{print $2}' <<<"$rendered" | sort)"
+installed_namespaces="$(awk '$2 ~ /^--tenancy-namespace=/{print $2}' <<<"$installed_manifest" | sort)"
+[[ "$installed_namespaces" == "$expected_namespaces" ]] || fail "installed scoped namespace allowlist differs from effective values"
+expected_control_namespaces="$(awk '/name: SWE_TENANCY_NAMESPACES/{found=1; next} found && /value:/{gsub(/[" ]/, "", $2); print $2; exit}' <<<"$rendered")"
+installed_control_namespaces="$(awk '/name: SWE_TENANCY_NAMESPACES/{found=1; next} found && /value:/{gsub(/[" ]/, "", $2); print $2; exit}' <<<"$installed_manifest")"
+[[ "$installed_control_namespaces" == "$expected_control_namespaces" ]] || fail "installed control-plane namespace allowlist differs from effective values"
+installed_postgres_secret="$(awk '/name: SWE_POSTGRES_URL/{found=1; next} found && /name:/{gsub(/[" ]/, "", $2); print $2; exit}' <<<"$installed_manifest")"
+installed_postgres_key="$(awk '/name: SWE_POSTGRES_URL/{found=1; next} found && /key:/{gsub(/[" ]/, "", $2); print $2; exit}' <<<"$installed_manifest")"
+installed_keyring_secret="$(awk '/secretName:/{gsub(/[" ]/, "", $2); print $2; exit}' <<<"$installed_manifest")"
+installed_keyring_key="$(awk '/secretName:/{found=1; next} found && /key:/{value=($1 == "-" ? $3 : $2); gsub(/[" ]/, "", value); print value; exit}' <<<"$installed_manifest")"
+[[ "$installed_postgres_secret:$installed_postgres_key" == "$postgres_secret:$postgres_key" ]] || fail "installed PostgreSQL Secret reference differs from effective values"
+[[ "$installed_keyring_secret:$installed_keyring_key" == "$keyring_secret:$keyring_key" ]] || fail "installed keyring Secret reference differs from effective values"
+for image in "${images[@]}"; do
+	grep -Fq "$image" <<<"$installed_manifest" || fail "installed manifest does not use expected image $image"
+done
+live_deployments="$(kubectl -n "$SYSTEM_NAMESPACE" get deployments -l "app.kubernetes.io/instance=$RELEASE" -o json)"
+expected_workload_images="$(printf '%s\n' "${images[@]}" | grep -E '/(operator|control-plane)(@|:)' | sort)"
+live_workload_images="$(jq -r '.items[].spec.template.spec.containers[].image' <<<"$live_deployments" | sort)"
+[[ "$live_workload_images" == "$expected_workload_images" ]] || fail "live workload images differ from effective values"
+live_namespaces="$(jq -r '.items[].spec.template.spec.containers[].args[]? | select(startswith("--tenancy-namespace="))' <<<"$live_deployments" | sort)"
+[[ "$live_namespaces" == "$expected_namespaces" ]] || fail "live operator namespace allowlist differs from effective values"
+live_control_namespaces="$(jq -r '.items[].spec.template.spec.containers[].env[]? | select(.name == "SWE_TENANCY_NAMESPACES") | .value' <<<"$live_deployments")"
+[[ "$live_control_namespaces" == "$expected_control_namespaces" ]] || fail "live control-plane namespace allowlist differs from effective values"
+live_postgres_ref="$(jq -r '.items[].spec.template.spec.containers[].env[]? | select(.name == "SWE_POSTGRES_URL") | "\(.valueFrom.secretKeyRef.name):\(.valueFrom.secretKeyRef.key)"' <<<"$live_deployments")"
+live_keyring_ref="$(jq -r '.items[].spec.template.spec.volumes[]? | select(.name == "session-keyring") | "\(.secret.secretName):\(.secret.items[0].key)"' <<<"$live_deployments")"
+[[ "$live_postgres_ref" == "$postgres_secret:$postgres_key" ]] || fail "live PostgreSQL Secret reference differs from effective values"
+[[ "$live_keyring_ref" == "$keyring_secret:$keyring_key" ]] || fail "live keyring Secret reference $live_keyring_ref differs from effective values $keyring_secret:$keyring_key"
+kubectl -n "$SYSTEM_NAMESPACE" rollout status deployment \
+	-l "app.kubernetes.io/instance=$RELEASE" --timeout=5m
+kubectl -n "$SYSTEM_NAMESPACE" wait pods \
+	-l "app.kubernetes.io/instance=$RELEASE" --for=condition=Ready --timeout=5m
+installation="$(awk -v RS='---' '/kind: Installation/{for (i=1;i<=NF;i++) if ($i == "name:") {print $(i+1); exit}}' <<<"$installed_manifest")"
+[[ -n "$installation" ]] || fail "installed manifest has no Installation identity"
+kubectl -n "$SYSTEM_NAMESPACE" get installation "$installation" >/dev/null || fail "Installation identity is missing"
+
+echo "installed release validation passed for $RELEASE in $SYSTEM_NAMESPACE"

--- a/hack/validate-byoc_test.sh
+++ b/hack/validate-byoc_test.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+VALIDATOR="$ROOT/hack/validate-byoc.sh"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+fail() {
+	echo "FAIL: $*" >&2
+	exit 1
+}
+
+for provider in k3s gke eks; do
+	"$VALIDATOR" render "$provider" >"${TMPDIR:-/tmp}/validate-byoc-$provider.out" 2>&1 || {
+		cat "${TMPDIR:-/tmp}/validate-byoc-$provider.out" >&2
+		fail "render validation failed for $provider"
+	}
+done
+
+if "$VALIDATOR" render kind >/dev/null 2>&1; then
+	fail "development preset was accepted as BYOC production input"
+fi
+if SWE_IMAGE_TAG=latest "$VALIDATOR" render k3s >/dev/null 2>&1; then
+	fail "mutable latest image override was accepted"
+fi
+SWE_IMAGE_TAG=sha-0123456 "$VALIDATOR" render k3s >/dev/null 2>&1 || fail "traceable main SHA override was rejected"
+
+digest="sha256:$(printf 'a%.0s' {1..64})"
+jq -n --arg digest "$digest" '{images:{operator:{repository:"ghcr.io/chris-cullins/swe-platform/operator",digest:$digest},"control-plane":{repository:"ghcr.io/chris-cullins/swe-platform/control-plane",digest:$digest},"env-base":{repository:"ghcr.io/chris-cullins/swe-platform/env-base",digest:$digest}}}' >"$TEST_ROOT/release-manifest.json"
+SWE_RELEASE_MANIFEST="$TEST_ROOT/release-manifest.json" "$VALIDATOR" render gke >/dev/null 2>&1 || fail "release-manifest digest pins were rejected"
+
+cat >"$TEST_ROOT/unsafe-values.yaml" <<'EOF'
+tenancy:
+  mode: trusted-admin
+EOF
+if SWE_PRIVATE_VALUES="$TEST_ROOT/unsafe-values.yaml" "$VALIDATOR" render eks >/dev/null 2>&1; then
+	fail "trusted-admin private values were accepted by BYOC validation"
+fi
+
+mkdir -p "$TEST_ROOT/bin"
+cat >"$TEST_ROOT/bin/kubectl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  "config current-context") echo byoc-test ;;
+  "version -o json") echo '{"serverVersion":{"major":"1","minor":"33+"}}' ;;
+  "get --raw /apis/networking.k8s.io/v1") echo '{"resources":[{"name":"networkpolicies"}]}' ;;
+  "get storageclass -o json") echo '{"items":[{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}]}' ;;
+  "get runtimeclass gvisor") : ;;
+  "get namespace swe-platform-system") : ;;
+  *"get secret swe-platform-postgres"*) echo -n present ;;
+  *"get secret swe-platform-session-keyring"*) echo -n present ;;
+  *"get deployments -l app.kubernetes.io/instance=swe-platform -o json")
+    cat <<'JSON'
+{"items":[{"spec":{"template":{"spec":{"containers":[{"image":"ghcr.io/chris-cullins/swe-platform/operator:0.1.0","args":[]} ]}}}},{"spec":{"template":{"spec":{"containers":[{"image":"ghcr.io/chris-cullins/swe-platform/control-plane:0.1.0","env":[{"name":"SWE_TENANCY_NAMESPACES","value":""},{"name":"SWE_POSTGRES_URL","valueFrom":{"secretKeyRef":{"name":"swe-platform-postgres","key":"url"}}}]}],"volumes":[{"name":"session-keyring","secret":{"secretName":"swe-platform-session-keyring","items":[{"key":"keyring.json"}]}}]}}}}]}
+JSON
+    ;;
+  *"rollout status deployment -l app.kubernetes.io/instance=swe-platform --timeout=5m") : ;;
+  *"wait pods -l app.kubernetes.io/instance=swe-platform --for=condition=Ready --timeout=5m") : ;;
+  *"get installation swe-platform-swe-platform") : ;;
+  *) echo "unexpected fake kubectl call: $*" >&2; exit 1 ;;
+esac
+EOF
+chmod +x "$TEST_ROOT/bin/kubectl"
+PATH="$TEST_ROOT/bin:$PATH" "$VALIDATOR" preflight gke >/dev/null 2>&1 || fail "valid mocked GKE preflight failed"
+
+real_helm="$(command -v helm)"
+"$real_helm" template swe-platform "$ROOT/charts/swe-platform" --namespace swe-platform-system \
+  --values "$ROOT/charts/swe-platform/values-gke.yaml" >"$TEST_ROOT/installed-manifest.yaml"
+cat >"$TEST_ROOT/bin/helm" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == status ]]; then
+  exit 0
+fi
+if [[ "$1 $2" == "get manifest" ]]; then
+  cat "$FAKE_INSTALLED_MANIFEST"
+  exit 0
+fi
+exec "$REAL_HELM" "$@"
+EOF
+chmod +x "$TEST_ROOT/bin/helm"
+PATH="$TEST_ROOT/bin:$PATH" REAL_HELM="$real_helm" FAKE_INSTALLED_MANIFEST="$TEST_ROOT/installed-manifest.yaml" \
+  "$VALIDATOR" installed gke >/dev/null 2>&1 || fail "valid mocked installed release failed"
+
+cat >"$TEST_ROOT/scoped-project-values.yaml" <<'EOF'
+tenancy:
+  mode: scoped
+  namespaces: [test-project]
+EOF
+if PATH="$TEST_ROOT/bin:$PATH" REAL_HELM="$real_helm" FAKE_INSTALLED_MANIFEST="$TEST_ROOT/installed-manifest.yaml" \
+  SWE_PRIVATE_VALUES="$TEST_ROOT/scoped-project-values.yaml" "$VALIDATOR" installed gke >/dev/null 2>&1; then
+	fail "installed validation accepted a stale scoped namespace allowlist"
+fi
+
+echo "BYOC validator covers production renders, digest pins, unsafe values, preflight, and installed state"

--- a/hack/validate-byoc_test.sh
+++ b/hack/validate-byoc_test.sh
@@ -25,6 +25,13 @@ if SWE_IMAGE_TAG=latest "$VALIDATOR" render k3s >/dev/null 2>&1; then
 	fail "mutable latest image override was accepted"
 fi
 SWE_IMAGE_TAG=sha-0123456 "$VALIDATOR" render k3s >/dev/null 2>&1 || fail "traceable main SHA override was rejected"
+mapfile -t fallback_args < <(SWE_IMAGE_TAG=sha-0123456 "$VALIDATOR" image-args k3s)
+[[ ${#fallback_args[@]} -eq 6 ]] || fail "fallback did not emit three Helm image overrides"
+fallback_render="$(helm template swe-platform "$ROOT/charts/swe-platform" --namespace swe-platform-system \
+	--values "$ROOT/charts/swe-platform/values-k3s.yaml" "${fallback_args[@]}")"
+for image in operator control-plane env-base; do
+	grep -q "ghcr.io/chris-cullins/swe-platform/$image:sha-0123456" <<<"$fallback_render" || fail "fallback install args did not select $image SHA tag"
+done
 
 digest="sha256:$(printf 'a%.0s' {1..64})"
 jq -n --arg digest "$digest" '{images:{operator:{repository:"ghcr.io/chris-cullins/swe-platform/operator",digest:$digest},"control-plane":{repository:"ghcr.io/chris-cullins/swe-platform/control-plane",digest:$digest},"env-base":{repository:"ghcr.io/chris-cullins/swe-platform/env-base",digest:$digest}}}' >"$TEST_ROOT/release-manifest.json"
@@ -36,6 +43,49 @@ tenancy:
 EOF
 if SWE_PRIVATE_VALUES="$TEST_ROOT/unsafe-values.yaml" "$VALIDATOR" render eks >/dev/null 2>&1; then
 	fail "trusted-admin private values were accepted by BYOC validation"
+fi
+
+cat >"$TEST_ROOT/zero-templates.yaml" <<'EOF'
+environmentTemplates: []
+EOF
+SWE_PRIVATE_VALUES="$TEST_ROOT/zero-templates.yaml" "$VALIDATOR" render k3s >/dev/null 2>&1 || fail "zero catalog templates were rejected"
+SWE_PRIVATE_VALUES="$TEST_ROOT/zero-templates.yaml" SWE_RELEASE_MANIFEST="$TEST_ROOT/release-manifest.json" \
+	"$VALIDATOR" render k3s >/dev/null 2>&1 || fail "zero templates were rejected with digest pinning"
+
+cat >"$TEST_ROOT/multiple-gvisor-templates.yaml" <<'EOF'
+environmentTemplates:
+  - name: medium
+    spec:
+      size: medium
+      runtimeClass: gvisor
+      idleTimeout: 15m
+      diskSize: 40Gi
+  - name: large
+    spec:
+      size: large
+      runtimeClass: gvisor
+      idleTimeout: 15m
+      diskSize: 80Gi
+EOF
+SWE_PRIVATE_VALUES="$TEST_ROOT/multiple-gvisor-templates.yaml" "$VALIDATOR" render gke >/dev/null 2>&1 || fail "multiple valid GKE templates were rejected"
+SWE_PRIVATE_VALUES="$TEST_ROOT/multiple-gvisor-templates.yaml" SWE_RELEASE_MANIFEST="$TEST_ROOT/release-manifest.json" \
+	"$VALIDATOR" render gke >/dev/null 2>&1 || fail "repeated digest-pinned environment images were rejected"
+
+cat >"$TEST_ROOT/missing-gvisor-template.yaml" <<'EOF'
+environmentTemplates:
+  - name: medium
+    spec:
+      size: medium
+      idleTimeout: 15m
+      diskSize: 40Gi
+EOF
+if SWE_PRIVATE_VALUES="$TEST_ROOT/missing-gvisor-template.yaml" "$VALIDATOR" render gke >/dev/null 2>&1; then
+	fail "GKE template without runtimeClass was accepted"
+fi
+
+sed 's/runtimeClass: gvisor/runtimeClass: runc/' "$TEST_ROOT/multiple-gvisor-templates.yaml" >"$TEST_ROOT/changed-gvisor-templates.yaml"
+if SWE_PRIVATE_VALUES="$TEST_ROOT/changed-gvisor-templates.yaml" "$VALIDATOR" render gke >/dev/null 2>&1; then
+	fail "GKE template with a changed RuntimeClass was accepted"
 fi
 
 mkdir -p "$TEST_ROOT/bin"


### PR DESCRIPTION
## Summary

- add executable k3s, GKE, and EKS BYOC runbooks for exact-input selection, scoped install/onboarding/offboarding, upgrade, PostgreSQL backup/restore, and incident response
- pin all three coordinated images to the publish workflow's recorded OCI digests, while retaining the existing release-tag defaults
- add a cluster-aware validator for production preset rendering, prerequisites, Secret references, scoped namespace configuration, exact installed images, and live Deployment drift
- test render, digest, unsafe-value, mocked preflight, installed-state, and stale-allowlist behavior in `make test` and CI
- record exact hosted-alpha decisions required from maintainers without creating speculative shared infrastructure

## Audit conclusions

Issue #79 remains relevant. The checked-in production presets and scoped tenancy/offboarding contracts support customer-owned runbooks now, but not a hosted alpha or a production-security claim.

The runbook explicitly preserves these current limits:

- #9: remaining credential classes, profile authorization, same-UID isolation, and transcript redaction
- #10/#68: no complete fail-closed production isolation profile, default-deny egress, or authenticated egress proxy
- no platform purge; offboarding fences and retains
- singleton `Recreate` control plane; durable PostgreSQL is not HA
- Linux Pod backend only; native Windows Environments, `.ps1` hooks, and ConPTY terminals remain unsupported, and Windows terminal selection fails closed

Hosted alpha prerequisites are listed as maintainer decisions across product boundary, tenant identity, infrastructure ownership, commercial controls, operations/SLOs, and security launch gates.

## Release and recovery safety

- latest-main instructions select successful `ci` and `publish-images` runs for one full commit SHA
- the release artifact is downloaded into a fresh commit-specific directory and must contain exactly one manifest
- chart digest values validate `sha256:<64 hex>` and take precedence over tags
- restore requires a complete dedicated database, verifies backup/keyring inputs before shutdown, rejects any non-system destination relation, restores transactionally with exit-on-error, and brings the control plane back only after database/keyring Secret replacement
- Secret content is not decoded by validation or passed as literal command arguments

## Verification

- branch base: `d1bedf8c81c81a622b1dbb3c642f252d92d0d017` (exact origin/main requested after PR #166)
- `make test`
- `make vet`
- Helm lint/render for kind, Argo CD, k3s, GKE, and EKS presets
- production image coordination/mutability checks
- `git diff --check`
- `bash -n` for validator/tests and all 13 shell blocks in the BYOC runbook

Refs #79
