### PR TITLE
Add GitHub App-scoped per-run git credentials

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,9 +30,12 @@ control-plane bearer credential; interactive terminal attach is intentionally no
 The control plane also provides the authenticated declared-service portal gateway, with fenced
 wake/currentness checks and a purpose-scoped sandboxd tunnel. Remaining gaps are tracked in
 `ARCHITECTURE.md`, code comments, and linked issues — most notably additional credential forms,
-additional agent adapters, GitHub App–scoped git tokens, and egress networking. Repository
+additional agent adapters, and egress networking. Repository
 `.swe/services.yaml` ingestion and supervised service launch with
-gateway-discovered `PUBLIC_URL` are implemented. The `claude-code` (default), `amp`, `codex`, and `pi` adapters are
+gateway-discovered `PUBLIC_URL` are implemented. GitHub App repository credentials use
+short-lived, exact-repository `contents:write` installation tokens for authenticated clone and
+process-scoped Git/GitHub CLI access, with execution-fenced refresh and terminal cleanup.
+The `claude-code` (default), `amp`, `codex`, and `pi` adapters are
 registered and use sandboxd managed processes. API-key profiles use process-scoped launch
 material as `ANTHROPIC_API_KEY`,
 `AMP_API_KEY`, or `CODEX_API_KEY`; tests use fake process services and no provider credentials.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -541,8 +541,11 @@ as write-only sandboxd launch material only to the selected child process:
 The key is absent from public process specifications, setup/resume hooks, sandboxd's ambient
 environment, and ordinary exec calls. The selected agent and descendants can still read or
 emit it; same-UID peers are not strongly isolated and transcript redaction is not guaranteed.
-OAuth/subscription credentials, refresh/writeback, per-user profiles, Git/setup/service
-credentials, and GitHub App token minting are not implemented.
+OAuth/subscription credentials, refresh/writeback, per-user profiles, and service
+credentials are not implemented. Run intent may select immutable
+`repositoryCredential: GitHubApp`; the provider-neutral boundary and GitHub exchange
+use repository-scoped `contents:write` installation tokens. Controller persistence,
+pod/process delivery, rotation, and finalizer cleanup remain open work.
 
 ### Terminal and operations console
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -80,7 +80,7 @@ All current CRDs are namespaced:
 | `Project` | One repository URL (represented as a one-item list), a same-namespace default Template reference, changes-workflow metadata, and a reserved egress allowlist. A non-empty allowlist is rejected when an Environment uses the Project. |
 | `EnvironmentTemplate` | Pod image, size/resources, disk, runtime class, idle timeout, warm-pool minimum, and backend. Admission currently permits only the `pod` backend. Chart-owned system-namespace objects are inert catalog sources; execution accepts only installation-managed same-namespace copies bound to exact Installation, source, and Project identities. |
 | `Environment` | Immutable Template selection, an immutable optional backend override, one-way empty-to-nonempty Project binding, explicit hold policy, bounded wake/suspend/activity intents, and up to 32 API- or Repository-owned service declarations. New declarations have an immutable-per-incarnation random `instanceID`; upgrade-retained legacy declarations may omit it, receive no portal route, and can add it only with a higher revision. Omitted legacy service ownership defaults only to `API` and is immutable thereafter. Controller-owned status includes the immutable resolved `provisioning` snapshot, readiness, lifecycle/execution, claim, observations, activity, and nested backend-neutral recovery state; recovery records attempts, exhaustion, the exact failed execution generation being accounted, and the next allowed attempt time, while generation zero means no recovery identity. The gateway owns bounded `portalRoutes` and monotonic `nextPortalRouteGeneration`; inactive routes are denial tombstones preserved by other status writers. |
-| `Run` | Immutable agent task and Environment/Project/Template/credential selection plus monotonic cancellation; status records normalized lifecycle, exact Environment name/UID and ownership, exact credential profile identity, accepted lifecycle epoch, and accepted execution generation. `notify` and `parentRef` are schema placeholders without an implemented inbox. |
+| `Run` | Immutable agent task and Environment/Project/Template/agent-credential/repository-credential selection plus monotonic cancellation; status records normalized lifecycle, exact Environment name/UID and ownership, exact credential profile identity, repository credential readiness, accepted lifecycle epoch, and accepted execution generation. `notify` and `parentRef` are schema placeholders without an implemented inbox. |
 | `AgentCredentialProfile` | Immutable adapter and `APIKey` type metadata. Key bytes live in an owner-linked Secret whose name is derived from the profile UID. |
 
 The current ownership/reference shape is:
@@ -115,6 +115,11 @@ AgentCredentialProfile --owner UID--> Secret
           ^
           | exact name + UID in Run status
           +---------------- Run
+
+GitHub App --short-lived exact-repository token--> Run UID lease Secret
+                                                       |
+                                                       +--> clone init container
+                                                       +--> selected agent process launch material
 ```
 
 The Run controller creates an owned Environment or exclusively claims a reusable one.
@@ -541,11 +546,28 @@ as write-only sandboxd launch material only to the selected child process:
 The key is absent from public process specifications, setup/resume hooks, sandboxd's ambient
 environment, and ordinary exec calls. The selected agent and descendants can still read or
 emit it; same-UID peers are not strongly isolated and transcript redaction is not guaranteed.
-OAuth/subscription credentials, refresh/writeback, per-user profiles, and service
-credentials are not implemented. Run intent may select immutable
-`repositoryCredential: GitHubApp`; the provider-neutral boundary and GitHub exchange
-use repository-scoped `contents:write` installation tokens. Controller persistence,
-pod/process delivery, rotation, and finalizer cleanup remain open work.
+OAuth/subscription credentials, refresh/writeback for agent profiles, per-user profiles, and
+service credentials are not implemented.
+
+Run intent may immutably select `repositoryCredential: GitHubApp`. The provider-neutral
+repository-credential boundary exchanges an administrator-owned GitHub App key for a
+short-lived installation token scoped to the exact frozen `github.com` repository with only
+`contents:write`. The Run finalizer is persisted before issuance. A deterministic Run-UID lease
+Secret records the exact frozen source, canonical repository, installation, expiry, token
+generation, Environment UID, and execution generation. The clone init container receives the
+Secret through one exact key reference and derives only a temporary Git extra header; setup and
+resume hooks receive no credential. The selected adapter process receives `GH_TOKEN` and the
+same process-scoped Git header through sandboxd write-only launch material. The token is absent
+from status, transcripts, repository URLs, command arguments, persistent Git config, workspace,
+sandboxd's environment, and public process specifications.
+
+Before expiry or after pod loss, a durable rotation record fences the prior execution, revokes
+and deletes its exact lease, issues a replacement, and wakes or resumes with the next execution
+generation. Terminal cleanup cancels a reachable adapter where applicable, fences the
+Environment, revokes/deletes the token, then releases a claim and removes the finalizer.
+Provider failures produce stable secret-free conditions and retry without releasing the
+finalizer. GitHub Enterprise, SSH repository URLs, broader App permissions, and credentials for
+non-GitHub repositories remain unsupported.
 
 ### Terminal and operations console
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -557,9 +557,11 @@ Secret records the exact frozen source, canonical repository, installation, expi
 generation, Environment UID, and execution generation. The clone init container receives the
 Secret through one exact key reference and derives only a temporary Git extra header; setup and
 resume hooks receive no credential. The selected adapter process receives `GH_TOKEN` and the
-same process-scoped Git header through sandboxd write-only launch material. The token is absent
-from status, transcripts, repository URLs, command arguments, persistent Git config, workspace,
-sandboxd's environment, and public process specifications.
+same process-scoped Git header through sandboxd write-only launch material. Platform-owned
+serialization keeps the token out of status, transcript fields, repository URLs, command
+arguments, persistent Git config, workspace files, sandboxd's environment, and public process
+specifications. The selected process and descendants can nevertheless read, emit, or persist
+the token; transcript redaction is not guaranteed.
 
 Before expiry or after pod loss, a durable rotation record fences the prior execution, revokes
 and deletes its exact lease, issues a replacement, and wakes or resumes with the next execution

--- a/README.md
+++ b/README.md
@@ -379,16 +379,30 @@ its default template:
 > not upgrade files in a chart's `crds/` directory, and then run `helm upgrade`. The operator
 > upgrade replaces existing Environment pods so previously injected ambient Secret values are
 > removed. Private repository clones and `.agents/setup` or `.agents/resume` hooks that relied
-> on those values will break. There is no fallback; purpose-scoped Git and setup credentials
-> remain future work.
+> on those values will break. There is no ambient fallback. GitHub App repository credentials
+> are available only through explicit per-Run selection; setup/resume credentials remain
+> unsupported.
 
 ```sh
 swe --namespace my-project run --template small "Fix the flaky test"
 swe --namespace my-project run --project org-repo "Fix the flaky test"
 swe --namespace my-project run --name fix-flaky-42 --project org-repo "Fix the flaky test"
 swe --namespace my-project run --environment warm-env-1 "Fix the flaky test"
+swe --namespace my-project run --project private-org-repo \
+  --git-credential github-app "Fix and push the flaky test"
 swe --namespace my-project cancel fix-flaky-42
 ```
+
+`--git-credential github-app` requires an administrator-configured GitHub App and an exact
+`https://github.com/<owner>/<repo>[.git]` Project repository. It mints a short-lived installation
+token for that repository with only `contents:write`, uses it for the initial clone, and supplies
+authenticated Git and `gh` access only to the selected agent process. The token is refreshed
+through an execution fence on resume or before expiry and revoked when the Run completes. It is
+not supplied to setup/resume hooks, sandboxd's ambient environment, status, transcripts,
+repository URLs, or persistent workspace configuration. Public repositories continue to clone
+without credentials when the flag is omitted. See the
+[chart configuration](charts/swe-platform/README.md#github-app-repository-credentials) for the
+administrator-owned Secret contract.
 
 ### Claude Code adapter
 
@@ -434,8 +448,9 @@ output. Transcript redaction is not guaranteed. Anyone authorized to create Runs
 can initially select any profile there; profile creation and rotation additionally require
 Secret and CRD administration. Subscription/OAuth credentials, refresh and writeback, leases,
 Amp login persistence, per-user profiles, Git/setup/service credentials, hard same-user
-isolation, and stronger redaction remain deferred to issue #9. Never place credentials in a Run
-prompt or Project configuration.
+isolation, and stronger redaction remain deferred to issue #9. GitHub App repository tokens use
+the separate per-Run contract above. Never place credentials in a Run prompt or Project
+configuration.
 
 Current limitations: Claude print mode has no live input continuation channel, so an exit-zero
 successful result remains `Succeeded` even when its history contains permission denials.
@@ -537,7 +552,9 @@ the `Ready` condition and nested backend-neutral `status.recovery` fields. Envir
 is reported by
 the current-generation `Ready` condition only after initialization completes and the sandboxd
 startup/readiness probes pass; `status.phase` is a display summary rather than the scheduling
-contract. GitHub App token minting is not implemented yet.
+contract. When a Run explicitly selects `--git-credential github-app`, repository clone occurs
+in a separate preceding init container with an exact Run lease Secret; the later project-hook
+container receives no repository token or temporary Git header.
 
 Upgrade compatibility: the deprecated flat `status.podRecovery*` fields remain in the CRD for
 one rollout. An early phase after deletion handling and before lifecycle or dependency gates

--- a/README.md
+++ b/README.md
@@ -397,10 +397,11 @@ swe --namespace my-project cancel fix-flaky-42
 `https://github.com/<owner>/<repo>[.git]` Project repository. It mints a short-lived installation
 token for that repository with only `contents:write`, uses it for the initial clone, and supplies
 authenticated Git and `gh` access only to the selected agent process. The token is refreshed
-through an execution fence on resume or before expiry and revoked when the Run completes. It is
-not supplied to setup/resume hooks, sandboxd's ambient environment, status, transcripts,
-repository URLs, or persistent workspace configuration. Public repositories continue to clone
-without credentials when the flag is omitted. See the
+through an execution fence on resume or before expiry and revoked when the Run completes. The
+platform does not supply it to setup/resume hooks or sandboxd's ambient environment and does not
+serialize it into status, transcripts, repository URLs, or persistent workspace configuration.
+The selected agent and descendants can still read, emit, or persist it; transcript redaction is
+not guaranteed. Public repositories continue to clone without credentials when the flag is omitted. See the
 [chart configuration](charts/swe-platform/README.md#github-app-repository-credentials) for the
 administrator-owned Secret contract.
 
@@ -447,7 +448,7 @@ or its descendants, repository wrappers left by setup, same-UID peers, or explic
 output. Transcript redaction is not guaranteed. Anyone authorized to create Runs in a namespace
 can initially select any profile there; profile creation and rotation additionally require
 Secret and CRD administration. Subscription/OAuth credentials, refresh and writeback, leases,
-Amp login persistence, per-user profiles, Git/setup/service credentials, hard same-user
+Amp login persistence, per-user profiles, setup/service credentials, hard same-user
 isolation, and stronger redaction remain deferred to issue #9. GitHub App repository tokens use
 the separate per-Run contract above. Never place credentials in a Run prompt or Project
 configuration.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,6 +12,13 @@ repository URLs, or persistent git config. Cleanup fences the Environment before
 revocation. GitHub's fixed one-hour maximum expiry bounds a crash between issuance
 and persistence, where no token exists locally to revoke.
 
+Repository initialization is split into ordered clone and project-hook init
+containers. After uncached exact Run, Environment, frozen repository, and lease
+validation, kubelet injects the token from the deterministic Run Secret only into
+the clone container. That shell derives a temporary Git extra header for the
+`git clone` process and clears the token and header variables; the hook and main
+containers receive no reference to the repository credential Secret.
+
 Only `https://github.com/<owner>/<repo>[.git]` is accepted. SSH, userinfo,
 ports, query/fragment components, redirects, enterprise hosts, and alternate API
 hosts are rejected.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,21 @@
 # Security model
 
+## GitHub App repository credentials
+
+When explicitly selected by immutable Run intent, the operator exchanges its
+administrator-owned GitHub App private key for a short-lived installation token.
+The recipient is only the canonical `github.com` repository in frozen provisioning
+data; scope is exactly that repository with `contents:write`. App keys are mounted
+only in the operator. Tokens are intended only for clone and Run-owned agent
+processes, never status, transcripts, sandboxd, hooks, command arguments,
+repository URLs, or persistent git config. Cleanup fences the Environment before
+revocation. GitHub's fixed one-hour maximum expiry bounds a crash between issuance
+and persistence, where no token exists locally to revoke.
+
+Only `https://github.com/<owner>/<repo>[.git]` is accepted. SSH, userinfo,
+ports, query/fragment components, redirects, enterprise hosts, and alternate API
+hosts are rejected.
+
 ## sandboxd threat model
 
 `sandboxd` is a privileged capability endpoint: successful calls can execute arbitrary

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,11 +6,13 @@ When explicitly selected by immutable Run intent, the operator exchanges its
 administrator-owned GitHub App private key for a short-lived installation token.
 The recipient is only the canonical `github.com` repository in frozen provisioning
 data; scope is exactly that repository with `contents:write`. App keys are mounted
-only in the operator. Tokens are intended only for clone and Run-owned agent
-processes, never status, transcripts, sandboxd, hooks, command arguments,
-repository URLs, or persistent git config. Cleanup fences the Environment before
-revocation. GitHub's fixed one-hour maximum expiry bounds a crash between issuance
-and persistence, where no token exists locally to revoke.
+only in the operator. The platform serializes tokens only to the lease Secret, clone
+container, and Run-owned agent process launch material—not status, transcripts,
+sandboxd's ambient environment, hooks, command arguments, repository URLs, or
+persistent git config. The selected agent and its descendants can read, emit, or
+persist the token; transcript redaction is not guaranteed. Cleanup fences the
+Environment before revocation. GitHub's fixed one-hour maximum expiry bounds a crash
+between issuance and persistence, where no token exists locally to revoke.
 
 Repository initialization is split into ordered clone and project-hook init
 containers. After uncached exact Run, Environment, frozen repository, and lease

--- a/api/v1alpha1/run_types.go
+++ b/api/v1alpha1/run_types.go
@@ -9,6 +9,12 @@ import (
 // +kubebuilder:validation:Enum=Allocating;EnvironmentReady;AdapterAccepted;Running;NeedsInput;Paused;Succeeded;Failed;Cancelled
 type RunState string
 
+// RepositoryCredential selects administrator-provided repository authentication.
+// +kubebuilder:validation:Enum=GitHubApp
+type RepositoryCredential string
+
+const RepositoryCredentialGitHubApp RepositoryCredential = "GitHubApp"
+
 const (
 	RunStateAllocating       RunState = "Allocating"
 	RunStateEnvironmentReady RunState = "EnvironmentReady"
@@ -25,7 +31,7 @@ const (
 // A Run either claims environmentRef or asks the controller to allocate an
 // Environment from templateRef/projectRef.
 // +kubebuilder:validation:XValidation:rule="has(self.environmentRef) ? (!has(self.templateRef) && !has(self.projectRef)) : (has(self.templateRef) || has(self.projectRef))",message="set environmentRef or templateRef/projectRef, not both"
-// +kubebuilder:validation:XValidation:rule="self.agent == oldSelf.agent && self.prompt == oldSelf.prompt && ((!has(self.environmentRef) && !has(oldSelf.environmentRef)) || (has(self.environmentRef) && has(oldSelf.environmentRef) && self.environmentRef == oldSelf.environmentRef)) && ((!has(self.projectRef) && !has(oldSelf.projectRef)) || (has(self.projectRef) && has(oldSelf.projectRef) && self.projectRef == oldSelf.projectRef)) && ((!has(self.templateRef) && !has(oldSelf.templateRef)) || (has(self.templateRef) && has(oldSelf.templateRef) && self.templateRef == oldSelf.templateRef)) && ((!has(self.credentialProfileRef) && !has(oldSelf.credentialProfileRef)) || (has(self.credentialProfileRef) && has(oldSelf.credentialProfileRef) && self.credentialProfileRef == oldSelf.credentialProfileRef))",message="agent, prompt, environment selection, and credential profile are immutable"
+// +kubebuilder:validation:XValidation:rule="self.agent == oldSelf.agent && self.prompt == oldSelf.prompt && ((!has(self.environmentRef) && !has(oldSelf.environmentRef)) || (has(self.environmentRef) && has(oldSelf.environmentRef) && self.environmentRef == oldSelf.environmentRef)) && ((!has(self.projectRef) && !has(oldSelf.projectRef)) || (has(self.projectRef) && has(oldSelf.projectRef) && self.projectRef == oldSelf.projectRef)) && ((!has(self.templateRef) && !has(oldSelf.templateRef)) || (has(self.templateRef) && has(oldSelf.templateRef) && self.templateRef == oldSelf.templateRef)) && ((!has(self.credentialProfileRef) && !has(oldSelf.credentialProfileRef)) || (has(self.credentialProfileRef) && has(oldSelf.credentialProfileRef) && self.credentialProfileRef == oldSelf.credentialProfileRef)) && ((!has(self.repositoryCredential) && !has(oldSelf.repositoryCredential)) || (has(self.repositoryCredential) && has(oldSelf.repositoryCredential) && self.repositoryCredential == oldSelf.repositoryCredential))",message="agent, prompt, environment selection, credential profile, and repository credential are immutable"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.cancel) || !oldSelf.cancel || (has(self.cancel) && self.cancel)",message="cancel cannot be unset"
 type RunSpec struct {
 	// EnvironmentRef claims an existing Environment. Claimed Environments are
@@ -51,6 +57,10 @@ type RunSpec struct {
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
 	CredentialProfileRef string `json:"credentialProfileRef,omitempty"`
+
+	// RepositoryCredential selects short-lived repository authentication.
+	// +optional
+	RepositoryCredential RepositoryCredential `json:"repositoryCredential,omitempty"`
 
 	// Agent names the agent adapter to use (e.g. claude-code, aider).
 	Agent string `json:"agent"`

--- a/charts/swe-platform/BYOC.md
+++ b/charts/swe-platform/BYOC.md
@@ -87,6 +87,13 @@ tenancy:
   namespaces: []
 ```
 
+GitHub App repository credentials are optional and disabled by default. When enabled, keep only
+the App client ID and administrator-owned private-key Secret reference in this file; create and
+back up the Secret out of band as described in
+[GitHub App repository credentials](README.md#github-app-repository-credentials). The BYOC
+renderer validates the required references, and installed validation catches a missing mount via
+workload readiness; it never reads or prints the App private key.
+
 ## Provider runbooks
 
 All providers require a default `ReadWriteOnce` StorageClass, an enforcing CNI for the chart's

--- a/charts/swe-platform/README.md
+++ b/charts/swe-platform/README.md
@@ -26,6 +26,42 @@ The stock image contains no Pi authentication. Ambient auth or configuration int
 custom image, attached user, hooks/repository code, or the process environment is outside the
 supported process-scoped credential contract and should not be added to chart values.
 
+## GitHub App repository credentials
+
+Per-Run private repository access is disabled by default. To enable
+`swe run --git-credential github-app`, create a GitHub App whose installation can access the
+intended repositories and whose repository permissions include **Contents: Read and write**.
+Do not grant pull-request or administration permissions for this platform contract. Install the
+App on each repository that Runs may select, then create the private-key Secret out of band:
+
+```sh
+kubectl -n swe-platform-system create secret generic swe-platform-github-app \
+  --from-file=private-key.pem=/secure/path/to/github-app-private-key.pem
+```
+
+Configure the App client ID and Secret reference in an administrator-owned values file:
+
+```yaml
+operator:
+  githubApp:
+    enabled: true
+    clientID: Iv1.example
+    secretName: swe-platform-github-app
+    privateKeyKey: private-key.pem
+```
+
+The chart references but never creates or copies this Secret, and mounts its sole selected key
+only into the operator. The operator accepts only canonical
+`https://github.com/<owner>/<repo>[.git]` repositories and requests one short-lived installation
+token scoped to the exact frozen repository with only `contents:write`. Tokens are held in
+finalizer-managed, Run-UID-named lease Secrets in the Project namespace, delivered only to the
+clone init container and selected agent process, refreshed through an execution fence, and
+revoked on terminal cleanup. They are not projected into hooks, sandboxd, or other containers.
+Removing or disabling the App configuration while live credentialed Runs exist prevents new
+issuance and leaves terminal revocation pending until the provider is restored or each token's
+fixed expiry proves it inactive. Never place an App key or installation token in values, Project
+configuration, prompts, or repository URLs.
+
 This chart installs the swe-platform CRDs, operator, first control-plane API, and one
 system-namespaced `Installation` identity. Configured `environmentTemplates` are inert catalog
 sources in that system namespace; Helm never creates a Project tenancy there.

--- a/charts/swe-platform/crds/swe.dev_runs.yaml
+++ b/charts/swe-platform/crds/swe.dev_runs.yaml
@@ -94,6 +94,11 @@ spec:
               prompt:
                 description: Prompt is the task handed to the agent.
                 type: string
+              repositoryCredential:
+                description: RepositoryCredential selects short-lived repository authentication.
+                enum:
+                - GitHubApp
+                type: string
               templateRef:
                 description: TemplateRef selects the template for a controller-allocated
                   Environment.
@@ -107,8 +112,8 @@ spec:
             - message: set environmentRef or templateRef/projectRef, not both
               rule: 'has(self.environmentRef) ? (!has(self.templateRef) && !has(self.projectRef))
                 : (has(self.templateRef) || has(self.projectRef))'
-            - message: agent, prompt, environment selection, and credential profile
-                are immutable
+            - message: agent, prompt, environment selection, credential profile, and
+                repository credential are immutable
               rule: self.agent == oldSelf.agent && self.prompt == oldSelf.prompt &&
                 ((!has(self.environmentRef) && !has(oldSelf.environmentRef)) || (has(self.environmentRef)
                 && has(oldSelf.environmentRef) && self.environmentRef == oldSelf.environmentRef))
@@ -118,7 +123,10 @@ spec:
                 && has(oldSelf.templateRef) && self.templateRef == oldSelf.templateRef))
                 && ((!has(self.credentialProfileRef) && !has(oldSelf.credentialProfileRef))
                 || (has(self.credentialProfileRef) && has(oldSelf.credentialProfileRef)
-                && self.credentialProfileRef == oldSelf.credentialProfileRef))
+                && self.credentialProfileRef == oldSelf.credentialProfileRef)) &&
+                ((!has(self.repositoryCredential) && !has(oldSelf.repositoryCredential))
+                || (has(self.repositoryCredential) && has(oldSelf.repositoryCredential)
+                && self.repositoryCredential == oldSelf.repositoryCredential))
             - message: cancel cannot be unset
               rule: '!has(oldSelf.cancel) || !oldSelf.cancel || (has(self.cancel)
                 && self.cancel)'

--- a/charts/swe-platform/templates/000-validate.yaml
+++ b/charts/swe-platform/templates/000-validate.yaml
@@ -23,6 +23,17 @@
     {{- fail (printf "%s.digest must be a sha256 digest" $name) -}}
   {{- end -}}
 {{- end -}}
+{{- if .Values.operator.githubApp.enabled -}}
+  {{- if not .Values.operator.githubApp.clientID -}}
+    {{- fail "operator.githubApp.enabled requires operator.githubApp.clientID" -}}
+  {{- end -}}
+  {{- if not .Values.operator.githubApp.secretName -}}
+    {{- fail "operator.githubApp.enabled requires operator.githubApp.secretName" -}}
+  {{- end -}}
+  {{- if not .Values.operator.githubApp.privateKeyKey -}}
+    {{- fail "operator.githubApp.enabled requires operator.githubApp.privateKeyKey" -}}
+  {{- end -}}
+{{- end -}}
 {{- $operatorMetricsPort := int .Values.operator.metrics.port -}}
 {{- $operatorHealthPort := int .Values.operator.health.port -}}
 {{- if or (lt $operatorMetricsPort 1) (gt $operatorMetricsPort 65535) -}}

--- a/charts/swe-platform/templates/deployment.yaml
+++ b/charts/swe-platform/templates/deployment.yaml
@@ -54,6 +54,10 @@ spec:
             - --transcript-url=http://{{ include "swe-platform.controlPlaneFullname" . }}
             - --transcript-token-file=/var/run/secrets/swe-platform/transcript-token
             {{- end }}
+            {{- if .Values.operator.githubApp.enabled }}
+            - --github-app-client-id={{ required "operator.githubApp.clientID is required" .Values.operator.githubApp.clientID }}
+            - --github-app-private-key-file=/var/run/secrets/swe-platform-github-app/private-key.pem
+            {{- end }}
           env:
             - name: POD_NAMESPACE
               valueFrom:
@@ -72,14 +76,22 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if .Values.controlPlane.enabled }}
+          {{- if or .Values.controlPlane.enabled .Values.operator.githubApp.enabled }}
           volumeMounts:
+            {{- if .Values.controlPlane.enabled }}
             - name: transcript-token
               mountPath: /var/run/secrets/swe-platform
               readOnly: true
+            {{- end }}
+            {{- if .Values.operator.githubApp.enabled }}
+            - name: github-app
+              mountPath: /var/run/secrets/swe-platform-github-app
+              readOnly: true
+            {{- end }}
           {{- end }}
-      {{- if .Values.controlPlane.enabled }}
+      {{- if or .Values.controlPlane.enabled .Values.operator.githubApp.enabled }}
       volumes:
+        {{- if .Values.controlPlane.enabled }}
         - name: transcript-token
           projected:
             sources:
@@ -87,6 +99,15 @@ spec:
                   path: transcript-token
                   audience: {{ .Values.controlPlane.auth.tokenAudience | quote }}
                   expirationSeconds: 3600
+        {{- end }}
+        {{- if .Values.operator.githubApp.enabled }}
+        - name: github-app
+          secret:
+            secretName: {{ required "operator.githubApp.secretName is required" .Values.operator.githubApp.secretName }}
+            items:
+              - key: {{ .Values.operator.githubApp.privateKeyKey }}
+                path: private-key.pem
+        {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/swe-platform/values.yaml
+++ b/charts/swe-platform/values.yaml
@@ -9,6 +9,13 @@ image:
   pullPolicy: IfNotPresent
 
 operator:
+  # Short-lived repository credentials are disabled unless an administrator-owned
+  # GitHub App Secret is explicitly selected. The chart never creates it.
+  githubApp:
+    enabled: false
+    clientID: ""
+    secretName: ""
+    privateKeyKey: private-key.pem
   metrics:
     # Exposed on the internal operator metrics Service.
     port: 8080

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -31,6 +31,8 @@ import (
 	"github.com/Chris-Cullins/swe-platform/internal/agent"
 	"github.com/Chris-Cullins/swe-platform/internal/controllers"
 	"github.com/Chris-Cullins/swe-platform/internal/controlplaneclient"
+	"github.com/Chris-Cullins/swe-platform/internal/repositorycredential"
+	"github.com/Chris-Cullins/swe-platform/internal/repositorycredential/githubapp"
 	"github.com/Chris-Cullins/swe-platform/internal/sandboxclient"
 	"github.com/Chris-Cullins/swe-platform/internal/tenancy"
 	"github.com/Chris-Cullins/swe-platform/internal/transcriptclient"
@@ -55,6 +57,8 @@ func main() {
 	var controlPlaneInstance string
 	var transcriptURL string
 	var transcriptTokenFile string
+	var githubAppClientID string
+	var githubAppPrivateKeyFile string
 	var tenancyModeValue string
 	var installationNamespace string
 	var installationName string
@@ -67,6 +71,8 @@ func main() {
 	flag.StringVar(&controlPlaneInstance, "control-plane-instance", "swe-platform", "app.kubernetes.io/instance label of the control plane.")
 	flag.StringVar(&transcriptURL, "transcript-url", "", "Control-plane base URL for adapter transcript events (disabled when empty).")
 	flag.StringVar(&transcriptTokenFile, "transcript-token-file", "", "Projected service-account token used to append adapter transcript events.")
+	flag.StringVar(&githubAppClientID, "github-app-client-id", "", "GitHub App client ID (requires private key file).")
+	flag.StringVar(&githubAppPrivateKeyFile, "github-app-private-key-file", "", "GitHub App PEM private key file.")
 	flag.StringVar(&tenancyModeValue, "tenancy-mode", "", "Required tenancy mode: scoped or trusted-admin.")
 	flag.StringVar(&installationNamespace, "installation-namespace", "", "System namespace containing this installation's Installation object.")
 	flag.StringVar(&installationName, "installation-name", "", "Name of this installation's Installation object.")
@@ -185,6 +191,24 @@ func main() {
 		}
 	}
 	var eventSink agent.AdapterEventSink
+	var repositoryCredentials repositorycredential.Provider
+	if (githubAppClientID == "") != (githubAppPrivateKeyFile == "") {
+		setupLog.Error(nil, "github-app-client-id and github-app-private-key-file must be set together")
+		os.Exit(1)
+	}
+	if githubAppClientID != "" {
+		privateKey, readErr := os.ReadFile(githubAppPrivateKeyFile)
+		if readErr != nil {
+			setupLog.Error(readErr, "read GitHub App private key")
+			os.Exit(1)
+		}
+		repositoryCredentials, err = githubapp.New(githubAppClientID, privateKey, nil)
+		clear(privateKey)
+		if err != nil {
+			setupLog.Error(err, "configure GitHub App")
+			os.Exit(1)
+		}
+	}
 	if transcriptURL != "" {
 		if transcriptTokenFile == "" {
 			setupLog.Error(nil, "transcript-token-file is required when transcript-url is set")
@@ -197,14 +221,15 @@ func main() {
 	}
 	if !(mode == tenancy.ModeScoped && len(tenancyNamespaces) == 0) {
 		if err := (&controllers.RunReconciler{
-			Client:    guardedClient,
-			APIReader: mgr.GetAPIReader(),
-			Scheme:    mgr.GetScheme(),
-			Scope:     scope,
-			Adapters:  adapters,
-			EventSink: eventSink,
-			Connector: connector,
-			Metrics:   operatorMetrics,
+			Client:                guardedClient,
+			APIReader:             mgr.GetAPIReader(),
+			Scheme:                mgr.GetScheme(),
+			Scope:                 scope,
+			Adapters:              adapters,
+			EventSink:             eventSink,
+			Connector:             connector,
+			Metrics:               operatorMetrics,
+			RepositoryCredentials: repositoryCredentials,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "Run")
 			os.Exit(1)

--- a/config/crd/bases/swe.dev_runs.yaml
+++ b/config/crd/bases/swe.dev_runs.yaml
@@ -94,6 +94,11 @@ spec:
               prompt:
                 description: Prompt is the task handed to the agent.
                 type: string
+              repositoryCredential:
+                description: RepositoryCredential selects short-lived repository authentication.
+                enum:
+                - GitHubApp
+                type: string
               templateRef:
                 description: TemplateRef selects the template for a controller-allocated
                   Environment.
@@ -107,8 +112,8 @@ spec:
             - message: set environmentRef or templateRef/projectRef, not both
               rule: 'has(self.environmentRef) ? (!has(self.templateRef) && !has(self.projectRef))
                 : (has(self.templateRef) || has(self.projectRef))'
-            - message: agent, prompt, environment selection, and credential profile
-                are immutable
+            - message: agent, prompt, environment selection, credential profile, and
+                repository credential are immutable
               rule: self.agent == oldSelf.agent && self.prompt == oldSelf.prompt &&
                 ((!has(self.environmentRef) && !has(oldSelf.environmentRef)) || (has(self.environmentRef)
                 && has(oldSelf.environmentRef) && self.environmentRef == oldSelf.environmentRef))
@@ -118,7 +123,10 @@ spec:
                 && has(oldSelf.templateRef) && self.templateRef == oldSelf.templateRef))
                 && ((!has(self.credentialProfileRef) && !has(oldSelf.credentialProfileRef))
                 || (has(self.credentialProfileRef) && has(oldSelf.credentialProfileRef)
-                && self.credentialProfileRef == oldSelf.credentialProfileRef))
+                && self.credentialProfileRef == oldSelf.credentialProfileRef)) &&
+                ((!has(self.repositoryCredential) && !has(oldSelf.repositoryCredential))
+                || (has(self.repositoryCredential) && has(oldSelf.repositoryCredential)
+                && self.repositoryCredential == oldSelf.repositoryCredential))
             - message: cancel cannot be unset
               rule: '!has(oldSelf.cancel) || !oldSelf.cancel || (has(self.cancel)
                 && self.cancel)'

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -1382,27 +1382,6 @@ fi
 kubectl wait --for=jsonpath='{.status.phase}'=Ready environment/"$RUN_ENV_NAME" --timeout=3m
 ENV_NAME=$RUN_ENV_NAME
 ENV_UID=$(kubectl get environment "$ENV_NAME" -o jsonpath='{.metadata.uid}')
-
-echo "==> verifying deterministic disabled GitHub App credential status"
-GIT_CREDENTIAL_DISABLED_RUN=e2e-github-app-disabled
-bin/swe --namespace "$PROJECT_NAMESPACE" run "disabled GitHub App status smoke test" \
-	--name "$GIT_CREDENTIAL_DISABLED_RUN" --environment "$ENV_NAME" --git-credential github-app --wait=false
-kubectl wait --for=jsonpath='{.status.state}'=Failed run/"$GIT_CREDENTIAL_DISABLED_RUN" --timeout=2m
-GIT_CREDENTIAL_DISABLED_UID=$(kubectl get run "$GIT_CREDENTIAL_DISABLED_RUN" -o jsonpath='{.metadata.uid}')
-GIT_CREDENTIAL_DISABLED_SPEC=$(kubectl get run "$GIT_CREDENTIAL_DISABLED_RUN" -o jsonpath='{.spec.repositoryCredential}')
-GIT_CREDENTIAL_DISABLED_REASON=$(kubectl get run "$GIT_CREDENTIAL_DISABLED_RUN" -o json | \
-	jq -r '.status.conditions[] | select(.type == "RepositoryCredentialReady") | .reason')
-if [[ "$GIT_CREDENTIAL_DISABLED_SPEC" != "GitHubApp" || "$GIT_CREDENTIAL_DISABLED_REASON" != "ProviderDisabled" ]]; then
-	echo "FAIL: disabled GitHub App intent/status was ${GIT_CREDENTIAL_DISABLED_SPEC}/${GIT_CREDENTIAL_DISABLED_REASON}"
-	exit 1
-fi
-if kubectl get secret "run-repository-credential-${GIT_CREDENTIAL_DISABLED_UID}" >/dev/null 2>&1; then
-	echo "FAIL: disabled GitHub App Run persisted repository credential material"
-	exit 1
-fi
-kubectl delete run "$GIT_CREDENTIAL_DISABLED_RUN" --wait=true >/dev/null
-kubectl wait --for=jsonpath='{.status.phase}'=Ready environment/"$ENV_NAME" --timeout=2m
-
 for _ in $(seq 1 60); do
 	REPLACEMENT_NAME=$(kubectl get environments -l swe.dev/warm-pool=small -o jsonpath='{range .items[*]}{.metadata.name}{end}' 2>/dev/null || true)
 	REPLACEMENT_PHASE=$(kubectl get environments -l swe.dev/warm-pool=small -o jsonpath='{range .items[*]}{.status.phase}{end}' 2>/dev/null || true)
@@ -3016,6 +2995,25 @@ if [[ "$POD_PHASE" != "Running" ]]; then
 	kubectl -n "$SYSTEM_NAMESPACE" logs deployment/swe-platform-swe-platform --tail=50
 	exit 1
 fi
+
+echo "==> verifying deterministic disabled GitHub App credential status"
+GIT_CREDENTIAL_DISABLED_RUN=e2e-github-app-disabled
+bin/swe --namespace "$PROJECT_NAMESPACE" run "disabled GitHub App status smoke test" \
+	--name "$GIT_CREDENTIAL_DISABLED_RUN" --project "$PROJECT_NAME" --git-credential github-app --wait=false
+kubectl wait --for=jsonpath='{.status.state}'=Failed run/"$GIT_CREDENTIAL_DISABLED_RUN" --timeout=2m
+GIT_CREDENTIAL_DISABLED_UID=$(kubectl get run "$GIT_CREDENTIAL_DISABLED_RUN" -o jsonpath='{.metadata.uid}')
+GIT_CREDENTIAL_DISABLED_SPEC=$(kubectl get run "$GIT_CREDENTIAL_DISABLED_RUN" -o jsonpath='{.spec.repositoryCredential}')
+GIT_CREDENTIAL_DISABLED_REASON=$(kubectl get run "$GIT_CREDENTIAL_DISABLED_RUN" -o json | \
+	jq -r '.status.conditions[] | select(.type == "RepositoryCredentialReady") | .reason')
+if [[ "$GIT_CREDENTIAL_DISABLED_SPEC" != "GitHubApp" || "$GIT_CREDENTIAL_DISABLED_REASON" != "ProviderDisabled" ]]; then
+	echo "FAIL: disabled GitHub App intent/status was ${GIT_CREDENTIAL_DISABLED_SPEC}/${GIT_CREDENTIAL_DISABLED_REASON}"
+	exit 1
+fi
+if kubectl get secret "run-repository-credential-${GIT_CREDENTIAL_DISABLED_UID}" >/dev/null 2>&1; then
+	echo "FAIL: disabled GitHub App Run persisted repository credential material"
+	exit 1
+fi
+kubectl delete run "$GIT_CREDENTIAL_DISABLED_RUN" --wait=true >/dev/null
 
 echo "==> sandboxd logs from the environment pod"
 kubectl logs "$POD_NAME" -c environment | head -3

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -2224,10 +2224,14 @@ if ! jq -e --argjson snapshot "$PROVISIONING_SNAPSHOT" '
 	([.spec.containers[] | select(.name == "environment")] | length == 1 and
 	 .[0].image == $snapshot.image and .[0].resources.requests == $snapshot.resources and
 	 .[0].resources.limits == $snapshot.resources) and
-	([.spec.initContainers[] | select(.name == "project-setup")] | length == 1 and
+	([.spec.initContainers[] | select(.name == "repository-clone")] | length == 1 and
 	 .[0].image == $snapshot.image and .[0].resources.requests == $snapshot.resources and
 	 .[0].resources.limits == $snapshot.resources and
-	 ([.[0].env[] | select(.name == "SWE_REPOSITORY") | .value] | first) == $snapshot.project.repository)' <<<"$RECREATED_POD" >/dev/null ||
+	 ([.[0].env[] | select(.name == "SWE_REPOSITORY") | .value] | first) == $snapshot.project.repository) and
+	([.spec.initContainers[] | select(.name == "project-hooks")] | length == 1 and
+	 .[0].image == $snapshot.image and .[0].resources.requests == $snapshot.resources and
+	 .[0].resources.limits == $snapshot.resources and
+	 ([.[0].env[] | select(.name == "SWE_REPOSITORY_TOKEN")] | length) == 0)' <<<"$RECREATED_POD" >/dev/null ||
 	[[ "$(jq -r '.spec.runtimeClassName // ""' <<<"$RECREATED_POD")" != "$(jq -r '.runtimeClassName' <<<"$PROVISIONING_SNAPSHOT")" ]]; then
 	echo "FAIL: recreated Pod does not match the provisioning image/runtime/resources/repository"
 	exit 1

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -1331,6 +1331,23 @@ PROJECT_REPO=""
 PROJECT_WORKTREE=""
 echo "==> creating project environment + run intent via swe"
 printf '%s' "$E2E_AGENT_API_KEY" | bin/swe --namespace "$PROJECT_NAMESPACE" credentials create e2e-claude --agent claude-code --api-key-stdin
+GIT_CREDENTIAL_DISABLED_RUN=e2e-github-app-disabled
+bin/swe --namespace "$PROJECT_NAMESPACE" run "disabled GitHub App status smoke test" \
+	--name "$GIT_CREDENTIAL_DISABLED_RUN" --project "$PROJECT_NAME" --git-credential github-app --wait=false
+kubectl wait --for=jsonpath='{.status.state}'=Failed run/"$GIT_CREDENTIAL_DISABLED_RUN" --timeout=2m
+GIT_CREDENTIAL_DISABLED_UID=$(kubectl get run "$GIT_CREDENTIAL_DISABLED_RUN" -o jsonpath='{.metadata.uid}')
+GIT_CREDENTIAL_DISABLED_SPEC=$(kubectl get run "$GIT_CREDENTIAL_DISABLED_RUN" -o jsonpath='{.spec.repositoryCredential}')
+GIT_CREDENTIAL_DISABLED_REASON=$(kubectl get run "$GIT_CREDENTIAL_DISABLED_RUN" -o json | \
+	jq -r '.status.conditions[] | select(.type == "RepositoryCredentialReady") | .reason')
+if [[ "$GIT_CREDENTIAL_DISABLED_SPEC" != "GitHubApp" || "$GIT_CREDENTIAL_DISABLED_REASON" != "ProviderDisabled" ]]; then
+	echo "FAIL: disabled GitHub App intent/status was ${GIT_CREDENTIAL_DISABLED_SPEC}/${GIT_CREDENTIAL_DISABLED_REASON}"
+	exit 1
+fi
+if kubectl get secret "run-repository-credential-${GIT_CREDENTIAL_DISABLED_UID}" >/dev/null 2>&1; then
+	echo "FAIL: disabled GitHub App Run persisted repository credential material"
+	exit 1
+fi
+kubectl delete run "$GIT_CREDENTIAL_DISABLED_RUN" --wait=true >/dev/null
 bin/swe --namespace "$PROJECT_NAMESPACE" run "end-to-end smoke test" --project "$PROJECT_NAME" --credential-profile e2e-claude --wait=false
 RUN_NAME=$(kubectl get runs -o jsonpath='{.items[0].metadata.name}')
 kubectl wait --for=jsonpath='{.status.state}'=Running run/"$RUN_NAME" --timeout=3m

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -1331,23 +1331,6 @@ PROJECT_REPO=""
 PROJECT_WORKTREE=""
 echo "==> creating project environment + run intent via swe"
 printf '%s' "$E2E_AGENT_API_KEY" | bin/swe --namespace "$PROJECT_NAMESPACE" credentials create e2e-claude --agent claude-code --api-key-stdin
-GIT_CREDENTIAL_DISABLED_RUN=e2e-github-app-disabled
-bin/swe --namespace "$PROJECT_NAMESPACE" run "disabled GitHub App status smoke test" \
-	--name "$GIT_CREDENTIAL_DISABLED_RUN" --project "$PROJECT_NAME" --git-credential github-app --wait=false
-kubectl wait --for=jsonpath='{.status.state}'=Failed run/"$GIT_CREDENTIAL_DISABLED_RUN" --timeout=2m
-GIT_CREDENTIAL_DISABLED_UID=$(kubectl get run "$GIT_CREDENTIAL_DISABLED_RUN" -o jsonpath='{.metadata.uid}')
-GIT_CREDENTIAL_DISABLED_SPEC=$(kubectl get run "$GIT_CREDENTIAL_DISABLED_RUN" -o jsonpath='{.spec.repositoryCredential}')
-GIT_CREDENTIAL_DISABLED_REASON=$(kubectl get run "$GIT_CREDENTIAL_DISABLED_RUN" -o json | \
-	jq -r '.status.conditions[] | select(.type == "RepositoryCredentialReady") | .reason')
-if [[ "$GIT_CREDENTIAL_DISABLED_SPEC" != "GitHubApp" || "$GIT_CREDENTIAL_DISABLED_REASON" != "ProviderDisabled" ]]; then
-	echo "FAIL: disabled GitHub App intent/status was ${GIT_CREDENTIAL_DISABLED_SPEC}/${GIT_CREDENTIAL_DISABLED_REASON}"
-	exit 1
-fi
-if kubectl get secret "run-repository-credential-${GIT_CREDENTIAL_DISABLED_UID}" >/dev/null 2>&1; then
-	echo "FAIL: disabled GitHub App Run persisted repository credential material"
-	exit 1
-fi
-kubectl delete run "$GIT_CREDENTIAL_DISABLED_RUN" --wait=true >/dev/null
 bin/swe --namespace "$PROJECT_NAMESPACE" run "end-to-end smoke test" --project "$PROJECT_NAME" --credential-profile e2e-claude --wait=false
 RUN_NAME=$(kubectl get runs -o jsonpath='{.items[0].metadata.name}')
 kubectl wait --for=jsonpath='{.status.state}'=Running run/"$RUN_NAME" --timeout=3m
@@ -1399,6 +1382,27 @@ fi
 kubectl wait --for=jsonpath='{.status.phase}'=Ready environment/"$RUN_ENV_NAME" --timeout=3m
 ENV_NAME=$RUN_ENV_NAME
 ENV_UID=$(kubectl get environment "$ENV_NAME" -o jsonpath='{.metadata.uid}')
+
+echo "==> verifying deterministic disabled GitHub App credential status"
+GIT_CREDENTIAL_DISABLED_RUN=e2e-github-app-disabled
+bin/swe --namespace "$PROJECT_NAMESPACE" run "disabled GitHub App status smoke test" \
+	--name "$GIT_CREDENTIAL_DISABLED_RUN" --environment "$ENV_NAME" --git-credential github-app --wait=false
+kubectl wait --for=jsonpath='{.status.state}'=Failed run/"$GIT_CREDENTIAL_DISABLED_RUN" --timeout=2m
+GIT_CREDENTIAL_DISABLED_UID=$(kubectl get run "$GIT_CREDENTIAL_DISABLED_RUN" -o jsonpath='{.metadata.uid}')
+GIT_CREDENTIAL_DISABLED_SPEC=$(kubectl get run "$GIT_CREDENTIAL_DISABLED_RUN" -o jsonpath='{.spec.repositoryCredential}')
+GIT_CREDENTIAL_DISABLED_REASON=$(kubectl get run "$GIT_CREDENTIAL_DISABLED_RUN" -o json | \
+	jq -r '.status.conditions[] | select(.type == "RepositoryCredentialReady") | .reason')
+if [[ "$GIT_CREDENTIAL_DISABLED_SPEC" != "GitHubApp" || "$GIT_CREDENTIAL_DISABLED_REASON" != "ProviderDisabled" ]]; then
+	echo "FAIL: disabled GitHub App intent/status was ${GIT_CREDENTIAL_DISABLED_SPEC}/${GIT_CREDENTIAL_DISABLED_REASON}"
+	exit 1
+fi
+if kubectl get secret "run-repository-credential-${GIT_CREDENTIAL_DISABLED_UID}" >/dev/null 2>&1; then
+	echo "FAIL: disabled GitHub App Run persisted repository credential material"
+	exit 1
+fi
+kubectl delete run "$GIT_CREDENTIAL_DISABLED_RUN" --wait=true >/dev/null
+kubectl wait --for=jsonpath='{.status.phase}'=Ready environment/"$ENV_NAME" --timeout=2m
+
 for _ in $(seq 1 60); do
 	REPLACEMENT_NAME=$(kubectl get environments -l swe.dev/warm-pool=small -o jsonpath='{range .items[*]}{.metadata.name}{end}' 2>/dev/null || true)
 	REPLACEMENT_PHASE=$(kubectl get environments -l swe.dev/warm-pool=small -o jsonpath='{range .items[*]}{.status.phase}{end}' 2>/dev/null || true)

--- a/hack/helm-rbac_test.sh
+++ b/hack/helm-rbac_test.sh
@@ -74,4 +74,27 @@ for mode in scoped trusted-admin; do
 	fi
 done
 
-echo "scoped and trusted-admin Helm RBAC deny status by default and grant portal-only status update"
+if helm template rbac-test charts/swe-platform --namespace rbac-system \
+	--set tenancy.mode=scoped --set operator.githubApp.enabled=true >/dev/null 2>&1; then
+	echo "GitHub App enablement without administrator-owned identity/Secret references must fail" >&2
+	exit 1
+fi
+github_app_render=$(helm template rbac-test charts/swe-platform \
+	--namespace rbac-system \
+	--set tenancy.mode=scoped \
+	--set operator.githubApp.enabled=true \
+	--set-string operator.githubApp.clientID=Iv1.test \
+	--set-string operator.githubApp.secretName=github-app-private-key)
+github_app_operator=$(awk -v RS='---' '
+	/kind: Deployment/ && /app.kubernetes.io\/component: operator/ { print; exit }
+' <<<"$github_app_render")
+if [[ -z "$github_app_operator" ]] ||
+	! grep -Fq -- '--github-app-client-id=Iv1.test' <<<"$github_app_operator" ||
+	! grep -Fq -- '--github-app-private-key-file=/var/run/secrets/swe-platform-github-app/private-key.pem' <<<"$github_app_operator" ||
+	! grep -Fq 'secretName: github-app-private-key' <<<"$github_app_operator" ||
+	! grep -Fq 'key: private-key.pem' <<<"$github_app_operator"; then
+	echo "GitHub App render did not mount the exact administrator-owned key only for the operator" >&2
+	exit 1
+fi
+
+echo "scoped and trusted-admin Helm RBAC plus disabled-by-default GitHub App mounts are fenced"

--- a/internal/adapters/amp/adapter.go
+++ b/internal/adapters/amp/adapter.go
@@ -13,7 +13,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
 	"github.com/Chris-Cullins/swe-platform/internal/agent"
 	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
 )
@@ -83,24 +82,24 @@ func (a *Adapter) spec(task agent.AdapterTask) *sandboxdv1.ProcessSpec {
 }
 
 // EnsureAccepted duplicate-safely starts (or recovers) the Run-keyed process.
-func (a *Adapter) EnsureAccepted(ctx context.Context, task agent.AdapterTask, sandbox agent.AdapterSandbox, credential *agent.AdapterCredential) error {
-	if credential != nil && credential.Type != platformv1alpha1.AgentCredentialTypeAPIKey {
-		return fmt.Errorf("%w: unsupported credential type %q", agent.ErrAdapterTaskRejected, credential.Type)
+func (a *Adapter) EnsureAccepted(ctx context.Context, task agent.AdapterTask, sandbox agent.AdapterSandbox, material *agent.AdapterLaunchMaterial) error {
+	launch, cleanup, err := agent.PrepareLaunchMaterial(material, "AMP_API_KEY", true)
+	if err != nil {
+		return err
 	}
+	defer cleanup()
 	client, closeConnection, err := sandbox.DialProcess(ctx)
 	if err != nil {
 		return err
 	}
 	defer closeConnection()
-	if credential == nil {
+	if launch == nil || len(launch.SecretEnv) == 0 {
 		_, err = client.Start(ctx, &sandboxdv1.StartProcessRequest{Key: key(task), Spec: a.spec(task)})
 		return err
 	}
-	apiKey := append([]byte(nil), credential.APIKey...)
-	defer clear(apiKey)
 	_, err = client.StartWithLaunchMaterial(ctx, &sandboxdv1.StartProcessWithLaunchMaterialRequest{
 		Key: key(task), Spec: a.spec(task),
-		LaunchMaterial: &sandboxdv1.LaunchMaterial{SecretEnv: map[string][]byte{"AMP_API_KEY": apiKey}},
+		LaunchMaterial: launch,
 	})
 	return err
 }

--- a/internal/adapters/amp/adapter_test.go
+++ b/internal/adapters/amp/adapter_test.go
@@ -18,6 +18,21 @@ import (
 	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
 )
 
+func launchCredential(credential *agent.AdapterCredential) *agent.AdapterLaunchMaterial {
+	return &agent.AdapterLaunchMaterial{AgentCredential: credential}
+}
+
+func TestRepositoryOnlyLaunchMaterial(t *testing.T) {
+	client := &fakeClient{}
+	material := &agent.AdapterLaunchMaterial{RepositorySecretEnv: map[string][]byte{"REPOSITORY_TOKEN": []byte("secret")}}
+	if err := (&Adapter{}).EnsureAccepted(context.Background(), agent.AdapterTask{ID: "run", Prompt: "task"}, testSandbox(client), material); err != nil {
+		t.Fatal(err)
+	}
+	if client.launchCalls != 1 || client.starts != 0 || client.launchRequest.Spec.Env["REPOSITORY_TOKEN"] != "" {
+		t.Fatalf("repository launch = %#v", client.launchRequest)
+	}
+}
+
 type fakeClient struct {
 	process         *sandboxdv1.Process
 	stdout          []byte
@@ -176,7 +191,7 @@ func TestAPIKeyUsesLaunchMaterialOnlyAndClearsTemporaryCopy(t *testing.T) {
 	client := &fakeClient{}
 	key := []byte("!!AMP-API-KEY-FIXTURE!!")
 	credential := &agent.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: key}
-	if err := (&Adapter{}).EnsureAccepted(context.Background(), agent.AdapterTask{ID: "run", Prompt: "task"}, testSandbox(client), credential); err != nil {
+	if err := (&Adapter{}).EnsureAccepted(context.Background(), agent.AdapterTask{ID: "run", Prompt: "task"}, testSandbox(client), launchCredential(credential)); err != nil {
 		t.Fatal(err)
 	}
 	if client.launchCalls != 1 || client.starts != 0 || string(client.launchValue) != string(key) || string(credential.APIKey) != string(key) {
@@ -199,7 +214,7 @@ func TestUnsupportedCredentialTypeFailsBeforeDial(t *testing.T) {
 		dials++
 		return nil, nil, nil
 	}}
-	err := (&Adapter{}).EnsureAccepted(context.Background(), agent.AdapterTask{}, sandbox, &agent.AdapterCredential{Type: "OAuth", APIKey: []byte("!!UNUSED-KEY-FIXTURE!!")})
+	err := (&Adapter{}).EnsureAccepted(context.Background(), agent.AdapterTask{}, sandbox, launchCredential(&agent.AdapterCredential{Type: "OAuth", APIKey: []byte("!!UNUSED-KEY-FIXTURE!!")}))
 	if !errors.Is(err, agent.ErrAdapterTaskRejected) || dials != 0 {
 		t.Fatalf("error/dials = %v/%d", err, dials)
 	}
@@ -208,7 +223,7 @@ func TestUnsupportedCredentialTypeFailsBeforeDial(t *testing.T) {
 func TestLaunchMaterialFailureDoesNotFallbackOrExposeKey(t *testing.T) {
 	key := []byte("!!AMP-FAILURE-KEY-FIXTURE!!")
 	client := &fakeClient{beforeLaunchErr: status.Error(codes.Unimplemented, "old sandboxd")}
-	err := (&Adapter{}).EnsureAccepted(context.Background(), agent.AdapterTask{ID: "run", Prompt: "task"}, testSandbox(client), &agent.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: key})
+	err := (&Adapter{}).EnsureAccepted(context.Background(), agent.AdapterTask{ID: "run", Prompt: "task"}, testSandbox(client), launchCredential(&agent.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: key}))
 	if status.Code(err) != codes.Unimplemented || client.starts != 0 || client.launchCalls != 1 || client.launches != 0 || strings.Contains(err.Error(), string(key)) {
 		t.Fatalf("error/start/calls/launches = %v/%d/%d/%d", err, client.starts, client.launchCalls, client.launches)
 	}
@@ -220,7 +235,7 @@ func TestKeyedAcceptancePreservesDuplicateRotationAndFreshEpochSemantics(t *test
 	first := &fakeClient{}
 	for _, value := range []string{"first-key", "rotated-key"} {
 		credential := &agent.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: []byte(value)}
-		if err := adapter.EnsureAccepted(context.Background(), task, testSandbox(first), credential); err != nil {
+		if err := adapter.EnsureAccepted(context.Background(), task, testSandbox(first), launchCredential(credential)); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -229,7 +244,7 @@ func TestKeyedAcceptancePreservesDuplicateRotationAndFreshEpochSemantics(t *test
 	}
 	second := &fakeClient{}
 	credential := &agent.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: []byte("current-key")}
-	if err := adapter.EnsureAccepted(context.Background(), task, testSandbox(second), credential); err != nil {
+	if err := adapter.EnsureAccepted(context.Background(), task, testSandbox(second), launchCredential(credential)); err != nil {
 		t.Fatal(err)
 	}
 	if second.launches != 1 || string(second.launchValue) != "current-key" || second.startedKey.OwnerId != task.ID {
@@ -241,12 +256,12 @@ func TestUncertainKeyedStartRetryDoesNotUsePlainStart(t *testing.T) {
 	client := &fakeClient{afterLaunchErr: status.Error(codes.Unavailable, "response lost")}
 	credential := &agent.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: []byte("first-key")}
 	task := agent.AdapterTask{ID: "run", Prompt: "task"}
-	if err := (&Adapter{}).EnsureAccepted(context.Background(), task, testSandbox(client), credential); status.Code(err) != codes.Unavailable {
+	if err := (&Adapter{}).EnsureAccepted(context.Background(), task, testSandbox(client), launchCredential(credential)); status.Code(err) != codes.Unavailable {
 		t.Fatalf("first start error = %v", err)
 	}
 	client.afterLaunchErr = nil
 	credential.APIKey = []byte("rotated-key")
-	if err := (&Adapter{}).EnsureAccepted(context.Background(), task, testSandbox(client), credential); err != nil {
+	if err := (&Adapter{}).EnsureAccepted(context.Background(), task, testSandbox(client), launchCredential(credential)); err != nil {
 		t.Fatal(err)
 	}
 	if client.launchCalls != 2 || client.launches != 1 || client.starts != 0 || string(client.launchValue) != "first-key" || string(client.submittedValue) != "rotated-key" {

--- a/internal/adapters/claudecode/adapter.go
+++ b/internal/adapters/claudecode/adapter.go
@@ -13,7 +13,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
 	"github.com/Chris-Cullins/swe-platform/internal/agent"
 	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
 )
@@ -87,24 +86,24 @@ func (a *Adapter) processSpec(task agent.AdapterTask) *sandboxdv1.ProcessSpec {
 }
 
 // EnsureAccepted duplicate-safely starts (or recovers) the Run-keyed process.
-func (a *Adapter) EnsureAccepted(ctx context.Context, task agent.AdapterTask, sandbox agent.AdapterSandbox, credential *agent.AdapterCredential) error {
-	if credential != nil && credential.Type != platformv1alpha1.AgentCredentialTypeAPIKey {
-		return fmt.Errorf("unsupported credential type %q", credential.Type)
+func (a *Adapter) EnsureAccepted(ctx context.Context, task agent.AdapterTask, sandbox agent.AdapterSandbox, material *agent.AdapterLaunchMaterial) error {
+	launch, cleanup, err := agent.PrepareLaunchMaterial(material, "ANTHROPIC_API_KEY", true)
+	if err != nil {
+		return err
 	}
+	defer cleanup()
 	client, closeConnection, err := sandbox.DialProcess(ctx)
 	if err != nil {
 		return err
 	}
 	defer closeConnection()
-	if credential == nil {
+	if launch == nil || len(launch.SecretEnv) == 0 {
 		_, err = client.Start(ctx, &sandboxdv1.StartProcessRequest{Key: processKey(task), Spec: a.processSpec(task)})
 		return err
 	}
-	apiKey := append([]byte(nil), credential.APIKey...)
-	defer clear(apiKey)
 	_, err = client.StartWithLaunchMaterial(ctx, &sandboxdv1.StartProcessWithLaunchMaterialRequest{
 		Key: processKey(task), Spec: a.processSpec(task),
-		LaunchMaterial: &sandboxdv1.LaunchMaterial{SecretEnv: map[string][]byte{"ANTHROPIC_API_KEY": apiKey}},
+		LaunchMaterial: launch,
 	})
 	return err
 }

--- a/internal/adapters/claudecode/adapter_test.go
+++ b/internal/adapters/claudecode/adapter_test.go
@@ -16,6 +16,21 @@ import (
 	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
 )
 
+func launchCredential(credential *agent.AdapterCredential) *agent.AdapterLaunchMaterial {
+	return &agent.AdapterLaunchMaterial{AgentCredential: credential}
+}
+
+func TestRepositoryOnlyLaunchMaterial(t *testing.T) {
+	client := &fakeProcessClient{}
+	material := &agent.AdapterLaunchMaterial{RepositorySecretEnv: map[string][]byte{"REPOSITORY_TOKEN": []byte("secret")}}
+	if err := (&Adapter{}).EnsureAccepted(context.Background(), agent.AdapterTask{ID: "run", Prompt: "task"}, sandboxFor(client), material); err != nil {
+		t.Fatal(err)
+	}
+	if client.launchCalls != 1 || client.startCalls != 0 || len(client.launchRequest.Spec.Env) != 0 {
+		t.Fatalf("repository launch = %#v", client.launchRequest)
+	}
+}
+
 type fakeProcessClient struct {
 	process       *sandboxdv1.Process
 	stdout        []byte
@@ -149,7 +164,7 @@ func TestPromptIsSeparatedFromClaudeFlags(t *testing.T) {
 func TestAPIKeyUsesLaunchMaterialOnly(t *testing.T) {
 	client := &fakeProcessClient{}
 	key := []byte("!!CLAUDE-API-KEY-FIXTURE!!")
-	err := (&Adapter{}).EnsureAccepted(context.Background(), agent.AdapterTask{ID: "run", Prompt: "task"}, sandboxFor(client), &agent.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: key})
+	err := (&Adapter{}).EnsureAccepted(context.Background(), agent.AdapterTask{ID: "run", Prompt: "task"}, sandboxFor(client), launchCredential(&agent.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: key}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -166,7 +181,7 @@ func TestAPIKeyUsesLaunchMaterialOnly(t *testing.T) {
 
 func TestLaunchMaterialUnimplementedDoesNotFallback(t *testing.T) {
 	client := &fakeProcessClient{launchErr: status.Error(codes.Unimplemented, "old sandboxd")}
-	err := (&Adapter{}).EnsureAccepted(context.Background(), agent.AdapterTask{ID: "run"}, sandboxFor(client), &agent.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: []byte("key")})
+	err := (&Adapter{}).EnsureAccepted(context.Background(), agent.AdapterTask{ID: "run"}, sandboxFor(client), launchCredential(&agent.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: []byte("key")}))
 	if status.Code(err) != codes.Unimplemented || client.startCalls != 0 {
 		t.Fatalf("error/start calls = %v/%d", err, client.startCalls)
 	}
@@ -178,7 +193,7 @@ func TestUnsupportedCredentialTypeFailsBeforeDial(t *testing.T) {
 		dials++
 		return &fakeProcessClient{}, func() error { return nil }, nil
 	}}
-	err := (&Adapter{}).EnsureAccepted(context.Background(), agent.AdapterTask{ID: "run"}, sandbox, &agent.AdapterCredential{Type: "FutureType", APIKey: []byte("!!UNUSED-KEY-FIXTURE!!")})
+	err := (&Adapter{}).EnsureAccepted(context.Background(), agent.AdapterTask{ID: "run"}, sandbox, launchCredential(&agent.AdapterCredential{Type: "FutureType", APIKey: []byte("!!UNUSED-KEY-FIXTURE!!")}))
 	if err == nil || dials != 0 {
 		t.Fatalf("unsupported credential = error %v, dials %d", err, dials)
 	}

--- a/internal/adapters/codex/adapter.go
+++ b/internal/adapters/codex/adapter.go
@@ -13,7 +13,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
 	"github.com/Chris-Cullins/swe-platform/internal/agent"
 	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
 )
@@ -82,25 +81,25 @@ func (a *Adapter) spec(t agent.AdapterTask) *sandboxdv1.ProcessSpec {
 	return &sandboxdv1.ProcessSpec{Argv: []string{a.executable(), "exec", "--json", "--ephemeral", "--ignore-user-config", "--ignore-rules", "--sandbox", "workspace-write", "--color", "never", "--skip-git-repo-check", "--", t.Prompt}, EnvMode: sandboxdv1.EnvironmentMode_ENVIRONMENT_MODE_INHERIT}
 }
 
-func (a *Adapter) EnsureAccepted(ctx context.Context, task agent.AdapterTask, sandbox agent.AdapterSandbox, credential *agent.AdapterCredential) error {
+func (a *Adapter) EnsureAccepted(ctx context.Context, task agent.AdapterTask, sandbox agent.AdapterSandbox, material *agent.AdapterLaunchMaterial) error {
 	if task.Prompt == "-" {
 		return fmt.Errorf("%w: Codex prompt '-' requires managed stdin", agent.ErrAdapterTaskRejected)
 	}
-	if credential != nil && credential.Type != platformv1alpha1.AgentCredentialTypeAPIKey {
-		return fmt.Errorf("%w: unsupported credential type %q", agent.ErrAdapterTaskRejected, credential.Type)
+	launch, cleanup, err := agent.PrepareLaunchMaterial(material, "CODEX_API_KEY", true)
+	if err != nil {
+		return err
 	}
+	defer cleanup()
 	client, closeConnection, err := sandbox.DialProcess(ctx)
 	if err != nil {
 		return err
 	}
 	defer closeConnection()
-	if credential == nil {
+	if launch == nil || len(launch.SecretEnv) == 0 {
 		_, err = client.Start(ctx, &sandboxdv1.StartProcessRequest{Key: key(task), Spec: a.spec(task)})
 		return err
 	}
-	apiKey := append([]byte(nil), credential.APIKey...)
-	defer clear(apiKey)
-	_, err = client.StartWithLaunchMaterial(ctx, &sandboxdv1.StartProcessWithLaunchMaterialRequest{Key: key(task), Spec: a.spec(task), LaunchMaterial: &sandboxdv1.LaunchMaterial{SecretEnv: map[string][]byte{"CODEX_API_KEY": apiKey}}})
+	_, err = client.StartWithLaunchMaterial(ctx, &sandboxdv1.StartProcessWithLaunchMaterialRequest{Key: key(task), Spec: a.spec(task), LaunchMaterial: launch})
 	return err
 }
 

--- a/internal/adapters/codex/adapter_test.go
+++ b/internal/adapters/codex/adapter_test.go
@@ -18,6 +18,21 @@ import (
 	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
 )
 
+func launchCredential(credential *agent.AdapterCredential) *agent.AdapterLaunchMaterial {
+	return &agent.AdapterLaunchMaterial{AgentCredential: credential}
+}
+
+func TestRepositoryOnlyLaunchMaterial(t *testing.T) {
+	client, dials := &launchClient{}, 0
+	material := &agent.AdapterLaunchMaterial{RepositorySecretEnv: map[string][]byte{"REPOSITORY_TOKEN": []byte("secret")}}
+	if err := (&Adapter{}).EnsureAccepted(context.Background(), agent.AdapterTask{ID: "run", Prompt: "task"}, sandboxFor(client, &dials), material); err != nil {
+		t.Fatal(err)
+	}
+	if client.launches != 1 || client.starts != 0 || len(client.launchRequest.Spec.Env) != 0 {
+		t.Fatalf("repository launch = %#v", client.launchRequest)
+	}
+}
+
 type launchClient struct {
 	sandboxdv1.ProcessServiceClient
 	starts        int
@@ -67,7 +82,7 @@ func TestAcceptancePromptAndCredentialSafety(t *testing.T) {
 		t.Fatalf("spec/start = %#v/%d", c.spec, c.starts)
 	}
 	credential := &agent.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: []byte("secret")}
-	if err := a.EnsureAccepted(context.Background(), task, sandboxFor(c, &dials), credential); err != nil {
+	if err := a.EnsureAccepted(context.Background(), task, sandboxFor(c, &dials), launchCredential(credential)); err != nil {
 		t.Fatal(err)
 	}
 	if c.launches != 1 || string(c.material.SecretEnv["CODEX_API_KEY"]) != "secret" || string(credential.APIKey) != "secret" {
@@ -81,7 +96,7 @@ func TestAcceptancePromptAndCredentialSafety(t *testing.T) {
 		task agent.AdapterTask
 		cred *agent.AdapterCredential
 	}{{task: agent.AdapterTask{Prompt: "-"}}, {task: task, cred: &agent.AdapterCredential{Type: "OAuth"}}} {
-		if err := a.EnsureAccepted(context.Background(), rejected.task, sandboxFor(c, &dials), rejected.cred); !errors.Is(err, agent.ErrAdapterTaskRejected) {
+		if err := a.EnsureAccepted(context.Background(), rejected.task, sandboxFor(c, &dials), launchCredential(rejected.cred)); !errors.Is(err, agent.ErrAdapterTaskRejected) {
 			t.Fatalf("rejection = %v", err)
 		}
 	}
@@ -93,7 +108,7 @@ func TestAcceptancePromptAndCredentialSafety(t *testing.T) {
 func TestLaunchMaterialFailureDoesNotFallbackToAmbientStart(t *testing.T) {
 	dials := 0
 	client := &launchClient{launchErr: status.Error(codes.Unimplemented, "old sandboxd")}
-	err := (&Adapter{}).EnsureAccepted(context.Background(), agent.AdapterTask{ID: "run", Prompt: "task"}, sandboxFor(client, &dials), &agent.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: []byte("secret")})
+	err := (&Adapter{}).EnsureAccepted(context.Background(), agent.AdapterTask{ID: "run", Prompt: "task"}, sandboxFor(client, &dials), launchCredential(&agent.AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: []byte("secret")}))
 	if status.Code(err) != codes.Unimplemented || client.starts != 0 || client.launches != 1 {
 		t.Fatalf("EnsureAccepted = %v, starts/launches %d/%d", err, client.starts, client.launches)
 	}

--- a/internal/adapters/pi/adapter.go
+++ b/internal/adapters/pi/adapter.go
@@ -82,10 +82,12 @@ func (a *Adapter) spec(t agent.AdapterTask) *sandboxdv1.ProcessSpec {
 	return &sandboxdv1.ProcessSpec{Argv: []string{a.executable(), "--mode", "json", "--no-session", "-p", t.Prompt}, EnvMode: sandboxdv1.EnvironmentMode_ENVIRONMENT_MODE_INHERIT}
 }
 
-func (a *Adapter) EnsureAccepted(ctx context.Context, task agent.AdapterTask, sandbox agent.AdapterSandbox, credential *agent.AdapterCredential) error {
-	if credential != nil {
-		return fmt.Errorf("%w: Pi does not support credential profiles", agent.ErrAdapterTaskRejected)
+func (a *Adapter) EnsureAccepted(ctx context.Context, task agent.AdapterTask, sandbox agent.AdapterSandbox, material *agent.AdapterLaunchMaterial) error {
+	launch, cleanup, err := agent.PrepareLaunchMaterial(material, "", false)
+	if err != nil {
+		return err
 	}
+	defer cleanup()
 	if strings.HasPrefix(task.Prompt, "-") || strings.HasPrefix(task.Prompt, "@") {
 		return fmt.Errorf("%w: Pi prompt begins with unsupported parser prefix", agent.ErrAdapterTaskRejected)
 	}
@@ -94,7 +96,11 @@ func (a *Adapter) EnsureAccepted(ctx context.Context, task agent.AdapterTask, sa
 		return err
 	}
 	defer close()
-	_, err = c.Start(ctx, &sandboxdv1.StartProcessRequest{Key: key(task), Spec: a.spec(task)})
+	if launch != nil && len(launch.SecretEnv) != 0 {
+		_, err = c.StartWithLaunchMaterial(ctx, &sandboxdv1.StartProcessWithLaunchMaterialRequest{Key: key(task), Spec: a.spec(task), LaunchMaterial: launch})
+	} else {
+		_, err = c.Start(ctx, &sandboxdv1.StartProcessRequest{Key: key(task), Spec: a.spec(task)})
+	}
 	return err
 }
 func (a *Adapter) Observe(ctx context.Context, task agent.AdapterTask, sandbox agent.AdapterSandbox) (agent.AdapterObservation, string, error) {

--- a/internal/adapters/pi/adapter_test.go
+++ b/internal/adapters/pi/adapter_test.go
@@ -17,19 +17,36 @@ import (
 	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
 )
 
+func launchCredential(credential *agent.AdapterCredential) *agent.AdapterLaunchMaterial {
+	return &agent.AdapterLaunchMaterial{AgentCredential: credential}
+}
+
 type startClient struct {
 	sandboxdv1.ProcessServiceClient
-	requests []*sandboxdv1.StartProcessRequest
-	launches int
+	requests      []*sandboxdv1.StartProcessRequest
+	launches      int
+	launchRequest *sandboxdv1.StartProcessWithLaunchMaterialRequest
 }
 
 func (c *startClient) Start(_ context.Context, r *sandboxdv1.StartProcessRequest, _ ...grpc.CallOption) (*sandboxdv1.Process, error) {
 	c.requests = append(c.requests, r)
 	return &sandboxdv1.Process{}, nil
 }
-func (c *startClient) StartWithLaunchMaterial(context.Context, *sandboxdv1.StartProcessWithLaunchMaterialRequest, ...grpc.CallOption) (*sandboxdv1.Process, error) {
+func (c *startClient) StartWithLaunchMaterial(_ context.Context, request *sandboxdv1.StartProcessWithLaunchMaterialRequest, _ ...grpc.CallOption) (*sandboxdv1.Process, error) {
 	c.launches++
-	return nil, errors.New("unexpected launch material")
+	c.launchRequest = request
+	return &sandboxdv1.Process{}, nil
+}
+
+func TestRepositoryLaunchMaterialAccepted(t *testing.T) {
+	client, dials := &startClient{}, 0
+	material := &agent.AdapterLaunchMaterial{RepositorySecretEnv: map[string][]byte{"REPOSITORY_TOKEN": []byte("secret")}}
+	if err := (&Adapter{}).EnsureAccepted(context.Background(), agent.AdapterTask{ID: "run", Prompt: "task"}, acceptanceSandbox(client, &dials), material); err != nil {
+		t.Fatal(err)
+	}
+	if client.launches != 1 || client.launchRequest.Spec.Env != nil || client.launchRequest.LaunchMaterial == nil {
+		t.Fatalf("repository launch request = %#v", client.launchRequest)
+	}
 }
 
 func acceptanceSandbox(client sandboxdv1.ProcessServiceClient, dials *int) agent.AdapterSandbox {
@@ -58,7 +75,7 @@ func TestAcceptanceArgvAndPreDialRejections(t *testing.T) {
 			t.Fatalf("prompt %q: %v", prompt, err)
 		}
 	}
-	if err := adapter.EnsureAccepted(context.Background(), task, sandbox, &agent.AdapterCredential{}); !errors.Is(err, agent.ErrAdapterTaskRejected) {
+	if err := adapter.EnsureAccepted(context.Background(), task, sandbox, launchCredential(&agent.AdapterCredential{})); !errors.Is(err, agent.ErrAdapterTaskRejected) {
 		t.Fatalf("credential rejection = %v", err)
 	}
 	if dials != 1 {

--- a/internal/agent/adapter.go
+++ b/internal/agent/adapter.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
 	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
@@ -47,6 +48,47 @@ type AdapterCredential struct {
 	APIKey []byte
 }
 
+// AdapterLaunchMaterial is ephemeral, write-only material supplied only when
+// starting an adapter process. RepositorySecretEnv is provider-neutral; its
+// values must never be copied into the public ProcessSpec environment.
+type AdapterLaunchMaterial struct {
+	AgentCredential     *AdapterCredential
+	RepositorySecretEnv map[string][]byte
+}
+
+// PrepareLaunchMaterial validates and defensively copies launch secrets for an
+// adapter RPC. The returned cleanup must be called immediately after the RPC.
+func PrepareLaunchMaterial(material *AdapterLaunchMaterial, apiEnvName string, supportsCredential bool) (*sandboxdv1.LaunchMaterial, func(), error) {
+	if material == nil {
+		return nil, func() {}, nil
+	}
+	credential := material.AgentCredential
+	if credential != nil && !supportsCredential {
+		return nil, func() {}, fmt.Errorf("%w: adapter does not support credential profiles", ErrAdapterTaskRejected)
+	}
+	if credential != nil && credential.Type != platformv1alpha1.AgentCredentialTypeAPIKey {
+		return nil, func() {}, fmt.Errorf("%w: unsupported credential type %q", ErrAdapterTaskRejected, credential.Type)
+	}
+	if credential != nil {
+		if _, exists := material.RepositorySecretEnv[apiEnvName]; exists {
+			return nil, func() {}, fmt.Errorf("%w: duplicate adapter API secret environment name", ErrAdapterTaskRejected)
+		}
+	}
+	secretEnv := make(map[string][]byte, len(material.RepositorySecretEnv)+1)
+	for name, value := range material.RepositorySecretEnv {
+		secretEnv[name] = append([]byte(nil), value...)
+	}
+	if credential != nil {
+		secretEnv[apiEnvName] = append([]byte(nil), credential.APIKey...)
+	}
+	cleanup := func() {
+		for _, value := range secretEnv {
+			clear(value)
+		}
+	}
+	return &sandboxdv1.LaunchMaterial{SecretEnv: secretEnv}, cleanup, nil
+}
+
 // AdapterEvent is an adapter-owned transcript event carried by the platform's
 // generic transcript transport. Data is opaque to the controller.
 type AdapterEvent struct {
@@ -85,7 +127,7 @@ type AdapterSandbox struct {
 // work is already absent or terminal and returns
 // ErrAdapterCancellationPending while its execution tree is still stopping.
 type AdapterLifecycle interface {
-	EnsureAccepted(context.Context, AdapterTask, AdapterSandbox, *AdapterCredential) error
+	EnsureAccepted(context.Context, AdapterTask, AdapterSandbox, *AdapterLaunchMaterial) error
 	Observe(context.Context, AdapterTask, AdapterSandbox) (AdapterObservation, string, error)
 	Cancel(context.Context, AdapterTask, AdapterSandbox) error
 }

--- a/internal/agent/adapter_test.go
+++ b/internal/agent/adapter_test.go
@@ -1,0 +1,44 @@
+package agent
+
+import (
+	"errors"
+	"testing"
+
+	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
+)
+
+func TestPrepareLaunchMaterialMergeCopyCleanupAndConflict(t *testing.T) {
+	repositoryValue := []byte("repository-secret")
+	apiValue := []byte("api-secret")
+	input := &AdapterLaunchMaterial{
+		AgentCredential:     &AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey, APIKey: apiValue},
+		RepositorySecretEnv: map[string][]byte{"REPOSITORY_TOKEN": repositoryValue},
+	}
+	launch, cleanup, err := PrepareLaunchMaterial(input, "AGENT_API_KEY", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(launch.SecretEnv["REPOSITORY_TOKEN"]) != string(repositoryValue) || string(launch.SecretEnv["AGENT_API_KEY"]) != string(apiValue) {
+		t.Fatalf("merged launch material = %#v", launch.SecretEnv)
+	}
+	launch.SecretEnv["REPOSITORY_TOKEN"][0] = 'x'
+	if string(repositoryValue) != "repository-secret" {
+		t.Fatal("repository input was not defensively copied")
+	}
+	cleanup()
+	for name, value := range launch.SecretEnv {
+		for _, b := range value {
+			if b != 0 {
+				t.Fatalf("temporary %s value was not cleared", name)
+			}
+		}
+	}
+
+	_, _, err = PrepareLaunchMaterial(&AdapterLaunchMaterial{
+		AgentCredential:     &AdapterCredential{Type: platformv1alpha1.AgentCredentialTypeAPIKey},
+		RepositorySecretEnv: map[string][]byte{"AGENT_API_KEY": []byte("conflict")},
+	}, "AGENT_API_KEY", true)
+	if !errors.Is(err, ErrAdapterTaskRejected) {
+		t.Fatalf("duplicate conflict = %v", err)
+	}
+}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -158,6 +158,11 @@ func waitForRun(ctx context.Context, clients *kubeClients, namespace, name strin
 			}
 			return nil
 		case platformv1alpha1.RunStateFailed:
+			for _, condition := range run.Status.Conditions {
+				if condition.Status == metav1.ConditionFalse && (condition.Type == "RepositoryCredentialReady" || condition.Type == "AdapterAccepted") && condition.Reason != "" {
+					return fmt.Errorf("run failed: %s", condition.Reason)
+				}
+			}
 			return fmt.Errorf("run failed")
 		case platformv1alpha1.RunStateCancelled:
 			return fmt.Errorf("run was cancelled")

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -24,6 +24,7 @@ func newRunCommand() *cobra.Command {
 		agent             string
 		name              string
 		credentialProfile string
+		gitCredential     string
 		wait              bool
 		timeout           time.Duration
 	)
@@ -34,7 +35,10 @@ func newRunCommand() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			namespace, _ := cmd.Flags().GetString("namespace")
-			return runEnvironmentWithCredential(cmd.Context(), namespace, name, template, project, environment, agent, args[0], credentialProfile, wait, timeout)
+			if gitCredential != "" && gitCredential != "github-app" {
+				return fmt.Errorf("--git-credential must be github-app")
+			}
+			return runEnvironmentWithCredentials(cmd.Context(), namespace, name, template, project, environment, agent, args[0], credentialProfile, gitCredential, wait, timeout)
 		},
 	}
 
@@ -44,6 +48,7 @@ func newRunCommand() *cobra.Command {
 	cmd.Flags().StringVarP(&environment, "environment", "e", "", "Existing unclaimed Environment to reuse (exclusive with --template/--project)")
 	cmd.Flags().StringVar(&agent, "agent", "claude-code", "Agent adapter to run")
 	cmd.Flags().StringVar(&credentialProfile, "credential-profile", "", "AgentCredentialProfile to use")
+	cmd.Flags().StringVar(&gitCredential, "git-credential", "", "Repository credential provider (github-app)")
 	cmd.Flags().BoolVar(&wait, "wait", true, "Wait for the adapter to start or the Run to finish")
 	cmd.Flags().DurationVar(&timeout, "timeout", 5*time.Minute, "How long to wait for the Run")
 	return cmd
@@ -54,11 +59,15 @@ func runEnvironment(ctx context.Context, namespace, name, template, project, env
 }
 
 func runEnvironmentWithCredential(ctx context.Context, namespace, name, template, project, environment, agent, prompt, credentialProfile string, wait bool, timeout time.Duration) error {
+	return runEnvironmentWithCredentials(ctx, namespace, name, template, project, environment, agent, prompt, credentialProfile, "", wait, timeout)
+}
+
+func runEnvironmentWithCredentials(ctx context.Context, namespace, name, template, project, environment, agent, prompt, credentialProfile, gitCredential string, wait bool, timeout time.Duration) error {
 	clients, err := newKubeClients()
 	if err != nil {
 		return err
 	}
-	return createRunWithCredential(ctx, clients, namespace, name, template, project, environment, agent, prompt, credentialProfile, wait, timeout)
+	return createRunWithCredentials(ctx, clients, namespace, name, template, project, environment, agent, prompt, credentialProfile, gitCredential, wait, timeout)
 }
 
 func createRun(ctx context.Context, clients *kubeClients, namespace, name, template, project, environment, agent, prompt string, wait bool, timeout time.Duration) error {
@@ -66,6 +75,10 @@ func createRun(ctx context.Context, clients *kubeClients, namespace, name, templ
 }
 
 func createRunWithCredential(ctx context.Context, clients *kubeClients, namespace, name, template, project, environment, agent, prompt, credentialProfile string, wait bool, timeout time.Duration) error {
+	return createRunWithCredentials(ctx, clients, namespace, name, template, project, environment, agent, prompt, credentialProfile, "", wait, timeout)
+}
+
+func createRunWithCredentials(ctx context.Context, clients *kubeClients, namespace, name, template, project, environment, agent, prompt, credentialProfile, gitCredential string, wait bool, timeout time.Duration) error {
 	if credentialProfile != "" && len(validation.IsDNS1123Subdomain(credentialProfile)) != 0 {
 		return fmt.Errorf("--credential-profile must be a Kubernetes DNS subdomain")
 	}
@@ -89,6 +102,9 @@ func createRunWithCredential(ctx context.Context, clients *kubeClients, namespac
 			Prompt:               prompt,
 			CredentialProfileRef: credentialProfile,
 		},
+	}
+	if gitCredential == "github-app" {
+		run.Spec.RepositoryCredential = platformv1alpha1.RepositoryCredentialGitHubApp
 	}
 	if err := clients.Create(ctx, run); err != nil {
 		// A timeout may mean the API server persisted the object but its response

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -275,7 +275,7 @@ func TestCreateRunIsDeclarativeAndIdempotent(t *testing.T) {
 	c := fake.NewClientBuilder().WithScheme(s).Build()
 	clients := &kubeClients{Client: c}
 	call := func(prompt string) error {
-		return createRun(context.Background(), clients, "ns", "stable", "small", "", "", "test", prompt, false, 0)
+		return createRunWithCredentials(context.Background(), clients, "ns", "stable", "small", "", "", "test", prompt, "", "github-app", false, 0)
 	}
 	if err := call("do it"); err != nil {
 		t.Fatal(err)
@@ -294,7 +294,7 @@ func TestCreateRunIsDeclarativeAndIdempotent(t *testing.T) {
 	if err := c.List(context.Background(), &envs); err != nil {
 		t.Fatal(err)
 	}
-	if len(runs.Items) != 1 || len(envs.Items) != 0 {
+	if len(runs.Items) != 1 || runs.Items[0].Spec.RepositoryCredential != platformv1alpha1.RepositoryCredentialGitHubApp || len(envs.Items) != 0 {
 		t.Fatalf("runs=%d environments=%d", len(runs.Items), len(envs.Items))
 	}
 }

--- a/internal/controllers/environment_controller.go
+++ b/internal/controllers/environment_controller.go
@@ -14,6 +14,7 @@ import (
 	"encoding/pem"
 	stderrors "errors"
 	"fmt"
+	"io"
 	"math"
 	"math/big"
 	"strconv"
@@ -66,7 +67,33 @@ const (
 	projectAnnotation                = "swe.dev/project"
 	runtimeClassUIDAnnotation        = "swe.dev/runtime-class-uid"
 	executionGenerationAnnotation    = "swe.dev/execution-generation"
+	repositoryProvisioningAnnotation = "credentials.swe.dev/repository-provisioning"
 )
+
+type repositoryProvisioningRecord struct {
+	SecretUID           types.UID `json:"secretUID"`
+	ExecutionGeneration int64     `json:"executionGeneration"`
+}
+
+func parseRepositoryProvisioningRecord(value string) (*repositoryProvisioningRecord, error) {
+	if value == "" {
+		return nil, nil
+	}
+	decoder := json.NewDecoder(strings.NewReader(value))
+	decoder.DisallowUnknownFields()
+	var record repositoryProvisioningRecord
+	if decoder.Decode(&record) != nil || record.SecretUID == "" || record.ExecutionGeneration < 1 {
+		return nil, stderrors.New("invalid repository provisioning record")
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return nil, stderrors.New("invalid repository provisioning record")
+	}
+	return &record, nil
+}
+
+func repositoryProvisioning(env *platformv1alpha1.Environment) (*repositoryProvisioningRecord, error) {
+	return parseRepositoryProvisioningRecord(env.Annotations[repositoryProvisioningAnnotation])
+}
 
 var (
 	errPodReplacing                  = stderrors.New("environment pod is being replaced")
@@ -815,10 +842,17 @@ func (r *EnvironmentReconciler) repositoryCloneCredential(ctx context.Context, e
 		repositorycredential.ClearLease(lease)
 		return nil, terminalEnvironment(stderrors.New("repository credential Secret does not match provisioning authority"))
 	}
-	nextExecution := env.Status.ExecutionGeneration + 1
-	if lease.EnvironmentUID != "" && (lease.EnvironmentUID != env.UID || lease.ExecutionGeneration != nextExecution) {
-		repositorycredential.ClearLease(lease)
-		return nil, errRepositoryCredentialPending
+	if lease.EnvironmentUID != "" {
+		record, recordErr := repositoryProvisioning(env)
+		if recordErr != nil {
+			repositorycredential.ClearLease(lease)
+			return nil, terminalEnvironment(recordErr)
+		}
+		if lease.EnvironmentUID != env.UID || record == nil || record.SecretUID != lease.SecretUID ||
+			record.ExecutionGeneration != env.Status.ExecutionGeneration || lease.ExecutionGeneration != record.ExecutionGeneration {
+			repositorycredential.ClearLease(lease)
+			return nil, errRepositoryCredentialPending
+		}
 	}
 	return lease, nil
 }
@@ -916,6 +950,9 @@ func (r *EnvironmentReconciler) ensurePodForProject(ctx context.Context, env *pl
 					return &pod, nil
 				}
 			}
+			if err := r.clearRepositoryProvisioning(ctx, env); err != nil {
+				return nil, err
+			}
 			if err := r.setEnvironmentStatus(ctx, env, platformv1alpha1.EnvironmentPhaseCreating, "", "", "PodTerminating", "the previous environment pod is terminating"); err != nil {
 				return nil, err
 			}
@@ -925,6 +962,13 @@ func (r *EnvironmentReconciler) ensurePodForProject(ctx context.Context, env *pl
 			return nil, nil
 		}
 		if metav1.IsControlledBy(&pod, env) {
+			recovered, recoverErr := r.recoverRepositoryProvisioningPod(ctx, env, &pod)
+			if recoverErr != nil {
+				return nil, recoverErr
+			}
+			if recovered {
+				return &pod, nil
+			}
 			secure, err := r.currentSandboxdPod(ctx, env, &pod)
 			if err != nil {
 				return nil, err
@@ -942,6 +986,9 @@ func (r *EnvironmentReconciler) ensurePodForProject(ctx context.Context, env *pl
 				return nil, errPodReplacing
 			}
 			if secure {
+				if err := r.clearRepositoryProvisioning(ctx, env); err != nil {
+					return nil, err
+				}
 				return &pod, nil
 			}
 		}
@@ -954,6 +1001,9 @@ func (r *EnvironmentReconciler) ensurePodForProject(ctx context.Context, env *pl
 		if env.Status.PodName != "" || env.Status.Endpoints.Sandboxd != "" {
 			return nil, errPodReplacing
 		}
+		if err := r.clearRepositoryProvisioning(ctx, env); err != nil {
+			return nil, err
+		}
 		if err := r.deleteObservedChild(ctx, &pod); err != nil && !errors.IsNotFound(err) {
 			return nil, err
 		}
@@ -962,12 +1012,40 @@ func (r *EnvironmentReconciler) ensurePodForProject(ctx context.Context, env *pl
 	if !errors.IsNotFound(err) {
 		return nil, err
 	}
+	// A persisted provisioning record means this exact execution may already
+	// have created a Pod and exposed the repository token. Without that Pod's
+	// UID, absence is ambiguous: clear the reservation and let the Run
+	// controller revoke/rotate the bound lease before any replacement.
+	provisioningRecord, err := repositoryProvisioning(env)
+	if err != nil {
+		return nil, terminalEnvironment(err)
+	}
+	if provisioningRecord != nil {
+		if err := r.clearRepositoryProvisioning(ctx, env); err != nil {
+			return nil, err
+		}
+		return nil, errRepositoryCredentialPending
+	}
 	repositoryLease, err := r.repositoryCloneCredential(ctx, env)
 	if err != nil {
 		return nil, err
 	}
 	if repositoryLease != nil {
 		defer repositorycredential.ClearLease(repositoryLease)
+	}
+	if repositoryLease != nil {
+		provisioningRecord = &repositoryProvisioningRecord{
+			SecretUID:           repositoryLease.SecretUID,
+			ExecutionGeneration: env.Status.ExecutionGeneration + 1,
+		}
+		if err := r.persistRepositoryProvisioning(ctx, env, *provisioningRecord); err != nil {
+			return nil, err
+		}
+		if provisioningRecord.SecretUID != repositoryLease.SecretUID ||
+			provisioningRecord.ExecutionGeneration < env.Status.ExecutionGeneration ||
+			provisioningRecord.ExecutionGeneration > env.Status.ExecutionGeneration+1 {
+			return nil, errRepositoryCredentialPending
+		}
 	}
 	var existingCredentials corev1.Secret
 	err = r.Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: envCredentialName(env)}, &existingCredentials)
@@ -988,9 +1066,17 @@ func (r *EnvironmentReconciler) ensurePodForProject(ctx context.Context, env *pl
 	if err := r.Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: envCredentialName(env)}, &credentials); err != nil {
 		return nil, fmt.Errorf("get rotated sandboxd credentials: %w", err)
 	}
-	executionGeneration, err := r.reserveExecutionGeneration(ctx, env)
-	if err != nil {
-		return nil, fmt.Errorf("reserve execution generation: %w", err)
+	executionGeneration := int64(0)
+	if provisioningRecord != nil && provisioningRecord.ExecutionGeneration == env.Status.ExecutionGeneration {
+		executionGeneration = env.Status.ExecutionGeneration
+	} else {
+		executionGeneration, err = r.reserveExecutionGeneration(ctx, env)
+		if err != nil {
+			return nil, fmt.Errorf("reserve execution generation: %w", err)
+		}
+		if provisioningRecord != nil && provisioningRecord.ExecutionGeneration != executionGeneration {
+			return nil, errRepositoryCredentialPending
+		}
 	}
 	repositoryCredentialSecret := ""
 	if repositoryLease != nil {
@@ -1002,10 +1088,14 @@ func (r *EnvironmentReconciler) ensurePodForProject(ctx context.Context, env *pl
 		if secret.UID != repositoryLease.SecretUID || secret.ResourceVersion != repositoryLease.ResourceVersion {
 			return nil, errRepositoryCredentialPending
 		}
-		secret.Annotations[repositorycredential.AnnotationEnvironmentUID] = string(env.UID)
-		secret.Annotations[repositorycredential.AnnotationExecutionGeneration] = strconv.FormatInt(executionGeneration, 10)
-		if err := r.Update(ctx, &secret); err != nil {
-			return nil, err
+		if repositoryLease.EnvironmentUID == "" {
+			secret.Annotations[repositorycredential.AnnotationEnvironmentUID] = string(env.UID)
+			secret.Annotations[repositorycredential.AnnotationExecutionGeneration] = strconv.FormatInt(executionGeneration, 10)
+			if err := r.Update(ctx, &secret); err != nil {
+				return nil, err
+			}
+		} else if repositoryLease.EnvironmentUID != env.UID || repositoryLease.ExecutionGeneration != executionGeneration {
+			return nil, errRepositoryCredentialPending
 		}
 		repositoryCredentialSecret = secret.Name
 	}
@@ -1182,6 +1272,9 @@ func (r *EnvironmentReconciler) ensurePodForProject(ctx context.Context, env *pl
 		if deleteErr != nil && !errors.IsNotFound(deleteErr) {
 			return nil, fmt.Errorf("delete Pod after provisioning authority changed: %w", deleteErr)
 		}
+		if clearErr := r.clearRepositoryProvisioning(ctx, env); clearErr != nil {
+			return nil, fmt.Errorf("clear repository provisioning after Pod deletion: %w", clearErr)
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -1197,7 +1290,64 @@ func (r *EnvironmentReconciler) ensurePodForProject(ctx context.Context, env *pl
 	if err := r.Update(ctx, &credentials); err != nil {
 		return nil, fmt.Errorf("bind sandboxd credentials to pod: %w", err)
 	}
+	if err := r.clearRepositoryProvisioning(ctx, env); err != nil {
+		return nil, err
+	}
 	return &pod, nil
+}
+
+func (r *EnvironmentReconciler) recoverRepositoryProvisioningPod(ctx context.Context, env *platformv1alpha1.Environment, pod *corev1.Pod) (bool, error) {
+	record, err := repositoryProvisioning(env)
+	if err != nil {
+		return false, terminalEnvironment(err)
+	}
+	if record == nil {
+		return false, nil
+	}
+	lease, err := r.repositoryCloneCredential(ctx, env)
+	if err != nil {
+		return false, err
+	}
+	if lease == nil {
+		return false, nil
+	}
+	defer repositorycredential.ClearLease(lease)
+	executionGeneration, generationValid := podExecutionGeneration(pod)
+	if pod.UID == "" || !metav1.IsControlledBy(pod, env) || pod.Spec.RestartPolicy != corev1.RestartPolicyNever ||
+		!generationValid || executionGeneration != record.ExecutionGeneration || executionGeneration != env.Status.ExecutionGeneration ||
+		record.SecretUID != lease.SecretUID || lease.EnvironmentUID != env.UID || lease.ExecutionGeneration != executionGeneration ||
+		pod.Annotations[projectAnnotation] != env.Spec.ProjectRef || pod.Annotations[sandboxdRevisionAnnotation] != sandboxdSecurityRevision ||
+		pod.Annotations[sandboxdauth.IdentityAnnotation] == "" || pod.Annotations[sandboxdauth.TrustAnnotation] == "" ||
+		pod.Annotations[sandboxdauth.TokenAnnotation] == "" || pod.Annotations[sandboxdauth.SecretNameAnnotation] != envCredentialName(env) {
+		return false, nil
+	}
+	var secret corev1.Secret
+	if err := r.Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: envCredentialName(env)}, &secret); err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if !exactControllerOwner(&secret, platformv1alpha1.GroupVersion.String(), "Environment", env.Name, env.UID) ||
+		secret.UID == "" || pod.Annotations[sandboxdauth.SecretUIDAnnotation] != string(secret.UID) ||
+		secret.Annotations[sandboxdauth.IdentityAnnotation] != pod.Annotations[sandboxdauth.IdentityAnnotation] ||
+		secret.Annotations[sandboxdauth.PodUIDAnnotation] != "" && secret.Annotations[sandboxdauth.PodUIDAnnotation] != string(pod.UID) ||
+		len(secret.Data[sandboxdauth.TLSCertKey]) == 0 || len(secret.Data[sandboxdauth.TLSKeyKey]) == 0 ||
+		len(secret.Data[sandboxdauth.CapabilitiesKey]) == 0 || len(secret.Data[sandboxdauth.HealthTokenKey]) == 0 ||
+		len(secret.Data[sandboxdauth.ProcessTokenKey]) == 0 || len(secret.Data[sandboxdauth.FilesystemTokenKey]) == 0 ||
+		len(secret.Data[sandboxdauth.ServiceObservationTokenKey]) == 0 || len(secret.Data[sandboxdauth.PortalTokenKey]) == 0 {
+		return false, nil
+	}
+	if secret.Annotations[sandboxdauth.PodUIDAnnotation] == "" {
+		secret.Annotations[sandboxdauth.PodUIDAnnotation] = string(pod.UID)
+		if err := r.Update(ctx, &secret); err != nil {
+			return false, err
+		}
+	}
+	if err := r.clearRepositoryProvisioning(ctx, env); err != nil {
+		return false, fmt.Errorf("acknowledge recovered repository provisioning: %w", err)
+	}
+	return true, nil
 }
 
 func (r *EnvironmentReconciler) currentSandboxdPod(ctx context.Context, env *platformv1alpha1.Environment, pod *corev1.Pod) (bool, error) {
@@ -1450,6 +1600,28 @@ func (r *EnvironmentReconciler) apiReader() client.Reader {
 	return r.Client
 }
 
+func (r *EnvironmentReconciler) persistRepositoryProvisioning(ctx context.Context, env *platformv1alpha1.Environment, record repositoryProvisioningRecord) error {
+	data, err := json.Marshal(record)
+	if err != nil {
+		return err
+	}
+	before := env.DeepCopy()
+	if env.Annotations == nil {
+		env.Annotations = map[string]string{}
+	}
+	env.Annotations[repositoryProvisioningAnnotation] = string(data)
+	return r.Patch(ctx, env, client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{}))
+}
+
+func (r *EnvironmentReconciler) clearRepositoryProvisioning(ctx context.Context, env *platformv1alpha1.Environment) error {
+	if env.Annotations[repositoryProvisioningAnnotation] == "" {
+		return nil
+	}
+	before := env.DeepCopy()
+	delete(env.Annotations, repositoryProvisioningAnnotation)
+	return r.Patch(ctx, env, client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{}))
+}
+
 // reserveExecutionGeneration durably allocates a fresh backend-neutral
 // execution identity before a Pod creation attempt. Values may be skipped
 // after failed or uncertain creates, but are never reused.
@@ -1481,6 +1653,7 @@ func (r *EnvironmentReconciler) reserveExecutionGeneration(ctx context.Context, 
 		return 0, err
 	}
 	env.Status = current.Status
+	env.ResourceVersion = current.ResourceVersion
 	return next, nil
 }
 

--- a/internal/controllers/environment_controller.go
+++ b/internal/controllers/environment_controller.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
+	"github.com/Chris-Cullins/swe-platform/internal/repositorycredential"
 	"github.com/Chris-Cullins/swe-platform/internal/tenancy"
 	sandboxdauth "github.com/Chris-Cullins/swe-platform/sandboxd/auth"
 )
@@ -50,19 +51,21 @@ var sizePresets = map[string]corev1.ResourceList{
 }
 
 const (
-	defaultDiskSize               = "40Gi"
-	defaultIdleTimeout            = 15 * time.Minute
-	projectHookTimeout            = "30m"
-	hookKillAfter                 = "5s"
-	podRecoveryLimit              = int32(3)
-	podRecoveryDelay              = 5 * time.Second
-	templateRefField              = "spec.templateRef"
-	projectRefField               = "spec.projectRef"
-	provisioningRuntimeClassField = "status.provisioning.runtimeClassName"
-	warmPoolLabel                 = "swe.dev/warm-pool"
-	projectAnnotation             = "swe.dev/project"
-	runtimeClassUIDAnnotation     = "swe.dev/runtime-class-uid"
-	executionGenerationAnnotation = "swe.dev/execution-generation"
+	defaultDiskSize                  = "40Gi"
+	defaultIdleTimeout               = 15 * time.Minute
+	projectHookTimeout               = "30m"
+	repositoryCloneTimeout           = "30m"
+	repositoryCredentialRequeueDelay = 5 * time.Second
+	hookKillAfter                    = "5s"
+	podRecoveryLimit                 = int32(3)
+	podRecoveryDelay                 = 5 * time.Second
+	templateRefField                 = "spec.templateRef"
+	projectRefField                  = "spec.projectRef"
+	provisioningRuntimeClassField    = "status.provisioning.runtimeClassName"
+	warmPoolLabel                    = "swe.dev/warm-pool"
+	projectAnnotation                = "swe.dev/project"
+	runtimeClassUIDAnnotation        = "swe.dev/runtime-class-uid"
+	executionGenerationAnnotation    = "swe.dev/execution-generation"
 )
 
 var (
@@ -70,6 +73,7 @@ var (
 	errPodRecoveryChanged            = stderrors.New("environment pod recovery state changed")
 	errEnvironmentIncarnationChanged = stderrors.New("environment incarnation changed")
 	errEnvironmentExecutionChanged   = stderrors.New("environment execution changed")
+	errRepositoryCredentialPending   = stderrors.New("repository credential is not yet available for environment provisioning")
 )
 
 type childOwnershipCollisionError struct {
@@ -114,10 +118,24 @@ run_hook() {
 }
 `
 
-const projectSetupScript = hookRunnerScript + `
+const repositoryCloneScript = `set -eu
 if [ ! -d /workspace/.git ]; then
-	git clone -- "$SWE_REPOSITORY" /workspace
+	if [ -n "${SWE_REPOSITORY_TOKEN:-}" ]; then
+		authorization="AUTHORIZATION: basic $(printf '%s' "x-access-token:$SWE_REPOSITORY_TOKEN" | base64 | tr -d '\n')"
+		unset SWE_REPOSITORY_TOKEN
+		export GIT_CONFIG_COUNT=1
+		export GIT_CONFIG_KEY_0=http.https://github.com/.extraheader
+		export GIT_CONFIG_VALUE_0="$authorization"
+		unset authorization
+		timeout --kill-after="$SWE_CLONE_KILL_AFTER" "$SWE_CLONE_TIMEOUT" git clone -- "$SWE_REPOSITORY" /workspace
+		unset GIT_CONFIG_COUNT GIT_CONFIG_KEY_0 GIT_CONFIG_VALUE_0
+	else
+		timeout --kill-after="$SWE_CLONE_KILL_AFTER" "$SWE_CLONE_TIMEOUT" git clone -- "$SWE_REPOSITORY" /workspace
+	fi
 fi
+`
+
+const projectHooksScript = hookRunnerScript + `
 if ! git -c safe.directory=/workspace -C /workspace config --local --get swe.setup-complete >/dev/null 2>&1; then
 	if [ -f /workspace/.agents/setup ]; then
 		run_hook /workspace/.agents/setup
@@ -725,6 +743,86 @@ func validateEnvironmentProject(project *platformv1alpha1.Project) error {
 	return nil
 }
 
+// repositoryCloneCredential validates the complete uncached association and lease.
+func (r *EnvironmentReconciler) repositoryCloneCredential(ctx context.Context, env *platformv1alpha1.Environment) (*repositorycredential.Lease, error) {
+	var ref *platformv1alpha1.RunReference
+	var ownership platformv1alpha1.EnvironmentOwnership
+	if owner := metav1.GetControllerOf(env); owner != nil && owner.APIVersion == platformv1alpha1.GroupVersion.String() && owner.Kind == "Run" {
+		ref = &platformv1alpha1.RunReference{Name: owner.Name, UID: owner.UID}
+		ownership = platformv1alpha1.EnvironmentOwnershipOwned
+	} else if env.Status.ClaimedBy != nil {
+		ref = env.Status.ClaimedBy.DeepCopy()
+		ownership = platformv1alpha1.EnvironmentOwnershipClaimed
+	}
+	if ref == nil {
+		return nil, nil
+	}
+	var run platformv1alpha1.Run
+	if err := r.apiReader().Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: ref.Name}, &run); err != nil {
+		if errors.IsNotFound(err) {
+			return nil, errRepositoryCredentialPending
+		}
+		return nil, err
+	}
+	if run.UID != ref.UID || !run.DeletionTimestamp.IsZero() || terminalRunState(run.Status.State) {
+		return nil, terminalEnvironment(stderrors.New("associated Run is foreign or inactive"))
+	}
+	if run.Status.EnvironmentRef == nil {
+		return nil, errRepositoryCredentialPending
+	}
+	if run.Status.EnvironmentRef.Name != env.Name || run.Status.EnvironmentRef.UID != env.UID || run.Status.EnvironmentRef.Ownership != ownership {
+		return nil, terminalEnvironment(stderrors.New("associated Run environment reference is invalid"))
+	}
+	if run.Spec.RepositoryCredential == "" {
+		return nil, nil
+	}
+	if run.Spec.RepositoryCredential != platformv1alpha1.RepositoryCredentialGitHubApp || env.Status.Provisioning == nil || env.Status.Provisioning.Project == nil {
+		return nil, terminalEnvironment(stderrors.New("associated Run repository credential selection is invalid"))
+	}
+	credentialCondition := apimeta.FindStatusCondition(run.Status.Conditions, runConditionRepositoryCredentialReady)
+	if (credentialCondition == nil || credentialCondition.Status != metav1.ConditionTrue || credentialCondition.Reason != "Ready") && run.Annotations[repositoryRefreshAnnotation] == "" {
+		return nil, errRepositoryCredentialPending
+	}
+	name := repositorycredential.SecretName(run.UID)
+	key := types.NamespacedName{Namespace: env.Namespace, Name: name}
+	metadata := &metav1.PartialObjectMetadata{TypeMeta: metav1.TypeMeta{APIVersion: corev1.SchemeGroupVersion.String(), Kind: "Secret"}}
+	if err := r.apiReader().Get(ctx, key, metadata); err != nil {
+		if errors.IsNotFound(err) {
+			return nil, errRepositoryCredentialPending
+		}
+		return nil, err
+	}
+	var secret corev1.Secret
+	if err := r.apiReader().Get(ctx, key, &secret); err != nil {
+		if errors.IsNotFound(err) {
+			return nil, errRepositoryCredentialPending
+		}
+		return nil, err
+	}
+	defer func() {
+		for _, value := range secret.Data {
+			clear(value)
+		}
+	}()
+	if secret.UID != metadata.UID || secret.ResourceVersion != metadata.ResourceVersion {
+		return nil, errRepositoryCredentialPending
+	}
+	lease, err := repositorycredential.Parse(&secret, run.Name, run.UID)
+	if err != nil {
+		return nil, terminalEnvironment(stderrors.New("repository credential Secret is invalid"))
+	}
+	if lease.Provider != string(platformv1alpha1.RepositoryCredentialGitHubApp) || env.Status.Provisioning.Project == nil || lease.SourceRepository != env.Status.Provisioning.Project.Repository || !lease.ExpiresAt.After(r.now().Add(repositorycredential.MinimumValidity)) {
+		repositorycredential.ClearLease(lease)
+		return nil, terminalEnvironment(stderrors.New("repository credential Secret does not match provisioning authority"))
+	}
+	nextExecution := env.Status.ExecutionGeneration + 1
+	if lease.EnvironmentUID != "" && (lease.EnvironmentUID != env.UID || lease.ExecutionGeneration != nextExecution) {
+		repositorycredential.ClearLease(lease)
+		return nil, errRepositoryCredentialPending
+	}
+	return lease, nil
+}
+
 func unsupportedEgressAllowlistMessage(projectName string) string {
 	return fmt.Sprintf("project %q has a non-empty egressAllowlist, which is unsupported until GitHub issue #68 is implemented", projectName)
 }
@@ -864,6 +962,13 @@ func (r *EnvironmentReconciler) ensurePodForProject(ctx context.Context, env *pl
 	if !errors.IsNotFound(err) {
 		return nil, err
 	}
+	repositoryLease, err := r.repositoryCloneCredential(ctx, env)
+	if err != nil {
+		return nil, err
+	}
+	if repositoryLease != nil {
+		defer repositorycredential.ClearLease(repositoryLease)
+	}
 	var existingCredentials corev1.Secret
 	err = r.Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: envCredentialName(env)}, &existingCredentials)
 	if err == nil {
@@ -886,6 +991,23 @@ func (r *EnvironmentReconciler) ensurePodForProject(ctx context.Context, env *pl
 	executionGeneration, err := r.reserveExecutionGeneration(ctx, env)
 	if err != nil {
 		return nil, fmt.Errorf("reserve execution generation: %w", err)
+	}
+	repositoryCredentialSecret := ""
+	if repositoryLease != nil {
+		var secret corev1.Secret
+		key := types.NamespacedName{Namespace: env.Namespace, Name: repositorycredential.SecretName(repositoryLease.RunUID)}
+		if err := r.apiReader().Get(ctx, key, &secret); err != nil {
+			return nil, err
+		}
+		if secret.UID != repositoryLease.SecretUID || secret.ResourceVersion != repositoryLease.ResourceVersion {
+			return nil, errRepositoryCredentialPending
+		}
+		secret.Annotations[repositorycredential.AnnotationEnvironmentUID] = string(env.UID)
+		secret.Annotations[repositorycredential.AnnotationExecutionGeneration] = strconv.FormatInt(executionGeneration, 10)
+		if err := r.Update(ctx, &secret); err != nil {
+			return nil, err
+		}
+		repositoryCredentialSecret = secret.Name
 	}
 
 	resources, ok := sizePresets[tmpl.Spec.Size]
@@ -1006,21 +1128,25 @@ func (r *EnvironmentReconciler) ensurePodForProject(ctx context.Context, env *pl
 		if repository == "" {
 			repository = project.Spec.Repositories[0]
 		}
-		projectEnv := []corev1.EnvVar{
+		cloneEnv := []corev1.EnvVar{
 			{Name: "SWE_REPOSITORY", Value: repository},
+			{Name: "SWE_CLONE_TIMEOUT", Value: repositoryCloneTimeout},
+			{Name: "SWE_CLONE_KILL_AFTER", Value: hookKillAfter},
+		}
+		if repositoryCredentialSecret != "" {
+			cloneEnv = append(cloneEnv, corev1.EnvVar{Name: "SWE_REPOSITORY_TOKEN", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: repositoryCredentialSecret}, Key: repositorycredential.TokenKey}}})
+		}
+		hooksEnv := []corev1.EnvVar{
 			{Name: "SWE_HOOK_TIMEOUT", Value: projectHookTimeout},
 			{Name: "SWE_HOOK_KILL_AFTER", Value: hookKillAfter},
 		}
 		if resuming {
-			projectEnv = append(projectEnv, corev1.EnvVar{Name: "SWE_RESUMING", Value: "true"})
+			hooksEnv = append(hooksEnv, corev1.EnvVar{Name: "SWE_RESUMING", Value: "true"})
 		}
-		pod.Spec.InitContainers = []corev1.Container{{
-			Name:                     "project-setup",
+		baseInit := corev1.Container{
 			Image:                    image,
 			ImagePullPolicy:          envImagePullPolicy(image),
-			Command:                  []string{"/bin/sh", "-c", projectSetupScript},
-			Env:                      projectEnv,
-			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+			TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 			Resources: corev1.ResourceRequirements{
 				Requests: resources,
 				Limits:   resources,
@@ -1030,7 +1156,12 @@ func (r *EnvironmentReconciler) ensurePodForProject(ctx context.Context, env *pl
 				Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
 			},
 			VolumeMounts: []corev1.VolumeMount{{Name: "workspace", MountPath: "/workspace"}},
-		}}
+		}
+		clone := baseInit.DeepCopy()
+		clone.Name, clone.Command, clone.Env = "repository-clone", []string{"/bin/sh", "-c", repositoryCloneScript}, cloneEnv
+		hooks := baseInit.DeepCopy()
+		hooks.Name, hooks.Command, hooks.Env = "project-hooks", []string{"/bin/sh", "-c", projectHooksScript}, hooksEnv
+		pod.Spec.InitContainers = []corev1.Container{*clone, *hooks}
 	}
 	if err := controllerutil.SetControllerReference(env, &pod, r.Scheme); err != nil {
 		return nil, err

--- a/internal/controllers/environment_lifecycle_test.go
+++ b/internal/controllers/environment_lifecycle_test.go
@@ -319,8 +319,8 @@ func TestEnsurePodMarksProjectInitializationAsResume(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensurePod() error = %v", err)
 	}
-	setup := pod.Spec.InitContainers[0]
-	if len(setup.Env) != 4 || setup.Env[3].Name != "SWE_RESUMING" || setup.Env[3].Value != "true" {
+	setup := pod.Spec.InitContainers[1]
+	if len(setup.Env) != 3 || setup.Env[2].Name != "SWE_RESUMING" || setup.Env[2].Value != "true" {
 		t.Fatalf("init container Env = %#v, want SWE_RESUMING=true", setup.Env)
 	}
 }
@@ -1225,7 +1225,7 @@ func TestWakeAndHoldReleaseWaitForBackendFence(t *testing.T) {
 			if replacementPod.Annotations[executionGenerationAnnotation] != "8" || fencing.Status.ExecutionGeneration != 8 {
 				t.Fatalf("resume execution generation = status %d, Pod %q, want 8", fencing.Status.ExecutionGeneration, replacementPod.Annotations[executionGenerationAnnotation])
 			}
-			setup := replacementPod.Spec.InitContainers[0]
+			setup := replacementPod.Spec.InitContainers[1]
 			resuming := false
 			for _, variable := range setup.Env {
 				if variable.Name == "SWE_RESUMING" && variable.Value == "true" {

--- a/internal/controllers/environment_reconcile.go
+++ b/internal/controllers/environment_reconcile.go
@@ -583,6 +583,9 @@ func reconcileEnvironmentProvisioningGate(r *EnvironmentReconciler, ctx context.
 	if stderrors.Is(err, errPodReplacing) {
 		return phaseHandled(ctrl.Result{Requeue: true}, nil)
 	}
+	if stderrors.Is(err, errRepositoryCredentialPending) {
+		return phaseHandled(ctrl.Result{RequeueAfter: repositoryCredentialRequeueDelay}, nil)
+	}
 	if err != nil {
 		return phaseHandled(ctrl.Result{}, r.fail(ctx, env, fmt.Errorf("ensure pod: %w", err)))
 	}

--- a/internal/controllers/environment_resources_test.go
+++ b/internal/controllers/environment_resources_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
+	"github.com/Chris-Cullins/swe-platform/internal/repositorycredential"
 	"github.com/Chris-Cullins/swe-platform/internal/tenancy"
 	sandboxdauth "github.com/Chris-Cullins/swe-platform/sandboxd/auth"
 )
@@ -73,6 +74,188 @@ func setTestProvisioningSnapshot(env *platformv1alpha1.Environment, tmpl *platfo
 	env.Status.Provisioning = platformv1alpha1.ResolveEnvironmentProvisioning(env, tmpl, project)
 	env.Status.Provisioning.TemplateVerified = true
 	env.Status.Provisioning.ProjectVerified = project != nil
+}
+
+func TestRepositoryCloneCredentialRecoversBoundProvisioningLease(t *testing.T) {
+	scheme := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{corev1.AddToScheme, platformv1alpha1.AddToScheme} {
+		if err := add(scheme); err != nil {
+			t.Fatal(err)
+		}
+	}
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "project", Namespace: "default", UID: "project-uid", Generation: 1}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/acme/repo"}}}
+	tmpl := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: "default", UID: "template-uid", Generation: 1}, Spec: platformv1alpha1.EnvironmentTemplateSpec{Image: "image", Size: "small"}}
+	run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "run", Namespace: "default", UID: "run-uid"}, Spec: platformv1alpha1.RunSpec{RepositoryCredential: platformv1alpha1.RepositoryCredentialGitHubApp}}
+	env := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "env", Namespace: "default", UID: "env-uid", Generation: 1, OwnerReferences: []metav1.OwnerReference{{APIVersion: platformv1alpha1.GroupVersion.String(), Kind: "Run", Name: run.Name, UID: run.UID, Controller: ptr(true)}}},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: tmpl.Name, ProjectRef: project.Name},
+		Status:     platformv1alpha1.EnvironmentStatus{ExecutionGeneration: 1},
+	}
+	setTestProvisioningSnapshot(env, tmpl, project)
+	run.Status.EnvironmentRef = &platformv1alpha1.RunEnvironmentReference{Name: env.Name, UID: env.UID, Ownership: platformv1alpha1.EnvironmentOwnershipOwned}
+	run.Status.Conditions = []metav1.Condition{{Type: runConditionRepositoryCredentialReady, Status: metav1.ConditionTrue, Reason: "Ready"}}
+	credential := &repositorycredential.Credential{Token: []byte("provisioning-token"), Repository: "https://github.com/acme/repo", InstallationID: 7, ExpiresAt: now.Add(time.Hour)}
+	secret, err := repositorycredential.NewSecret(env.Namespace, run.Name, run.UID, string(run.Spec.RepositoryCredential), project.Spec.Repositories[0], credential, 1, env.UID, 1, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secret.UID = "repository-secret-uid"
+	record, _ := json.Marshal(repositoryProvisioningRecord{SecretUID: secret.UID, ExecutionGeneration: 1})
+	env.Annotations = map[string]string{repositoryProvisioningAnnotation: string(record)}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env, run).WithObjects(env, run, project, tmpl, secret).Build()
+	r := &EnvironmentReconciler{Client: c, APIReader: c, Scheme: scheme, Now: func() time.Time { return now }}
+
+	lease, err := r.repositoryCloneCredential(context.Background(), env)
+	if err != nil || lease == nil || lease.SecretUID != secret.UID || lease.ExecutionGeneration != 1 {
+		t.Fatalf("recovered lease = %#v, %v", lease, err)
+	}
+	repositorycredential.ClearLease(lease)
+	delete(env.Annotations, repositoryProvisioningAnnotation)
+	if _, err := r.repositoryCloneCredential(context.Background(), env); !stderrors.Is(err, errRepositoryCredentialPending) {
+		t.Fatalf("bound lease without provisioning record error = %v", err)
+	}
+}
+
+func TestEnsurePodRecoversReservedRepositoryCredentialExecution(t *testing.T) {
+	scheme := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{corev1.AddToScheme, platformv1alpha1.AddToScheme} {
+		if err := add(scheme); err != nil {
+			t.Fatal(err)
+		}
+	}
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "project", Namespace: "default", UID: "project-uid", Generation: 1}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/acme/repo"}}}
+	tmpl := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: "default", UID: "template-uid", Generation: 1}, Spec: platformv1alpha1.EnvironmentTemplateSpec{Image: "image", Size: "small"}}
+	run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "run", Namespace: "default", UID: "run-uid"}, Spec: platformv1alpha1.RunSpec{RepositoryCredential: platformv1alpha1.RepositoryCredentialGitHubApp}}
+	env := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "env", Namespace: "default", UID: "env-uid", Generation: 1, OwnerReferences: []metav1.OwnerReference{{APIVersion: platformv1alpha1.GroupVersion.String(), Kind: "Run", Name: run.Name, UID: run.UID, Controller: ptr(true)}}},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: tmpl.Name, ProjectRef: project.Name},
+		Status:     platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhaseCreating},
+	}
+	setTestProvisioningSnapshot(env, tmpl, project)
+	run.Status.EnvironmentRef = &platformv1alpha1.RunEnvironmentReference{Name: env.Name, UID: env.UID, Ownership: platformv1alpha1.EnvironmentOwnershipOwned}
+	run.Status.Conditions = []metav1.Condition{{Type: runConditionRepositoryCredentialReady, Status: metav1.ConditionTrue, Reason: "Ready"}}
+	credential := &repositorycredential.Credential{Token: []byte("provisioning-token"), Repository: "https://github.com/acme/repo", InstallationID: 7, ExpiresAt: now.Add(time.Hour)}
+	secret, err := repositorycredential.NewSecret(env.Namespace, run.Name, run.UID, string(run.Spec.RepositoryCredential), project.Spec.Repositories[0], credential, 1, "", 0, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secret.UID = "repository-secret-uid"
+	record, _ := json.Marshal(repositoryProvisioningRecord{SecretUID: secret.UID, ExecutionGeneration: 1})
+	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env, run).WithObjects(env, run, project, tmpl, secret).Build()
+	r := &EnvironmentReconciler{Client: c, APIReader: c, Scheme: scheme, Now: func() time.Time { return now }}
+	var current platformv1alpha1.Environment
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(env), &current); err != nil {
+		t.Fatal(err)
+	}
+
+	pod, err := r.ensurePodForProject(context.Background(), &current, tmpl, project, "", tenancy.Claim{})
+	if err != nil || pod == nil {
+		t.Fatalf("recover reserved execution = %#v, %v", pod, err)
+	}
+	if generation, valid := podExecutionGeneration(pod); !valid || generation != 1 {
+		t.Fatalf("recovered Pod execution = %d, valid %t", generation, valid)
+	}
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(env), &current); err != nil {
+		t.Fatal(err)
+	}
+	if current.Status.ExecutionGeneration != 1 || current.Annotations[repositoryProvisioningAnnotation] != "" {
+		t.Fatalf("recovered Environment = %#v", current)
+	}
+	var retained corev1.Secret
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(secret), &retained); err != nil {
+		t.Fatal(err)
+	}
+	lease, err := repositorycredential.Parse(&retained, run.Name, run.UID)
+	if err != nil || lease.ExecutionGeneration != 1 || lease.EnvironmentUID != env.UID {
+		t.Fatalf("retained lease = %#v, %v", lease, err)
+	}
+	repositorycredential.ClearLease(lease)
+
+	// Reconstruct the exact crash point after Pod creation but before its UID
+	// was bound into sandboxd credentials and provisioning was acknowledged.
+	var persistedPod corev1.Pod
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: env.Namespace, Name: envPodName(env)}, &persistedPod); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Delete(context.Background(), &persistedPod); err != nil {
+		t.Fatal(err)
+	}
+	persistedPod.ResourceVersion = ""
+	persistedPod.UID = "created-pod-uid"
+	if err := c.Create(context.Background(), &persistedPod); err != nil {
+		t.Fatal(err)
+	}
+	var sandboxSecret corev1.Secret
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: env.Namespace, Name: envCredentialName(env)}, &sandboxSecret); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Delete(context.Background(), &sandboxSecret); err != nil {
+		t.Fatal(err)
+	}
+	sandboxSecret.ResourceVersion = ""
+	sandboxSecret.UID = "sandbox-secret-uid"
+	sandboxSecret.Annotations[sandboxdauth.PodUIDAnnotation] = ""
+	if err := c.Create(context.Background(), &sandboxSecret); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: env.Namespace, Name: envPodName(env)}, &persistedPod); err != nil {
+		t.Fatal(err)
+	}
+	persistedPod.Annotations[sandboxdauth.SecretUIDAnnotation] = string(sandboxSecret.UID)
+	if err := c.Update(context.Background(), &persistedPod); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(env), &current); err != nil {
+		t.Fatal(err)
+	}
+	if current.Annotations == nil {
+		current.Annotations = map[string]string{}
+	}
+	current.Annotations[repositoryProvisioningAnnotation] = string(record)
+	if err := c.Update(context.Background(), &current); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(env), &current); err != nil {
+		t.Fatal(err)
+	}
+	recoveredPod, err := r.ensurePodForProject(context.Background(), &current, tmpl, project, "", tenancy.Claim{})
+	if err != nil || recoveredPod == nil || recoveredPod.UID != persistedPod.UID {
+		t.Fatalf("created Pod recovery = %#v, %v", recoveredPod, err)
+	}
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: env.Namespace, Name: envCredentialName(env)}, &sandboxSecret); err != nil {
+		t.Fatal(err)
+	}
+	if sandboxSecret.Annotations[sandboxdauth.PodUIDAnnotation] != string(persistedPod.UID) {
+		t.Fatalf("recovered sandboxd Pod UID = %q", sandboxSecret.Annotations[sandboxdauth.PodUIDAnnotation])
+	}
+
+	// If that exact Pod later disappears while its provisioning record remains,
+	// absence cannot prove the token was never consumed. Require Run-side token
+	// rotation instead of recreating a Pod with the same lease.
+	if err := c.Delete(context.Background(), &persistedPod); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(env), &current); err != nil {
+		t.Fatal(err)
+	}
+	if current.Annotations == nil {
+		current.Annotations = map[string]string{}
+	}
+	current.Annotations[repositoryProvisioningAnnotation] = string(record)
+	if err := c.Update(context.Background(), &current); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.ensurePodForProject(context.Background(), &current, tmpl, project, "", tenancy.Claim{}); !stderrors.Is(err, errRepositoryCredentialPending) {
+		t.Fatalf("missing reserved Pod error = %v", err)
+	}
+	if current.Annotations[repositoryProvisioningAnnotation] != "" {
+		t.Fatalf("missing Pod retained provisioning record: %#v", current.Annotations)
+	}
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: env.Namespace, Name: envPodName(env)}, &persistedPod); !apierrors.IsNotFound(err) {
+		t.Fatalf("replacement Pod was created with consumed lease: %v", err)
+	}
 }
 
 func TestEnsurePodUsesOnlyNonSecretProjectValues(t *testing.T) {

--- a/internal/controllers/environment_resources_test.go
+++ b/internal/controllers/environment_resources_test.go
@@ -122,22 +122,22 @@ func TestEnsurePodUsesOnlyNonSecretProjectValues(t *testing.T) {
 	if len(pod.Spec.Containers[0].EnvFrom) != 0 {
 		t.Fatalf("environment EnvFrom = %#v, want no ambient project secrets", pod.Spec.Containers[0].EnvFrom)
 	}
-	if len(pod.Spec.InitContainers) != 1 {
-		t.Fatalf("InitContainers length = %d, want 1", len(pod.Spec.InitContainers))
+	if len(pod.Spec.InitContainers) != 2 {
+		t.Fatalf("InitContainers length = %d, want 2", len(pod.Spec.InitContainers))
 	}
-	setup := pod.Spec.InitContainers[0]
-	if setup.Name != "project-setup" {
-		t.Errorf("init container name = %q, want project-setup", setup.Name)
+	clone, setup := pod.Spec.InitContainers[0], pod.Spec.InitContainers[1]
+	if clone.Name != "repository-clone" || setup.Name != "project-hooks" {
+		t.Errorf("init container order = %q, %q", clone.Name, setup.Name)
 	}
-	envValues := make(map[string]string, len(setup.Env))
-	for _, envVar := range setup.Env {
+	envValues := make(map[string]string, len(clone.Env))
+	for _, envVar := range clone.Env {
 		envValues[envVar.Name] = envVar.Value
 	}
-	if len(setup.Env) != 3 || envValues["SWE_REPOSITORY"] != "https://github.com/example/repo" ||
-		envValues["SWE_HOOK_TIMEOUT"] != projectHookTimeout || envValues["SWE_HOOK_KILL_AFTER"] != hookKillAfter {
-		t.Errorf("init container Env = %#v, want repository and bounded hook timeout", setup.Env)
+	if len(clone.Env) != 3 || envValues["SWE_REPOSITORY"] != "https://github.com/example/repo" ||
+		envValues["SWE_CLONE_TIMEOUT"] != repositoryCloneTimeout || envValues["SWE_CLONE_KILL_AFTER"] != hookKillAfter {
+		t.Errorf("clone Env = %#v, want repository and bounded clone timeout", clone.Env)
 	}
-	if len(setup.EnvFrom) != 0 {
+	if len(setup.Env) != 2 || setup.Env[0].Name != "SWE_HOOK_TIMEOUT" || setup.Env[1].Name != "SWE_HOOK_KILL_AFTER" || len(setup.EnvFrom) != 0 {
 		t.Errorf("init container EnvFrom = %#v, want no ambient project secrets", setup.EnvFrom)
 	}
 	if len(setup.VolumeMounts) != 1 || setup.VolumeMounts[0].MountPath != "/workspace" {
@@ -462,11 +462,11 @@ func TestFailedPodCreateLeavesGenerationGap(t *testing.T) {
 		t.Fatalf("retry reused failed generation: %#v", replacement.Annotations)
 	}
 	resume := false
-	for _, variable := range replacement.Spec.InitContainers[0].Env {
+	for _, variable := range replacement.Spec.InitContainers[1].Env {
 		resume = resume || variable.Name == "SWE_RESUMING" && variable.Value == "true"
 	}
 	if !resume {
-		t.Fatalf("retry omitted resume hook intent: %#v", replacement.Spec.InitContainers[0].Env)
+		t.Fatalf("retry omitted resume hook intent: %#v", replacement.Spec.InitContainers[1].Env)
 	}
 }
 

--- a/internal/controllers/operator_metrics_test.go
+++ b/internal/controllers/operator_metrics_test.go
@@ -33,7 +33,7 @@ type dialAfterMutationAdapter struct {
 	mutate func()
 }
 
-func (a *dialAfterMutationAdapter) EnsureAccepted(ctx context.Context, _ agent.AdapterTask, sandbox agent.AdapterSandbox, _ *agent.AdapterCredential) error {
+func (a *dialAfterMutationAdapter) EnsureAccepted(ctx context.Context, _ agent.AdapterTask, sandbox agent.AdapterSandbox, _ *agent.AdapterLaunchMaterial) error {
 	a.mutate()
 	_, _, err := sandbox.DialProcess(ctx)
 	return err

--- a/internal/controllers/run_controller.go
+++ b/internal/controllers/run_controller.go
@@ -2,9 +2,13 @@ package controllers
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"reflect"
+	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -46,7 +50,48 @@ const (
 	runConditionCredentialProfileBound     = "CredentialProfileBound"
 	runConditionAdapterAcceptanceAttempted = "AdapterAcceptanceAttempted"
 	runConditionAdapterAccepted            = "AdapterAccepted"
+	runConditionRepositoryCredentialReady  = "RepositoryCredentialReady"
+	repositoryRefreshAnnotation            = "credentials.swe.dev/repository-refresh"
 )
+
+type repositoryRotationRecord struct {
+	OldSecretUID     types.UID `json:"oldSecretUID"`
+	TargetGeneration int64     `json:"targetGeneration"`
+	Wake             bool      `json:"wake"`
+}
+
+func parseRepositoryRotationRecord(value string) (*repositoryRotationRecord, error) {
+	decoder := json.NewDecoder(strings.NewReader(value))
+	decoder.DisallowUnknownFields()
+	var record repositoryRotationRecord
+	if value == "" || decoder.Decode(&record) != nil || record.OldSecretUID == "" || strings.TrimSpace(string(record.OldSecretUID)) != string(record.OldSecretUID) || record.TargetGeneration < 2 {
+		return nil, errors.New("invalid repository credential rotation record")
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return nil, errors.New("invalid repository credential rotation record")
+	}
+	return &record, nil
+}
+
+func repositoryRotation(run *platformv1alpha1.Run) (*repositoryRotationRecord, error) {
+	return parseRepositoryRotationRecord(run.Annotations[repositoryRefreshAnnotation])
+}
+
+func (r *RunReconciler) persistRepositoryRotation(ctx context.Context, run *platformv1alpha1.Run, lease *repositorycredential.Lease, wake bool) error {
+	if lease.SecretUID == "" {
+		return errors.New("repository credential Secret has no UID")
+	}
+	record := repositoryRotationRecord{OldSecretUID: lease.SecretUID, TargetGeneration: lease.TokenGeneration + 1, Wake: wake}
+	data, err := json.Marshal(record)
+	if err != nil {
+		return err
+	}
+	if run.Annotations == nil {
+		run.Annotations = map[string]string{}
+	}
+	run.Annotations[repositoryRefreshAnnotation] = string(data)
+	return r.Update(ctx, run)
+}
 
 // RunReconciler turns a Run intent into one Environment allocation and drives
 // its adapter lifecycle. sandboxd, reached through an adapter, owns all agent
@@ -61,6 +106,14 @@ type RunReconciler struct {
 	Connector             sandboxclient.Connector
 	Metrics               *OperatorMetrics
 	RepositoryCredentials repositorycredential.Provider
+	Now                   func() time.Time
+}
+
+func (r *RunReconciler) now() time.Time {
+	if r.Now != nil {
+		return r.Now()
+	}
+	return time.Now()
 }
 
 // +kubebuilder:rbac:groups=swe.dev,resources=runs,verbs=get;list;watch;update;patch
@@ -70,7 +123,7 @@ type RunReconciler struct {
 // +kubebuilder:rbac:groups=swe.dev,resources=environments/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=swe.dev,resources=projects,verbs=get;list;watch
 // +kubebuilder:rbac:groups=swe.dev,resources=agentcredentialprofiles,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;create;update;patch;delete
 
 func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var run platformv1alpha1.Run
@@ -103,6 +156,14 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	}
 	if terminalRunState(run.Status.State) {
 		return r.cleanupTerminal(ctx, &run)
+	}
+	// Persist cleanup ownership before profile resolution or any external
+	// credential side effect.
+	if !controllerutil.ContainsFinalizer(&run, runFinalizer) {
+		controllerutil.AddFinalizer(&run, runFinalizer)
+		if err := r.Update(ctx, &run); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 	if run.Spec.Cancel && run.Status.EnvironmentRef == nil {
 		ref, err := r.recoverEnvironmentReference(ctx, &run)
@@ -147,11 +208,6 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			return result, err
 		}
 	}
-	if !controllerutil.ContainsFinalizer(&run, runFinalizer) {
-		controllerutil.AddFinalizer(&run, runFinalizer)
-		return ctrl.Result{}, r.Update(ctx, &run)
-	}
-
 	if run.Status.EnvironmentRef == nil {
 		allocatedNow := false
 		ref, err := r.recoverEnvironmentReference(ctx, &run)
@@ -204,10 +260,18 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		}
 		return ctrl.Result{Requeue: true}, nil
 	}
+	result, done, err := r.ensureRepositoryCredential(ctx, &run)
+	if done || err != nil {
+		return result, err
+	}
+	repositoryRefreshAfter := result.RequeueAfter
 
 	env, err := r.getAllocatedEnvironment(ctx, &run)
 	if err != nil {
 		if apierrors.IsNotFound(err) || errors.Is(err, errAllocatedEnvironmentGone) {
+			if done, cleanupResult, cleanupErr := r.cleanupRepositoryCredential(ctx, &run, nil); !done || cleanupErr != nil {
+				return cleanupResult, cleanupErr
+			}
 			return ctrl.Result{}, r.setRunState(ctx, &run, platformv1alpha1.RunStateFailed, "EnvironmentLost", err.Error(), false)
 		}
 		return ctrl.Result{}, err
@@ -259,7 +323,7 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 
 	switch env.Status.Phase {
 	case platformv1alpha1.EnvironmentPhasePaused, platformv1alpha1.EnvironmentPhaseResuming:
-		return ctrl.Result{}, r.setRunState(ctx, &run, platformv1alpha1.RunStatePaused, "EnvironmentPaused", "managed processes stop; workspace and transcript are retained", false)
+		return ctrl.Result{RequeueAfter: repositoryRefreshAfter}, r.setRunState(ctx, &run, platformv1alpha1.RunStatePaused, "EnvironmentPaused", "managed processes stop; workspace and transcript are retained", false)
 	case platformv1alpha1.EnvironmentPhaseFailed, platformv1alpha1.EnvironmentPhaseTerminated:
 		message := fmt.Sprintf("environment phase is %s", env.Status.Phase)
 		if condition := apiMeta.FindStatusCondition(env.Status.Conditions, platformv1alpha1.EnvironmentConditionReady); condition != nil && condition.Message != "" {
@@ -269,7 +333,7 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	case platformv1alpha1.EnvironmentPhaseReady, platformv1alpha1.EnvironmentPhaseRunning:
 		// Continue below.
 	default:
-		return ctrl.Result{}, r.setRunState(ctx, &run, platformv1alpha1.RunStateAllocating, "EnvironmentNotReady", fmt.Sprintf("environment phase is %s", env.Status.Phase), false)
+		return ctrl.Result{RequeueAfter: repositoryRefreshAfter}, r.setRunState(ctx, &run, platformv1alpha1.RunStateAllocating, "EnvironmentNotReady", fmt.Sprintf("environment phase is %s", env.Status.Phase), false)
 	}
 	if !environmentReachable(env) {
 		return ctrl.Result{RequeueAfter: adapterPollInterval}, r.setRunState(ctx, &run, platformv1alpha1.RunStateAllocating, "EnvironmentNotReachable", "sandboxd endpoint is not currently reachable", false)
@@ -313,7 +377,19 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			return ctrl.Result{Requeue: true}, nil
 		}
 		started := time.Now()
-		acceptErr := adapter.EnsureAccepted(ctx, adapterTask(&run), r.adapterSandbox(&run, env, executionFence, fenceRejections), &agent.AdapterLaunchMaterial{AgentCredential: credential})
+		repositoryEnv, lease, err := r.repositoryLaunchMaterial(ctx, &run, env)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if lease != nil {
+			defer repositorycredential.ClearLease(lease)
+		}
+		defer func() {
+			for _, value := range repositoryEnv {
+				clear(value)
+			}
+		}()
+		acceptErr := adapter.EnsureAccepted(ctx, adapterTask(&run), r.adapterSandbox(&run, env, executionFence, fenceRejections), &agent.AdapterLaunchMaterial{AgentCredential: credential, RepositorySecretEnv: repositoryEnv})
 		r.Metrics.observeAdapter(run.Spec.Agent, adapterOperationEnsureAccepted, started, acceptErr)
 		current, err = r.allocatedExecutionCurrent(ctx, &run, env, execution, fenceRejections)
 		if err != nil {
@@ -542,6 +618,276 @@ func bytesContainNUL(value []byte) bool {
 		}
 	}
 	return false
+}
+
+func (r *RunReconciler) setRepositoryCredentialCondition(ctx context.Context, run *platformv1alpha1.Run, status metav1.ConditionStatus, reason, message string) error {
+	before := run.Status.DeepCopy()
+	apiMeta.SetStatusCondition(&run.Status.Conditions, metav1.Condition{Type: runConditionRepositoryCredentialReady, Status: status, Reason: reason, Message: message, ObservedGeneration: run.Generation})
+	if reflect.DeepEqual(*before, run.Status) {
+		return nil
+	}
+	return r.Status().Update(ctx, run)
+}
+
+func (r *RunReconciler) repositoryForRun(ctx context.Context, run *platformv1alpha1.Run) (string, error) {
+	if run.Status.EnvironmentRef == nil {
+		return "", errors.New("run has no frozen environment association")
+	}
+	var env platformv1alpha1.Environment
+	if err := r.apiReader().Get(ctx, types.NamespacedName{Namespace: run.Namespace, Name: run.Status.EnvironmentRef.Name}, &env); err != nil {
+		return "", err
+	}
+	if env.UID != run.Status.EnvironmentRef.UID || !env.DeletionTimestamp.IsZero() {
+		return "", errors.New("environment repository association is malformed")
+	}
+	if env.Status.Provisioning == nil || env.Status.Provisioning.Project == nil || platformv1alpha1.ValidateEnvironmentProvisioningSnapshot(&env, env.Status.Provisioning) != nil || !env.Status.Provisioning.ProjectVerified {
+		return "", errRepositoryCredentialPending
+	}
+	p := env.Status.Provisioning.Project
+	var project platformv1alpha1.Project
+	if err := r.apiReader().Get(ctx, types.NamespacedName{Namespace: run.Namespace, Name: p.Name}, &project); err != nil {
+		return "", err
+	}
+	if project.UID != p.UID || !project.DeletionTimestamp.IsZero() {
+		return "", errors.New("environment project association was replaced")
+	}
+	return p.Repository, nil
+}
+
+func (r *RunReconciler) readRepositoryLease(ctx context.Context, run *platformv1alpha1.Run) (*repositorycredential.Lease, error) {
+	key := types.NamespacedName{Namespace: run.Namespace, Name: repositorycredential.SecretName(run.UID)}
+	metadata := &metav1.PartialObjectMetadata{TypeMeta: metav1.TypeMeta{APIVersion: corev1.SchemeGroupVersion.String(), Kind: "Secret"}}
+	if err := r.apiReader().Get(ctx, key, metadata); err != nil {
+		return nil, err
+	}
+	var secret corev1.Secret
+	if err := r.apiReader().Get(ctx, key, &secret); err != nil {
+		return nil, err
+	}
+	defer func() {
+		for _, value := range secret.Data {
+			clear(value)
+		}
+	}()
+	if secret.UID != metadata.UID || secret.ResourceVersion != metadata.ResourceVersion {
+		return nil, errors.New("repository credential secret changed during validation")
+	}
+	return repositorycredential.Parse(&secret, run.Name, run.UID)
+}
+
+func (r *RunReconciler) ensureRepositoryCredential(ctx context.Context, run *platformv1alpha1.Run) (ctrl.Result, bool, error) {
+	if run.Spec.RepositoryCredential == "" {
+		return ctrl.Result{}, false, r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionTrue, "NotRequested", "repository credential was not requested")
+	}
+	if run.Spec.RepositoryCredential != platformv1alpha1.RepositoryCredentialGitHubApp {
+		return ctrl.Result{}, true, r.failRepositoryCredential(ctx, run, "RepositoryUnsupported")
+	}
+	if r.RepositoryCredentials == nil {
+		return ctrl.Result{}, true, r.failRepositoryCredential(ctx, run, "ProviderDisabled")
+	}
+	repository, err := r.repositoryForRun(ctx, run)
+	if err != nil {
+		if errors.Is(err, errRepositoryCredentialPending) {
+			return ctrl.Result{RequeueAfter: repositoryCredentialRequeueDelay}, true, r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionFalse, "Issuing", "repository credential is waiting for the frozen provisioning snapshot")
+		}
+		return ctrl.Result{}, true, r.failRepositoryCredential(ctx, run, "RepositoryUnsupported")
+	}
+	canonicalRepository, err := r.RepositoryCredentials.CanonicalRepository(repository)
+	if err != nil {
+		return ctrl.Result{}, true, r.failRepositoryCredential(ctx, run, repositorycredential.Reason(err))
+	}
+	var rotation *repositoryRotationRecord
+	if run.Annotations[repositoryRefreshAnnotation] != "" {
+		rotation, err = repositoryRotation(run)
+		if err != nil {
+			return ctrl.Result{}, true, r.failRepositoryCredential(ctx, run, "MalformedRotationRecord")
+		}
+	}
+	lease, err := r.readRepositoryLease(ctx, run)
+	if err == nil {
+		defer repositorycredential.ClearLease(lease)
+		if lease.Provider != string(run.Spec.RepositoryCredential) || lease.SourceRepository != repository || lease.Repository != canonicalRepository {
+			return ctrl.Result{}, true, r.failRepositoryCredential(ctx, run, "SecretChanged")
+		}
+		if rotation != nil {
+			if lease.SecretUID != rotation.OldSecretUID {
+				if lease.TokenGeneration != rotation.TargetGeneration {
+					return ctrl.Result{}, true, r.failRepositoryCredential(ctx, run, "SecretChanged")
+				}
+				if rotation.Wake {
+					var env platformv1alpha1.Environment
+					if getErr := r.getExactEnvironment(ctx, run, &env); getErr != nil {
+						return ctrl.Result{}, true, getErr
+					}
+					if explicitHoldEnabled(&env) {
+						return ctrl.Result{}, false, r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionTrue, "Ready", "fresh repository credential is ready while environment is held")
+					}
+					// A missing old Secret is not itself proof that the execution
+					// which received it has stopped. Always finish the requested
+					// fence before publishing the refresh wake.
+					if !environmentFenced(&env) {
+						result, fenceErr := r.requestEnvironmentFence(ctx, &env)
+						return result, true, fenceErr
+					}
+					requestID := fmt.Sprintf("run/%s/repository-refresh/%s", run.UID, lease.SecretUID)
+					if wakeErr := lifecycle.RequestWakeForReason(ctx, r.Client, client.ObjectKeyFromObject(&env), env.UID, lifecycle.HoldPolicyRevision(&env), requestID, platformv1alpha1.EnvironmentSuspensionReasonRequested); wakeErr != nil {
+						return ctrl.Result{}, true, wakeErr
+					}
+				}
+				delete(run.Annotations, repositoryRefreshAnnotation)
+				if updateErr := r.Update(ctx, run); updateErr != nil {
+					return ctrl.Result{}, true, updateErr
+				}
+				return ctrl.Result{Requeue: true}, true, nil
+			}
+			if lease.TokenGeneration+1 != rotation.TargetGeneration {
+				return ctrl.Result{}, true, r.failRepositoryCredential(ctx, run, "SecretChanged")
+			}
+			if rotation.Wake {
+				if condition := apiMeta.FindStatusCondition(run.Status.Conditions, runConditionRepositoryCredentialReady); condition == nil || condition.Reason != "Refreshing" {
+					return ctrl.Result{Requeue: true}, true, r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionFalse, "Refreshing", "repository credential refresh is fencing the current execution")
+				}
+				var env platformv1alpha1.Environment
+				if getErr := r.getExactEnvironment(ctx, run, &env); getErr != nil {
+					return ctrl.Result{}, true, getErr
+				}
+				if !environmentFenced(&env) {
+					result, fenceErr := r.requestEnvironmentFence(ctx, &env)
+					return result, true, fenceErr
+				}
+			}
+			if revokeErr := r.RepositoryCredentials.Revoke(ctx, &lease.Credential); revokeErr != nil && r.now().Before(lease.ExpiresAt) {
+				return ctrl.Result{RequeueAfter: repositorycredential.RetryDelay(revokeErr)}, true, nil
+			}
+			uid := lease.SecretUID
+			if deleteErr := r.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: run.Namespace, Name: repositorycredential.SecretName(run.UID), UID: uid}}, &client.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid}}); deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
+				return ctrl.Result{}, true, deleteErr
+			}
+			return ctrl.Result{Requeue: true}, true, r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionFalse, "Issuing", "repository credential lease is being issued")
+		}
+		// A bound lease belonged to a process in an already-created execution.
+		// If that execution's Pod is gone, revoke it before Environment resume so
+		// the clone init container can consume a fresh unbound lease.
+		if lease.EnvironmentUID != "" && run.Status.EnvironmentRef != nil {
+			var env platformv1alpha1.Environment
+			if getErr := r.apiReader().Get(ctx, types.NamespacedName{Namespace: run.Namespace, Name: run.Status.EnvironmentRef.Name}, &env); getErr == nil && env.UID == run.Status.EnvironmentRef.UID {
+				var pod corev1.Pod
+				podErr := r.apiReader().Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: envPodName(&env)}, &pod)
+				if apierrors.IsNotFound(podErr) {
+					if persistErr := r.persistRepositoryRotation(ctx, run, lease, false); persistErr != nil {
+						return ctrl.Result{}, true, persistErr
+					}
+					return ctrl.Result{Requeue: true}, true, nil
+				}
+			}
+		}
+		if lease.ExpiresAt.Sub(r.now()) <= repositorycredential.RefreshMargin && run.Status.EnvironmentRef != nil {
+			if persistErr := r.persistRepositoryRotation(ctx, run, lease, true); persistErr != nil {
+				return ctrl.Result{}, true, persistErr
+			}
+			return ctrl.Result{Requeue: true}, true, nil
+		}
+		delay := lease.ExpiresAt.Add(-repositorycredential.RefreshMargin).Sub(r.now())
+		if delay < 0 {
+			delay = 0
+		}
+		return ctrl.Result{RequeueAfter: delay}, false, r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionTrue, "Ready", "repository credential lease is ready")
+	}
+	if !apierrors.IsNotFound(err) {
+		reason := "MalformedSecret"
+		if strings.Contains(err.Error(), "foreign repository credential secret") {
+			reason = "ForeignSecret"
+		} else if strings.Contains(err.Error(), "changed during validation") {
+			reason = "SecretChanged"
+		}
+		return ctrl.Result{}, true, r.failRepositoryCredential(ctx, run, reason)
+	}
+	condition := apiMeta.FindStatusCondition(run.Status.Conditions, runConditionRepositoryCredentialReady)
+	if condition == nil || condition.Reason != "Issuing" && condition.Reason != "Refreshing" {
+		return ctrl.Result{Requeue: true}, true, r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionFalse, "Issuing", "repository credential lease is being issued")
+	}
+	credential, issueErr := r.RepositoryCredentials.Issue(ctx, canonicalRepository)
+	if issueErr != nil {
+		reason := repositorycredential.Reason(issueErr)
+		if repositorycredential.IsRetryable(issueErr) {
+			if err := r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionFalse, reason, "repository credential provider is temporarily unavailable"); err != nil {
+				return ctrl.Result{}, true, err
+			}
+			return ctrl.Result{RequeueAfter: repositorycredential.RetryDelay(issueErr)}, true, nil
+		}
+		return ctrl.Result{}, true, r.failRepositoryCredential(ctx, run, reason)
+	}
+	if credential != nil {
+		defer clear(credential.Token)
+	}
+	generation := int64(1)
+	if rotation != nil {
+		generation = rotation.TargetGeneration
+	}
+	secret, createErr := repositorycredential.NewSecret(run.Namespace, run.Name, run.UID, string(run.Spec.RepositoryCredential), repository, credential, generation, "", 0, r.now())
+	if createErr == nil {
+		createErr = r.Create(ctx, secret)
+	}
+	if createErr != nil {
+		if credential != nil {
+			_ = r.RepositoryCredentials.Revoke(ctx, credential)
+		}
+		if apierrors.IsAlreadyExists(createErr) {
+			return ctrl.Result{Requeue: true}, true, nil
+		}
+		return ctrl.Result{}, true, createErr
+	}
+	return ctrl.Result{Requeue: true}, true, nil
+}
+
+func (r *RunReconciler) failRepositoryCredential(ctx context.Context, run *platformv1alpha1.Run, reason string) error {
+	apiMeta.SetStatusCondition(&run.Status.Conditions, metav1.Condition{Type: runConditionRepositoryCredentialReady, Status: metav1.ConditionFalse, Reason: reason, Message: "repository credential is unavailable", ObservedGeneration: run.Generation})
+	return r.setRunState(ctx, run, platformv1alpha1.RunStateFailed, reason, "repository credential is unavailable", false)
+}
+
+func (r *RunReconciler) getExactEnvironment(ctx context.Context, run *platformv1alpha1.Run, env *platformv1alpha1.Environment) error {
+	if run.Status.EnvironmentRef == nil {
+		return errors.New("run has no allocated environment")
+	}
+	if err := r.apiReader().Get(ctx, types.NamespacedName{Namespace: run.Namespace, Name: run.Status.EnvironmentRef.Name}, env); err != nil {
+		return err
+	}
+	if env.UID != run.Status.EnvironmentRef.UID {
+		return errAllocatedEnvironmentGone
+	}
+	return nil
+}
+
+func (r *RunReconciler) repositoryLaunchMaterial(ctx context.Context, run *platformv1alpha1.Run, env *platformv1alpha1.Environment) (map[string][]byte, *repositorycredential.Lease, error) {
+	if run.Spec.RepositoryCredential == "" {
+		return nil, nil, nil
+	}
+	lease, err := r.readRepositoryLease(ctx, run)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !lease.ExpiresAt.After(r.now()) || env.Status.Provisioning == nil || env.Status.Provisioning.Project == nil || lease.SourceRepository != env.Status.Provisioning.Project.Repository {
+		repositorycredential.ClearLease(lease)
+		return nil, nil, errors.New("repository credential does not match frozen provisioning authority")
+	}
+	canonical, err := r.RepositoryCredentials.CanonicalRepository(env.Status.Provisioning.Project.Repository)
+	if err != nil || lease.Repository != canonical {
+		repositorycredential.ClearLease(lease)
+		return nil, nil, errors.New("repository credential canonical repository mismatch")
+	}
+	if lease.EnvironmentUID == "" || lease.EnvironmentUID != env.UID || lease.ExecutionGeneration != env.Status.ExecutionGeneration {
+		repositorycredential.ClearLease(lease)
+		return nil, nil, errors.New("repository credential is not bound to the exact environment execution")
+	}
+	source := make([]byte, len("x-access-token:")+len(lease.Token))
+	copy(source, "x-access-token:")
+	copy(source[len("x-access-token:"):], lease.Token)
+	encoded := make([]byte, base64.StdEncoding.EncodedLen(len(source)))
+	base64.StdEncoding.Encode(encoded, source)
+	clear(source)
+	header := append([]byte("AUTHORIZATION: basic "), encoded...)
+	clear(encoded)
+	return map[string][]byte{"GH_TOKEN": append([]byte(nil), lease.Token...), "GIT_CONFIG_COUNT": []byte("1"), "GIT_CONFIG_KEY_0": []byte("http.https://github.com/.extraheader"), "GIT_CONFIG_VALUE_0": header}, lease, nil
 }
 
 func (r *RunReconciler) allocateEnvironment(ctx context.Context, run *platformv1alpha1.Run) (*platformv1alpha1.RunEnvironmentReference, error) {
@@ -939,6 +1285,9 @@ func (r *RunReconciler) requestEnvironmentFence(ctx context.Context, env *platfo
 
 func (r *RunReconciler) cleanupTerminal(ctx context.Context, run *platformv1alpha1.Run) (ctrl.Result, error) {
 	if run.Status.EnvironmentRef == nil {
+		if done, result, err := r.cleanupRepositoryCredential(ctx, run, nil); !done || err != nil {
+			return result, err
+		}
 		return ctrl.Result{}, r.setEnvironmentReadyCondition(ctx, run, false, "EnvironmentReleased", "Run has no allocated environment")
 	}
 	if run.Status.EnvironmentRef.Ownership == platformv1alpha1.EnvironmentOwnershipClaimed {
@@ -949,6 +1298,9 @@ func (r *RunReconciler) cleanupTerminal(ctx context.Context, run *platformv1alph
 	}
 	env, err := r.getAllocatedEnvironment(ctx, run)
 	if apierrors.IsNotFound(err) || errors.Is(err, errAllocatedEnvironmentGone) {
+		if done, result, cleanupErr := r.cleanupRepositoryCredential(ctx, run, nil); !done || cleanupErr != nil {
+			return result, cleanupErr
+		}
 		return ctrl.Result{}, r.setEnvironmentReadyCondition(ctx, run, false, "EnvironmentLost", err.Error())
 	}
 	if err != nil {
@@ -990,8 +1342,14 @@ func (r *RunReconciler) cleanupTerminal(ctx context.Context, run *platformv1alph
 			return ctrl.Result{Requeue: true}, nil
 		}
 	}
+	if run.Spec.RepositoryCredential != "" && !environmentFenced(env) {
+		return r.requestEnvironmentFence(ctx, env)
+	}
 	if env.Spec.Lifecycle.Suspend != nil || env.Status.Lifecycle.PendingSuspendRequestID != "" {
 		return ctrl.Result{RequeueAfter: adapterPollInterval}, nil
+	}
+	if done, result, err := r.cleanupRepositoryCredential(ctx, run, env); !done || err != nil {
+		return result, err
 	}
 	if run.Status.EnvironmentRef.Ownership == platformv1alpha1.EnvironmentOwnershipOwned {
 		if !environmentSuspended(env) {
@@ -1042,7 +1400,11 @@ func (r *RunReconciler) finalize(ctx context.Context, run *platformv1alpha1.Run)
 		if err != nil && !apierrors.IsNotFound(err) && !errors.Is(err, errAllocatedEnvironmentGone) {
 			return ctrl.Result{}, err
 		}
-		if err == nil {
+		if err != nil {
+			if done, result, cleanupErr := r.cleanupRepositoryCredential(ctx, run, nil); !done || cleanupErr != nil {
+				return result, cleanupErr
+			}
+		} else {
 			if runMayHaveAccepted(run) && !environmentFenced(env) {
 				adapter := r.Adapters[run.Spec.Agent]
 				if !environmentReachable(env) || adapter == nil {
@@ -1074,8 +1436,14 @@ func (r *RunReconciler) finalize(ctx context.Context, run *platformv1alpha1.Run)
 					return ctrl.Result{Requeue: true}, nil
 				}
 			}
+			if run.Spec.RepositoryCredential != "" && !environmentFenced(env) {
+				return r.requestEnvironmentFence(ctx, env)
+			}
 			if env.Spec.Lifecycle.Suspend != nil || env.Status.Lifecycle.PendingSuspendRequestID != "" {
 				return ctrl.Result{RequeueAfter: adapterPollInterval}, nil
+			}
+			if done, result, cleanupErr := r.cleanupRepositoryCredential(ctx, run, env); !done || cleanupErr != nil {
+				return result, cleanupErr
 			}
 			if run.Status.EnvironmentRef.Ownership == platformv1alpha1.EnvironmentOwnershipClaimed {
 				if err := r.releaseClaim(ctx, run, env); err != nil {
@@ -1084,8 +1452,90 @@ func (r *RunReconciler) finalize(ctx context.Context, run *platformv1alpha1.Run)
 			}
 		}
 	}
+	if run.Status.EnvironmentRef == nil {
+		if done, result, cleanupErr := r.cleanupRepositoryCredential(ctx, run, nil); !done || cleanupErr != nil {
+			return result, cleanupErr
+		}
+	}
 	controllerutil.RemoveFinalizer(run, runFinalizer)
 	return ctrl.Result{}, r.Update(ctx, run)
+}
+
+func (r *RunReconciler) cleanupRepositoryCredential(ctx context.Context, run *platformv1alpha1.Run, env *platformv1alpha1.Environment) (bool, ctrl.Result, error) {
+	if run.Spec.RepositoryCredential == "" {
+		return true, ctrl.Result{}, nil
+	}
+	if env != nil && !environmentFenced(env) {
+		result, err := r.requestEnvironmentFence(ctx, env)
+		return false, result, err
+	}
+	lease, err := r.readRepositoryLease(ctx, run)
+	if apierrors.IsNotFound(err) {
+		if run.Annotations[repositoryRefreshAnnotation] != "" {
+			delete(run.Annotations, repositoryRefreshAnnotation)
+			if updateErr := r.Update(ctx, run); updateErr != nil {
+				return false, ctrl.Result{}, updateErr
+			}
+		}
+		_ = r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionTrue, "Revoked", "repository credential lifecycle is complete")
+		return true, ctrl.Result{}, nil
+	}
+	if err != nil {
+		// An expired exact secret no longer represents an active provider token.
+		var secret corev1.Secret
+		key := types.NamespacedName{Namespace: run.Namespace, Name: repositorycredential.SecretName(run.UID)}
+		if getErr := r.apiReader().Get(ctx, key, &secret); getErr != nil {
+			return false, ctrl.Result{}, getErr
+		}
+		source, identityErr := r.repositoryForRun(ctx, run)
+		if identityErr != nil {
+			return false, ctrl.Result{}, fmt.Errorf("repository credential cleanup identity unavailable: %w", identityErr)
+		}
+		if r.RepositoryCredentials == nil {
+			return false, ctrl.Result{}, errors.New("repository credential cleanup provider is unavailable")
+		}
+		canonical, canonicalErr := r.RepositoryCredentials.CanonicalRepository(source)
+		if canonicalErr != nil {
+			return false, ctrl.Result{}, fmt.Errorf("repository credential cleanup canonical identity unavailable: %w", canonicalErr)
+		}
+		expires, parseErr := time.Parse(time.RFC3339Nano, secret.Annotations[repositorycredential.AnnotationExpiry])
+		if !repositorycredential.ExactManagedIdentity(&secret, run.Name, run.UID, string(run.Spec.RepositoryCredential), source, canonical) {
+			return false, ctrl.Result{}, errors.New("repository credential cleanup blocked by foreign Secret collision")
+		}
+		if parseErr != nil || r.now().Before(expires) {
+			return false, ctrl.Result{}, err
+		}
+		uid := secret.UID
+		if deleteErr := r.Delete(ctx, &secret, &client.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid}}); deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
+			return false, ctrl.Result{}, deleteErr
+		}
+		return true, ctrl.Result{}, nil
+	}
+	defer repositorycredential.ClearLease(lease)
+	if r.RepositoryCredentials == nil {
+		_ = r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionFalse, "RevocationPending", "repository credential revocation is pending")
+		return false, ctrl.Result{RequeueAfter: repositorycredential.DefaultRetryDelay}, nil
+	}
+	if err := r.RepositoryCredentials.Revoke(ctx, &lease.Credential); err != nil {
+		if r.now().After(lease.ExpiresAt) { /* expiry is proof */
+		} else {
+			_ = r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionFalse, "RevocationPending", "repository credential revocation is pending")
+			return false, ctrl.Result{RequeueAfter: repositorycredential.RetryDelay(err)}, nil
+		}
+	}
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: run.Namespace, Name: repositorycredential.SecretName(run.UID), UID: lease.SecretUID}}
+	uid := lease.SecretUID
+	if err := r.Delete(ctx, secret, &client.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid}}); err != nil && !apierrors.IsNotFound(err) {
+		return false, ctrl.Result{}, err
+	}
+	if run.Annotations[repositoryRefreshAnnotation] != "" {
+		delete(run.Annotations, repositoryRefreshAnnotation)
+		if err := r.Update(ctx, run); err != nil {
+			return false, ctrl.Result{}, err
+		}
+	}
+	_ = r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionTrue, "Revoked", "repository credential lifecycle is complete")
+	return true, ctrl.Result{}, nil
 }
 
 func (r *RunReconciler) releaseClaim(ctx context.Context, run *platformv1alpha1.Run, env *platformv1alpha1.Environment) error {

--- a/internal/controllers/run_controller.go
+++ b/internal/controllers/run_controller.go
@@ -25,6 +25,7 @@ import (
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
 	"github.com/Chris-Cullins/swe-platform/internal/agent"
 	"github.com/Chris-Cullins/swe-platform/internal/lifecycle"
+	"github.com/Chris-Cullins/swe-platform/internal/repositorycredential"
 	"github.com/Chris-Cullins/swe-platform/internal/sandboxclient"
 	"github.com/Chris-Cullins/swe-platform/internal/tenancy"
 	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
@@ -52,13 +53,14 @@ const (
 // and declared-service processes inside the Environment.
 type RunReconciler struct {
 	client.Client
-	APIReader client.Reader
-	Scheme    *runtime.Scheme
-	Scope     *tenancy.ReconcileScope
-	Adapters  map[string]agent.AdapterLifecycle
-	EventSink agent.AdapterEventSink
-	Connector sandboxclient.Connector
-	Metrics   *OperatorMetrics
+	APIReader             client.Reader
+	Scheme                *runtime.Scheme
+	Scope                 *tenancy.ReconcileScope
+	Adapters              map[string]agent.AdapterLifecycle
+	EventSink             agent.AdapterEventSink
+	Connector             sandboxclient.Connector
+	Metrics               *OperatorMetrics
+	RepositoryCredentials repositorycredential.Provider
 }
 
 // +kubebuilder:rbac:groups=swe.dev,resources=runs,verbs=get;list;watch;update;patch

--- a/internal/controllers/run_controller.go
+++ b/internal/controllers/run_controller.go
@@ -313,7 +313,7 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			return ctrl.Result{Requeue: true}, nil
 		}
 		started := time.Now()
-		acceptErr := adapter.EnsureAccepted(ctx, adapterTask(&run), r.adapterSandbox(&run, env, executionFence, fenceRejections), credential)
+		acceptErr := adapter.EnsureAccepted(ctx, adapterTask(&run), r.adapterSandbox(&run, env, executionFence, fenceRejections), &agent.AdapterLaunchMaterial{AgentCredential: credential})
 		r.Metrics.observeAdapter(run.Spec.Agent, adapterOperationEnsureAccepted, started, acceptErr)
 		current, err = r.allocatedExecutionCurrent(ctx, &run, env, execution, fenceRejections)
 		if err != nil {

--- a/internal/controllers/run_controller.go
+++ b/internal/controllers/run_controller.go
@@ -262,11 +262,14 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		}
 		return ctrl.Result{Requeue: true}, nil
 	}
-	result, done, err := r.ensureRepositoryCredential(ctx, &run)
-	if done || err != nil {
-		return result, err
+	repositoryRefreshAfter := time.Duration(0)
+	if !run.Spec.Cancel {
+		result, done, err := r.ensureRepositoryCredential(ctx, &run)
+		if done || err != nil {
+			return result, err
+		}
+		repositoryRefreshAfter = result.RequeueAfter
 	}
-	repositoryRefreshAfter := result.RequeueAfter
 
 	env, err := r.getAllocatedEnvironment(ctx, &run)
 	if err != nil {
@@ -722,14 +725,16 @@ func (r *RunReconciler) cleanupPendingRepositoryRevocation(ctx context.Context, 
 		return false, ctrl.Result{}, err
 	}
 	defer repositorycredential.ClearLease(pending)
-	if r.RepositoryCredentials == nil {
+	if r.RepositoryCredentials == nil && r.now().Before(pending.ExpiresAt) {
 		return false, ctrl.Result{RequeueAfter: repositorycredential.DefaultRetryDelay}, r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionFalse, "RevocationPending", "repository credential revocation is pending")
 	}
-	if revokeErr := r.RepositoryCredentials.Revoke(ctx, &pending.Credential); revokeErr != nil && r.now().Before(pending.ExpiresAt) {
-		if statusErr := r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionFalse, "RevocationPending", "repository credential revocation is pending"); statusErr != nil {
-			return false, ctrl.Result{}, statusErr
+	if r.RepositoryCredentials != nil {
+		if revokeErr := r.RepositoryCredentials.Revoke(ctx, &pending.Credential); revokeErr != nil && r.now().Before(pending.ExpiresAt) {
+			if statusErr := r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionFalse, "RevocationPending", "repository credential revocation is pending"); statusErr != nil {
+				return false, ctrl.Result{}, statusErr
+			}
+			return false, ctrl.Result{RequeueAfter: repositorycredential.RetryDelay(revokeErr)}, nil
 		}
-		return false, ctrl.Result{RequeueAfter: repositorycredential.RetryDelay(revokeErr)}, nil
 	}
 	active, activeErr := r.readRepositoryLease(ctx, run)
 	if activeErr == nil {
@@ -1612,9 +1617,6 @@ func (r *RunReconciler) cleanupRepositoryCredential(ctx context.Context, run *pl
 		if getErr := r.apiReader().Get(ctx, key, &secret); getErr != nil {
 			return false, ctrl.Result{}, getErr
 		}
-		if r.RepositoryCredentials == nil {
-			return false, ctrl.Result{}, errors.New("repository credential cleanup provider is unavailable")
-		}
 		source, identityErr := r.repositoryForRun(ctx, run)
 		if identityErr != nil {
 			if !apierrors.IsNotFound(identityErr) {
@@ -1622,9 +1624,13 @@ func (r *RunReconciler) cleanupRepositoryCredential(ctx context.Context, run *pl
 			}
 			source = secret.Annotations[repositorycredential.AnnotationSourceRepository]
 		}
-		canonical, canonicalErr := r.RepositoryCredentials.CanonicalRepository(source)
-		if canonicalErr != nil {
-			return false, ctrl.Result{}, fmt.Errorf("repository credential cleanup canonical identity unavailable: %w", canonicalErr)
+		canonical := secret.Annotations[repositorycredential.AnnotationRepository]
+		if r.RepositoryCredentials != nil {
+			var canonicalErr error
+			canonical, canonicalErr = r.RepositoryCredentials.CanonicalRepository(source)
+			if canonicalErr != nil {
+				return false, ctrl.Result{}, fmt.Errorf("repository credential cleanup canonical identity unavailable: %w", canonicalErr)
+			}
 		}
 		expires, parseErr := time.Parse(time.RFC3339Nano, secret.Annotations[repositorycredential.AnnotationExpiry])
 		if !repositorycredential.ExactManagedIdentity(&secret, run.Name, run.UID, string(run.Spec.RepositoryCredential), source, canonical) {
@@ -1640,15 +1646,14 @@ func (r *RunReconciler) cleanupRepositoryCredential(ctx context.Context, run *pl
 		return true, ctrl.Result{}, nil
 	}
 	defer repositorycredential.ClearLease(lease)
-	if r.RepositoryCredentials == nil {
+	if r.RepositoryCredentials == nil && r.now().Before(lease.ExpiresAt) {
 		_ = r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionFalse, "RevocationPending", "repository credential revocation is pending")
 		return false, ctrl.Result{RequeueAfter: repositorycredential.DefaultRetryDelay}, nil
 	}
-	if err := r.RepositoryCredentials.Revoke(ctx, &lease.Credential); err != nil {
-		if r.now().After(lease.ExpiresAt) { /* expiry is proof */
-		} else {
+	if r.RepositoryCredentials != nil {
+		if revokeErr := r.RepositoryCredentials.Revoke(ctx, &lease.Credential); revokeErr != nil && r.now().Before(lease.ExpiresAt) {
 			_ = r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionFalse, "RevocationPending", "repository credential revocation is pending")
-			return false, ctrl.Result{RequeueAfter: repositorycredential.RetryDelay(err)}, nil
+			return false, ctrl.Result{RequeueAfter: repositorycredential.RetryDelay(revokeErr)}, nil
 		}
 	}
 	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: run.Namespace, Name: repositorycredential.SecretName(run.UID), UID: lease.SecretUID}}

--- a/internal/controllers/run_controller.go
+++ b/internal/controllers/run_controller.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -44,6 +45,7 @@ var errAllocatedEnvironmentGone = errors.New("allocated environment is gone or n
 var errExplicitEnvironmentClaimed = errors.New("explicit environment is already claimed")
 var errExplicitEnvironmentHeld = errors.New("explicit environment is held")
 var errExplicitEnvironmentSuspensionNotWakeable = errors.New("explicit environment suspension is not wakeable")
+var errRepositoryCredentialInvalid = errors.New("repository credential authority is invalid")
 
 const (
 	runConditionEnvironmentReady           = "EnvironmentReady"
@@ -123,7 +125,7 @@ func (r *RunReconciler) now() time.Time {
 // +kubebuilder:rbac:groups=swe.dev,resources=environments/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=swe.dev,resources=projects,verbs=get;list;watch
 // +kubebuilder:rbac:groups=swe.dev,resources=agentcredentialprofiles,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;create;update;delete
 
 func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var run platformv1alpha1.Run
@@ -631,14 +633,14 @@ func (r *RunReconciler) setRepositoryCredentialCondition(ctx context.Context, ru
 
 func (r *RunReconciler) repositoryForRun(ctx context.Context, run *platformv1alpha1.Run) (string, error) {
 	if run.Status.EnvironmentRef == nil {
-		return "", errors.New("run has no frozen environment association")
+		return "", fmt.Errorf("%w: run has no frozen environment association", errRepositoryCredentialInvalid)
 	}
 	var env platformv1alpha1.Environment
 	if err := r.apiReader().Get(ctx, types.NamespacedName{Namespace: run.Namespace, Name: run.Status.EnvironmentRef.Name}, &env); err != nil {
 		return "", err
 	}
 	if env.UID != run.Status.EnvironmentRef.UID || !env.DeletionTimestamp.IsZero() {
-		return "", errors.New("environment repository association is malformed")
+		return "", fmt.Errorf("%w: environment repository association is malformed", errRepositoryCredentialInvalid)
 	}
 	if env.Status.Provisioning == nil || env.Status.Provisioning.Project == nil || platformv1alpha1.ValidateEnvironmentProvisioningSnapshot(&env, env.Status.Provisioning) != nil || !env.Status.Provisioning.ProjectVerified {
 		return "", errRepositoryCredentialPending
@@ -649,7 +651,7 @@ func (r *RunReconciler) repositoryForRun(ctx context.Context, run *platformv1alp
 		return "", err
 	}
 	if project.UID != p.UID || !project.DeletionTimestamp.IsZero() {
-		return "", errors.New("environment project association was replaced")
+		return "", fmt.Errorf("%w: environment project association was replaced", errRepositoryCredentialInvalid)
 	}
 	return p.Repository, nil
 }
@@ -675,12 +677,89 @@ func (r *RunReconciler) readRepositoryLease(ctx context.Context, run *platformv1
 	return repositorycredential.Parse(&secret, run.Name, run.UID)
 }
 
+func (r *RunReconciler) readPendingRepositoryRevocation(ctx context.Context, run *platformv1alpha1.Run) (*repositorycredential.Lease, error) {
+	key := types.NamespacedName{Namespace: run.Namespace, Name: repositorycredential.PendingRevocationSecretName(run.UID)}
+	var secret corev1.Secret
+	if err := r.apiReader().Get(ctx, key, &secret); err != nil {
+		return nil, err
+	}
+	defer func() {
+		for _, value := range secret.Data {
+			clear(value)
+		}
+	}()
+	return repositorycredential.ParsePendingRevocation(&secret, run.Name, run.UID)
+}
+
+func (r *RunReconciler) persistPendingRepositoryRevocation(ctx context.Context, run *platformv1alpha1.Run, source string, credential *repositorycredential.Credential, generation int64) error {
+	secret, err := repositorycredential.NewPendingRevocationSecret(run.Namespace, run.Name, run.UID, string(run.Spec.RepositoryCredential), source, credential, generation, r.now())
+	if err != nil {
+		return err
+	}
+	if err = r.Create(ctx, secret); err == nil {
+		return nil
+	}
+	persisted, readErr := r.readPendingRepositoryRevocation(ctx, run)
+	if readErr != nil {
+		return err
+	}
+	exact := persisted.Provider == string(run.Spec.RepositoryCredential) && persisted.SourceRepository == source &&
+		persisted.Repository == credential.Repository && persisted.InstallationID == credential.InstallationID &&
+		persisted.ExpiresAt.Equal(credential.ExpiresAt) && persisted.TokenGeneration == generation && bytes.Equal(persisted.Token, credential.Token)
+	repositorycredential.ClearLease(persisted)
+	if !exact {
+		return err
+	}
+	return nil
+}
+
+func (r *RunReconciler) cleanupPendingRepositoryRevocation(ctx context.Context, run *platformv1alpha1.Run) (bool, ctrl.Result, error) {
+	pending, err := r.readPendingRepositoryRevocation(ctx, run)
+	if apierrors.IsNotFound(err) {
+		return true, ctrl.Result{}, nil
+	}
+	if err != nil {
+		return false, ctrl.Result{}, err
+	}
+	defer repositorycredential.ClearLease(pending)
+	if r.RepositoryCredentials == nil {
+		return false, ctrl.Result{RequeueAfter: repositorycredential.DefaultRetryDelay}, r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionFalse, "RevocationPending", "repository credential revocation is pending")
+	}
+	if revokeErr := r.RepositoryCredentials.Revoke(ctx, &pending.Credential); revokeErr != nil && r.now().Before(pending.ExpiresAt) {
+		if statusErr := r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionFalse, "RevocationPending", "repository credential revocation is pending"); statusErr != nil {
+			return false, ctrl.Result{}, statusErr
+		}
+		return false, ctrl.Result{RequeueAfter: repositorycredential.RetryDelay(revokeErr)}, nil
+	}
+	active, activeErr := r.readRepositoryLease(ctx, run)
+	if activeErr == nil {
+		sameToken := active.Provider == pending.Provider && active.SourceRepository == pending.SourceRepository &&
+			active.Repository == pending.Repository && active.InstallationID == pending.InstallationID && active.ExpiresAt.Equal(pending.ExpiresAt) &&
+			active.TokenGeneration == pending.TokenGeneration && bytes.Equal(active.Token, pending.Token)
+		uid := active.SecretUID
+		repositorycredential.ClearLease(active)
+		if sameToken {
+			if deleteErr := r.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: run.Namespace, Name: repositorycredential.SecretName(run.UID), UID: uid}}, &client.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid}}); deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
+				return false, ctrl.Result{}, deleteErr
+			}
+		}
+	}
+	uid := pending.SecretUID
+	if deleteErr := r.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: run.Namespace, Name: repositorycredential.PendingRevocationSecretName(run.UID), UID: uid}}, &client.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid}}); deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
+		return false, ctrl.Result{}, deleteErr
+	}
+	return false, ctrl.Result{Requeue: true}, nil
+}
+
 func (r *RunReconciler) ensureRepositoryCredential(ctx context.Context, run *platformv1alpha1.Run) (ctrl.Result, bool, error) {
 	if run.Spec.RepositoryCredential == "" {
 		return ctrl.Result{}, false, r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionTrue, "NotRequested", "repository credential was not requested")
 	}
 	if run.Spec.RepositoryCredential != platformv1alpha1.RepositoryCredentialGitHubApp {
 		return ctrl.Result{}, true, r.failRepositoryCredential(ctx, run, "RepositoryUnsupported")
+	}
+	if done, result, err := r.cleanupPendingRepositoryRevocation(ctx, run); !done || err != nil {
+		return result, true, err
 	}
 	if r.RepositoryCredentials == nil {
 		return ctrl.Result{}, true, r.failRepositoryCredential(ctx, run, "ProviderDisabled")
@@ -690,7 +769,10 @@ func (r *RunReconciler) ensureRepositoryCredential(ctx context.Context, run *pla
 		if errors.Is(err, errRepositoryCredentialPending) {
 			return ctrl.Result{RequeueAfter: repositoryCredentialRequeueDelay}, true, r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionFalse, "Issuing", "repository credential is waiting for the frozen provisioning snapshot")
 		}
-		return ctrl.Result{}, true, r.failRepositoryCredential(ctx, run, "RepositoryUnsupported")
+		if errors.Is(err, errRepositoryCredentialInvalid) {
+			return ctrl.Result{}, true, r.failRepositoryCredential(ctx, run, "RepositoryUnsupported")
+		}
+		return ctrl.Result{}, true, err
 	}
 	canonicalRepository, err := r.RepositoryCredentials.CanonicalRepository(repository)
 	if err != nil {
@@ -719,6 +801,15 @@ func (r *RunReconciler) ensureRepositoryCredential(ctx context.Context, run *pla
 					if getErr := r.getExactEnvironment(ctx, run, &env); getErr != nil {
 						return ctrl.Result{}, true, getErr
 					}
+					requestID := fmt.Sprintf("run/%s/repository-refresh/%s", run.UID, lease.SecretUID)
+					wakePublished := env.Spec.Lifecycle.Wake != nil && env.Spec.Lifecycle.Wake.ID == requestID || env.Status.Lifecycle.LastWakeRequestID == requestID
+					if wakePublished {
+						delete(run.Annotations, repositoryRefreshAnnotation)
+						if updateErr := r.Update(ctx, run); updateErr != nil {
+							return ctrl.Result{}, true, updateErr
+						}
+						return ctrl.Result{Requeue: true}, true, nil
+					}
 					if explicitHoldEnabled(&env) {
 						return ctrl.Result{}, false, r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionTrue, "Ready", "fresh repository credential is ready while environment is held")
 					}
@@ -729,7 +820,6 @@ func (r *RunReconciler) ensureRepositoryCredential(ctx context.Context, run *pla
 						result, fenceErr := r.requestEnvironmentFence(ctx, &env)
 						return result, true, fenceErr
 					}
-					requestID := fmt.Sprintf("run/%s/repository-refresh/%s", run.UID, lease.SecretUID)
 					if wakeErr := lifecycle.RequestWakeForReason(ctx, r.Client, client.ObjectKeyFromObject(&env), env.UID, lifecycle.HoldPolicyRevision(&env), requestID, platformv1alpha1.EnvironmentSuspensionReasonRequested); wakeErr != nil {
 						return ctrl.Result{}, true, wakeErr
 					}
@@ -774,11 +864,23 @@ func (r *RunReconciler) ensureRepositoryCredential(ctx context.Context, run *pla
 				var pod corev1.Pod
 				podErr := r.apiReader().Get(ctx, types.NamespacedName{Namespace: env.Namespace, Name: envPodName(&env)}, &pod)
 				if apierrors.IsNotFound(podErr) {
-					if persistErr := r.persistRepositoryRotation(ctx, run, lease, false); persistErr != nil {
-						return ctrl.Result{}, true, persistErr
+					provisioning, provisioningErr := repositoryProvisioning(&env)
+					if provisioningErr != nil {
+						return ctrl.Result{}, true, provisioningErr
 					}
-					return ctrl.Result{Requeue: true}, true, nil
+					provisioningCurrent := provisioning != nil && provisioning.SecretUID == lease.SecretUID &&
+						provisioning.ExecutionGeneration == lease.ExecutionGeneration && lease.EnvironmentUID == env.UID
+					if !provisioningCurrent {
+						if persistErr := r.persistRepositoryRotation(ctx, run, lease, false); persistErr != nil {
+							return ctrl.Result{}, true, persistErr
+						}
+						return ctrl.Result{Requeue: true}, true, nil
+					}
+				} else if podErr != nil {
+					return ctrl.Result{}, true, podErr
 				}
+			} else if getErr != nil && !apierrors.IsNotFound(getErr) {
+				return ctrl.Result{}, true, getErr
 			}
 		}
 		if lease.ExpiresAt.Sub(r.now()) <= repositorycredential.RefreshMargin && run.Status.EnvironmentRef != nil {
@@ -828,14 +930,34 @@ func (r *RunReconciler) ensureRepositoryCredential(ctx context.Context, run *pla
 	if createErr == nil {
 		createErr = r.Create(ctx, secret)
 	}
+	if createErr != nil && secret != nil {
+		persisted, readErr := r.readRepositoryLease(ctx, run)
+		if readErr == nil {
+			exact := persisted.Provider == string(run.Spec.RepositoryCredential) && persisted.SourceRepository == repository &&
+				persisted.Repository == credential.Repository && persisted.InstallationID == credential.InstallationID &&
+				persisted.ExpiresAt.Equal(credential.ExpiresAt) && persisted.TokenGeneration == generation && bytes.Equal(persisted.Token, credential.Token)
+			repositorycredential.ClearLease(persisted)
+			if exact {
+				createErr = nil
+			}
+		}
+	}
 	if createErr != nil {
 		if credential != nil {
-			_ = r.RepositoryCredentials.Revoke(ctx, credential)
+			if revokeErr := r.RepositoryCredentials.Revoke(ctx, credential); revokeErr != nil {
+				if pendingErr := r.persistPendingRepositoryRevocation(ctx, run, repository, credential, generation); pendingErr != nil {
+					return ctrl.Result{}, true, r.failRepositoryCredential(ctx, run, "SecretPersistenceFailed")
+				}
+				if statusErr := r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionFalse, "RevocationPending", "repository credential revocation is pending"); statusErr != nil {
+					return ctrl.Result{}, true, statusErr
+				}
+				return ctrl.Result{RequeueAfter: repositorycredential.RetryDelay(revokeErr)}, true, nil
+			}
 		}
 		if apierrors.IsAlreadyExists(createErr) {
-			return ctrl.Result{Requeue: true}, true, nil
+			return ctrl.Result{}, true, r.failRepositoryCredential(ctx, run, "SecretChanged")
 		}
-		return ctrl.Result{}, true, createErr
+		return ctrl.Result{}, true, r.failRepositoryCredential(ctx, run, "SecretPersistenceFailed")
 	}
 	return ctrl.Result{Requeue: true}, true, nil
 }
@@ -1469,6 +1591,9 @@ func (r *RunReconciler) cleanupRepositoryCredential(ctx context.Context, run *pl
 		result, err := r.requestEnvironmentFence(ctx, env)
 		return false, result, err
 	}
+	if done, result, err := r.cleanupPendingRepositoryRevocation(ctx, run); !done || err != nil {
+		return false, result, err
+	}
 	lease, err := r.readRepositoryLease(ctx, run)
 	if apierrors.IsNotFound(err) {
 		if run.Annotations[repositoryRefreshAnnotation] != "" {
@@ -1487,12 +1612,15 @@ func (r *RunReconciler) cleanupRepositoryCredential(ctx context.Context, run *pl
 		if getErr := r.apiReader().Get(ctx, key, &secret); getErr != nil {
 			return false, ctrl.Result{}, getErr
 		}
-		source, identityErr := r.repositoryForRun(ctx, run)
-		if identityErr != nil {
-			return false, ctrl.Result{}, fmt.Errorf("repository credential cleanup identity unavailable: %w", identityErr)
-		}
 		if r.RepositoryCredentials == nil {
 			return false, ctrl.Result{}, errors.New("repository credential cleanup provider is unavailable")
+		}
+		source, identityErr := r.repositoryForRun(ctx, run)
+		if identityErr != nil {
+			if !apierrors.IsNotFound(identityErr) {
+				return false, ctrl.Result{}, fmt.Errorf("repository credential cleanup identity unavailable: %w", identityErr)
+			}
+			source = secret.Annotations[repositorycredential.AnnotationSourceRepository]
 		}
 		canonical, canonicalErr := r.RepositoryCredentials.CanonicalRepository(source)
 		if canonicalErr != nil {

--- a/internal/controllers/run_controller_test.go
+++ b/internal/controllers/run_controller_test.go
@@ -366,6 +366,46 @@ func TestExpiredMalformedRepositoryCredentialCleanupRequiresExactIdentity(t *tes
 	t.Run("exact expired malformed token", func(t *testing.T) { testExpiredMalformedCleanup(t, now, func(*corev1.Secret) {}, true) })
 }
 
+func TestExpiredRepositoryCredentialsCleanUpWithoutProvider(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid"}, Spec: platformv1alpha1.RunSpec{RepositoryCredential: platformv1alpha1.RepositoryCredentialGitHubApp}}
+	credential := &repositorycredential.Credential{Token: []byte("expired-token"), Repository: "https://github.com/acme/repo", InstallationID: 7, ExpiresAt: now.Add(time.Hour)}
+	active, err := repositorycredential.NewSecret(run.Namespace, run.Name, run.UID, string(run.Spec.RepositoryCredential), credential.Repository, credential, 1, "", 0, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	active.UID = "active-uid"
+	active.Annotations[repositorycredential.AnnotationExpiry] = now.Add(-time.Minute).Format(time.RFC3339Nano)
+	r := reconciler(t, &scriptedAdapter{}, run, active)
+	r.RepositoryCredentials, r.Now = nil, func() time.Time { return now }
+	var current platformv1alpha1.Run
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil {
+		t.Fatal(err)
+	}
+	if done, _, err := r.cleanupRepositoryCredential(context.Background(), &current, nil); err != nil || !done {
+		t.Fatalf("expired cleanup = done %t, err %v", done, err)
+	}
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(active), &corev1.Secret{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("expired active Secret retained: %v", err)
+	}
+
+	pending, err := repositorycredential.NewPendingRevocationSecret(run.Namespace, run.Name, run.UID, string(run.Spec.RepositoryCredential), credential.Repository, credential, 1, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pending.UID = "pending-uid"
+	pending.Annotations[repositorycredential.AnnotationExpiry] = now.Add(-time.Minute).Format(time.RFC3339Nano)
+	if err := r.Create(context.Background(), pending); err != nil {
+		t.Fatal(err)
+	}
+	if done, result, err := r.cleanupPendingRepositoryRevocation(context.Background(), &current); err != nil || done || !result.Requeue {
+		t.Fatalf("expired pending cleanup = (%#v, done %t, err %v)", result, done, err)
+	}
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(pending), &corev1.Secret{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("expired pending Secret retained: %v", err)
+	}
+}
+
 func testExpiredMalformedCleanup(t *testing.T, now time.Time, mutate func(*corev1.Secret), wantDeleted bool) {
 	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "project-uid", Generation: 1}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/acme/repo"}}}
 	env, tmpl := frozenRepositoryEnvironment(project)
@@ -1735,6 +1775,25 @@ func TestCancellationWhilePausedRequiresNoAdapterRPC(t *testing.T) {
 	}
 	if retained.Status.ClaimedBy != nil || adapter.cancelled != 0 {
 		t.Fatalf("claim = %#v, adapter cancellations = %d", retained.Status.ClaimedBy, adapter.cancelled)
+	}
+}
+
+func TestCancellationBypassesRepositoryCredentialIssuance(t *testing.T) {
+	run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid", Finalizers: []string{runFinalizer}}, Spec: platformv1alpha1.RunSpec{Agent: "test", Cancel: true, RepositoryCredential: platformv1alpha1.RepositoryCredentialGitHubApp}, Status: platformv1alpha1.RunStatus{
+		State:          platformv1alpha1.RunStatePaused,
+		EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{Name: "shared", UID: "env-uid", Ownership: platformv1alpha1.EnvironmentOwnershipClaimed},
+	}}
+	env := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "shared", Namespace: "ns", UID: "env-uid"}, Spec: platformv1alpha1.EnvironmentSpec{Paused: true}, Status: platformv1alpha1.EnvironmentStatus{
+		Phase: platformv1alpha1.EnvironmentPhasePaused, ClaimedBy: &platformv1alpha1.RunReference{Name: run.Name, UID: run.UID},
+	}}
+	provider := &fakeRepositoryCredentialProvider{canonical: "https://github.com/acme/repo", issueErr: &repositorycredential.Error{Operation: "issue", Reason: "ProviderUnavailable", RetryAfter: time.Minute}}
+	r := reconciler(t, &scriptedAdapter{}, run, env)
+	r.RepositoryCredentials = provider
+	if got := reconcileRun(t, r, run.Name); got.Status.State != platformv1alpha1.RunStateCancelled {
+		t.Fatalf("state = %s, want Cancelled", got.Status.State)
+	}
+	if len(provider.issued) != 0 {
+		t.Fatalf("cancellation issued repository credentials: %v", provider.issued)
 	}
 }
 

--- a/internal/controllers/run_controller_test.go
+++ b/internal/controllers/run_controller_test.go
@@ -26,7 +26,242 @@ import (
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
 	"github.com/Chris-Cullins/swe-platform/internal/agent"
 	"github.com/Chris-Cullins/swe-platform/internal/lifecycle"
+	"github.com/Chris-Cullins/swe-platform/internal/repositorycredential"
 )
+
+type fakeRepositoryCredentialProvider struct {
+	canonical string
+	issued    []string
+	revoked   [][]byte
+	issueErr  error
+	revokeErr error
+	now       time.Time
+	token     []byte
+}
+
+func (f *fakeRepositoryCredentialProvider) CanonicalRepository(repository string) (string, error) {
+	if f.canonical == "" {
+		return "", &repositorycredential.Error{Operation: "repository", Reason: "RepositoryUnsupported"}
+	}
+	return f.canonical, nil
+}
+func (f *fakeRepositoryCredentialProvider) Issue(_ context.Context, repository string) (*repositorycredential.Credential, error) {
+	f.issued = append(f.issued, repository)
+	if f.issueErr != nil {
+		return nil, f.issueErr
+	}
+	if f.token == nil {
+		f.token = []byte("fake-token")
+	}
+	return &repositorycredential.Credential{Token: f.token, Repository: f.canonical, InstallationID: 7, ExpiresAt: f.now.Add(time.Hour)}, nil
+}
+func (f *fakeRepositoryCredentialProvider) Revoke(_ context.Context, credential *repositorycredential.Credential) error {
+	f.revoked = append(f.revoked, append([]byte(nil), credential.Token...))
+	return f.revokeErr
+}
+
+func TestRepositoryCredentialIssueCanonicalizesAndClearsProviderToken(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "project-uid", Generation: 1}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/acme/repo.git"}}}
+	env, tmpl := frozenRepositoryEnvironment(project)
+	run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid"}, Spec: platformv1alpha1.RunSpec{ProjectRef: "p", RepositoryCredential: platformv1alpha1.RepositoryCredentialGitHubApp}, Status: platformv1alpha1.RunStatus{EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{Name: env.Name, UID: env.UID, Ownership: platformv1alpha1.EnvironmentOwnershipOwned}}}
+	r := reconciler(t, &scriptedAdapter{}, run, project, env, tmpl)
+	provider := &fakeRepositoryCredentialProvider{canonical: "https://github.com/acme/repo", now: now, token: []byte("fake-token")}
+	r.RepositoryCredentials, r.Now = provider, func() time.Time { return now }
+	var current platformv1alpha1.Run
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil {
+		t.Fatal(err)
+	}
+	if _, done, err := r.ensureRepositoryCredential(context.Background(), &current); err != nil || !done {
+		t.Fatalf("mark issuing = done %v, err %v", done, err)
+	}
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil {
+		t.Fatal(err)
+	}
+	if _, done, err := r.ensureRepositoryCredential(context.Background(), &current); err != nil || !done {
+		t.Fatalf("issue = done %v, err %v", done, err)
+	}
+	if len(provider.issued) != 1 || provider.issued[0] != provider.canonical {
+		t.Fatalf("issued repositories = %v", provider.issued)
+	}
+	if string(provider.token) != strings.Repeat("\x00", len(provider.token)) {
+		t.Fatalf("provider token was not defensively cleared: %v", provider.token)
+	}
+	var secret corev1.Secret
+	if err := r.Get(context.Background(), types.NamespacedName{Namespace: "ns", Name: repositorycredential.SecretName(run.UID)}, &secret); err != nil {
+		t.Fatal(err)
+	}
+	if got := secret.Annotations[repositorycredential.AnnotationRepository]; got != provider.canonical {
+		t.Fatalf("lease repository = %q", got)
+	}
+}
+
+func TestRepositoryCredentialUsesFrozenRepositoryAfterProjectChanges(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "project-uid", Generation: 1}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/acme/old"}}}
+	env, tmpl := frozenRepositoryEnvironment(project)
+	project.Generation, project.Spec.Repositories[0] = 2, "https://github.com/acme/new"
+	run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid", Finalizers: []string{runFinalizer}}, Spec: platformv1alpha1.RunSpec{ProjectRef: "p", RepositoryCredential: platformv1alpha1.RepositoryCredentialGitHubApp}, Status: platformv1alpha1.RunStatus{EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{Name: env.Name, UID: env.UID, Ownership: platformv1alpha1.EnvironmentOwnershipOwned}}}
+	credential := &repositorycredential.Credential{Token: []byte("old"), Repository: "https://github.com/acme/old", InstallationID: 7, ExpiresAt: now.Add(time.Hour)}
+	secret, err := repositorycredential.NewSecret("ns", run.Name, run.UID, string(run.Spec.RepositoryCredential), "https://github.com/acme/old", credential, 1, "", 0, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := reconciler(t, &scriptedAdapter{}, run, project, env, tmpl, secret)
+	r.RepositoryCredentials, r.Now = &fakeRepositoryCredentialProvider{canonical: "https://github.com/acme/old", now: now}, func() time.Time { return now }
+	var current platformv1alpha1.Run
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil {
+		t.Fatal(err)
+	}
+	if _, done, err := r.ensureRepositoryCredential(context.Background(), &current); err != nil || done {
+		t.Fatalf("frozen repository = done %v, err %v", done, err)
+	}
+	condition := apiMeta.FindStatusCondition(current.Status.Conditions, runConditionRepositoryCredentialReady)
+	if condition == nil || condition.Reason != "Ready" {
+		t.Fatalf("condition = %#v", condition)
+	}
+}
+
+func TestRepositoryRotationRecordStrictJSON(t *testing.T) {
+	valid := `{"oldSecretUID":"old-uid","targetGeneration":2,"wake":true}`
+	if record, err := parseRepositoryRotationRecord(valid); err != nil || record.OldSecretUID != "old-uid" || record.TargetGeneration != 2 || !record.Wake {
+		t.Fatalf("valid record = %#v, %v", record, err)
+	}
+	for _, value := range []string{"", `{}`, `{"oldSecretUID":"","targetGeneration":2,"wake":false}`, `{"oldSecretUID":"x","targetGeneration":1,"wake":false}`, valid + `{}`, `{"oldSecretUID":"x","targetGeneration":2,"wake":false,"extra":1}`} {
+		if _, err := parseRepositoryRotationRecord(value); err == nil {
+			t.Errorf("parseRepositoryRotationRecord(%q) succeeded", value)
+		}
+	}
+}
+
+func TestRepositoryCredentialRefreshFencesAfterOldSecretDisappears(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "project-uid", Generation: 1}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/acme/repo"}}}
+	env, tmpl := frozenRepositoryEnvironment(project)
+	env.Status.ExecutionGeneration = 1
+	run := &platformv1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "r", Namespace: "ns", UID: "run-uid", Finalizers: []string{runFinalizer},
+			Annotations: map[string]string{repositoryRefreshAnnotation: `{"oldSecretUID":"old-secret-uid","targetGeneration":2,"wake":true}`},
+		},
+		Spec: platformv1alpha1.RunSpec{ProjectRef: "p", RepositoryCredential: platformv1alpha1.RepositoryCredentialGitHubApp},
+		Status: platformv1alpha1.RunStatus{EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{
+			Name: env.Name, UID: env.UID, Ownership: platformv1alpha1.EnvironmentOwnershipOwned,
+		}},
+	}
+	credential := &repositorycredential.Credential{Token: []byte("fresh-token"), Repository: "https://github.com/acme/repo", InstallationID: 7, ExpiresAt: now.Add(time.Hour)}
+	secret, err := repositorycredential.NewSecret("ns", run.Name, run.UID, string(run.Spec.RepositoryCredential), project.Spec.Repositories[0], credential, 2, "", 0, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secret.UID = "fresh-secret-uid"
+	r := reconciler(t, &scriptedAdapter{}, run, project, env, tmpl, secret)
+	r.RepositoryCredentials, r.Now = &fakeRepositoryCredentialProvider{canonical: credential.Repository, now: now}, func() time.Time { return now }
+
+	var current platformv1alpha1.Run
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil {
+		t.Fatal(err)
+	}
+	result, done, err := r.ensureRepositoryCredential(context.Background(), &current)
+	if err != nil || !done || result.RequeueAfter != adapterPollInterval {
+		t.Fatalf("refresh recovery = (%#v, %t, %v)", result, done, err)
+	}
+	var fenced platformv1alpha1.Environment
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(env), &fenced); err != nil {
+		t.Fatal(err)
+	}
+	if fenced.Spec.Lifecycle.Suspend == nil || fenced.Spec.Lifecycle.Wake != nil {
+		t.Fatalf("refresh lifecycle intent = %#v, want suspend without wake", fenced.Spec.Lifecycle)
+	}
+	var retained platformv1alpha1.Run
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &retained); err != nil {
+		t.Fatal(err)
+	}
+	if retained.Annotations[repositoryRefreshAnnotation] == "" {
+		t.Fatal("refresh record was cleared before the old execution was fenced")
+	}
+}
+
+func TestRepositoryCredentialPendingFrozenSnapshotIsBounded(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "project-uid", Generation: 1}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/acme/repo"}}}
+	env, tmpl := frozenRepositoryEnvironment(project)
+	env.Status.Provisioning.ProjectVerified = false
+	run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid"}, Spec: platformv1alpha1.RunSpec{ProjectRef: "p", RepositoryCredential: platformv1alpha1.RepositoryCredentialGitHubApp}, Status: platformv1alpha1.RunStatus{EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{Name: env.Name, UID: env.UID, Ownership: platformv1alpha1.EnvironmentOwnershipOwned}}}
+	r := reconciler(t, &scriptedAdapter{}, run, project, env, tmpl)
+	r.RepositoryCredentials, r.Now = &fakeRepositoryCredentialProvider{canonical: "https://github.com/acme/repo", now: now}, func() time.Time { return now }
+	var current platformv1alpha1.Run
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil {
+		t.Fatal(err)
+	}
+	result, done, err := r.ensureRepositoryCredential(context.Background(), &current)
+	if err != nil || !done || result.RequeueAfter != repositoryCredentialRequeueDelay {
+		t.Fatalf("pending ensure = (%#v, %t, %v)", result, done, err)
+	}
+	condition := apiMeta.FindStatusCondition(current.Status.Conditions, runConditionRepositoryCredentialReady)
+	if condition == nil || condition.Reason != "Issuing" || condition.Status != metav1.ConditionFalse {
+		t.Fatalf("pending condition = %#v", condition)
+	}
+}
+
+func TestExpiredMalformedRepositoryCredentialCleanupRequiresExactIdentity(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	mutations := map[string]func(*corev1.Secret){
+		"foreign owner":   func(s *corev1.Secret) { s.OwnerReferences = []metav1.OwnerReference{{Name: "foreign"}} },
+		"wrong type":      func(s *corev1.Secret) { s.Type = corev1.SecretTypeOpaque },
+		"wrong run name":  func(s *corev1.Secret) { s.Annotations[repositorycredential.AnnotationRunName] = "other" },
+		"wrong provider":  func(s *corev1.Secret) { s.Annotations[repositorycredential.AnnotationProvider] = "other" },
+		"wrong source":    func(s *corev1.Secret) { s.Annotations[repositorycredential.AnnotationSourceRepository] = "other" },
+		"wrong canonical": func(s *corev1.Secret) { s.Annotations[repositorycredential.AnnotationRepository] = "other" },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) { testExpiredMalformedCleanup(t, now, mutate, false) })
+	}
+	t.Run("exact expired malformed token", func(t *testing.T) { testExpiredMalformedCleanup(t, now, func(*corev1.Secret) {}, true) })
+}
+
+func testExpiredMalformedCleanup(t *testing.T, now time.Time, mutate func(*corev1.Secret), wantDeleted bool) {
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "project-uid", Generation: 1}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/acme/repo"}}}
+	env, tmpl := frozenRepositoryEnvironment(project)
+	run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid"}, Spec: platformv1alpha1.RunSpec{RepositoryCredential: platformv1alpha1.RepositoryCredentialGitHubApp}, Status: platformv1alpha1.RunStatus{EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{Name: env.Name, UID: env.UID, Ownership: platformv1alpha1.EnvironmentOwnershipOwned}}}
+	credential := &repositorycredential.Credential{Token: []byte("token"), Repository: "https://github.com/acme/repo", InstallationID: 7, ExpiresAt: now.Add(time.Hour)}
+	secret, err := repositorycredential.NewSecret("ns", run.Name, run.UID, string(run.Spec.RepositoryCredential), project.Spec.Repositories[0], credential, 1, "", 0, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secret.UID = "secret-uid"
+	secret.Annotations[repositorycredential.AnnotationExpiry] = now.Add(-time.Minute).Format(time.RFC3339Nano)
+	secret.Data[repositorycredential.TokenKey] = nil
+	mutate(secret)
+	r := reconciler(t, &scriptedAdapter{}, run, project, env, tmpl, secret)
+	r.RepositoryCredentials, r.Now = &fakeRepositoryCredentialProvider{canonical: credential.Repository, now: now}, func() time.Time { return now }
+	var current platformv1alpha1.Run
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil {
+		t.Fatal(err)
+	}
+	done, _, cleanupErr := r.cleanupRepositoryCredential(context.Background(), &current, nil)
+	if wantDeleted {
+		if cleanupErr != nil || !done {
+			t.Fatalf("cleanup = done %t, err %v", done, cleanupErr)
+		}
+	} else if cleanupErr == nil || done {
+		t.Fatalf("foreign cleanup = done %t, err %v", done, cleanupErr)
+	}
+	var retained corev1.Secret
+	err = r.Get(context.Background(), client.ObjectKeyFromObject(secret), &retained)
+	if wantDeleted != apierrors.IsNotFound(err) {
+		t.Fatalf("Secret get error = %v, wantDeleted %t", err, wantDeleted)
+	}
+}
+
+func frozenRepositoryEnvironment(project *platformv1alpha1.Project) (*platformv1alpha1.Environment, *platformv1alpha1.EnvironmentTemplate) {
+	tmpl := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "tmpl", Namespace: "ns", UID: "template-uid", Generation: 1}, Spec: platformv1alpha1.EnvironmentTemplateSpec{Image: "image", Size: "tiny"}}
+	env := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "env", Namespace: "ns", UID: "env-uid", Generation: 1}, Spec: platformv1alpha1.EnvironmentSpec{TemplateRef: tmpl.Name, ProjectRef: project.Name}}
+	env.Status.Provisioning = platformv1alpha1.ResolveEnvironmentProvisioning(env, tmpl, project)
+	env.Status.Provisioning.TemplateVerified = true
+	env.Status.Provisioning.ProjectVerified = true
+	return env, tmpl
+}
 
 type scriptedAdapter struct {
 	observations          []agent.AdapterObservation

--- a/internal/controllers/run_controller_test.go
+++ b/internal/controllers/run_controller_test.go
@@ -39,6 +39,35 @@ type fakeRepositoryCredentialProvider struct {
 	token     []byte
 }
 
+type lostRepositorySecretCreateClient struct {
+	client.Client
+	lost bool
+}
+
+type failRepositoryLeaseCreateClient struct {
+	client.Client
+	failed bool
+}
+
+func (c *lostRepositorySecretCreateClient) Create(ctx context.Context, object client.Object, options ...client.CreateOption) error {
+	if err := c.Client.Create(ctx, object, options...); err != nil {
+		return err
+	}
+	if secret, ok := object.(*corev1.Secret); ok && secret.Type == repositorycredential.SecretType && !c.lost {
+		c.lost = true
+		return errors.New("repository Secret create response lost")
+	}
+	return nil
+}
+
+func (c *failRepositoryLeaseCreateClient) Create(ctx context.Context, object client.Object, options ...client.CreateOption) error {
+	if secret, ok := object.(*corev1.Secret); ok && secret.Name == repositorycredential.SecretName("run-uid") && !c.failed {
+		c.failed = true
+		return errors.New("repository Secret persistence unavailable")
+	}
+	return c.Client.Create(ctx, object, options...)
+}
+
 func (f *fakeRepositoryCredentialProvider) CanonicalRepository(repository string) (string, error) {
 	if f.canonical == "" {
 		return "", &repositorycredential.Error{Operation: "repository", Reason: "RepositoryUnsupported"}
@@ -93,6 +122,92 @@ func TestRepositoryCredentialIssueCanonicalizesAndClearsProviderToken(t *testing
 	}
 	if got := secret.Annotations[repositorycredential.AnnotationRepository]; got != provider.canonical {
 		t.Fatalf("lease repository = %q", got)
+	}
+}
+
+func TestRepositoryCredentialRecoversLostSecretCreateResponse(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "project-uid", Generation: 1}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/acme/repo"}}}
+	env, tmpl := frozenRepositoryEnvironment(project)
+	run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid"}, Spec: platformv1alpha1.RunSpec{ProjectRef: "p", RepositoryCredential: platformv1alpha1.RepositoryCredentialGitHubApp}, Status: platformv1alpha1.RunStatus{EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{Name: env.Name, UID: env.UID, Ownership: platformv1alpha1.EnvironmentOwnershipOwned}}}
+	r := reconciler(t, &scriptedAdapter{}, run, project, env, tmpl)
+	provider := &fakeRepositoryCredentialProvider{canonical: "https://github.com/acme/repo", now: now, token: []byte("fake-token")}
+	r.RepositoryCredentials, r.Now = provider, func() time.Time { return now }
+	lost := &lostRepositorySecretCreateClient{Client: r.Client}
+	r.Client = lost
+
+	var current platformv1alpha1.Run
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil {
+		t.Fatal(err)
+	}
+	if _, done, err := r.ensureRepositoryCredential(context.Background(), &current); err != nil || !done {
+		t.Fatalf("mark issuing = done %v, err %v", done, err)
+	}
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil {
+		t.Fatal(err)
+	}
+	if _, done, err := r.ensureRepositoryCredential(context.Background(), &current); err != nil || !done {
+		t.Fatalf("lost response recovery = done %v, err %v", done, err)
+	}
+	if !lost.lost || len(provider.revoked) != 0 {
+		t.Fatalf("lost=%t revocations=%d", lost.lost, len(provider.revoked))
+	}
+	var secret corev1.Secret
+	if err := r.Get(context.Background(), types.NamespacedName{Namespace: run.Namespace, Name: repositorycredential.SecretName(run.UID)}, &secret); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRepositoryCredentialPersistsAndDrainsFailedImmediateRevocation(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "project-uid", Generation: 1}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/acme/repo"}}}
+	env, tmpl := frozenRepositoryEnvironment(project)
+	run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid"}, Spec: platformv1alpha1.RunSpec{ProjectRef: "p", RepositoryCredential: platformv1alpha1.RepositoryCredentialGitHubApp}, Status: platformv1alpha1.RunStatus{EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{Name: env.Name, UID: env.UID, Ownership: platformv1alpha1.EnvironmentOwnershipOwned}}}
+	r := reconciler(t, &scriptedAdapter{}, run, project, env, tmpl)
+	provider := &fakeRepositoryCredentialProvider{canonical: "https://github.com/acme/repo", now: now, token: []byte("token-pending-revocation"), revokeErr: &repositorycredential.Error{Operation: "revoke", Reason: "ProviderUnavailable", RetryAfter: time.Minute}}
+	r.RepositoryCredentials, r.Now = provider, func() time.Time { return now }
+	failingClient := &failRepositoryLeaseCreateClient{Client: r.Client}
+	r.Client = failingClient
+
+	var current platformv1alpha1.Run
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil {
+		t.Fatal(err)
+	}
+	if _, done, err := r.ensureRepositoryCredential(context.Background(), &current); err != nil || !done {
+		t.Fatalf("mark issuing = done %v, err %v", done, err)
+	}
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil {
+		t.Fatal(err)
+	}
+	if result, done, err := r.ensureRepositoryCredential(context.Background(), &current); err != nil || !done || result.RequeueAfter != time.Minute {
+		t.Fatalf("persist pending revocation = (%#v, done %v, err %v)", result, done, err)
+	}
+	if !failingClient.failed || len(provider.issued) != 1 || len(provider.revoked) != 1 {
+		t.Fatalf("failed=%t issued=%d revoked=%d", failingClient.failed, len(provider.issued), len(provider.revoked))
+	}
+	condition := apiMeta.FindStatusCondition(current.Status.Conditions, runConditionRepositoryCredentialReady)
+	if condition == nil || condition.Reason != "RevocationPending" {
+		t.Fatalf("condition = %#v", condition)
+	}
+	var pendingSecret corev1.Secret
+	pendingKey := types.NamespacedName{Namespace: run.Namespace, Name: repositorycredential.PendingRevocationSecretName(run.UID)}
+	if err := r.Get(context.Background(), pendingKey, &pendingSecret); err != nil {
+		t.Fatal(err)
+	}
+	pending, err := repositorycredential.ParsePendingRevocation(&pendingSecret, run.Name, run.UID)
+	if err != nil || string(pending.Credential.Token) != "token-pending-revocation" {
+		t.Fatalf("pending revocation = %#v, %v", pending, err)
+	}
+
+	provider.revokeErr = nil
+	if result, done, err := r.ensureRepositoryCredential(context.Background(), &current); err != nil || !done || !result.Requeue {
+		t.Fatalf("drain pending revocation = (%#v, done %v, err %v)", result, done, err)
+	}
+	if len(provider.issued) != 1 || len(provider.revoked) != 2 {
+		t.Fatalf("pending drain issued=%d revoked=%d", len(provider.issued), len(provider.revoked))
+	}
+	if err := r.Get(context.Background(), pendingKey, &pendingSecret); !apierrors.IsNotFound(err) {
+		t.Fatalf("pending Secret after drain = %v", err)
 	}
 }
 
@@ -179,6 +294,37 @@ func TestRepositoryCredentialRefreshFencesAfterOldSecretDisappears(t *testing.T)
 	}
 	if retained.Annotations[repositoryRefreshAnnotation] == "" {
 		t.Fatal("refresh record was cleared before the old execution was fenced")
+	}
+}
+
+func TestRepositoryCredentialDoesNotRotateDuringDurablePodProvisioning(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "project-uid", Generation: 1}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/acme/repo"}}}
+	env, tmpl := frozenRepositoryEnvironment(project)
+	env.Status.ExecutionGeneration = 1
+	run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid", Finalizers: []string{runFinalizer}}, Spec: platformv1alpha1.RunSpec{ProjectRef: "p", RepositoryCredential: platformv1alpha1.RepositoryCredentialGitHubApp}, Status: platformv1alpha1.RunStatus{EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{Name: env.Name, UID: env.UID, Ownership: platformv1alpha1.EnvironmentOwnershipOwned}}}
+	credential := &repositorycredential.Credential{Token: []byte("provisioning-token"), Repository: "https://github.com/acme/repo", InstallationID: 7, ExpiresAt: now.Add(time.Hour)}
+	secret, err := repositorycredential.NewSecret("ns", run.Name, run.UID, string(run.Spec.RepositoryCredential), project.Spec.Repositories[0], credential, 1, env.UID, 1, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secret.UID = "provisioning-secret-uid"
+	record, _ := json.Marshal(repositoryProvisioningRecord{SecretUID: secret.UID, ExecutionGeneration: 1})
+	env.Annotations = map[string]string{repositoryProvisioningAnnotation: string(record)}
+	provider := &fakeRepositoryCredentialProvider{canonical: credential.Repository, now: now}
+	r := reconciler(t, &scriptedAdapter{}, run, project, env, tmpl, secret)
+	r.RepositoryCredentials, r.Now = provider, func() time.Time { return now }
+
+	var current platformv1alpha1.Run
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil {
+		t.Fatal(err)
+	}
+	result, done, err := r.ensureRepositoryCredential(context.Background(), &current)
+	if err != nil || done || result.RequeueAfter != 50*time.Minute {
+		t.Fatalf("provisioning lease = (%#v, %t, %v)", result, done, err)
+	}
+	if len(provider.revoked) != 0 || current.Annotations[repositoryRefreshAnnotation] != "" {
+		t.Fatalf("active provisioning was rotated: revoked=%d annotations=%v", len(provider.revoked), current.Annotations)
 	}
 }
 

--- a/internal/controllers/run_controller_test.go
+++ b/internal/controllers/run_controller_test.go
@@ -47,7 +47,7 @@ type blockingObserveAdapter struct {
 	release     chan struct{}
 }
 
-func (*blockingObserveAdapter) EnsureAccepted(context.Context, agent.AdapterTask, agent.AdapterSandbox, *agent.AdapterCredential) error {
+func (*blockingObserveAdapter) EnsureAccepted(context.Context, agent.AdapterTask, agent.AdapterSandbox, *agent.AdapterLaunchMaterial) error {
 	return nil
 }
 
@@ -87,7 +87,7 @@ func (w *failAcceptedStatusWriter) Update(ctx context.Context, object client.Obj
 // outcome.
 type foregroundAdapter struct{ process agent.AdapterObservation }
 
-func (*foregroundAdapter) EnsureAccepted(context.Context, agent.AdapterTask, agent.AdapterSandbox, *agent.AdapterCredential) error {
+func (*foregroundAdapter) EnsureAccepted(context.Context, agent.AdapterTask, agent.AdapterSandbox, *agent.AdapterLaunchMaterial) error {
 	return nil
 }
 func (a *foregroundAdapter) Observe(context.Context, agent.AdapterTask, agent.AdapterSandbox) (agent.AdapterObservation, string, error) {
@@ -104,7 +104,7 @@ type serviceAdapter struct {
 	event          agent.AdapterObservation
 }
 
-func (a *serviceAdapter) EnsureAccepted(context.Context, agent.AdapterTask, agent.AdapterSandbox, *agent.AdapterCredential) error {
+func (a *serviceAdapter) EnsureAccepted(context.Context, agent.AdapterTask, agent.AdapterSandbox, *agent.AdapterLaunchMaterial) error {
 	a.serviceRunning = true
 	return nil
 }
@@ -116,7 +116,11 @@ func (a *serviceAdapter) Cancel(context.Context, agent.AdapterTask, agent.Adapte
 	return nil
 }
 
-func (a *scriptedAdapter) EnsureAccepted(_ context.Context, _ agent.AdapterTask, _ agent.AdapterSandbox, credential *agent.AdapterCredential) error {
+func (a *scriptedAdapter) EnsureAccepted(_ context.Context, _ agent.AdapterTask, _ agent.AdapterSandbox, material *agent.AdapterLaunchMaterial) error {
+	var credential *agent.AdapterCredential
+	if material != nil {
+		credential = material.AgentCredential
+	}
 	a.accepted++
 	if a.onAccept != nil {
 		a.onAccept()

--- a/internal/controlplane/api_contract.go
+++ b/internal/controlplane/api_contract.go
@@ -28,19 +28,21 @@ type RunSelector struct {
 // CreateRunRequest is the immutable intent accepted by the Run create API.
 // Name is required and acts as the retry/idempotency key.
 type CreateRunRequest struct {
-	Name              string      `json:"name"`
-	Selector          RunSelector `json:"selector"`
-	Agent             string      `json:"agent"`
-	Prompt            string      `json:"prompt"`
-	CredentialProfile string      `json:"credentialProfile,omitempty"`
+	Name                 string      `json:"name"`
+	Selector             RunSelector `json:"selector"`
+	Agent                string      `json:"agent"`
+	Prompt               string      `json:"prompt"`
+	CredentialProfile    string      `json:"credentialProfile,omitempty"`
+	RepositoryCredential string      `json:"repositoryCredential,omitempty"`
 }
 
 // RunIntent is the immutable portion of a Run exposed to API clients.
 type RunIntent struct {
-	Selector          RunSelector `json:"selector"`
-	Agent             string      `json:"agent"`
-	Prompt            string      `json:"prompt"`
-	CredentialProfile string      `json:"credentialProfile,omitempty"`
+	Selector             RunSelector `json:"selector"`
+	Agent                string      `json:"agent"`
+	Prompt               string      `json:"prompt"`
+	CredentialProfile    string      `json:"credentialProfile,omitempty"`
+	RepositoryCredential string      `json:"repositoryCredential,omitempty"`
 }
 
 // RunEnvironment identifies the controller-selected allocation without

--- a/internal/controlplane/api_contract.go
+++ b/internal/controlplane/api_contract.go
@@ -62,19 +62,20 @@ type RunUsage struct {
 
 // Run is the stable HTTP representation of a Run CRD.
 type Run struct {
-	Name              string          `json:"name"`
-	UID               string          `json:"uid"`
-	Generation        int64           `json:"generation"`
-	CreatedAt         time.Time       `json:"createdAt"`
-	Intent            RunIntent       `json:"intent"`
-	CancelRequested   bool            `json:"cancelRequested"`
-	State             string          `json:"state"`
-	StartedAt         *time.Time      `json:"startedAt,omitempty"`
-	FinishedAt        *time.Time      `json:"finishedAt,omitempty"`
-	Environment       *RunEnvironment `json:"environment,omitempty"`
-	TerminalAvailable bool            `json:"terminalAvailable,omitempty"`
-	Branch            string          `json:"branch,omitempty"`
-	Usage             RunUsage        `json:"usage"`
+	Name                       string          `json:"name"`
+	UID                        string          `json:"uid"`
+	Generation                 int64           `json:"generation"`
+	CreatedAt                  time.Time       `json:"createdAt"`
+	Intent                     RunIntent       `json:"intent"`
+	CancelRequested            bool            `json:"cancelRequested"`
+	State                      string          `json:"state"`
+	RepositoryCredentialReason string          `json:"repositoryCredentialReason,omitempty"`
+	StartedAt                  *time.Time      `json:"startedAt,omitempty"`
+	FinishedAt                 *time.Time      `json:"finishedAt,omitempty"`
+	Environment                *RunEnvironment `json:"environment,omitempty"`
+	TerminalAvailable          bool            `json:"terminalAvailable,omitempty"`
+	Branch                     string          `json:"branch,omitempty"`
+	Usage                      RunUsage        `json:"usage"`
 }
 
 // RunList is a bounded page of Runs. Continue is opaque and may be supplied to

--- a/internal/controlplane/resource_handlers.go
+++ b/internal/controlplane/resource_handlers.go
@@ -324,6 +324,9 @@ func decodeCreateRun(w http.ResponseWriter, r *http.Request) (CreateRunRequest, 
 	if request.Prompt == "" {
 		return CreateRunRequest{}, fmt.Errorf("prompt is required")
 	}
+	if request.RepositoryCredential != "" && request.RepositoryCredential != "GitHubApp" {
+		return CreateRunRequest{}, fmt.Errorf("repositoryCredential must be GitHubApp")
+	}
 	return request, nil
 }
 

--- a/internal/controlplane/resource_handlers_test.go
+++ b/internal/controlplane/resource_handlers_test.go
@@ -160,7 +160,7 @@ func TestRunListQueryValidation(t *testing.T) {
 }
 
 func TestCreateRunValidation(t *testing.T) {
-	valid := `{"name":"r","selector":{"template":"small"},"agent":"amp","prompt":"go","credentialProfile":"amp-production"}`
+	valid := `{"name":"r","selector":{"template":"small"},"agent":"amp","prompt":"go","credentialProfile":"amp-production","repositoryCredential":"GitHubApp"}`
 	cases := []string{"{", valid + " {}", `{"name":"r","selector":{"template":"small"},"agent":"amp","prompt":"go","x":1}`, `{"name":"r","selector":{"template":"small","x":1},"agent":"amp","prompt":"go"}`, `{"name":"r","selector":{},"agent":"amp","prompt":"go"}`, `{"name":"r","selector":{"environment":"e","project":"p"},"agent":"amp","prompt":"go"}`, `{"name":"BAD NAME","selector":{"template":"small"},"agent":"amp","prompt":"go"}`, `{"name":"r","selector":{"template":"BAD NAME"},"agent":"amp","prompt":"go"}`, `{"name":"r","selector":{"template":"small"},"agent":"amp","prompt":"go","credentialProfile":"BAD PROFILE"}`, `{"name":"r","selector":{"template":"small"},"agent":"","prompt":"go"}`, `{"name":"r","selector":{"template":"small"},"agent":"` + strings.Repeat("a", 129) + `","prompt":"go"}`, `{"name":"r","selector":{"template":"small"},"agent":"amp","prompt":""}`}
 	for i, body := range cases {
 		f := &fakeResources{}
@@ -179,7 +179,7 @@ func TestCreateRunValidation(t *testing.T) {
 	if w.Code != 201 || !strings.Contains(w.Body.String(), `"name":"r"`) {
 		t.Errorf("success=%d %s", w.Code, w.Body.String())
 	}
-	if f.createdRequest.CredentialProfile != "amp-production" {
+	if f.createdRequest.CredentialProfile != "amp-production" || f.createdRequest.RepositoryCredential != "GitHubApp" {
 		t.Fatalf("profile create request = %#v", f.createdRequest)
 	}
 }

--- a/internal/controlplane/resource_service.go
+++ b/internal/controlplane/resource_service.go
@@ -145,6 +145,7 @@ func desiredRunSpec(request CreateRunRequest) platformv1alpha1.RunSpec {
 		Agent:                request.Agent,
 		Prompt:               request.Prompt,
 		CredentialProfileRef: request.CredentialProfile,
+		RepositoryCredential: platformv1alpha1.RepositoryCredential(request.RepositoryCredential),
 		Notify:               nil,
 		ParentRef:            "",
 	}
@@ -263,10 +264,11 @@ func runDTO(run *platformv1alpha1.Run) Run {
 		Generation: run.Generation,
 		CreatedAt:  run.CreationTimestamp.Time,
 		Intent: RunIntent{
-			Selector:          RunSelector{Environment: run.Spec.EnvironmentRef, Project: run.Spec.ProjectRef, Template: run.Spec.TemplateRef},
-			Agent:             run.Spec.Agent,
-			Prompt:            run.Spec.Prompt,
-			CredentialProfile: run.Spec.CredentialProfileRef,
+			Selector:             RunSelector{Environment: run.Spec.EnvironmentRef, Project: run.Spec.ProjectRef, Template: run.Spec.TemplateRef},
+			Agent:                run.Spec.Agent,
+			Prompt:               run.Spec.Prompt,
+			CredentialProfile:    run.Spec.CredentialProfileRef,
+			RepositoryCredential: string(run.Spec.RepositoryCredential),
 		},
 		CancelRequested: run.Spec.Cancel,
 		State:           string(run.Status.State),

--- a/internal/controlplane/resource_service.go
+++ b/internal/controlplane/resource_service.go
@@ -9,6 +9,7 @@ import (
 
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apiMeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
@@ -284,6 +285,9 @@ func runDTO(run *platformv1alpha1.Run) Run {
 	}
 	if run.Status.FinishedAt != nil {
 		result.FinishedAt = &run.Status.FinishedAt.Time
+	}
+	if condition := apiMeta.FindStatusCondition(run.Status.Conditions, "RepositoryCredentialReady"); condition != nil && len(condition.Reason) <= 128 {
+		result.RepositoryCredentialReason = condition.Reason
 	}
 	if run.Status.EnvironmentRef != nil {
 		result.Environment = &RunEnvironment{

--- a/internal/controlplane/resource_service_test.go
+++ b/internal/controlplane/resource_service_test.go
@@ -59,12 +59,12 @@ func TestResourceServiceCreateRunIntentOnlyAndAlreadyExistsDoesNotGet(t *testing
 	scheme := resourceScheme(t)
 	base := fake.NewClientBuilder().WithScheme(scheme).Build()
 	service := &KubernetesResourceService{Client: base}
-	req := CreateRunRequest{Name: "new", Selector: RunSelector{Project: "p", Template: "t"}, Agent: "a", Prompt: "do it"}
+	req := CreateRunRequest{Name: "new", Selector: RunSelector{Project: "p", Template: "t"}, Agent: "a", Prompt: "do it", RepositoryCredential: "GitHubApp"}
 	created, err := service.CreateRun(context.Background(), "ns", req)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if created.Intent.Selector != req.Selector {
+	if created.Intent.Selector != req.Selector || created.Intent.RepositoryCredential != "GitHubApp" {
 		t.Fatalf("selector = %#v", created.Intent.Selector)
 	}
 	var runs platformv1alpha1.RunList
@@ -87,7 +87,7 @@ func TestResourceServiceCreateRunIntentOnlyAndAlreadyExistsDoesNotGet(t *testing
 }
 
 func TestResourceServiceCreateCollisionComparesFullRunSpec(t *testing.T) {
-	request := CreateRunRequest{Name: "same", Selector: RunSelector{Template: "small"}, Agent: "agent", Prompt: "prompt", CredentialProfile: "profile"}
+	request := CreateRunRequest{Name: "same", Selector: RunSelector{Template: "small"}, Agent: "agent", Prompt: "prompt", CredentialProfile: "profile", RepositoryCredential: "GitHubApp"}
 	for _, test := range []struct {
 		name   string
 		mutate func(*platformv1alpha1.RunSpec)
@@ -100,6 +100,7 @@ func TestResourceServiceCreateCollisionComparesFullRunSpec(t *testing.T) {
 		{name: "notify conflicts", mutate: func(spec *platformv1alpha1.RunSpec) { spec.Notify = []string{"parent"} }, want: errRunIntentConflict},
 		{name: "selector conflicts", mutate: func(spec *platformv1alpha1.RunSpec) { spec.TemplateRef = "other" }, want: errRunIntentConflict},
 		{name: "credential profile conflicts", mutate: func(spec *platformv1alpha1.RunSpec) { spec.CredentialProfileRef = "other" }, want: errRunIntentConflict},
+		{name: "repository credential conflicts", mutate: func(spec *platformv1alpha1.RunSpec) { spec.RepositoryCredential = "" }, want: errRunIntentConflict},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			spec := desiredRunSpec(request)
@@ -280,6 +281,21 @@ func TestResourceServiceRunDTOMapsLifecycleTimestamps(t *testing.T) {
 	}
 	if got.FinishedAt == nil || !got.FinishedAt.Equal(finishedAt.Time) {
 		t.Fatalf("FinishedAt = %v, want %v", got.FinishedAt, finishedAt.Time)
+	}
+}
+
+func TestResourceServiceRunDTOMapsRepositoryCredentialReason(t *testing.T) {
+	run := &platformv1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{Name: "run", Namespace: "ns", UID: "run-uid"},
+		Spec:       platformv1alpha1.RunSpec{RepositoryCredential: platformv1alpha1.RepositoryCredentialGitHubApp},
+		Status: platformv1alpha1.RunStatus{State: platformv1alpha1.RunStateFailed, Conditions: []metav1.Condition{{
+			Type: "RepositoryCredentialReady", Status: metav1.ConditionFalse, Reason: "ProviderDisabled",
+		}}},
+	}
+	service := &KubernetesResourceService{Client: fake.NewClientBuilder().WithScheme(resourceScheme(t)).WithObjects(run).Build()}
+	got, err := service.GetRun(context.Background(), "ns", "run")
+	if err != nil || got.RepositoryCredentialReason != "ProviderDisabled" {
+		t.Fatalf("GetRun() = %#v, %v", got, err)
 	}
 }
 

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -34,13 +34,14 @@ type controlPlaneClient interface {
 
 // CreateRunInput is the bounded immutable Run intent exposed to MCP clients.
 type CreateRunInput struct {
-	Name              string `json:"name" jsonschema:"Stable Run name and idempotency key."`
-	Prompt            string `json:"prompt" jsonschema:"Task for the selected agent."`
-	Agent             string `json:"agent,omitempty" jsonschema:"Agent adapter; defaults to claude-code."`
-	Environment       string `json:"environment,omitempty" jsonschema:"Existing Environment; exclusive with project and template."`
-	Project           string `json:"project,omitempty" jsonschema:"Project supplying repository and default template configuration."`
-	Template          string `json:"template,omitempty" jsonschema:"EnvironmentTemplate; may override a Project default."`
-	CredentialProfile string `json:"credentialProfile,omitempty" jsonschema:"Same-namespace AgentCredentialProfile name."`
+	Name                 string `json:"name" jsonschema:"Stable Run name and idempotency key."`
+	Prompt               string `json:"prompt" jsonschema:"Task for the selected agent."`
+	Agent                string `json:"agent,omitempty" jsonschema:"Agent adapter; defaults to claude-code."`
+	Environment          string `json:"environment,omitempty" jsonschema:"Existing Environment; exclusive with project and template."`
+	Project              string `json:"project,omitempty" jsonschema:"Project supplying repository and default template configuration."`
+	Template             string `json:"template,omitempty" jsonschema:"EnvironmentTemplate; may override a Project default."`
+	CredentialProfile    string `json:"credentialProfile,omitempty" jsonschema:"Same-namespace AgentCredentialProfile name."`
+	RepositoryCredential string `json:"repositoryCredential,omitempty" jsonschema:"Repository credential provider; GitHubApp when selected."`
 }
 
 // RunReference is the concise, immutable identity returned by create_run.
@@ -132,9 +133,10 @@ func createRun(ctx context.Context, client controlPlaneClient, namespace string,
 			Project:     input.Project,
 			Template:    input.Template,
 		},
-		Agent:             agent,
-		Prompt:            input.Prompt,
-		CredentialProfile: input.CredentialProfile,
+		Agent:                agent,
+		Prompt:               input.Prompt,
+		CredentialProfile:    input.CredentialProfile,
+		RepositoryCredential: input.RepositoryCredential,
 	})
 	if err != nil {
 		return CreateRunOutput{}, fmt.Errorf("create Run: %w", err)
@@ -171,6 +173,9 @@ func validateCreateRun(input CreateRunInput) error {
 	}
 	if input.Prompt == "" || len(input.Prompt) > maxPromptBytes {
 		return fmt.Errorf("prompt is required and must not exceed %d bytes", maxPromptBytes)
+	}
+	if input.RepositoryCredential != "" && input.RepositoryCredential != "GitHubApp" {
+		return fmt.Errorf("repositoryCredential must be GitHubApp")
 	}
 	return nil
 }
@@ -292,6 +297,7 @@ func createRunSchema() *jsonschema.Schema {
 	for _, field := range []string{"environment", "project", "template", "credentialProfile"} {
 		setStringBounds(schema, field, 0, 253)
 	}
+	setStringBounds(schema, "repositoryCredential", 0, 9)
 	return schema
 }
 

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -66,7 +66,7 @@ func TestMCPCreateRunUsesFixedNamespaceAndReturnsUID(t *testing.T) {
 	result, err := clientSession.CallTool(context.Background(), &mcp.CallToolParams{
 		Name: "create_run",
 		Arguments: map[string]any{
-			"name": "task-1", "prompt": "do the work", "project": "repo",
+			"name": "task-1", "prompt": "do the work", "project": "repo", "repositoryCredential": "GitHubApp",
 		},
 	})
 	if err != nil || result.IsError {
@@ -76,7 +76,7 @@ func TestMCPCreateRunUsesFixedNamespaceAndReturnsUID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if fake.createdNamespace != "team-a" || fake.createdRequest.Agent != "claude-code" || fake.createdRequest.Selector.Project != "repo" {
+	if fake.createdNamespace != "team-a" || fake.createdRequest.Agent != "claude-code" || fake.createdRequest.Selector.Project != "repo" || fake.createdRequest.RepositoryCredential != "GitHubApp" {
 		t.Fatalf("create = %q/%#v", fake.createdNamespace, fake.createdRequest)
 	}
 	if !strings.Contains(string(encoded), `"namespace":"team-a"`) || !strings.Contains(string(encoded), `"uid":"run-uid"`) || strings.Contains(string(encoded), "do the work") {

--- a/internal/repositorycredential/githubapp/provider.go
+++ b/internal/repositorycredential/githubapp/provider.go
@@ -12,10 +12,12 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -25,6 +27,11 @@ import (
 
 const apiBase = "https://api.github.com"
 const maxBody = 64 << 10
+
+var (
+	ownerPattern      = regexp.MustCompile(`^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$`)
+	repositoryPattern = regexp.MustCompile(`^[A-Za-z0-9._-]{1,100}$`)
+)
 
 type Provider struct {
 	ClientID string
@@ -55,16 +62,19 @@ func New(clientID string, keyPEM []byte, client *http.Client) (*Provider, error)
 
 func canonical(repository string) (string, string, string, error) {
 	u, err := url.Parse(repository)
-	if err != nil || u.Scheme != "https" || u.Host != "github.com" || u.User != nil || u.RawQuery != "" || u.Fragment != "" || u.Port() != "" {
+	if err != nil || u.Scheme != "https" || u.Host != "github.com" || u.User != nil || u.RawQuery != "" || u.Fragment != "" || u.Port() != "" || u.RawPath != "" || strings.Contains(repository, "%") {
 		return "", "", "", fmt.Errorf("unsupported repository URL")
 	}
-	parts := strings.Split(strings.Trim(u.EscapedPath(), "/"), "/")
+	if !strings.HasPrefix(u.Path, "/") || strings.HasSuffix(u.Path, "/") {
+		return "", "", "", fmt.Errorf("unsupported repository URL")
+	}
+	parts := strings.Split(strings.TrimPrefix(u.Path, "/"), "/")
 	if len(parts) != 2 {
 		return "", "", "", fmt.Errorf("unsupported repository URL")
 	}
-	owner, err1 := url.PathUnescape(parts[0])
-	repo, err2 := url.PathUnescape(strings.TrimSuffix(parts[1], ".git"))
-	if err1 != nil || err2 != nil || owner == "" || repo == "" || strings.ContainsAny(owner+repo, "/\\") {
+	owner := parts[0]
+	repo := strings.TrimSuffix(parts[1], ".git")
+	if !ownerPattern.MatchString(owner) || !repositoryPattern.MatchString(repo) || repo == "." || repo == ".." {
 		return "", "", "", fmt.Errorf("unsupported repository URL")
 	}
 	return "https://github.com/" + owner + "/" + repo, owner, repo, nil
@@ -81,7 +91,8 @@ func (p *Provider) CanonicalRepository(repository string) (string, error) {
 func (p *Provider) jwt() (string, error) {
 	now := p.Now()
 	enc := base64.RawURLEncoding
-	header := enc.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	headerJSON, _ := json.Marshal(map[string]string{"alg": "RS256", "typ": "JWT"})
+	header := enc.EncodeToString(headerJSON)
 	payload, _ := json.Marshal(map[string]any{"iat": now.Add(-time.Minute).Unix(), "exp": now.Add(9 * time.Minute).Unix(), "iss": p.ClientID})
 	unsigned := header + "." + enc.EncodeToString(payload)
 	h := sha256.Sum256([]byte(unsigned))
@@ -126,6 +137,13 @@ func (p *Provider) request(ctx context.Context, method, path, authorization stri
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		retryable := resp.StatusCode == 429 || resp.StatusCode >= 500
 		delay := time.Duration(0)
+		var envelope struct {
+			Message string `json:"message"`
+		}
+		_ = json.Unmarshal(data, &envelope)
+		message := strings.ToLower(envelope.Message)
+		secondaryLimit := resp.StatusCode == http.StatusForbidden &&
+			(strings.Contains(message, "secondary rate limit") || strings.Contains(message, "abuse detection"))
 		if value := resp.Header.Get("Retry-After"); value != "" {
 			if seconds, parseErr := strconv.ParseInt(value, 10, 64); parseErr == nil && seconds > 0 {
 				delay = time.Duration(seconds) * time.Second
@@ -140,13 +158,19 @@ func (p *Provider) request(ctx context.Context, method, path, authorization stri
 				delay = time.Unix(reset, 0).Sub(p.Now())
 			}
 		}
+		if secondaryLimit {
+			retryable = true
+			if delay < time.Minute {
+				delay = time.Minute
+			}
+		}
 		if retryable && delay <= 0 {
 			delay = repositorycredential.DefaultRetryDelay
 		}
 		if delay > 15*time.Minute {
 			delay = 15 * time.Minute
 		}
-		return &repositorycredential.Error{Retryable: retryable, RetryAfter: delay, Operation: "API", Reason: "ProviderAPIError"}
+		return &repositorycredential.Error{Retryable: retryable, RetryAfter: delay, Operation: "API", Reason: "ProviderAPIError", StatusCode: resp.StatusCode}
 	}
 	if out != nil && json.Unmarshal(data, out) != nil {
 		return &repositorycredential.Error{Retryable: false, Operation: "response", Reason: "ProviderInvalidResponse"}
@@ -169,15 +193,30 @@ func (p *Provider) Issue(ctx context.Context, repository string) (*repositorycre
 	if err = p.request(ctx, http.MethodGet, "/repos/"+url.PathEscape(owner)+"/"+url.PathEscape(repo)+"/installation", j, nil, &installation); err != nil {
 		return nil, err
 	}
+	if installation.ID < 1 {
+		return nil, &repositorycredential.Error{Operation: "installation", Reason: "ProviderInvalidResponse"}
+	}
 	var token struct {
-		Token     string    `json:"token"`
-		ExpiresAt time.Time `json:"expires_at"`
+		Token               string            `json:"token"`
+		ExpiresAt           time.Time         `json:"expires_at"`
+		RepositorySelection string            `json:"repository_selection"`
+		Permissions         map[string]string `json:"permissions"`
+		Repositories        []struct {
+			FullName string `json:"full_name"`
+		} `json:"repositories"`
 	}
 	body := map[string]any{"repositories": []string{repo}, "permissions": map[string]string{"contents": "write"}}
 	if err = p.request(ctx, http.MethodPost, fmt.Sprintf("/app/installations/%d/access_tokens", installation.ID), j, body, &token); err != nil {
 		return nil, err
 	}
-	if token.Token == "" || len(token.Token) > repositorycredential.MaxTokenBytes || strings.IndexByte(token.Token, 0) >= 0 || !token.ExpiresAt.After(p.Now().Add(repositorycredential.MinimumValidity)) {
+	validPermissions := len(token.Permissions) >= 1 && len(token.Permissions) <= 2 && token.Permissions["contents"] == "write"
+	for name, access := range token.Permissions {
+		if name != "contents" && (name != "metadata" || access != "read") {
+			validPermissions = false
+		}
+	}
+	validRepositories := len(token.Repositories) == 0 || len(token.Repositories) == 1 && strings.EqualFold(token.Repositories[0].FullName, owner+"/"+repo)
+	if token.Token == "" || len(token.Token) > repositorycredential.MaxTokenBytes || strings.IndexByte(token.Token, 0) >= 0 || !token.ExpiresAt.After(p.Now().Add(repositorycredential.MinimumValidity)) || token.RepositorySelection != "selected" || !validPermissions || !validRepositories {
 		return nil, &repositorycredential.Error{Operation: "token", Reason: "ProviderInvalidToken"}
 	}
 	return &repositorycredential.Credential{Token: []byte(token.Token), Repository: canonicalURL, InstallationID: installation.ID, ExpiresAt: token.ExpiresAt}, nil
@@ -187,5 +226,10 @@ func (p *Provider) Revoke(ctx context.Context, credential *repositorycredential.
 	if credential == nil || len(credential.Token) == 0 {
 		return nil
 	}
-	return p.request(ctx, http.MethodDelete, "/installation/token", string(credential.Token), nil, nil)
+	err := p.request(ctx, http.MethodDelete, "/installation/token", string(credential.Token), nil, nil)
+	var providerErr *repositorycredential.Error
+	if errors.As(err, &providerErr) && providerErr.StatusCode == http.StatusUnauthorized {
+		return nil
+	}
+	return err
 }

--- a/internal/repositorycredential/githubapp/provider.go
+++ b/internal/repositorycredential/githubapp/provider.go
@@ -1,0 +1,158 @@
+// Package githubapp implements repository-scoped GitHub App installation tokens.
+package githubapp
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/Chris-Cullins/swe-platform/internal/repositorycredential"
+)
+
+const apiBase = "https://api.github.com"
+const maxBody = 64 << 10
+
+type Provider struct {
+	ClientID string
+	Key      *rsa.PrivateKey
+	Client   *http.Client
+	Now      func() time.Time
+}
+
+func New(clientID string, keyPEM []byte, client *http.Client) (*Provider, error) {
+	block, _ := pem.Decode(keyPEM)
+	if block == nil {
+		return nil, fmt.Errorf("invalid GitHub App private key")
+	}
+	var key *rsa.PrivateKey
+	if parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes); err == nil {
+		key, _ = parsed.(*rsa.PrivateKey)
+	} else {
+		key, _ = x509.ParsePKCS1PrivateKey(block.Bytes)
+	}
+	if clientID == "" || key == nil || key.Validate() != nil {
+		return nil, fmt.Errorf("invalid GitHub App configuration")
+	}
+	if client == nil {
+		client = &http.Client{Timeout: 15 * time.Second, CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+	}
+	return &Provider{ClientID: clientID, Key: key, Client: client, Now: time.Now}, nil
+}
+
+func canonical(repository string) (string, string, string, error) {
+	u, err := url.Parse(repository)
+	if err != nil || u.Scheme != "https" || u.Host != "github.com" || u.User != nil || u.RawQuery != "" || u.Fragment != "" || u.Port() != "" {
+		return "", "", "", fmt.Errorf("unsupported repository URL")
+	}
+	parts := strings.Split(strings.Trim(u.EscapedPath(), "/"), "/")
+	if len(parts) != 2 {
+		return "", "", "", fmt.Errorf("unsupported repository URL")
+	}
+	owner, err1 := url.PathUnescape(parts[0])
+	repo, err2 := url.PathUnescape(strings.TrimSuffix(parts[1], ".git"))
+	if err1 != nil || err2 != nil || owner == "" || repo == "" || strings.ContainsAny(owner+repo, "/\\") {
+		return "", "", "", fmt.Errorf("unsupported repository URL")
+	}
+	return "https://github.com/" + owner + "/" + repo, owner, repo, nil
+}
+
+func (p *Provider) jwt() (string, error) {
+	now := p.Now()
+	enc := base64.RawURLEncoding
+	header := enc.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	payload, _ := json.Marshal(map[string]any{"iat": now.Add(-time.Minute).Unix(), "exp": now.Add(9 * time.Minute).Unix(), "iss": p.ClientID})
+	unsigned := header + "." + enc.EncodeToString(payload)
+	h := sha256.Sum256([]byte(unsigned))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, p.Key, crypto.SHA256, h[:])
+	if err != nil {
+		return "", err
+	}
+	return unsigned + "." + enc.EncodeToString(sig), nil
+}
+
+func (p *Provider) request(ctx context.Context, method, path, authorization string, body any, out any) error {
+	var reader io.Reader
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		reader = bytes.NewReader(encoded)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, apiBase+path, reader)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+authorization)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := p.Client.Do(req)
+	if err != nil {
+		return &repositorycredential.Error{Retryable: true, Operation: "request"}
+	}
+	defer resp.Body.Close()
+	limited := io.LimitReader(resp.Body, maxBody+1)
+	data, err := io.ReadAll(limited)
+	if err != nil || len(data) > maxBody {
+		return &repositorycredential.Error{Retryable: true, Operation: "response"}
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return &repositorycredential.Error{Retryable: resp.StatusCode == 429 || resp.StatusCode >= 500, Operation: "API"}
+	}
+	if out != nil && json.Unmarshal(data, out) != nil {
+		return &repositorycredential.Error{Retryable: false, Operation: "response"}
+	}
+	return nil
+}
+
+func (p *Provider) Issue(ctx context.Context, repository string) (*repositorycredential.Credential, error) {
+	canonicalURL, owner, repo, err := canonical(repository)
+	if err != nil {
+		return nil, &repositorycredential.Error{Operation: "repository"}
+	}
+	j, err := p.jwt()
+	if err != nil {
+		return nil, &repositorycredential.Error{Operation: "sign"}
+	}
+	var installation struct {
+		ID int64 `json:"id"`
+	}
+	if err = p.request(ctx, http.MethodGet, "/repos/"+url.PathEscape(owner)+"/"+url.PathEscape(repo)+"/installation", j, nil, &installation); err != nil {
+		return nil, err
+	}
+	var token struct {
+		Token     string    `json:"token"`
+		ExpiresAt time.Time `json:"expires_at"`
+	}
+	body := map[string]any{"repositories": []string{repo}, "permissions": map[string]string{"contents": "write"}}
+	if err = p.request(ctx, http.MethodPost, fmt.Sprintf("/app/installations/%d/access_tokens", installation.ID), j, body, &token); err != nil {
+		return nil, err
+	}
+	if token.Token == "" || len(token.Token) > repositorycredential.MaxTokenBytes || token.ExpiresAt.IsZero() {
+		return nil, &repositorycredential.Error{Operation: "token"}
+	}
+	return &repositorycredential.Credential{Token: []byte(token.Token), Repository: canonicalURL, InstallationID: installation.ID, ExpiresAt: token.ExpiresAt}, nil
+}
+
+func (p *Provider) Revoke(ctx context.Context, credential *repositorycredential.Credential) error {
+	if credential == nil || len(credential.Token) == 0 {
+		return nil
+	}
+	return p.request(ctx, http.MethodDelete, "/installation/token", string(credential.Token), nil, nil)
+}

--- a/internal/repositorycredential/githubapp/provider.go
+++ b/internal/repositorycredential/githubapp/provider.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -69,6 +70,14 @@ func canonical(repository string) (string, string, string, error) {
 	return "https://github.com/" + owner + "/" + repo, owner, repo, nil
 }
 
+func (p *Provider) CanonicalRepository(repository string) (string, error) {
+	canonicalURL, _, _, err := canonical(repository)
+	if err != nil {
+		return "", &repositorycredential.Error{Operation: "repository", Reason: "RepositoryUnsupported"}
+	}
+	return canonicalURL, nil
+}
+
 func (p *Provider) jwt() (string, error) {
 	now := p.Now()
 	enc := base64.RawURLEncoding
@@ -102,21 +111,45 @@ func (p *Provider) request(ctx context.Context, method, path, authorization stri
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	resp, err := p.Client.Do(req)
+	client := *p.Client
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	resp, err := client.Do(req)
 	if err != nil {
-		return &repositorycredential.Error{Retryable: true, Operation: "request"}
+		return &repositorycredential.Error{Retryable: true, Operation: "request", Reason: "ProviderUnavailable"}
 	}
 	defer resp.Body.Close()
 	limited := io.LimitReader(resp.Body, maxBody+1)
 	data, err := io.ReadAll(limited)
 	if err != nil || len(data) > maxBody {
-		return &repositorycredential.Error{Retryable: true, Operation: "response"}
+		return &repositorycredential.Error{Retryable: true, Operation: "response", Reason: "ProviderInvalidResponse"}
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return &repositorycredential.Error{Retryable: resp.StatusCode == 429 || resp.StatusCode >= 500, Operation: "API"}
+		retryable := resp.StatusCode == 429 || resp.StatusCode >= 500
+		delay := time.Duration(0)
+		if value := resp.Header.Get("Retry-After"); value != "" {
+			if seconds, parseErr := strconv.ParseInt(value, 10, 64); parseErr == nil && seconds > 0 {
+				delay = time.Duration(seconds) * time.Second
+			} else if at, parseErr := http.ParseTime(value); parseErr == nil {
+				delay = at.Sub(p.Now())
+			}
+			retryable = retryable || resp.StatusCode == http.StatusForbidden
+		}
+		if resp.Header.Get("X-RateLimit-Remaining") == "0" {
+			retryable = retryable || resp.StatusCode == http.StatusForbidden
+			if reset, parseErr := strconv.ParseInt(resp.Header.Get("X-RateLimit-Reset"), 10, 64); parseErr == nil {
+				delay = time.Unix(reset, 0).Sub(p.Now())
+			}
+		}
+		if retryable && delay <= 0 {
+			delay = repositorycredential.DefaultRetryDelay
+		}
+		if delay > 15*time.Minute {
+			delay = 15 * time.Minute
+		}
+		return &repositorycredential.Error{Retryable: retryable, RetryAfter: delay, Operation: "API", Reason: "ProviderAPIError"}
 	}
 	if out != nil && json.Unmarshal(data, out) != nil {
-		return &repositorycredential.Error{Retryable: false, Operation: "response"}
+		return &repositorycredential.Error{Retryable: false, Operation: "response", Reason: "ProviderInvalidResponse"}
 	}
 	return nil
 }
@@ -124,11 +157,11 @@ func (p *Provider) request(ctx context.Context, method, path, authorization stri
 func (p *Provider) Issue(ctx context.Context, repository string) (*repositorycredential.Credential, error) {
 	canonicalURL, owner, repo, err := canonical(repository)
 	if err != nil {
-		return nil, &repositorycredential.Error{Operation: "repository"}
+		return nil, &repositorycredential.Error{Operation: "repository", Reason: "RepositoryUnsupported"}
 	}
 	j, err := p.jwt()
 	if err != nil {
-		return nil, &repositorycredential.Error{Operation: "sign"}
+		return nil, &repositorycredential.Error{Operation: "sign", Reason: "ProviderSigningFailed"}
 	}
 	var installation struct {
 		ID int64 `json:"id"`
@@ -144,8 +177,8 @@ func (p *Provider) Issue(ctx context.Context, repository string) (*repositorycre
 	if err = p.request(ctx, http.MethodPost, fmt.Sprintf("/app/installations/%d/access_tokens", installation.ID), j, body, &token); err != nil {
 		return nil, err
 	}
-	if token.Token == "" || len(token.Token) > repositorycredential.MaxTokenBytes || token.ExpiresAt.IsZero() {
-		return nil, &repositorycredential.Error{Operation: "token"}
+	if token.Token == "" || len(token.Token) > repositorycredential.MaxTokenBytes || strings.IndexByte(token.Token, 0) >= 0 || !token.ExpiresAt.After(p.Now().Add(repositorycredential.MinimumValidity)) {
+		return nil, &repositorycredential.Error{Operation: "token", Reason: "ProviderInvalidToken"}
 	}
 	return &repositorycredential.Credential{Token: []byte(token.Token), Repository: canonicalURL, InstallationID: installation.ID, ExpiresAt: token.ExpiresAt}, nil
 }

--- a/internal/repositorycredential/githubapp/provider_test.go
+++ b/internal/repositorycredential/githubapp/provider_test.go
@@ -1,6 +1,7 @@
 package githubapp
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
@@ -31,7 +32,7 @@ func TestCanonicalRepository(t *testing.T) {
 			t.Fatalf("CanonicalRepository(%q) = %q, %v", test.input, got, err)
 		}
 	}
-	for _, invalid := range []string{"http://github.com/a/b", "https://evil.test/a/b", "https://github.com/a/b/c", "git@github.com:a/b"} {
+	for _, invalid := range []string{"http://github.com/a/b", "https://evil.test/a/b", "https://github.com/a/b/c", "git@github.com:a/b", "https://github.com/a/b/", "https://github.com/a/%3Freleases", "https://github.com/-bad/repo", "https://github.com/acme/.."} {
 		if _, err := p.CanonicalRepository(invalid); err == nil {
 			t.Errorf("CanonicalRepository(%q) succeeded", invalid)
 		}
@@ -48,6 +49,7 @@ func TestGitHubRateLimitClassification(t *testing.T) {
 		delay     time.Duration
 	}{
 		{name: "ordinary forbidden", status: 403, headers: http.Header{}, retryable: false},
+		{name: "secondary limit", status: 403, headers: http.Header{}, retryable: true, delay: time.Minute},
 		{name: "forbidden retry after", status: 403, headers: http.Header{"Retry-After": []string{"30"}}, retryable: true, delay: 30 * time.Second},
 		{name: "forbidden exhausted", status: 403, headers: http.Header{"X-Ratelimit-Remaining": []string{"0"}, "X-Ratelimit-Reset": []string{strconv.FormatInt(now.Add(time.Minute).Unix(), 10)}}, retryable: true, delay: time.Minute},
 		{name: "too many requests fallback", status: 429, headers: http.Header{}, retryable: true, delay: repositorycredential.DefaultRetryDelay},
@@ -55,7 +57,12 @@ func TestGitHubRateLimitClassification(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			p := &Provider{Now: func() time.Time { return now }, Client: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
-				return &http.Response{StatusCode: tc.status, Header: tc.headers, Body: io.NopCloser(strings.NewReader("sensitive body"))}, nil
+				body := "sensitive body"
+				if tc.name == "secondary limit" {
+					encoded, _ := json.Marshal(map[string]string{"message": "You have exceeded a secondary rate limit."})
+					body = string(encoded)
+				}
+				return &http.Response{StatusCode: tc.status, Header: tc.headers, Body: io.NopCloser(strings.NewReader(body))}, nil
 			})}}
 			err := p.request(context.Background(), http.MethodGet, "/test", "token", nil, nil)
 			if repositorycredential.IsRetryable(err) != tc.retryable || repositorycredential.RetryDelay(err) != func() time.Duration {
@@ -88,6 +95,17 @@ func TestIssueAndRevokeGitHubContract(t *testing.T) {
 			if len(parts) != 3 {
 				t.Fatalf("authorization is not JWT")
 			}
+			header, decodeErr := base64.RawURLEncoding.DecodeString(parts[0])
+			if decodeErr != nil {
+				t.Fatal(decodeErr)
+			}
+			var protected struct {
+				Alg string `json:"alg"`
+				Typ string `json:"typ"`
+			}
+			if json.Unmarshal(header, &protected) != nil || protected.Alg != "RS256" || protected.Typ != "JWT" {
+				t.Errorf("JWT header = %q", header)
+			}
 			payload, decodeErr := base64.RawURLEncoding.DecodeString(parts[1])
 			if decodeErr != nil {
 				t.Fatal(decodeErr)
@@ -100,13 +118,19 @@ func TestIssueAndRevokeGitHubContract(t *testing.T) {
 				t.Errorf("JWT claims = %#v", claims)
 			}
 		}
-		body := `{"id":42}`
+		encoded, _ := json.Marshal(map[string]any{"id": int64(42)})
+		body := string(encoded)
 		if req.Method == http.MethodPost {
 			data, _ := io.ReadAll(req.Body)
-			if string(data) != `{"permissions":{"contents":"write"},"repositories":["widget"]}` {
+			var request struct {
+				Repositories []string          `json:"repositories"`
+				Permissions  map[string]string `json:"permissions"`
+			}
+			if json.Unmarshal(data, &request) != nil || len(request.Repositories) != 1 || request.Repositories[0] != "widget" || request.Permissions["contents"] != "write" || len(request.Permissions) != 1 {
 				t.Errorf("token body = %s", data)
 			}
-			body = `{"token":"secret-token","expires_at":"2026-08-03T13:00:00Z"}`
+			encoded, _ = json.Marshal(map[string]any{"token": "secret-token", "expires_at": "2026-08-03T13:00:00Z", "repository_selection": "selected", "permissions": map[string]string{"contents": "write", "metadata": "read"}, "repositories": []map[string]string{{"full_name": "acme/widget"}}})
+			body = string(encoded)
 		}
 		if req.Method == http.MethodDelete {
 			if auth != "secret-token" {
@@ -130,6 +154,16 @@ func TestIssueAndRevokeGitHubContract(t *testing.T) {
 	want := []string{"GET /repos/acme/widget/installation", "POST /app/installations/42/access_tokens", "DELETE /installation/token"}
 	if strings.Join(calls, "|") != strings.Join(want, "|") {
 		t.Fatalf("calls = %v", calls)
+	}
+}
+
+func TestRevokeTreatsUnauthorizedAsAlreadyInactive(t *testing.T) {
+	p := &Provider{Client: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		body, _ := json.Marshal(map[string]string{"message": "Bad credentials"})
+		return &http.Response{StatusCode: http.StatusUnauthorized, Header: make(http.Header), Body: io.NopCloser(bytes.NewReader(body))}, nil
+	})}}
+	if err := p.Revoke(context.Background(), &repositorycredential.Credential{Token: []byte("already-revoked")}); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/repositorycredential/githubapp/provider_test.go
+++ b/internal/repositorycredential/githubapp/provider_test.go
@@ -1,0 +1,150 @@
+package githubapp
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Chris-Cullins/swe-platform/internal/repositorycredential"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestCanonicalRepository(t *testing.T) {
+	p := &Provider{}
+	for _, test := range []struct{ input, want string }{
+		{"https://github.com/acme/widget", "https://github.com/acme/widget"},
+		{"https://github.com/acme/widget.git", "https://github.com/acme/widget"},
+	} {
+		got, err := p.CanonicalRepository(test.input)
+		if err != nil || got != test.want {
+			t.Fatalf("CanonicalRepository(%q) = %q, %v", test.input, got, err)
+		}
+	}
+	for _, invalid := range []string{"http://github.com/a/b", "https://evil.test/a/b", "https://github.com/a/b/c", "git@github.com:a/b"} {
+		if _, err := p.CanonicalRepository(invalid); err == nil {
+			t.Errorf("CanonicalRepository(%q) succeeded", invalid)
+		}
+	}
+}
+
+func TestGitHubRateLimitClassification(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name      string
+		status    int
+		headers   http.Header
+		retryable bool
+		delay     time.Duration
+	}{
+		{name: "ordinary forbidden", status: 403, headers: http.Header{}, retryable: false},
+		{name: "forbidden retry after", status: 403, headers: http.Header{"Retry-After": []string{"30"}}, retryable: true, delay: 30 * time.Second},
+		{name: "forbidden exhausted", status: 403, headers: http.Header{"X-Ratelimit-Remaining": []string{"0"}, "X-Ratelimit-Reset": []string{strconv.FormatInt(now.Add(time.Minute).Unix(), 10)}}, retryable: true, delay: time.Minute},
+		{name: "too many requests fallback", status: 429, headers: http.Header{}, retryable: true, delay: repositorycredential.DefaultRetryDelay},
+		{name: "clamped", status: 429, headers: http.Header{"Retry-After": []string{"9999"}}, retryable: true, delay: 15 * time.Minute},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &Provider{Now: func() time.Time { return now }, Client: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return &http.Response{StatusCode: tc.status, Header: tc.headers, Body: io.NopCloser(strings.NewReader("sensitive body"))}, nil
+			})}}
+			err := p.request(context.Background(), http.MethodGet, "/test", "token", nil, nil)
+			if repositorycredential.IsRetryable(err) != tc.retryable || repositorycredential.RetryDelay(err) != func() time.Duration {
+				if tc.delay > 0 {
+					return tc.delay
+				}
+				return repositorycredential.DefaultRetryDelay
+			}() || strings.Contains(err.Error(), "sensitive") {
+				t.Fatalf("error classification = %v retry=%v delay=%v", err, repositorycredential.IsRetryable(err), repositorycredential.RetryDelay(err))
+			}
+		})
+	}
+}
+
+func TestIssueAndRevokeGitHubContract(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var calls []string
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls = append(calls, req.Method+" "+req.URL.Path)
+		if req.Header.Get("Accept") != "application/vnd.github+json" || req.Header.Get("X-GitHub-Api-Version") != "2022-11-28" {
+			t.Errorf("fixed headers missing: %#v", req.Header)
+		}
+		auth := strings.TrimPrefix(req.Header.Get("Authorization"), "Bearer ")
+		if req.Method != http.MethodDelete {
+			parts := strings.Split(auth, ".")
+			if len(parts) != 3 {
+				t.Fatalf("authorization is not JWT")
+			}
+			payload, decodeErr := base64.RawURLEncoding.DecodeString(parts[1])
+			if decodeErr != nil {
+				t.Fatal(decodeErr)
+			}
+			var claims struct {
+				Iss      string `json:"iss"`
+				Iat, Exp int64
+			}
+			if json.Unmarshal(payload, &claims) != nil || claims.Iss != "client" || claims.Iat != now.Add(-time.Minute).Unix() || claims.Exp != now.Add(9*time.Minute).Unix() {
+				t.Errorf("JWT claims = %#v", claims)
+			}
+		}
+		body := `{"id":42}`
+		if req.Method == http.MethodPost {
+			data, _ := io.ReadAll(req.Body)
+			if string(data) != `{"permissions":{"contents":"write"},"repositories":["widget"]}` {
+				t.Errorf("token body = %s", data)
+			}
+			body = `{"token":"secret-token","expires_at":"2026-08-03T13:00:00Z"}`
+		}
+		if req.Method == http.MethodDelete {
+			if auth != "secret-token" {
+				t.Errorf("revoke authorization = %q", auth)
+			}
+			body = ""
+		}
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}, nil
+	})}
+	p := &Provider{ClientID: "client", Key: key, Client: client, Now: func() time.Time { return now }}
+	credential, err := p.Issue(context.Background(), "https://github.com/acme/widget.git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if credential.Repository != "https://github.com/acme/widget" || credential.InstallationID != 42 {
+		t.Fatalf("credential = %#v", credential)
+	}
+	if err := p.Revoke(context.Background(), credential); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"GET /repos/acme/widget/installation", "POST /app/installations/42/access_tokens", "DELETE /installation/token"}
+	if strings.Join(calls, "|") != strings.Join(want, "|") {
+		t.Fatalf("calls = %v", calls)
+	}
+}
+
+func TestProviderResponseBoundsAndStableRetry(t *testing.T) {
+	p := &Provider{Client: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 503, Body: io.NopCloser(strings.NewReader("provider detail must not escape")), Header: make(http.Header)}, nil
+	})}}
+	err := p.request(context.Background(), http.MethodGet, "/test", "token", nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "provider API failed") || strings.Contains(err.Error(), "detail") {
+		t.Fatalf("error = %v", err)
+	}
+	p.Client.Transport = roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(strings.Repeat("x", maxBody+1))), Header: make(http.Header)}, nil
+	})
+	if err := p.request(context.Background(), http.MethodGet, "/test", "token", nil, nil); err == nil {
+		t.Fatal("oversize body accepted")
+	}
+}

--- a/internal/repositorycredential/provider.go
+++ b/internal/repositorycredential/provider.go
@@ -9,6 +9,12 @@ import (
 
 const MaxTokenBytes = 16 << 10
 
+const (
+	DefaultRetryDelay = 10 * time.Second
+	MinimumValidity   = 5 * time.Minute
+	RefreshMargin     = 10 * time.Minute
+)
+
 type Credential struct {
 	Token          []byte
 	Repository     string
@@ -17,17 +23,36 @@ type Credential struct {
 }
 
 type Provider interface {
+	CanonicalRepository(string) (string, error)
 	Issue(context.Context, string) (*Credential, error)
 	Revoke(context.Context, *Credential) error
 }
 
 type Error struct {
-	Retryable bool
-	Operation string
+	Retryable  bool
+	Operation  string
+	Reason     string
+	RetryAfter time.Duration
 }
 
 func (e *Error) Error() string { return "repository credential provider " + e.Operation + " failed" }
 func IsRetryable(err error) bool {
 	var target *Error
 	return errors.As(err, &target) && target.Retryable
+}
+
+func Reason(err error) string {
+	var target *Error
+	if errors.As(err, &target) && target.Reason != "" {
+		return target.Reason
+	}
+	return "ProviderError"
+}
+
+func RetryDelay(err error) time.Duration {
+	var target *Error
+	if errors.As(err, &target) && target.RetryAfter > 0 {
+		return target.RetryAfter
+	}
+	return DefaultRetryDelay
 }

--- a/internal/repositorycredential/provider.go
+++ b/internal/repositorycredential/provider.go
@@ -1,0 +1,33 @@
+// Package repositorycredential defines the provider-neutral short-lived repository credential boundary.
+package repositorycredential
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+const MaxTokenBytes = 16 << 10
+
+type Credential struct {
+	Token          []byte
+	Repository     string
+	InstallationID int64
+	ExpiresAt      time.Time
+}
+
+type Provider interface {
+	Issue(context.Context, string) (*Credential, error)
+	Revoke(context.Context, *Credential) error
+}
+
+type Error struct {
+	Retryable bool
+	Operation string
+}
+
+func (e *Error) Error() string { return "repository credential provider " + e.Operation + " failed" }
+func IsRetryable(err error) bool {
+	var target *Error
+	return errors.As(err, &target) && target.Retryable
+}

--- a/internal/repositorycredential/provider.go
+++ b/internal/repositorycredential/provider.go
@@ -33,6 +33,7 @@ type Error struct {
 	Operation  string
 	Reason     string
 	RetryAfter time.Duration
+	StatusCode int
 }
 
 func (e *Error) Error() string { return "repository credential provider " + e.Operation + " failed" }

--- a/internal/repositorycredential/secret.go
+++ b/internal/repositorycredential/secret.go
@@ -1,0 +1,84 @@
+package repositorycredential
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	SecretType                    corev1.SecretType = "swe.dev/repository-credential"
+	TokenKey                                        = "token"
+	AnnotationRunName                               = "swe.dev/repository-credential-run-name"
+	AnnotationRunUID                                = "swe.dev/repository-credential-run-uid"
+	AnnotationProvider                              = "swe.dev/repository-credential-provider"
+	AnnotationRepository                            = "swe.dev/repository-credential-repository"
+	AnnotationSourceRepository                      = "swe.dev/repository-credential-source-repository"
+	AnnotationInstallationID                        = "swe.dev/repository-credential-installation-id"
+	AnnotationExpiry                                = "swe.dev/repository-credential-expiry"
+	AnnotationEnvironmentUID                        = "swe.dev/repository-credential-environment-uid"
+	AnnotationExecutionGeneration                   = "swe.dev/repository-credential-execution-generation"
+	AnnotationTokenGeneration                       = "swe.dev/repository-credential-token-generation"
+)
+
+func SecretName(runUID types.UID) string { return "run-repository-credential-" + string(runUID) }
+
+// ExactManagedIdentity validates deletion authority without requiring usable token data.
+func ExactManagedIdentity(secret *corev1.Secret, runName string, runUID types.UID, provider, source, canonical string) bool {
+	if secret == nil || secret.Name != SecretName(runUID) || secret.Type != SecretType || len(secret.OwnerReferences) != 0 {
+		return false
+	}
+	a := secret.Annotations
+	return a[AnnotationRunName] == runName && a[AnnotationRunUID] == string(runUID) && a[AnnotationProvider] == provider && a[AnnotationSourceRepository] == source && a[AnnotationRepository] == canonical
+}
+
+type Lease struct {
+	Credential
+	SecretUID           types.UID
+	ResourceVersion     string
+	RunName             string
+	RunUID              types.UID
+	Provider            string
+	SourceRepository    string
+	EnvironmentUID      types.UID
+	ExecutionGeneration int64
+	TokenGeneration     int64
+}
+
+func Parse(secret *corev1.Secret, runName string, runUID types.UID) (*Lease, error) {
+	if secret == nil || !secret.DeletionTimestamp.IsZero() || secret.Name != SecretName(runUID) || secret.Type != SecretType || len(secret.OwnerReferences) != 0 {
+		return nil, errors.New("foreign repository credential secret")
+	}
+	a := secret.Annotations
+	if a[AnnotationRunName] != runName || a[AnnotationRunUID] != string(runUID) || a[AnnotationProvider] == "" || a[AnnotationRepository] == "" || a[AnnotationSourceRepository] == "" {
+		return nil, errors.New("foreign repository credential secret")
+	}
+	installation, e1 := strconv.ParseInt(a[AnnotationInstallationID], 10, 64)
+	expiry, e2 := time.Parse(time.RFC3339Nano, a[AnnotationExpiry])
+	execution, e3 := strconv.ParseInt(a[AnnotationExecutionGeneration], 10, 64)
+	generation, e4 := strconv.ParseInt(a[AnnotationTokenGeneration], 10, 64)
+	token, ok := secret.Data[TokenKey]
+	if e1 != nil || e2 != nil || e3 != nil || e4 != nil || installation < 1 || execution < 0 || generation < 1 || !ok || len(secret.Data) != 1 || len(token) == 0 || len(token) > MaxTokenBytes || bytes.IndexByte(token, 0) >= 0 {
+		return nil, errors.New("malformed repository credential secret")
+	}
+	return &Lease{Credential: Credential{Token: append([]byte(nil), token...), Repository: a[AnnotationRepository], InstallationID: installation, ExpiresAt: expiry}, SecretUID: secret.UID, ResourceVersion: secret.ResourceVersion, RunName: runName, RunUID: runUID, Provider: a[AnnotationProvider], SourceRepository: a[AnnotationSourceRepository], EnvironmentUID: types.UID(a[AnnotationEnvironmentUID]), ExecutionGeneration: execution, TokenGeneration: generation}, nil
+}
+
+func NewSecret(namespace, runName string, runUID types.UID, provider, sourceRepository string, c *Credential, generation int64, envUID types.UID, execution int64, now time.Time) (*corev1.Secret, error) {
+	if sourceRepository == "" || c == nil || c.Repository == "" || c.InstallationID < 1 || !c.ExpiresAt.After(now.Add(MinimumValidity)) || len(c.Token) == 0 || len(c.Token) > MaxTokenBytes || bytes.IndexByte(c.Token, 0) >= 0 {
+		return nil, fmt.Errorf("invalid issued repository credential")
+	}
+	return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: SecretName(runUID), Annotations: map[string]string{AnnotationRunName: runName, AnnotationRunUID: string(runUID), AnnotationProvider: provider, AnnotationRepository: c.Repository, AnnotationSourceRepository: sourceRepository, AnnotationInstallationID: strconv.FormatInt(c.InstallationID, 10), AnnotationExpiry: c.ExpiresAt.Format(time.RFC3339Nano), AnnotationEnvironmentUID: string(envUID), AnnotationExecutionGeneration: strconv.FormatInt(execution, 10), AnnotationTokenGeneration: strconv.FormatInt(generation, 10)}}, Type: SecretType, Data: map[string][]byte{TokenKey: append([]byte(nil), c.Token...)}}, nil
+}
+
+func ClearLease(l *Lease) {
+	if l != nil {
+		clear(l.Token)
+	}
+}

--- a/internal/repositorycredential/secret.go
+++ b/internal/repositorycredential/secret.go
@@ -29,6 +29,10 @@ const (
 
 func SecretName(runUID types.UID) string { return "run-repository-credential-" + string(runUID) }
 
+func PendingRevocationSecretName(runUID types.UID) string {
+	return SecretName(runUID) + "-pending-revocation"
+}
+
 // ExactManagedIdentity validates deletion authority without requiring usable token data.
 func ExactManagedIdentity(secret *corev1.Secret, runName string, runUID types.UID, provider, source, canonical string) bool {
 	if secret == nil || secret.Name != SecretName(runUID) || secret.Type != SecretType || len(secret.OwnerReferences) != 0 {
@@ -70,11 +74,34 @@ func Parse(secret *corev1.Secret, runName string, runUID types.UID) (*Lease, err
 	return &Lease{Credential: Credential{Token: append([]byte(nil), token...), Repository: a[AnnotationRepository], InstallationID: installation, ExpiresAt: expiry}, SecretUID: secret.UID, ResourceVersion: secret.ResourceVersion, RunName: runName, RunUID: runUID, Provider: a[AnnotationProvider], SourceRepository: a[AnnotationSourceRepository], EnvironmentUID: types.UID(a[AnnotationEnvironmentUID]), ExecutionGeneration: execution, TokenGeneration: generation}, nil
 }
 
+func ParsePendingRevocation(secret *corev1.Secret, runName string, runUID types.UID) (*Lease, error) {
+	if secret == nil || secret.Name != PendingRevocationSecretName(runUID) {
+		return nil, errors.New("foreign pending repository credential revocation")
+	}
+	copy := secret.DeepCopy()
+	defer func() {
+		for _, value := range copy.Data {
+			clear(value)
+		}
+	}()
+	copy.Name = SecretName(runUID)
+	return Parse(copy, runName, runUID)
+}
+
 func NewSecret(namespace, runName string, runUID types.UID, provider, sourceRepository string, c *Credential, generation int64, envUID types.UID, execution int64, now time.Time) (*corev1.Secret, error) {
 	if sourceRepository == "" || c == nil || c.Repository == "" || c.InstallationID < 1 || !c.ExpiresAt.After(now.Add(MinimumValidity)) || len(c.Token) == 0 || len(c.Token) > MaxTokenBytes || bytes.IndexByte(c.Token, 0) >= 0 {
 		return nil, fmt.Errorf("invalid issued repository credential")
 	}
 	return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: SecretName(runUID), Annotations: map[string]string{AnnotationRunName: runName, AnnotationRunUID: string(runUID), AnnotationProvider: provider, AnnotationRepository: c.Repository, AnnotationSourceRepository: sourceRepository, AnnotationInstallationID: strconv.FormatInt(c.InstallationID, 10), AnnotationExpiry: c.ExpiresAt.Format(time.RFC3339Nano), AnnotationEnvironmentUID: string(envUID), AnnotationExecutionGeneration: strconv.FormatInt(execution, 10), AnnotationTokenGeneration: strconv.FormatInt(generation, 10)}}, Type: SecretType, Data: map[string][]byte{TokenKey: append([]byte(nil), c.Token...)}}, nil
+}
+
+func NewPendingRevocationSecret(namespace, runName string, runUID types.UID, provider, sourceRepository string, c *Credential, generation int64, now time.Time) (*corev1.Secret, error) {
+	secret, err := NewSecret(namespace, runName, runUID, provider, sourceRepository, c, generation, "", 0, now)
+	if err != nil {
+		return nil, err
+	}
+	secret.Name = PendingRevocationSecretName(runUID)
+	return secret, nil
 }
 
 func ClearLease(l *Lease) {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -235,7 +235,7 @@ function Overview() {
   })
   const env = environment.data
   return <section>
-    <dl className="facts"><dt>State</dt><dd>{run.state}</dd><dt>Agent</dt><dd>{run.intent.agent}</dd><dt>Credential profile</dt><dd>{run.intent.credentialProfile || '—'}</dd><dt>Git credential</dt><dd>{run.intent.repositoryCredential || '—'}</dd><dt>Prompt</dt><dd>{run.intent.prompt}</dd><dt>Created</dt><dd>{run.createdAt}</dd><dt>Started</dt><dd>{run.startedAt || '—'}</dd><dt>Finished</dt><dd>{run.finishedAt || '—'}</dd><dt>UID</dt><dd>{run.uid}</dd><dt>Branch</dt><dd>{run.branch || '—'}</dd></dl>
+    <dl className="facts"><dt>State</dt><dd>{run.state}</dd><dt>Agent</dt><dd>{run.intent.agent}</dd><dt>Credential profile</dt><dd>{run.intent.credentialProfile || '—'}</dd><dt>Git credential</dt><dd>{run.intent.repositoryCredential || '—'}</dd><dt>Git credential status</dt><dd>{run.repositoryCredentialReason || '—'}</dd><dt>Prompt</dt><dd>{run.intent.prompt}</dd><dt>Created</dt><dd>{run.createdAt}</dd><dt>Started</dt><dd>{run.startedAt || '—'}</dd><dt>Finished</dt><dd>{run.finishedAt || '—'}</dd><dt>UID</dt><dd>{run.uid}</dd><dt>Branch</dt><dd>{run.branch || '—'}</dd></dl>
     <h2>Usage</h2><dl className="facts"><dt>CPU seconds</dt><dd>{run.usage.cpuSeconds}</dd><dt>Tokens in</dt><dd>{run.usage.tokensIn}</dd><dt>Tokens out</dt><dd>{run.usage.tokensOut}</dd></dl>
     <h2>Operational conditions</h2><table><thead><tr><th>Exposed fact</th><th>Status</th></tr></thead><tbody>
       <tr><td>Cancellation requested</td><td>{run.cancelRequested ? 'Yes' : 'No'}</td></tr>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -161,11 +161,11 @@ function RunList() {
   </main>
 }
 
-type RunForm = { name: string; agent: string; prompt: string; credentialProfile: string; environment: string; project: string; template: string }
+type RunForm = { name: string; agent: string; prompt: string; credentialProfile: string; repositoryCredential: string; environment: string; project: string; template: string }
 function NewRun() {
   const { namespace = '' } = useParams()
   const navigate = useNavigate()
-  const [form, setForm] = React.useState<RunForm>({ name: '', agent: 'claude-code', prompt: '', credentialProfile: '', environment: '', project: '', template: '' })
+  const [form, setForm] = React.useState<RunForm>({ name: '', agent: 'claude-code', prompt: '', credentialProfile: '', repositoryCredential: '', environment: '', project: '', template: '' })
   const [validation, setValidation] = React.useState('')
   const mutation = useMutation({
     mutationFn: (value: CreateRun) => api.createRun(namespace, value),
@@ -178,12 +178,14 @@ function NewRun() {
     const selector: Selector = {}
     for (const key of ['environment', 'project', 'template'] as const) if (form[key].trim()) selector[key] = form[key].trim()
     const credentialProfile = form.credentialProfile.trim()
-    const value: CreateRun = { name: form.name.trim(), agent: form.agent.trim(), prompt: form.prompt, selector, ...(credentialProfile ? { credentialProfile } : {}) }
+    const repositoryCredential = form.repositoryCredential.trim()
+    const value: CreateRun = { name: form.name.trim(), agent: form.agent.trim(), prompt: form.prompt, selector, ...(credentialProfile ? { credentialProfile } : {}), ...(repositoryCredential ? { repositoryCredential: repositoryCredential as 'GitHubApp' } : {}) }
     const error = validateCreateRun(value)
     setValidation(error || '')
     if (!error) mutation.mutate(value, { onSuccess: run => navigate(`/namespaces/${encodeURIComponent(namespace)}/runs/${encodeURIComponent(run.name)}/overview`) })
   }}>
-    {field('name', 'Name')}{field('agent', 'Agent')}{field('credentialProfile', 'Credential profile')}{field('prompt', 'Prompt / task', true)}
+    {field('name', 'Name')}{field('agent', 'Agent')}{field('credentialProfile', 'Credential profile')}
+    <label>Git credential<select value={form.repositoryCredential} onChange={event => setForm({ ...form, repositoryCredential: event.target.value })}><option value="">None</option><option value="GitHubApp">GitHub App</option></select></label>{field('prompt', 'Prompt / task', true)}
     {field('project', 'Project reference')}{field('template', 'Template reference')}{field('environment', 'Existing environment reference')}
     <p className="hint">Use an existing environment alone, or provide a project and/or template.</p>
     {validation && <p role="alert">{validation}</p>}{mutation.isError && <Failure error={mutation.error} />}
@@ -233,7 +235,7 @@ function Overview() {
   })
   const env = environment.data
   return <section>
-    <dl className="facts"><dt>State</dt><dd>{run.state}</dd><dt>Agent</dt><dd>{run.intent.agent}</dd><dt>Credential profile</dt><dd>{run.intent.credentialProfile || '—'}</dd><dt>Prompt</dt><dd>{run.intent.prompt}</dd><dt>Created</dt><dd>{run.createdAt}</dd><dt>Started</dt><dd>{run.startedAt || '—'}</dd><dt>Finished</dt><dd>{run.finishedAt || '—'}</dd><dt>UID</dt><dd>{run.uid}</dd><dt>Branch</dt><dd>{run.branch || '—'}</dd></dl>
+    <dl className="facts"><dt>State</dt><dd>{run.state}</dd><dt>Agent</dt><dd>{run.intent.agent}</dd><dt>Credential profile</dt><dd>{run.intent.credentialProfile || '—'}</dd><dt>Git credential</dt><dd>{run.intent.repositoryCredential || '—'}</dd><dt>Prompt</dt><dd>{run.intent.prompt}</dd><dt>Created</dt><dd>{run.createdAt}</dd><dt>Started</dt><dd>{run.startedAt || '—'}</dd><dt>Finished</dt><dd>{run.finishedAt || '—'}</dd><dt>UID</dt><dd>{run.uid}</dd><dt>Branch</dt><dd>{run.branch || '—'}</dd></dl>
     <h2>Usage</h2><dl className="facts"><dt>CPU seconds</dt><dd>{run.usage.cpuSeconds}</dd><dt>Tokens in</dt><dd>{run.usage.tokensIn}</dd><dt>Tokens out</dt><dd>{run.usage.tokensOut}</dd></dl>
     <h2>Operational conditions</h2><table><thead><tr><th>Exposed fact</th><th>Status</th></tr></thead><tbody>
       <tr><td>Cancellation requested</td><td>{run.cancelRequested ? 'Yes' : 'No'}</td></tr>

--- a/ui/src/contracts.ts
+++ b/ui/src/contracts.ts
@@ -22,6 +22,7 @@ export interface CreateRun {
   agent: string
   prompt: string
   credentialProfile?: string
+	 repositoryCredential?: 'GitHubApp'
 }
 
 export interface Run {
@@ -34,6 +35,7 @@ export interface Run {
     agent: string
     prompt: string
     credentialProfile?: string
+		repositoryCredential?: 'GitHubApp'
   }
   cancelRequested: boolean
   state: string

--- a/ui/src/contracts.ts
+++ b/ui/src/contracts.ts
@@ -39,6 +39,7 @@ export interface Run {
   }
   cancelRequested: boolean
   state: string
+  repositoryCredentialReason?: string
   startedAt?: string
   finishedAt?: string
   environment?: {

--- a/ui/src/contracts.ts
+++ b/ui/src/contracts.ts
@@ -22,7 +22,7 @@ export interface CreateRun {
   agent: string
   prompt: string
   credentialProfile?: string
-	 repositoryCredential?: 'GitHubApp'
+  repositoryCredential?: 'GitHubApp'
 }
 
 export interface Run {
@@ -35,7 +35,7 @@ export interface Run {
     agent: string
     prompt: string
     credentialProfile?: string
-		repositoryCredential?: 'GitHubApp'
+    repositoryCredential?: 'GitHubApp'
   }
   cancelRequested: boolean
   state: string


### PR DESCRIPTION
Closes #67.

## Summary

- add immutable per-Run GitHub App repository credential intent across the CRD, CLI, MCP, control-plane API, and console
- mint exact-repository, short-lived installation tokens through a provider-neutral credential boundary with GitHub-specific JWT/API handling isolated behind it
- deliver credentials only to the clone init container and selected adapter process, with no token in clone URLs, argv, public process specs, workspace configuration, status, or transcripts
- bind leases to Environment execution incarnations, rotate on resume/Pod loss, and fence terminal execution before revocation and finalizer release
- make provisioning, ambiguous Secret creation, pending revocation, and controller-crash recovery deterministic without reusing a token across Pod UIDs
- add disabled-by-default Helm configuration, security/architecture/operator docs, fake-provider controller coverage, CLI/API contract coverage, and disabled-provider e2e acceptance

## Security properties

- installation lookup and token issuance are restricted to the one canonical repository
- requested permissions are `contents: write` only; unexpected repository selection or permissions fail closed
- administrator-owned GitHub App key material is mounted only into the control-plane process
- repository tokens live in dedicated Kubernetes Secrets and process/init-only launch material; project hooks and sandboxd ambient configuration do not receive them
- refresh/resume and terminal cleanup revoke before replacement or finalizer release; failed immediate revocations are durably retried and block issuance

## Validation

- `make test`
- `make vet`
- `make generate manifests`
- `make check-chart-crds`
- `./hack/helm-rbac_test.sh`
- `./hack/validate-byoc_test.sh`
- UI lint, typecheck, unit tests, and production build
- focused final security review of Pod-incarnation recovery and pending-revocation convergence
