### PR TITLE
Harden MVP identity and authorization boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,4 +201,3 @@ commit.**
 ## Safety
 
 - Never commit secrets or tokens.
-- Don't create git commits/pushes unless the maintainer explicitly asks.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -86,12 +86,50 @@ All current CRDs are namespaced:
 The current ownership/reference shape is:
 
 Environment status is controller-owned: the operator and its Run controller retain status
-subresource authority. The control plane has no `environments/status` permission unless the
-portal gateway is enabled; that gateway configuration adds update-only status authority for
-its bounded `portalRoutes` and `nextPortalRouteGeneration` ownership. A fail-closed admission
-policy binds that exact gateway ServiceAccount to those fields and rejects changes to all
-controller-owned status, including the provisioning snapshot. The policy is installed even
-when the gateway is disabled so the fence precedes any later RBAC enablement.
+subresource authority. The control plane has update-only `environments/status` authority for
+the gateway's bounded `portalRoutes` and `nextPortalRouteGeneration` ownership, including while
+portals are disabled so authenticated discovery can tombstone active routes and publish a
+durable denial generation. A fail-closed admission policy binds that exact gateway ServiceAccount
+to those fields and rejects changes to all controller-owned status, including the provisioning
+snapshot.
+
+The control plane's ordinary Environment patch authority is similarly bound by a fail-closed
+exact-ServiceAccount admission policy. It may replace only `spec.lifecycle.wake` with a current
+UID/current hold-policy, Idle-scoped Terminal or Portal wake intent, and may update only the
+fixed `lifecycle.swe.dev/activity-terminal` and `lifecycle.swe.dev/activity-portal` annotation
+slots. All other Environment spec, labels, finalizers, owner references, and annotations are
+frozen for that identity. This leaves hold/suspend/service and controller bookkeeping ownership
+with their existing CLI and controller writers without constraining the operator ServiceAccount.
+The fence also freezes mutable `generateName`; it deliberately ignores API-server bookkeeping
+(`resourceVersion`, `generation`, and `managedFields`) whose admission-time changes accompany
+legitimate patches and do not alter business intent.
+Chart validation unconditionally prevents the operator and control plane from resolving to the
+same ServiceAccount identity, including while the control plane is disabled and its admission
+fence remains pre-staged.
+
+Ordinary Environment mutation ownership is currently:
+
+| Base-resource field | Legitimate writer |
+|---|---|
+| `spec.lifecycle.wake` | Control-plane terminal/portal traffic and the Run controller through the shared UID/hold-revision-fenced lifecycle helper |
+| `metadata.annotations[lifecycle.swe.dev/activity-{terminal,portal}]` | Control-plane terminal and portal heartbeats through the execution-fenced lifecycle helper |
+| `metadata.annotations[lifecycle.swe.dev/activity-{inbox,agent,run}]` | Reserved shared lifecycle-helper slots for those platform sources; no current control-plane writer |
+| `spec.lifecycle.suspend` | Run cleanup/credential refresh through the shared lifecycle helper; the Environment controller clears rejected or replayed intent |
+| `spec.lifecycle.hold` | Environment hold/release CLI, Project offboarding CLI, and Environment controller offboarding/legacy-pause migration |
+| `spec.paused` | Deprecated input accepted from legacy clients; only the Environment controller clears it while migrating to `hold` |
+| `spec.services` | Environment services CLI for API-owned declarations and declared-service controller for Repository-owned declarations |
+| `spec.projectRef`, warm-pool label, and Template owner reference | Run controller's atomic warm-Environment promotion |
+| Environment finalizer | Environment controller |
+| Repository-provisioning and warm-pool-cleanup annotations | Environment controller and warm-pool controller respectively |
+
+`spec.templateRef` and `spec.backend` have no legitimate update writer after creation. Other
+labels, owner references, finalizers, and annotations are not control-plane-owned merely because
+Kubernetes permits their mutation. Status ownership remains the separate subresource contract
+above. A reciprocal policy binds the exact operator ServiceAccount and rejects changes to the
+two gateway-owned fields. Both status policies and the base-intent policy are installed even
+when the gateway or control plane is disabled, so the fences precede any later RBAC enablement.
+One Kubernetes principal cannot satisfy these disjoint writer contracts, hence the unconditional
+ServiceAccount collision check.
 
 ```text
 Installation --UID claim--> Namespace --exact name + UID--> Project
@@ -290,6 +328,12 @@ The Run UID is the idempotency key for allocation, adapter acceptance, and sandb
 process ownership. A durable acceptance-attempt condition is written before calling an
 adapter, so cancellation remains conservative after an uncertain response. Run status exposes
 adapter-neutral milestones from allocation through terminal success, failure, or cancellation.
+Normalized adapter observation reasons and messages are fixed, bounded platform vocabulary;
+the Run controller derives the persisted message from the observation enum and never persists
+an adapter-returned detail string. Process errors, provider fields, result text, thread IDs, and
+other agent-controlled bytes remain only in adapter-owned opaque transcript events. Permanent
+adapter rejection and cancellation conditions likewise use fixed platform messages. Reconcile
+also normalizes legacy adapter observation/rejection messages before terminal or deletion cleanup.
 
 One Environment controller owns suspension transitions. Explicit user/admin policy is a
 revisioned `spec.lifecycle.hold`; ordinary callers publish UID- and hold-revision-fenced wake,
@@ -464,9 +508,11 @@ Interactive terminal connections and the separately capability-scoped service-ob
 are not pooled.
 
 Uncached reads around an adapter call remain deliberate: the Run controller proves the exact
-Run/Environment association before the call, the pool proves the complete fence before every
-lease, and the controller repeats exact association plus backend-execution currentness after the
-call. Cached reads are not accepted for these authorization/currentness boundaries. In the stable
+Run/Environment association before the call, adapter acceptance revalidates the complete active
+Installation/Namespace/Project claim at the process-dial boundary, the pool proves the complete
+execution fence before every lease, and the controller repeats exact association plus
+backend-execution currentness after the call. Cached reads are not accepted for these
+authorization/currentness boundaries. In the stable
 one-minute-equivalent contract (30 polls at the fixed two-second cadence), reuse reduces physical
 connection creations from 30 to 1 and process-connector Kubernetes reads from 150 to 124. Across
 the complete adapter call path, including unchanged mandatory association and execution-receipt
@@ -478,6 +524,8 @@ is deterministic contract evidence, not an end-to-end API-server load benchmark.
 Transcript transport is fenced by namespace name, immutable Namespace UID, Run name, and
 immutable Run UID. It supplies
 idempotent append, monotonic per-Run cursors, bounded retention, explicit gaps, replay, and SSE.
+Established transcript SSE connections repeat TokenReview, exact transcript SAR, and tenancy
+authorization on the existing 15-second keepalive cadence and close on any failure.
 Production presets require an external PostgreSQL URL; live PostgreSQL delivery is currently
 database-polled. With no URL, the control plane logs a warning and uses a bounded, non-durable,
 process-local development store. Durable legacy rows without a Namespace UID are associated
@@ -586,13 +634,49 @@ Provider failures produce stable secret-free conditions and retry without releas
 finalizer. GitHub Enterprise, SSH repository URLs, broader App permissions, and credentials for
 non-GitHub repositories remain unsupported.
 
+Rejected structurally valid token handles and tokens whose active lease cannot be persisted use
+a deterministic pending-revocation Secret as a write-ahead log. The immutable record includes
+provider, frozen provisioning source, canonical repository, installation, expiry, and
+issuance/rotation generation, plus strict `pending`/`complete` state and an optional disposition
+(currently `ProviderInvalidToken`). The record is persisted before revoke. Pending records alone
+may invoke the provider; successful revoke or authoritative persisted expiry advances the exact
+UID/resourceVersion to complete, with uncached exact-content recovery for an ambiguous update.
+Complete records never revoke. A complete disposition is written to Run status while retaining
+the Secret, and deletion occurs on a later reconciliation only after an uncached read proves the
+exact durable failed Run reason. Delete uses UID/resourceVersion preconditions and safely treats
+only an uncached absent record as recovery from an ambiguous response. Every pending action and
+duplicate/deletion action first validates the expected provider, frozen source, stateless
+canonical identity, and issuance generation; an unprovable record retains the Secret and Run
+finalizer and reports a secret-free actionable condition. Legacy pending records with neither
+state annotation are interpreted as pending; partial or unknown state metadata is rejected.
+Terminal active-lease cleanup applies the same frozen provider/source/canonical proof before
+revoke or expiry deletion and never falls back to identity asserted by a colliding Secret. This
+cleanup authority comes only from the Run's exact Environment UID and its validated,
+`ProjectVerified` frozen provisioning snapshot and does not depend on the live Project continuing
+to exist. Issuance separately requires the live exact Project. During durable rotation, active
+terminal cleanup accepts either the recorded old Secret UID at target generation minus one or a
+replacement Secret UID at the target generation; malformed or mismatched records block before
+provider or delete side effects.
+
+Every structurally cleanup-capable token in a decoded GitHub response is returned as cleanup
+authority even when `expires_at` is absent, malformed, zero, past, too short, or beyond GitHub's
+fixed one-hour lifetime. Such responses are never delivered and receive a conservative local
+cleanup deadline exactly one hour after a single captured response-validation time. A valid
+future provider expiry no more than one hour away may be retained, while delivery additionally
+requires strict greater-than minimum validity and exact scope, permissions, and repository.
+
+Residuals remain: if pending persistence and immediate fallback revoke both fail or are
+ambiguous, no durable local handle exists and exposure is bounded only by provider expiry.
+Issuance response loss likewise may lose the handle.
+
 ### Terminal and operations console
 
 `swe attach`, `swe tui`, and the browser console bridge a WebSocket to sandboxd's bidirectional
 terminal RPC. Clients open with dimensions, exchange binary terminal bytes, and can resize.
 All clients share the Environment's `swe` tmux session. Terminal open and heartbeat record
 bounded lifecycle activity; stale hold, Run association, Environment, epoch, or Pod identity
-revokes the lease.
+revokes the lease. Established WebSockets also repeat their exact TokenReview, terminal SARs,
+and tenancy authorization every five seconds and close on any failure.
 
 The embedded React console and terminal TUI are agent-neutral operations clients. They list,
 watch, create, inspect, and cancel Runs; show exact Environment detail and opaque transcripts;

--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ Run states are observable milestones: `Allocating`, `EnvironmentReady`,
 `AdapterAccepted`, `Running`, `NeedsInput`, `Paused`, and terminal `Succeeded`, `Failed`,
 or `Cancelled`. Conditions additionally report environment readiness, a durable adapter
 acceptance-attempt marker written before the acceptance RPC, and confirmed adapter acceptance.
+Normalized adapter observation condition reasons and messages use fixed platform vocabulary and
+contain no process, provider, result, or transcript bytes; detailed agent output remains in the
+adapter-owned opaque transcript.
 The EnvironmentReady condition tracks the allocation independently from terminal task outcome;
 it remains true for an adapter failure while sandboxd is reachable and becomes false after the
 allocation is released, lost, paused, or fenced. The attempt marker makes cancellation
@@ -692,6 +695,12 @@ payload, and retention gaps are displayed generically; adapter-owned payloads ar
 a common event schema. Both native and browser consoles show terminal navigation only when the
 Run API returns `terminalAvailable` with an exact `environment.uid`; reconnects and component
 remounts retain that same Run and Environment identity and never follow same-name replacements.
+Ordinary Run detail GET remains a current-name read for compatibility. Clients that selected a
+Run from a list or create response send its immutable UID in `SWE-Run-UID`; a stale UID conflicts
+instead of returning a same-name replacement. Detail identity conflicts and deletion are terminal
+for that selection: consoles do not automatically refetch until the user explicitly selects again.
+For name-only browser deep links, the ordinary GET discovers only a UID; the console does not cache
+or render its Run fields or mount child controls until a second, exact GET confirms that identity.
 
 For a non-interactive authentication/connectivity check (including CI), use `swe tui --check`.
 It validates namespaced Run-list access without starting a terminal UI or printing credentials.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,8 +11,28 @@ container, and Run-owned agent process launch material—not status, transcripts
 sandboxd's ambient environment, hooks, command arguments, repository URLs, or
 persistent git config. The selected agent and its descendants can read, emit, or
 persist the token; transcript redaction is not guaranteed. Cleanup fences the
-Environment before revocation. GitHub's fixed one-hour maximum expiry bounds a crash
-between issuance and persistence, where no token exists locally to revoke.
+Environment before revocation. Rejected, structurally valid token handles and failed
+active-Secret persistence are first written to a deterministic Secret write-ahead log.
+Its explicit `pending` state is changed with an exact UID/resourceVersion compare-and-swap
+to `complete` only after revocation succeeds or the recorded expiry becomes authoritative;
+completed records are never revoked again. A failure disposition is applied only from a
+completed record, which is retained until the exact failed Run status is durably observed.
+All pending and active cleanup derives repository authority from the exact Run Environment UID
+and its validated, ProjectVerified frozen provisioning snapshot, independently of the live
+Project object. It then proves provider, frozen source, canonical repository, and issuance
+generation where applicable, and otherwise retains both Secret and finalizer
+without provider side effects. Exact active duplicates of a completed WAL record are removed
+with UID/resourceVersion preconditions before the WAL itself can be deleted.
+
+A structurally cleanup-capable token returned with an invalid, absent, or malformed provider
+expiry is retained only as cleanup authority and assigned a conservative local deadline of one
+hour from the single response-validation time; provider expiry outside GitHub's fixed one-hour
+maximum is never trusted. Terminal cleanup during durable rotation accepts only the recorded old
+Secret at target generation minus one or a replacement Secret at the target generation.
+
+Residual exposure is bounded by token expiry if both pending-Secret persistence and the
+immediate fallback revoke fail or have ambiguous outcomes. Issuance response loss can leave
+no locally known handle. GitHub's fixed one-hour maximum expiry bounds these cases.
 
 Repository initialization is split into ordered clone and project-hook init
 containers. After uncached exact Run, Environment, frozen repository, and lease
@@ -199,6 +219,19 @@ association, lifecycle, execution fence, pod, Secret, TLS identity, and exact po
 Idle may queue a bounded wake; hold and Requested suspension do not. Remove/re-add tombstones the
 old locator. Authorization, platform session cookies, and hop-by-hop headers are stripped before
 forwarding; response hop-by-hop headers are filtered. WebSocket upgrades use the same checks.
+
+The control-plane ServiceAccount's ordinary Environment `patch` authority is admission-fenced
+to current UID/current hold-policy, Idle-scoped Terminal or Portal wake intents and the two fixed
+Terminal/Portal activity annotation slots. It cannot use that RBAC grant to change holds,
+suspend requests, services, project/template/backend intent, other metadata, or controller
+bookkeeping. This fail-closed exact-ServiceAccount policy is installed regardless of whether
+portals are enabled; it does not match the distinct operator ServiceAccount.
+API-server field-management bookkeeping (`resourceVersion`, `generation`, and `managedFields`)
+is not frozen because it changes as part of legitimate patches; it cannot change the protected
+business fields.
+Helm rejects an operator ServiceAccount override that collides with the derived control-plane
+ServiceAccount, including when the control plane is disabled, so the exact-identity policy can
+never match legitimate operator writes.
 Environment NetworkPolicy still admits only sandboxd port 50051 from installation-labeled
 operator/control-plane pods; Ingress reaches the control-plane Service, never pods directly.
 
@@ -240,6 +273,13 @@ audience-mismatch results revoke durably and idempotently. TokenReview transport
 `status.error` failures return 503 and retain the session for retry; SAR denial returns 403 and
 also retains it. Every use repeats TokenReview, then exact SAR with the reviewed username, UID,
 groups, and extras, so Kubernetes credential expiry/revocation and RBAC remain authoritative.
+Established terminal WebSockets and transcript SSE connections repeat those checks on their
+existing five- and fifteen-second heartbeat cadences respectively and close on any failure;
+portal tunnels use their separate two-second polling cadence. Each terminal and transcript
+authorization evaluation has a five-second timeout, and each portal lease evaluation has a
+two-second timeout. A transient authorization service failure therefore disconnects an
+established stream without revoking its retained browser session, and the client may reconnect
+and retry.
 Cookie security and same-origin mutation checks remain mandatory.
 
 For rotation, add a uniquely identified key, select it as active, and roll the control plane.
@@ -261,7 +301,10 @@ profiles and malformed or foreign Secret collisions fail closed.
 
 The operator performs uncached, exact-name profile and Secret reads immediately before adapter
 acceptance, copies the key into a short-lived adapter credential, and best-effort clears the
-buffers after the call. The Claude Code adapter sends it only through sandboxd's distinct
+buffers after the call. At the acceptance process-dial boundary it also uncached-revalidates the
+complete active Installation/Namespace/Project claim, so offboarding prevents an already-running
+reconcile from starting new work with launch-only credentials. The Claude Code adapter sends the
+key only through sandboxd's distinct
 `StartWithLaunchMaterial` RPC as `ANTHROPIC_API_KEY`. It never falls back to the ordinary Start
 RPC if an old sandboxd server reports `Unimplemented`. sandboxd validates launch material before
 publishing a process, applies it only to the child environment, and stores and returns only the

--- a/charts/swe-platform/README.md
+++ b/charts/swe-platform/README.md
@@ -73,6 +73,12 @@ open SSE/WebSocket connections do not and this release makes no control-plane HA
 optional authenticated portal gateway exposes explicitly declared HTTP services through one
 wildcard host namespace.
 
+Set `controlPlane.enabled=false` for an operator-only installation. While disabled, the chart
+omits the control-plane workload, Service, identity/RBAC, and Ingress and ignores other
+`controlPlane.*` settings. Those settings are validated again before the control plane can be
+re-enabled, so stale values retained with `--reuse-values` must be corrected first. The
+portal-status admission fence remains pre-staged even in operator-only installs.
+
 ## Control-plane metrics
 
 The stable control-plane Service exposes a dedicated internal Prometheus scrape port named
@@ -166,11 +172,24 @@ The operator reconciles each `Run` as the single task intent and allocates or cl
 Run status/finalizer updates and Environment allocation/claim updates. Process execution
 remains behind the environment's portable sandboxd contract rather than Kubernetes exec.
 Environment status is controller-owned: the control-plane role can read and patch the base
-Environment resource where required, but has no `environments/status` authority unless the
-portal gateway is enabled. The enabled gateway receives update-only status authority for its
-bounded portal route allocation fields; a release-scoped fail-closed admission policy rejects
-changes by that ServiceAccount to every controller-owned status field. The policy is pre-staged
-when portals are disabled so later enablement cannot expose an unfenced status writer.
+Environment resource where required and receives update-only `environments/status` authority
+for the gateway's bounded portal route allocation fields. That narrow authority remains when
+portals are disabled so discovery can tombstone active routes and publish a durable denial
+generation; a release-scoped fail-closed admission policy rejects changes by that ServiceAccount
+to every controller-owned status field.
+The same exact-ServiceAccount fence restricts ordinary Environment patches to current,
+Idle-scoped Terminal/Portal wake intents and the fixed Terminal/Portal activity annotation
+slots; it rejects changes to holds, suspend intents, services, all other spec fields, labels,
+`generateName`, finalizers, owner references, and other annotations. API-server bookkeeping
+(`resourceVersion`, `generation`, and `managedFields`) remains exempt so legitimate patches are
+not denied. These policies require the chart's stated Kubernetes 1.33 minimum and do not match
+the operator ServiceAccount. Helm rejects an operator `serviceAccount.name` equal to the derived
+control-plane ServiceAccount name even when the control plane is disabled, because the admission
+policies are always pre-staged for later enablement. A reciprocal policy
+rejects operator ServiceAccount changes to gateway-owned portal route status. Both policies are
+pre-staged when portals are disabled so later enablement cannot expose an unfenced status writer.
+The chart rejects configurations that give the operator and control plane the same ServiceAccount
+name because that shared principal cannot meet the disjoint field-ownership contract.
 
 ## Install
 

--- a/charts/swe-platform/templates/000-validate.yaml
+++ b/charts/swe-platform/templates/000-validate.yaml
@@ -1,24 +1,32 @@
-{{- $backend := .Values.controlPlane.sessions.backend -}}
-{{- if not (has $backend (list "memory" "postgres")) -}}
-{{- fail "controlPlane.sessions.backend must be memory or postgres" -}}
+{{- if eq (include "swe-platform.serviceAccountName" .) (include "swe-platform.controlPlaneFullname" .) -}}
+{{- fail "serviceAccount.name must not equal the derived control-plane ServiceAccount name" -}}
 {{- end -}}
-{{- if eq $backend "postgres" -}}
-  {{- if not .Values.controlPlane.transcripts.postgresSecret.name -}}
-    {{- fail "controlPlane.sessions.backend=postgres requires controlPlane.transcripts.postgresSecret.name" -}}
+{{- if .Values.controlPlane.enabled -}}
+  {{- $backend := .Values.controlPlane.sessions.backend -}}
+  {{- if not (has $backend (list "memory" "postgres")) -}}
+    {{- fail "controlPlane.sessions.backend must be memory or postgres" -}}
   {{- end -}}
-  {{- if not .Values.controlPlane.transcripts.postgresSecret.key -}}
-    {{- fail "controlPlane.sessions.backend=postgres requires controlPlane.transcripts.postgresSecret.key" -}}
+  {{- if eq $backend "postgres" -}}
+    {{- if not .Values.controlPlane.transcripts.postgresSecret.name -}}
+      {{- fail "controlPlane.sessions.backend=postgres requires controlPlane.transcripts.postgresSecret.name" -}}
+    {{- end -}}
+    {{- if not .Values.controlPlane.transcripts.postgresSecret.key -}}
+      {{- fail "controlPlane.sessions.backend=postgres requires controlPlane.transcripts.postgresSecret.key" -}}
+    {{- end -}}
+    {{- if not .Values.controlPlane.sessions.keyringSecret.name -}}
+      {{- fail "controlPlane.sessions.backend=postgres requires controlPlane.sessions.keyringSecret.name" -}}
+    {{- end -}}
+    {{- if not .Values.controlPlane.sessions.keyringSecret.key -}}
+      {{- fail "controlPlane.sessions.backend=postgres requires controlPlane.sessions.keyringSecret.key" -}}
+    {{- end -}}
+  {{- else if .Values.controlPlane.sessions.keyringSecret.name -}}
+    {{- fail "controlPlane.sessions.backend=memory must not set controlPlane.sessions.keyringSecret.name" -}}
   {{- end -}}
-  {{- if not .Values.controlPlane.sessions.keyringSecret.name -}}
-    {{- fail "controlPlane.sessions.backend=postgres requires controlPlane.sessions.keyringSecret.name" -}}
+  {{- if and .Values.controlPlane.image.digest (not (regexMatch "^sha256:[0-9a-f]{64}$" .Values.controlPlane.image.digest)) -}}
+    {{- fail "controlPlane.image.digest must be a sha256 digest" -}}
   {{- end -}}
-  {{- if not .Values.controlPlane.sessions.keyringSecret.key -}}
-    {{- fail "controlPlane.sessions.backend=postgres requires controlPlane.sessions.keyringSecret.key" -}}
-  {{- end -}}
-{{- else if .Values.controlPlane.sessions.keyringSecret.name -}}
-  {{- fail "controlPlane.sessions.backend=memory must not set controlPlane.sessions.keyringSecret.name" -}}
 {{- end -}}
-{{- range $name, $image := dict "image" .Values.image "controlPlane.image" .Values.controlPlane.image "environmentImage" .Values.environmentImage -}}
+{{- range $name, $image := dict "image" .Values.image "environmentImage" .Values.environmentImage -}}
   {{- if and $image.digest (not (regexMatch "^sha256:[0-9a-f]{64}$" $image.digest)) -}}
     {{- fail (printf "%s.digest must be a sha256 digest" $name) -}}
   {{- end -}}
@@ -42,30 +50,32 @@
 {{- if or (lt $operatorHealthPort 1) (gt $operatorHealthPort 65535) (eq $operatorMetricsPort $operatorHealthPort) -}}
 {{- fail "operator.health.port must be from 1 through 65535 and must differ from operator.metrics.port" -}}
 {{- end -}}
-{{- $metricsPort := int .Values.controlPlane.metrics.port -}}
-{{- if or (lt $metricsPort 1) (gt $metricsPort 65535) (eq $metricsPort 80) (eq $metricsPort 8080) -}}
-{{- fail "controlPlane.metrics.port must be from 1 through 65535 and must not be 80 or 8080" -}}
-{{- end -}}
-{{- $portal := .Values.controlPlane.portal -}}
-{{- if $portal.enabled -}}
-  {{- if not (regexMatch "^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$" $portal.suffix) -}}
-    {{- fail "controlPlane.portal.enabled requires a canonical DNS suffix without wildcard or trailing dot" -}}
+{{- if .Values.controlPlane.enabled -}}
+  {{- $metricsPort := int .Values.controlPlane.metrics.port -}}
+  {{- if or (lt $metricsPort 1) (gt $metricsPort 65535) (eq $metricsPort 80) (eq $metricsPort 8080) -}}
+    {{- fail "controlPlane.metrics.port must be from 1 through 65535 and must not be 80 or 8080" -}}
   {{- end -}}
-  {{- if not (has $portal.scheme (list "http" "https")) -}}
-    {{- fail "controlPlane.portal.scheme must be http or https" -}}
+  {{- $portal := .Values.controlPlane.portal -}}
+  {{- if $portal.enabled -}}
+    {{- if not (regexMatch "^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$" $portal.suffix) -}}
+      {{- fail "controlPlane.portal.enabled requires a canonical DNS suffix without wildcard or trailing dot" -}}
+    {{- end -}}
+    {{- if not (has $portal.scheme (list "http" "https")) -}}
+      {{- fail "controlPlane.portal.scheme must be http or https" -}}
+    {{- end -}}
+    {{- if and (eq $portal.scheme "http") (or $portal.ingress.enabled (not .Values.controlPlane.auth.allowInsecureSessions)) -}}
+      {{- fail "HTTP portals are allowed only for explicit insecure development with portal ingress disabled" -}}
+    {{- end -}}
+    {{- if and $portal.ingress.enabled (ne $portal.scheme "https") -}}
+      {{- fail "controlPlane.portal.ingress.enabled requires controlPlane.portal.scheme=https" -}}
+    {{- end -}}
+    {{- if and $portal.ingress.enabled (not .Values.controlPlane.auth.trustProxyHeaders) -}}
+      {{- fail "controlPlane.portal.ingress.enabled requires controlPlane.auth.trustProxyHeaders=true and an ingress that overwrites X-Forwarded-Host/Proto" -}}
+    {{- end -}}
+    {{- if and $portal.ingress.enabled (not $portal.ingress.tls.secretName) -}}
+      {{- fail "controlPlane.portal.ingress.enabled requires an administrator-owned portal TLS Secret name" -}}
+    {{- end -}}
+  {{- else if or $portal.suffix $portal.ingress.enabled -}}
+    {{- fail "controlPlane.portal suffix/ingress requires controlPlane.portal.enabled=true" -}}
   {{- end -}}
-  {{- if and (eq $portal.scheme "http") (or $portal.ingress.enabled (not .Values.controlPlane.auth.allowInsecureSessions)) -}}
-    {{- fail "HTTP portals are allowed only for explicit insecure development with portal ingress disabled" -}}
-  {{- end -}}
-  {{- if and $portal.ingress.enabled (ne $portal.scheme "https") -}}
-    {{- fail "controlPlane.portal.ingress.enabled requires controlPlane.portal.scheme=https" -}}
-  {{- end -}}
-  {{- if and $portal.ingress.enabled (not .Values.controlPlane.auth.trustProxyHeaders) -}}
-    {{- fail "controlPlane.portal.ingress.enabled requires controlPlane.auth.trustProxyHeaders=true and an ingress that overwrites X-Forwarded-Host/Proto" -}}
-  {{- end -}}
-  {{- if and $portal.ingress.enabled (not $portal.ingress.tls.secretName) -}}
-    {{- fail "controlPlane.portal.ingress.enabled requires an administrator-owned portal TLS Secret name" -}}
-  {{- end -}}
-{{- else if or $portal.suffix $portal.ingress.enabled -}}
-  {{- fail "controlPlane.portal suffix/ingress requires controlPlane.portal.enabled=true" -}}
 {{- end -}}

--- a/charts/swe-platform/templates/_helpers.tpl
+++ b/charts/swe-platform/templates/_helpers.tpl
@@ -26,6 +26,18 @@
 {{- printf "%s-control-plane" (include "swe-platform.clusterFullname" . | trunc 49 | trimSuffix "-") -}}
 {{- end }}
 
+{{- define "swe-platform.controlPlaneEnvIntentFullname" -}}
+{{- printf "%s-%s-control-plane-env-intent" (include "swe-platform.fullname" . | trunc 29 | trimSuffix "-") (sha256sum .Release.Namespace | trunc 8) -}}
+{{- end }}
+
+{{- define "swe-platform.controlPlanePortalStatusFullname" -}}
+{{- printf "%s-%s-control-plane-portal-status" (include "swe-platform.fullname" . | trunc 26 | trimSuffix "-") (sha256sum .Release.Namespace | trunc 8) -}}
+{{- end }}
+
+{{- define "swe-platform.operatorPortalStatusFullname" -}}
+{{- printf "%s-%s-operator-status" (include "swe-platform.fullname" . | trunc 37 | trimSuffix "-") (sha256sum .Release.Namespace | trunc 8) -}}
+{{- end }}
+
 {{- define "swe-platform.labels" -}}
 helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
 app.kubernetes.io/name: {{ include "swe-platform.name" . }}

--- a/charts/swe-platform/templates/control-plane-portal-status-policy.yaml
+++ b/charts/swe-platform/templates/control-plane-portal-status-policy.yaml
@@ -1,7 +1,85 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
-  name: {{ include "swe-platform.controlPlaneClusterFullname" . }}-portal-status
+  name: {{ include "swe-platform.controlPlaneEnvIntentFullname" . }}
+  labels:
+    {{- include "swe-platform.labels" . | nindent 4 }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["swe.dev"]
+        apiVersions: ["v1alpha1"]
+        operations: ["UPDATE"]
+        resources: ["environments"]
+        scope: Namespaced
+  matchConditions:
+    - name: control-plane-service-account
+      expression: request.userInfo.username == {{ printf "system:serviceaccount:%s:%s" .Release.Namespace (include "swe-platform.controlPlaneFullname" .) | quote }}
+  validations:
+    # Terminal and portal traffic publish only an Idle-scoped wake for the
+    # current Environment and hold-policy revision.
+    - expression: >-
+        object.?spec.?lifecycle.?wake == oldObject.?spec.?lifecycle.?wake ||
+        (has(object.spec.lifecycle.wake) &&
+        object.spec.lifecycle.wake.environmentUID == object.metadata.uid &&
+        object.spec.lifecycle.wake.holdPolicyRevision ==
+        (has(object.spec.lifecycle.hold) ? object.spec.lifecycle.hold.revision : 0) &&
+        object.spec.lifecycle.wake.expectedSuspensionReason == 'Idle' &&
+        object.spec.lifecycle.wake.id.matches('^(terminal|portal)/wake/[0-9]+$'))
+      message: the control plane may publish only a current Idle wake intent
+    - expression: object.?spec.?projectRef == oldObject.?spec.?projectRef
+      message: the control plane may not change spec.projectRef
+    - expression: object.?spec.?templateRef == oldObject.?spec.?templateRef
+      message: the control plane may not change spec.templateRef
+    - expression: object.?spec.?backend == oldObject.?spec.?backend
+      message: the control plane may not change spec.backend
+    - expression: object.?spec.?lifecycle.?hold == oldObject.?spec.?lifecycle.?hold
+      message: the control plane may not change spec.lifecycle.hold
+    - expression: object.?spec.?lifecycle.?suspend == oldObject.?spec.?lifecycle.?suspend
+      message: the control plane may not change spec.lifecycle.suspend
+    - expression: object.?spec.?lifecycle.?activity == oldObject.?spec.?lifecycle.?activity
+      message: the control plane may not change spec.lifecycle.activity
+    - expression: object.?spec.?services == oldObject.?spec.?services
+      message: the control plane may not change spec.services
+    - expression: object.?spec.?paused == oldObject.?spec.?paused
+      message: the control plane may not change spec.paused
+    - expression: object.metadata.?generateName == oldObject.metadata.?generateName
+      message: the control plane may not change metadata.generateName
+    - expression: object.metadata.?labels == oldObject.metadata.?labels
+      message: the control plane may not change metadata.labels
+    - expression: object.metadata.?finalizers == oldObject.metadata.?finalizers
+      message: the control plane may not change metadata.finalizers
+    - expression: object.metadata.?ownerReferences == oldObject.metadata.?ownerReferences
+      message: the control plane may not change metadata.ownerReferences
+    # Activity heartbeats use two fixed annotation slots so they do not make
+    # status stale by advancing metadata.generation. Freeze every other key in
+    # both directions, including annotations introduced after chart install.
+    - expression: >-
+        object.metadata.?annotations.orValue({}).all(k, v,
+        k in ['lifecycle.swe.dev/activity-terminal', 'lifecycle.swe.dev/activity-portal'] ||
+        (k in oldObject.metadata.?annotations.orValue({}) &&
+        v == oldObject.metadata.?annotations.orValue({})[k])) &&
+        oldObject.metadata.?annotations.orValue({}).all(k, v,
+        k in ['lifecycle.swe.dev/activity-terminal', 'lifecycle.swe.dev/activity-portal'] ||
+        (k in object.metadata.?annotations.orValue({}) &&
+        v == object.metadata.?annotations.orValue({})[k]))
+      message: the control plane may change only its Terminal and Portal activity annotations
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ include "swe-platform.controlPlaneEnvIntentFullname" . }}
+  labels:
+    {{- include "swe-platform.labels" . | nindent 4 }}
+spec:
+  policyName: {{ include "swe-platform.controlPlaneEnvIntentFullname" . }}
+  validationActions: [Deny]
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: {{ include "swe-platform.controlPlanePortalStatusFullname" . }}
   labels:
     {{- include "swe-platform.labels" . | nindent 4 }}
 spec:
@@ -57,9 +135,43 @@ spec:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
-  name: {{ include "swe-platform.controlPlaneClusterFullname" . }}-portal-status
+  name: {{ include "swe-platform.controlPlanePortalStatusFullname" . }}
   labels:
     {{- include "swe-platform.labels" . | nindent 4 }}
 spec:
-  policyName: {{ include "swe-platform.controlPlaneClusterFullname" . }}-portal-status
+  policyName: {{ include "swe-platform.controlPlanePortalStatusFullname" . }}
+  validationActions: [Deny]
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: {{ include "swe-platform.operatorPortalStatusFullname" . }}
+  labels:
+    {{- include "swe-platform.labels" . | nindent 4 }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["swe.dev"]
+        apiVersions: ["v1alpha1"]
+        operations: ["UPDATE"]
+        resources: ["environments/status"]
+        scope: Namespaced
+  matchConditions:
+    - name: operator-service-account
+      expression: request.userInfo.username == {{ printf "system:serviceaccount:%s:%s" .Release.Namespace (include "swe-platform.serviceAccountName" .) | quote }}
+  validations:
+    - expression: object.?status.?portalRoutes == oldObject.?status.?portalRoutes
+      message: the operator may not change gateway-owned status.portalRoutes
+    - expression: object.?status.?nextPortalRouteGeneration == oldObject.?status.?nextPortalRouteGeneration
+      message: the operator may not change gateway-owned status.nextPortalRouteGeneration
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ include "swe-platform.operatorPortalStatusFullname" . }}
+  labels:
+    {{- include "swe-platform.labels" . | nindent 4 }}
+spec:
+  policyName: {{ include "swe-platform.operatorPortalStatusFullname" . }}
   validationActions: [Deny]

--- a/charts/swe-platform/templates/rbac.yaml
+++ b/charts/swe-platform/templates/rbac.yaml
@@ -154,20 +154,21 @@ rules:
     verbs: ["get", "list"]
   - apiGroups: ["swe.dev"]
     resources: ["environments"]
+    # An exact-ServiceAccount admission policy limits patch to current
+    # Idle-scoped wake intents and fixed Terminal/Portal activity slots.
     verbs:
       - "get"
       - "patch"
       {{- if .Values.controlPlane.portal.enabled }}
       - "list"
       {{- end }}
-  {{- if .Values.controlPlane.portal.enabled }}
   # The gateway is the sole owner of status.portalRoutes and
-  # status.nextPortalRouteGeneration. Keep status authority absent when the
-  # portal is disabled rather than granting it to every control-plane install.
+  # status.nextPortalRouteGeneration. Update-only authority remains when the
+  # portal is disabled so discovery can tombstone routes and publish a durable
+  # denial generation; the admission policy fences every other status field.
   - apiGroups: ["swe.dev"]
     resources: ["environments/status"]
     verbs: ["update"]
-  {{- end }}
   - apiGroups: ["swe.dev"]
     resources: ["environmenttemplates"]
     verbs: ["get"]

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -221,15 +221,16 @@ func main() {
 	}
 	if !(mode == tenancy.ModeScoped && len(tenancyNamespaces) == 0) {
 		if err := (&controllers.RunReconciler{
-			Client:                guardedClient,
-			APIReader:             mgr.GetAPIReader(),
-			Scheme:                mgr.GetScheme(),
-			Scope:                 scope,
-			Adapters:              adapters,
-			EventSink:             eventSink,
-			Connector:             connector,
-			Metrics:               operatorMetrics,
-			RepositoryCredentials: repositoryCredentials,
+			Client:                  guardedClient,
+			APIReader:               mgr.GetAPIReader(),
+			Scheme:                  mgr.GetScheme(),
+			Scope:                   scope,
+			Adapters:                adapters,
+			EventSink:               eventSink,
+			Connector:               connector,
+			Metrics:                 operatorMetrics,
+			RepositoryCredentials:   repositoryCredentials,
+			RepositoryCanonicalizer: githubapp.Canonicalizer{},
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "Run")
 			os.Exit(1)

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -844,6 +844,7 @@ EOF
 CONTROL_PLANE_SA_TOKEN=$(kubectl -n "$SYSTEM_NAMESPACE" create token "$CONTROL_PLANE_SA" --duration=10m)
 KUBE_API=$(kubectl config view --raw --minify -o jsonpath='{.clusters[0].cluster.server}')
 STATUS_URL="$KUBE_API/apis/swe.dev/v1alpha1/namespaces/${PROJECT_NAMESPACE}/environments/${STATUS_POLICY_PROBE}/status?dryRun=All"
+ENVIRONMENT_URL="$KUBE_API/apis/swe.dev/v1alpha1/namespaces/${PROJECT_NAMESPACE}/environments/${STATUS_POLICY_PROBE}?dryRun=All"
 for _ in {1..5}; do
 	kubectl -n "$PROJECT_NAMESPACE" get environment "$STATUS_POLICY_PROBE" -o json |
 		jq '.status.phase="Failed"' >/tmp/swe-e2e-status-policy-probe.json
@@ -853,9 +854,56 @@ for _ in {1..5}; do
 		-X PUT --data-binary @/tmp/swe-e2e-status-policy-probe.json "$STATUS_URL")
 	[[ "$STATUS_PATCH_CODE" == "409" ]] || break
 done
-unset CONTROL_PLANE_SA_TOKEN
 if [[ "$STATUS_PATCH_CODE" != "422" ]] || ! grep -q 'portal gateway may not change status.phase' /tmp/swe-e2e-status-policy.out; then
 	echo "FAIL: control-plane bearer-token non-portal status update returned $STATUS_PATCH_CODE without the field fence"
+	cat /tmp/swe-e2e-status-policy.out
+	exit 1
+fi
+ENVIRONMENT_PATCH_CODE=$(curl --silent --output /tmp/swe-e2e-environment-policy.out --write-out '%{http_code}' \
+	--cacert <(kubectl config view --raw --minify -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' | base64 --decode) \
+	-H "Authorization: Bearer ${CONTROL_PLANE_SA_TOKEN}" -H 'Content-Type: application/merge-patch+json' \
+	-X PATCH --data-binary '{"spec":{"paused":true}}' "$ENVIRONMENT_URL")
+if [[ "$ENVIRONMENT_PATCH_CODE" != "422" ]] || ! grep -q 'control plane may not change spec.paused' /tmp/swe-e2e-environment-policy.out; then
+	echo "FAIL: control-plane bearer-token unauthorized Environment intent patch returned $ENVIRONMENT_PATCH_CODE without the field fence"
+	cat /tmp/swe-e2e-environment-policy.out
+	exit 1
+fi
+ENVIRONMENT_METADATA_CODE=$(curl --silent --output /tmp/swe-e2e-environment-metadata.out --write-out '%{http_code}' \
+	--cacert <(kubectl config view --raw --minify -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' | base64 --decode) \
+	-H "Authorization: Bearer ${CONTROL_PLANE_SA_TOKEN}" -H 'Content-Type: application/merge-patch+json' \
+	-X PATCH --data-binary '{"metadata":{"generateName":"forbidden-"}}' "$ENVIRONMENT_URL")
+if [[ "$ENVIRONMENT_METADATA_CODE" != "422" ]] || ! grep -q 'control plane may not change metadata.generateName' /tmp/swe-e2e-environment-metadata.out; then
+	echo "FAIL: control-plane bearer-token unauthorized Environment metadata patch returned $ENVIRONMENT_METADATA_CODE without the field fence"
+	cat /tmp/swe-e2e-environment-metadata.out
+	exit 1
+fi
+STATUS_POLICY_PROBE_UID=$(kubectl -n "$PROJECT_NAMESPACE" get environment "$STATUS_POLICY_PROBE" -o jsonpath='{.metadata.uid}')
+ENVIRONMENT_WAKE_CODE=$(curl --silent --output /tmp/swe-e2e-environment-wake.out --write-out '%{http_code}' \
+	--cacert <(kubectl config view --raw --minify -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' | base64 --decode) \
+	-H "Authorization: Bearer ${CONTROL_PLANE_SA_TOKEN}" -H 'Content-Type: application/merge-patch+json' \
+	-X PATCH --data-binary "{\"spec\":{\"lifecycle\":{\"wake\":{\"id\":\"portal/wake/1\",\"environmentUID\":\"${STATUS_POLICY_PROBE_UID}\",\"holdPolicyRevision\":1,\"expectedSuspensionReason\":\"Idle\"}}}}" "$ENVIRONMENT_URL")
+if [[ "$ENVIRONMENT_WAKE_CODE" != "200" ]]; then
+	echo "FAIL: control-plane bearer-token bounded Environment wake dry run returned $ENVIRONMENT_WAKE_CODE"
+	cat /tmp/swe-e2e-environment-wake.out
+	exit 1
+fi
+unset CONTROL_PLANE_SA_TOKEN
+OPERATOR_SA_TOKEN=$(kubectl -n "$SYSTEM_NAMESPACE" create token "$INSTALLATION_NAME" --duration=10m)
+for _ in {1..5}; do
+	kubectl -n "$PROJECT_NAMESPACE" get environment "$STATUS_POLICY_PROBE" -o json |
+		jq '.status.nextPortalRouteGeneration=1 | .status.portalRoutes=[{
+			name:"web", presentationID:"0123456789abcdef", declarationInstanceID:"abcdefghijklmnopqrst",
+			declarationRevision:1, locator:"abcdefghijklmnopqrst", generation:1, active:false
+		}]' >/tmp/swe-e2e-status-policy-probe.json
+	STATUS_PATCH_CODE=$(curl --silent --output /tmp/swe-e2e-status-policy.out --write-out '%{http_code}' \
+		--cacert <(kubectl config view --raw --minify -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' | base64 --decode) \
+		-H "Authorization: Bearer ${OPERATOR_SA_TOKEN}" -H 'Content-Type: application/json' \
+		-X PUT --data-binary @/tmp/swe-e2e-status-policy-probe.json "$STATUS_URL")
+	[[ "$STATUS_PATCH_CODE" == "409" ]] || break
+done
+unset OPERATOR_SA_TOKEN
+if [[ "$STATUS_PATCH_CODE" != "422" ]] || ! grep -q 'operator may not change gateway-owned status.portalRoutes' /tmp/swe-e2e-status-policy.out; then
+	echo "FAIL: operator bearer-token portal status update returned $STATUS_PATCH_CODE without the reciprocal field fence"
 	cat /tmp/swe-e2e-status-policy.out
 	exit 1
 fi

--- a/hack/helm-rbac_test.sh
+++ b/hack/helm-rbac_test.sh
@@ -1,6 +1,84 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+assert_portal_status_policy_covers_environment_status() {
+	local policy=$1
+	local description=$2
+	local field
+	local -A status_fields=()
+	local -A frozen_fields=()
+
+	while IFS= read -r field; do
+		status_fields["$field"]=1
+	done < <(awk '
+		/^          status:$/ { in_status = 1; next }
+		in_status && /^            properties:$/ { in_properties = 1; next }
+		in_properties && /^              [[:alnum:]][[:alnum:]]*:$/ {
+			field = $1
+			sub(/:$/, "", field)
+			print field
+			next
+		}
+		in_properties && /^            [^ ]/ { exit }
+	' charts/swe-platform/crds/swe.dev_environments.yaml)
+	if (( ${#status_fields[@]} == 0 )); then
+		echo "$description could not read Environment status fields from the chart CRD" >&2
+		exit 1
+	fi
+
+	while IFS= read -r field; do
+		frozen_fields["$field"]=1
+	done < <(sed -nE 's/^[[:space:]]*- expression: object\.\?status\.\?([[:alnum:]]+) == oldObject\.\?status\.\?\1$/\1/p' <<<"$policy")
+
+	for field in "${!frozen_fields[@]}"; do
+		if [[ -z ${status_fields[$field]+x} ]]; then
+			echo "$description freezes unknown Environment status field $field" >&2
+			exit 1
+		fi
+	done
+	for field in "${!status_fields[@]}"; do
+		case "$field" in
+		portalRoutes|nextPortalRouteGeneration)
+			if [[ -n ${frozen_fields[$field]+x} ]]; then
+				echo "$description must leave portal-owned Environment status field $field writable" >&2
+				exit 1
+			fi
+			;;
+		*)
+			if [[ -z ${frozen_fields[$field]+x} ]]; then
+				echo "$description does not freeze controller-owned Environment status field $field" >&2
+				exit 1
+			fi
+			;;
+		esac
+	done
+}
+environment_crd=config/crd/bases/swe.dev_environments.yaml
+mapfile -t environment_spec_fields < <(awk '
+	/^          spec:$/ { in_spec = 1; next }
+	in_spec && /^            properties:$/ { in_properties = 1; next }
+	in_properties && /^              [a-zA-Z][a-zA-Z0-9]*:$/ {
+		field = $1; sub(/:$/, "", field); print field
+	}
+	in_spec && /^          status:$/ { exit }
+' "$environment_crd")
+mapfile -t environment_lifecycle_fields < <(awk '
+	/^              lifecycle:$/ { in_lifecycle = 1; next }
+	in_lifecycle && /^                properties:$/ { in_properties = 1; next }
+	in_properties && /^                  [a-zA-Z][a-zA-Z0-9]*:$/ {
+		field = $1; sub(/:$/, "", field); print field
+	}
+	in_lifecycle && /^              [a-zA-Z][a-zA-Z0-9]*:$/ { exit }
+' "$environment_crd")
+mapfile -t environment_status_fields < <(awk '
+	/^          status:$/ { in_status = 1; next }
+	in_status && /^            properties:$/ { in_properties = 1; next }
+	in_properties && /^              [a-zA-Z][a-zA-Z0-9]*:$/ {
+		field = $1; sub(/:$/, "", field); print field
+	}
+	in_status && /^          subresources:$/ { exit }
+' "$environment_crd")
+
 for mode in scoped trusted-admin; do
 	render=$(helm template rbac-test charts/swe-platform \
 		--namespace rbac-system \
@@ -31,16 +109,66 @@ for mode in scoped trusted-admin; do
 		echo "$mode render must let the operator watch owned credential Secret teardown" >&2
 		exit 1
 	fi
-	if grep -Eq 'resources: \[[^]]*"environments/status"|^[[:space:]]*-[[:space:]]*environments/status([[:space:]]|$)' <<<"$control_plane_role"; then
-		echo "$mode portal-disabled control-plane ClusterRole must not grant any environments/status authority" >&2
+	disabled_status_rule=$(awk -v RS='  - apiGroups:' '
+		/\["swe.dev"\]/ && /resources: \["environments\/status"\]/ { print; exit }
+	' <<<"$control_plane_role")
+	if [[ -z "$disabled_status_rule" ]] ||
+		[[ $(grep -Ec 'resources: \["environments/status"\]' <<<"$control_plane_role") -ne 1 ]] ||
+		! grep -Eq 'verbs: \["update"\]' <<<"$disabled_status_rule" ||
+		grep -Eq '"(create|delete|deletecollection|get|list|patch|watch)"' <<<"$disabled_status_rule"; then
+		echo "$mode portal-disabled control-plane ClusterRole must retain exactly update on environments/status for durable route denial" >&2
 		exit 1
 	fi
 	status_policy=$(helm template rbac-test charts/swe-platform \
 		--namespace rbac-system \
 		--set "tenancy.mode=$mode" \
 		--show-only templates/control-plane-portal-status-policy.yaml)
-	if ! grep -Fq 'object.?status.?provisioning == oldObject.?status.?provisioning' <<<"$status_policy"; then
-		echo "$mode portal-disabled render must pre-stage the control-plane provisioning status fence" >&2
+	environment_intent_policy=$(awk -v RS='---' '
+		/kind: ValidatingAdmissionPolicy\n/ && /name: control-plane-service-account/ { print; exit }
+	' <<<"$status_policy")
+	if [[ -z "$environment_intent_policy" ]] ||
+		! grep -Fq 'system:serviceaccount:rbac-system:rbac-test-swe-platform-control-plane' <<<"$environment_intent_policy" ||
+		! grep -Fq "resources: [\"environments\"]" <<<"$environment_intent_policy" ||
+		! grep -Fq "object.spec.lifecycle.wake.expectedSuspensionReason == 'Idle'" <<<"$environment_intent_policy" ||
+		! grep -Fq "lifecycle.swe.dev/activity-terminal" <<<"$environment_intent_policy" ||
+		! grep -Fq "lifecycle.swe.dev/activity-portal" <<<"$environment_intent_policy" ||
+		! grep -Fq "object.metadata.?generateName == oldObject.metadata.?generateName" <<<"$environment_intent_policy"; then
+		echo "$mode render must pre-stage the exact control-plane Environment intent fence" >&2
+		exit 1
+	fi
+	for field in "${environment_spec_fields[@]}"; do
+		[[ "$field" == lifecycle ]] && continue
+		if ! grep -Fq "object.?spec.?$field == oldObject.?spec.?$field" <<<"$environment_intent_policy"; then
+			echo "$mode Environment intent policy does not freeze spec.$field" >&2
+			exit 1
+		fi
+	done
+	for field in "${environment_lifecycle_fields[@]}"; do
+		[[ "$field" == wake ]] && continue
+		if ! grep -Fq "object.?spec.?lifecycle.?$field == oldObject.?spec.?lifecycle.?$field" <<<"$environment_intent_policy"; then
+			echo "$mode Environment intent policy does not freeze spec.lifecycle.$field" >&2
+			exit 1
+		fi
+	done
+	portal_status_policy=$(awk -v RS='---' '
+		/kind: ValidatingAdmissionPolicy\n/ && /portal-control-plane-service-account/ { print; exit }
+	' <<<"$status_policy")
+	assert_portal_status_policy_covers_environment_status "$portal_status_policy" "$mode portal-disabled render"
+	for field in "${environment_status_fields[@]}"; do
+		[[ "$field" == portalRoutes || "$field" == nextPortalRouteGeneration ]] && continue
+		if ! grep -Fq "object.?status.?$field == oldObject.?status.?$field" <<<"$portal_status_policy"; then
+			echo "$mode portal status policy does not freeze status.$field" >&2
+			exit 1
+		fi
+	done
+	operator_status_policy=$(awk -v RS='---' '
+		/kind: ValidatingAdmissionPolicy\n/ && /operator-service-account/ { print; exit }
+	' <<<"$status_policy")
+	if [[ -z "$operator_status_policy" ]] ||
+		! grep -Fq 'system:serviceaccount:rbac-system:rbac-test-swe-platform' <<<"$operator_status_policy" ||
+		! grep -Fq 'object.?status.?portalRoutes == oldObject.?status.?portalRoutes' <<<"$operator_status_policy" ||
+		! grep -Fq 'object.?status.?nextPortalRouteGeneration == oldObject.?status.?nextPortalRouteGeneration' <<<"$operator_status_policy"; then
+		echo "$mode portal-disabled render must pre-stage the exact operator ServiceAccount portal status fence" >&2
 		exit 1
 	fi
 
@@ -67,12 +195,87 @@ for mode in scoped trusted-admin; do
 		/kind: ValidatingAdmissionPolicy\n/ && /portal-control-plane-service-account/ { print; exit }
 	' <<<"$portal_render")
 	if [[ -z "$portal_status_policy" ]] ||
-		! grep -Fq 'system:serviceaccount:rbac-system:rbac-test-swe-platform-control-plane' <<<"$portal_status_policy" ||
-		! grep -Fq 'object.?status.?provisioning == oldObject.?status.?provisioning' <<<"$portal_status_policy"; then
-		echo "$mode portal-enabled render must field-fence the exact control-plane ServiceAccount from provisioning status" >&2
+		! grep -Fq 'system:serviceaccount:rbac-system:rbac-test-swe-platform-control-plane' <<<"$portal_status_policy"; then
+		echo "$mode portal-enabled render must field-fence the exact control-plane ServiceAccount" >&2
 		exit 1
 	fi
+	assert_portal_status_policy_covers_environment_status "$portal_status_policy" "$mode portal-enabled render"
 done
+
+assert_admission_policy_names() {
+	local description=$1 render=$2 suffix resource_names policy_name name
+	for suffix in env-intent portal-status; do
+		mapfile -t resource_names < <(awk -v suffix="$suffix" '
+			/^metadata:$/ { in_metadata = 1; next }
+			in_metadata && $1 == "name:" && $2 ~ ("-" suffix "$") { print $2; in_metadata = 0 }
+		' <<<"$render")
+		if [[ ${#resource_names[@]} -ne 2 || "${resource_names[0]}" != "${resource_names[1]}" ]]; then
+			echo "$description must render matching $suffix policy and binding names" >&2
+			exit 1
+		fi
+		for name in "${resource_names[@]}"; do
+			if (( ${#name} > 63 )); then
+				echo "$description $suffix admission resource name exceeds 63 characters: $name" >&2
+				exit 1
+			fi
+		done
+		policy_name=$(awk -v suffix="$suffix" '$1 == "policyName:" && $2 ~ ("-" suffix "$") { print $2; exit }' <<<"$render")
+		if [[ -z "$policy_name" || "$policy_name" != "${resource_names[0]}" ]]; then
+			echo "$description $suffix binding must reference its bounded policy name" >&2
+			exit 1
+		fi
+	done
+}
+
+render_admission_policies() {
+	local namespace=$1
+	shift
+	helm template swe-platform charts/swe-platform \
+		--namespace "$namespace" \
+		--set tenancy.mode=scoped \
+		--show-only templates/control-plane-portal-status-policy.yaml \
+		"$@"
+}
+
+standard_policy_render=$(render_admission_policies swe-platform-system)
+assert_admission_policy_names "standard release" "$standard_policy_render"
+long_name_override=$(printf 'n%.0s' {1..63})
+long_name_policy_render=$(render_admission_policies swe-platform-system --set-string "nameOverride=$long_name_override")
+assert_admission_policy_names "long nameOverride release" "$long_name_policy_render"
+long_fullname_override=$(printf 'f%.0s' {1..63})
+long_fullname_policy_render=$(render_admission_policies swe-platform-system --set-string "fullnameOverride=$long_fullname_override")
+assert_admission_policy_names "long fullnameOverride release" "$long_fullname_policy_render"
+other_namespace_policy_render=$(render_admission_policies another-system --set-string "fullnameOverride=$long_fullname_override")
+assert_admission_policy_names "long fullnameOverride release in another namespace" "$other_namespace_policy_render"
+if [[ $(awk '/^  name: .*-(env-intent|portal-status)$/ { print $2 }' <<<"$long_fullname_policy_render") == \
+	$(awk '/^  name: .*-(env-intent|portal-status)$/ { print $2 }' <<<"$other_namespace_policy_render") ]]; then
+	echo "long fullnameOverride admission names must retain distinct namespace hashes" >&2
+	exit 1
+fi
+
+for control_plane_enabled in true false; do
+	for service_account_create in true false; do
+		if collision_output=$(helm template rbac-test charts/swe-platform \
+			--namespace rbac-system \
+			--set tenancy.mode=scoped \
+			--set "controlPlane.enabled=$control_plane_enabled" \
+			--set "serviceAccount.create=$service_account_create" \
+			--set-string serviceAccount.name=rbac-test-swe-platform-control-plane 2>&1); then
+			echo "controlPlane.enabled=$control_plane_enabled serviceAccount.create=$service_account_create accepted colliding ServiceAccount identities" >&2
+			exit 1
+		fi
+		if ! grep -Fq 'serviceAccount.name must not equal the derived control-plane ServiceAccount name' <<<"$collision_output"; then
+			echo "controlPlane.enabled=$control_plane_enabled serviceAccount.create=$service_account_create failed without collision validation" >&2
+			exit 1
+		fi
+	done
+done
+helm template rbac-test charts/swe-platform \
+	--namespace rbac-system \
+	--set tenancy.mode=scoped \
+	--set controlPlane.enabled=false \
+	--set serviceAccount.create=false \
+	--set-string serviceAccount.name=external-operator >/dev/null
 
 if helm template rbac-test charts/swe-platform --namespace rbac-system \
 	--set tenancy.mode=scoped --set operator.githubApp.enabled=true >/dev/null 2>&1; then
@@ -97,4 +300,41 @@ if [[ -z "$github_app_operator" ]] ||
 	exit 1
 fi
 
-echo "scoped and trusted-admin Helm RBAC plus disabled-by-default GitHub App mounts are fenced"
+disabled_control_plane_render=$(helm template rbac-test charts/swe-platform \
+	--namespace rbac-system \
+	--set tenancy.mode=scoped \
+	--set controlPlane.enabled=false \
+	--set-string controlPlane.sessions.backend=invalid \
+	--set-string controlPlane.image.digest=invalid \
+	--set controlPlane.metrics.port=0 \
+	--set controlPlane.portal.enabled=true \
+	--set-string controlPlane.portal.suffix=invalid)
+if awk -v RS='---' '
+	/kind: (Deployment|Service|ServiceAccount|ClusterRole)\n/ &&
+	/app.kubernetes.io\/component: control-plane/ { found=1 }
+	END { exit !found }
+' <<<"$disabled_control_plane_render"; then
+	echo "controlPlane.enabled=false rendered a control-plane workload, Service, identity, or RBAC" >&2
+	exit 1
+fi
+
+if output=$(helm template rbac-test charts/swe-platform --namespace rbac-system \
+	--set tenancy.mode=scoped --set controlPlane.enabled=false \
+	--set-string image.digest=invalid 2>&1); then
+	echo "invalid operator image digest was accepted while the control plane was disabled" >&2
+	exit 1
+elif ! grep -Fq 'image.digest must be a sha256 digest' <<<"$output"; then
+	echo "invalid operator image digest failed for an unexpected reason: $output" >&2
+	exit 1
+fi
+if output=$(helm template rbac-test charts/swe-platform --namespace rbac-system \
+	--set tenancy.mode=scoped --set controlPlane.enabled=true \
+	--set-string controlPlane.sessions.backend=invalid 2>&1); then
+	echo "invalid enabled control-plane backend was accepted" >&2
+	exit 1
+elif ! grep -Fq 'controlPlane.sessions.backend must be memory or postgres' <<<"$output"; then
+	echo "invalid enabled control-plane backend failed for an unexpected reason: $output" >&2
+	exit 1
+fi
+
+echo "scoped and trusted-admin Helm RBAC, disabled control-plane values, and GitHub App mounts are fenced"

--- a/internal/adapters/amp/adapter.go
+++ b/internal/adapters/amp/adapter.go
@@ -114,53 +114,49 @@ func (a *Adapter) Observe(ctx context.Context, task agent.AdapterTask, sandbox a
 	process, err := client.Get(ctx, &sandboxdv1.GetProcessRequest{Key: key(task)})
 	if err != nil {
 		if status.Code(err) == codes.NotFound {
-			return agent.AdapterObservationFailed, "Amp execution is absent in the current sandbox epoch", nil
+			return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 		}
 		return "", "", err
 	}
 	if err := a.forward(ctx, client, task, sandbox, process); err != nil {
 		if errors.Is(err, agent.ErrAdapterEventRejected) {
-			return agent.AdapterObservationFailed, "Amp transcript output was permanently rejected", nil
+			return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 		}
 		return "", "", err
 	}
 	switch process.State {
 	case sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, sandboxdv1.ProcessState_PROCESS_STATE_STOPPING:
-		return agent.AdapterObservationRunning, "Amp is running", nil
+		return agent.AdapterObservationRunning, agent.AdapterObservationRunning.StatusMessage(), nil
 	case sandboxdv1.ProcessState_PROCESS_STATE_FAILED:
-		return agent.AdapterObservationFailed, message("Amp failed to start", process.Error), nil
+		return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 	case sandboxdv1.ProcessState_PROCESS_STATE_EXITED:
 		if process.ExitCode == nil {
-			return agent.AdapterObservationFailed, "Amp exited without an exit code", nil
+			return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 		}
 		if process.GetExitCode() != 0 {
-			return agent.AdapterObservationFailed, fmt.Sprintf("Amp exited with code %d", process.GetExitCode()), nil
+			return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 		}
 		output, err := readOutput(ctx, client, key(task), process.ExecutionId)
 		if err != nil {
 			var truncated *outputTruncatedError
 			if errors.As(err, &truncated) {
-				return agent.AdapterObservationFailed, message("Amp stdout was truncated before terminal validation", truncated.Error()), nil
+				return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 			}
 			return "", "", err
 		}
 		result, ok := finalResult(output)
 		if !ok {
-			return agent.AdapterObservationFailed, "Amp exited without a valid result event", nil
+			return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 		}
 		if result.IsError == nil {
-			return agent.AdapterObservationFailed, "Amp result is missing is_error", nil
+			return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 		}
 		if *result.IsError || result.Subtype != "success" {
-			detail := result.Result
-			if detail == "" {
-				detail = errorDetail(result.Error)
-			}
-			return agent.AdapterObservationFailed, message("Amp reported "+result.Subtype, detail), nil
+			return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 		}
-		return agent.AdapterObservationSucceeded, message("Amp completed", result.Result), nil
+		return agent.AdapterObservationSucceeded, agent.AdapterObservationSucceeded.StatusMessage(), nil
 	default:
-		return agent.AdapterObservationFailed, fmt.Sprintf("Amp returned invalid process state %s", process.State), nil
+		return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 	}
 }
 
@@ -173,6 +169,9 @@ func (a *Adapter) Cancel(ctx context.Context, task agent.AdapterTask, sandbox ag
 	defer closeConnection()
 	process, err := client.Stop(ctx, &sandboxdv1.StopProcessRequest{Key: key(task), Mode: sandboxdv1.StopMode_STOP_MODE_GRACEFUL, GracePeriodMs: 10_000})
 	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return nil
+		}
 		return err
 	}
 	switch process.State {
@@ -277,25 +276,6 @@ func streamName(stream sandboxdv1.OutputStream) string {
 		return "stderr"
 	}
 	return "stdout"
-}
-func message(summary, detail string) string {
-	if detail == "" {
-		return summary
-	}
-	if len(detail) > 512 {
-		detail = detail[:512] + "…"
-	}
-	return summary + ": " + detail
-}
-func errorDetail(raw json.RawMessage) string {
-	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
-		return ""
-	}
-	var text string
-	if json.Unmarshal(raw, &text) == nil {
-		return text
-	}
-	return string(raw)
 }
 func (a *Adapter) getCursor(c cursor) uint64 {
 	a.mu.Lock()

--- a/internal/adapters/amp/adapter_test.go
+++ b/internal/adapters/amp/adapter_test.go
@@ -50,6 +50,7 @@ type fakeClient struct {
 	beforeLaunchErr error
 	afterLaunchErr  error
 	stoppedKey      *sandboxdv1.ProcessKey
+	stopErr         error
 	readRequests    []*sandboxdv1.ReadOutputRequest
 }
 
@@ -101,6 +102,9 @@ func (f *fakeClient) Get(context.Context, *sandboxdv1.GetProcessRequest, ...grpc
 }
 func (f *fakeClient) Stop(_ context.Context, request *sandboxdv1.StopProcessRequest, _ ...grpc.CallOption) (*sandboxdv1.Process, error) {
 	f.stoppedKey = request.Key
+	if f.stopErr != nil {
+		return nil, f.stopErr
+	}
 	if f.process == nil {
 		return &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED}, nil
 	}
@@ -157,7 +161,7 @@ func TestTerminalValidationFailsOnRetainedOutputGap(t *testing.T) {
 		retainedFrom: 1024,
 	}
 	got, detail, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, testSandbox(client))
-	if err != nil || got != agent.AdapterObservationFailed || !strings.Contains(detail, "truncated before terminal validation") || !strings.Contains(detail, "retained from offset 1024") {
+	if err != nil || got != agent.AdapterObservationFailed || detail != got.StatusMessage() {
 		t.Fatalf("Observe = %q, %q, %v", got, detail, err)
 	}
 }
@@ -301,6 +305,29 @@ func TestObservationOutcomes(t *testing.T) {
 	}
 }
 
+func TestObservationMessagesExcludeAgentControlledDetails(t *testing.T) {
+	const sentinel = "!!AMP-STATUS-SECRET!!"
+	exit0 := int32(0)
+	tests := []struct {
+		name    string
+		process *sandboxdv1.Process
+		output  string
+		want    agent.AdapterObservation
+	}{
+		{"process failure", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_FAILED, Error: sentinel, ExecutionId: "e"}, "", agent.AdapterObservationFailed},
+		{"provider failure", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, `{"type":"result","subtype":"error","is_error":true,"error":{"message":"` + sentinel + `"}}` + "\n", agent.AdapterObservationFailed},
+		{"success result", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, `{"type":"result","subtype":"success","is_error":false,"result":"` + sentinel + `"}` + "\n", agent.AdapterObservationSucceeded},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			observation, message, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, testSandbox(&fakeClient{process: test.process, stdout: []byte(test.output)}))
+			if err != nil || observation != test.want || message != test.want.StatusMessage() || strings.Contains(message, sentinel) {
+				t.Fatalf("Observe = (%q, %q, %v), want fixed %q message", observation, message, err, test.want)
+			}
+		})
+	}
+}
+
 func TestCancellationAndBoundedIdempotentOutput(t *testing.T) {
 	client := &fakeClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"}, stdout: []byte("stdout"), stderr: []byte("stderr")}
 	var events []agent.AdapterEvent
@@ -329,6 +356,13 @@ func TestCancellationAndBoundedIdempotentOutput(t *testing.T) {
 	err := adapter.Cancel(context.Background(), agent.AdapterTask{ID: "run"}, sandbox)
 	if !errors.Is(err, agent.ErrAdapterCancellationPending) || client.stoppedKey.OwnerId != "run" {
 		t.Fatalf("cancel = %v/%#v", err, client.stoppedKey)
+	}
+}
+
+func TestCancellationTreatsAbsentProcessAsComplete(t *testing.T) {
+	client := &fakeClient{stopErr: status.Error(codes.NotFound, "absent")}
+	if err := (&Adapter{}).Cancel(context.Background(), agent.AdapterTask{ID: "run"}, testSandbox(client)); err != nil {
+		t.Fatalf("Cancel() error = %v, want absent process to be complete", err)
 	}
 }
 

--- a/internal/adapters/claudecode/adapter.go
+++ b/internal/adapters/claudecode/adapter.go
@@ -28,6 +28,7 @@ type Adapter struct {
 
 	mu      sync.Mutex
 	cursors map[outputCursor]uint64
+	pending map[outputCursor]pendingEvent
 }
 
 var _ agent.AdapterLifecycle = (*Adapter)(nil)
@@ -37,6 +38,11 @@ type outputCursor struct {
 	owner       string
 	execution   string
 	stream      sandboxdv1.OutputStream
+}
+
+type pendingEvent struct {
+	event      agent.AdapterEvent
+	nextOffset uint64
 }
 
 type outputEvent struct {
@@ -119,50 +125,50 @@ func (a *Adapter) Observe(ctx context.Context, task agent.AdapterTask, sandbox a
 	process, err := client.Get(ctx, &sandboxdv1.GetProcessRequest{Key: processKey(task)})
 	if err != nil {
 		if status.Code(err) == codes.NotFound {
-			return agent.AdapterObservationFailed, "Claude Code execution is absent in the current sandbox epoch", nil
+			return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 		}
 		return "", "", err
 	}
 	if err := a.forwardOutput(ctx, client, task, sandbox, process); err != nil {
 		if errors.Is(err, agent.ErrAdapterEventRejected) {
-			return agent.AdapterObservationFailed, "Claude Code transcript output was permanently rejected", nil
+			return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 		}
 		return "", "", err
 	}
 
 	switch process.State {
 	case sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, sandboxdv1.ProcessState_PROCESS_STATE_STOPPING:
-		return agent.AdapterObservationRunning, "Claude Code is running", nil
+		return agent.AdapterObservationRunning, agent.AdapterObservationRunning.StatusMessage(), nil
 	case sandboxdv1.ProcessState_PROCESS_STATE_FAILED:
-		return agent.AdapterObservationFailed, processMessage("Claude Code failed to start", process.Error), nil
+		return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 	case sandboxdv1.ProcessState_PROCESS_STATE_EXITED:
 		if process.ExitCode == nil {
-			return agent.AdapterObservationFailed, "Claude Code exited without an exit code", nil
+			return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 		}
 		if process.GetExitCode() != 0 {
-			return agent.AdapterObservationFailed, fmt.Sprintf("Claude Code exited with code %d", process.GetExitCode()), nil
+			return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 		}
 		output, err := readRetainedOutput(ctx, client, processKey(task), process.ExecutionId, sandboxdv1.OutputStream_OUTPUT_STREAM_STDOUT)
 		if err != nil {
 			var truncated *outputTruncatedError
 			if errors.As(err, &truncated) {
-				return agent.AdapterObservationFailed, processMessage("Claude Code stdout was truncated before terminal validation", truncated.Error()), nil
+				return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 			}
 			return "", "", err
 		}
 		result, ok := finalResult(output)
 		if !ok {
-			return agent.AdapterObservationFailed, "Claude Code exited without a valid result event", nil
+			return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 		}
 		if result.IsError == nil {
-			return agent.AdapterObservationFailed, "Claude Code result is missing is_error", nil
+			return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 		}
 		if *result.IsError || result.Subtype != "success" {
-			return agent.AdapterObservationFailed, processMessage("Claude Code reported "+result.Subtype, result.Result), nil
+			return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 		}
-		return agent.AdapterObservationSucceeded, processMessage("Claude Code completed", result.Result), nil
+		return agent.AdapterObservationSucceeded, agent.AdapterObservationSucceeded.StatusMessage(), nil
 	default:
-		return agent.AdapterObservationFailed, fmt.Sprintf("Claude Code returned invalid process state %s", process.State), nil
+		return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 	}
 }
 
@@ -179,6 +185,9 @@ func (a *Adapter) Cancel(ctx context.Context, task agent.AdapterTask, sandbox ag
 		GracePeriodMs: 10_000,
 	})
 	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return nil
+		}
 		return err
 	}
 	switch process.State {
@@ -203,6 +212,17 @@ func (a *Adapter) forwardOutput(ctx context.Context, client sandboxdv1.ProcessSe
 		cursor := outputCursor{environment: string(sandbox.EnvironmentUID), owner: task.ID, execution: process.ExecutionId, stream: stream}
 		offset := a.cursor(cursor)
 		for {
+			if pending, ok := a.pendingEvent(cursor); ok {
+				if err := sandbox.EmitEvent(ctx, pending.event); err != nil {
+					if errors.Is(err, agent.ErrAdapterEventRejected) {
+						a.dropPending(cursor)
+					}
+					return err
+				}
+				offset = pending.nextOffset
+				a.commitPending(cursor, offset)
+				continue
+			}
 			response, err := client.ReadOutput(ctx, &sandboxdv1.ReadOutputRequest{Key: processKey(task), ExecutionId: process.ExecutionId, Stream: stream, Offset: offset, MaxBytes: outputPageMax})
 			if err != nil {
 				return err
@@ -220,11 +240,16 @@ func (a *Adapter) forwardOutput(ctx context.Context, client sandboxdv1.ProcessSe
 			}
 			digest := sha256.Sum256(payload)
 			key := fmt.Sprintf("v1:%s:%x", streamName(stream), digest)
-			if err := sandbox.EmitEvent(ctx, agent.AdapterEvent{Source: "claude-code", IdempotencyKey: key, Type: "claude-code.process-output", Data: payload}); err != nil {
+			event := agent.AdapterEvent{Source: "claude-code", IdempotencyKey: key, Type: "claude-code.process-output", Data: payload}
+			a.setPending(cursor, pendingEvent{event: event, nextOffset: response.NextOffset})
+			if err := sandbox.EmitEvent(ctx, event); err != nil {
+				if errors.Is(err, agent.ErrAdapterEventRejected) {
+					a.dropPending(cursor)
+				}
 				return err
 			}
 			offset = response.NextOffset
-			a.setCursor(cursor, offset)
+			a.commitPending(cursor, offset)
 			if response.Eof || offset >= response.ProducedEnd {
 				break
 			}
@@ -279,17 +304,6 @@ func streamName(stream sandboxdv1.OutputStream) string {
 	return "stdout"
 }
 
-func processMessage(summary, detail string) string {
-	if detail == "" {
-		return summary
-	}
-	const maxDetail = 512
-	if len(detail) > maxDetail {
-		detail = detail[:maxDetail] + "…"
-	}
-	return summary + ": " + detail
-}
-
 func (a *Adapter) cursor(key outputCursor) uint64 {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -299,11 +313,34 @@ func (a *Adapter) cursor(key outputCursor) uint64 {
 	return a.cursors[key]
 }
 
-func (a *Adapter) setCursor(key outputCursor, offset uint64) {
+func (a *Adapter) pendingEvent(key outputCursor) (pendingEvent, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	pending, ok := a.pending[key]
+	return pending, ok
+}
+
+func (a *Adapter) setPending(key outputCursor, pending pendingEvent) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.pending == nil {
+		a.pending = make(map[outputCursor]pendingEvent)
+	}
+	a.pending[key] = pending
+}
+
+func (a *Adapter) dropPending(key outputCursor) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	delete(a.pending, key)
+}
+
+func (a *Adapter) commitPending(key outputCursor, offset uint64) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if a.cursors == nil {
 		a.cursors = make(map[outputCursor]uint64)
 	}
 	a.cursors[key] = offset
+	delete(a.pending, key)
 }

--- a/internal/adapters/claudecode/adapter_test.go
+++ b/internal/adapters/claudecode/adapter_test.go
@@ -43,6 +43,7 @@ type fakeProcessClient struct {
 	stoppedKey    *sandboxdv1.ProcessKey
 	stopMode      sandboxdv1.StopMode
 	getErr        error
+	stopErr       error
 	readRequests  []*sandboxdv1.ReadOutputRequest
 	launchRequest *sandboxdv1.StartProcessWithLaunchMaterialRequest
 	launchValue   []byte
@@ -90,6 +91,9 @@ func (f *fakeProcessClient) Get(context.Context, *sandboxdv1.GetProcessRequest, 
 
 func (f *fakeProcessClient) Stop(_ context.Context, request *sandboxdv1.StopProcessRequest, _ ...grpc.CallOption) (*sandboxdv1.Process, error) {
 	f.stoppedKey, f.stopMode = request.Key, request.Mode
+	if f.stopErr != nil {
+		return nil, f.stopErr
+	}
 	if f.process != nil {
 		return f.process, nil
 	}
@@ -218,6 +222,13 @@ func TestCancelWaitsForProcessTreeToBecomeTerminal(t *testing.T) {
 	}
 }
 
+func TestCancelTreatsAbsentProcessAsComplete(t *testing.T) {
+	client := &fakeProcessClient{stopErr: status.Error(codes.NotFound, "absent")}
+	if err := (&Adapter{}).Cancel(context.Background(), agent.AdapterTask{ID: "run-uid"}, sandboxFor(client)); err != nil {
+		t.Fatalf("Cancel() error = %v, want absent process to be complete", err)
+	}
+}
+
 func TestObservationMapping(t *testing.T) {
 	exit0, exit1 := int32(0), int32(1)
 	tests := []struct {
@@ -243,6 +254,29 @@ func TestObservationMapping(t *testing.T) {
 			got, _, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandboxFor(client))
 			if err != nil || got != test.want {
 				t.Fatalf("Observe() = (%q, %v), want %q", got, err, test.want)
+			}
+		})
+	}
+}
+
+func TestObservationMessagesExcludeAgentControlledDetails(t *testing.T) {
+	const sentinel = "!!CLAUDE-STATUS-SECRET!!"
+	exit0 := int32(0)
+	tests := []struct {
+		name    string
+		process *sandboxdv1.Process
+		stdout  string
+		want    agent.AdapterObservation
+	}{
+		{name: "process failure", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_FAILED, Error: sentinel, ExecutionId: "e"}, want: agent.AdapterObservationFailed},
+		{name: "provider failure", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: `{"type":"result","subtype":"` + sentinel + `","is_error":true,"result":"` + sentinel + `"}` + "\n", want: agent.AdapterObservationFailed},
+		{name: "success result", process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, stdout: `{"type":"result","subtype":"success","is_error":false,"result":"` + sentinel + `"}` + "\n", want: agent.AdapterObservationSucceeded},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			observation, message, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandboxFor(&fakeProcessClient{process: test.process, stdout: []byte(test.stdout)}))
+			if err != nil || observation != test.want || message != test.want.StatusMessage() || strings.Contains(message, sentinel) {
+				t.Fatalf("Observe() = (%q, %q, %v), want fixed %q message", observation, message, err, test.want)
 			}
 		})
 	}
@@ -313,11 +347,11 @@ func TestOutputRetryAfterRestartUsesContentAddressedKeys(t *testing.T) {
 func TestTransientOutputFailureRetriesSameEvent(t *testing.T) {
 	client := &fakeProcessClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"}, stdout: []byte("output")}
 	transient := errors.New("temporary transcript outage")
-	var keys []string
+	var events []agent.AdapterEvent
 	sandbox := sandboxFor(client)
 	sandbox.EmitEvent = func(_ context.Context, event agent.AdapterEvent) error {
-		keys = append(keys, event.IdempotencyKey)
-		if len(keys) == 1 {
+		events = append(events, event)
+		if len(events) == 1 {
 			return transient
 		}
 		return nil
@@ -326,12 +360,13 @@ func TestTransientOutputFailureRetriesSameEvent(t *testing.T) {
 	if _, _, err := adapter.Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox); !errors.Is(err, transient) {
 		t.Fatalf("first Observe() error = %v, want transient error", err)
 	}
+	client.stdout = []byte("output appended")
 	got, _, err := adapter.Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox)
 	if err != nil || got != agent.AdapterObservationRunning {
 		t.Fatalf("retry Observe() = (%q, %v)", got, err)
 	}
-	if len(keys) != 2 || keys[0] != keys[1] {
-		t.Fatalf("retry keys = %#v, want same idempotency key", keys)
+	if len(events) != 3 || !reflect.DeepEqual(events[0], events[1]) {
+		t.Fatalf("retry events = %#v, want exact pending event followed by appended output", events)
 	}
 }
 
@@ -341,9 +376,13 @@ func TestPermanentOutputRejectionFailsObservation(t *testing.T) {
 	sandbox.EmitEvent = func(context.Context, agent.AdapterEvent) error {
 		return agent.ErrAdapterEventRejected
 	}
-	got, message, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox)
-	if err != nil || got != agent.AdapterObservationFailed || !strings.Contains(message, "permanently rejected") {
+	adapter := &Adapter{}
+	got, message, err := adapter.Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox)
+	if err != nil || got != agent.AdapterObservationFailed || message != got.StatusMessage() {
 		t.Fatalf("Observe() = (%q, %q, %v)", got, message, err)
+	}
+	if len(adapter.pending) != 0 {
+		t.Fatalf("permanently rejected pending events retained: %d", len(adapter.pending))
 	}
 }
 
@@ -358,7 +397,7 @@ func TestTerminalValidationFailsOnRetainedOutputGap(t *testing.T) {
 		retainedFrom: 512,
 	}
 	got, detail, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandboxFor(client))
-	if err != nil || got != agent.AdapterObservationFailed || !strings.Contains(detail, "truncated before terminal validation") || !strings.Contains(detail, "retained from offset 512") {
+	if err != nil || got != agent.AdapterObservationFailed || detail != got.StatusMessage() {
 		t.Fatalf("Observe() = (%q, %q, %v)", got, detail, err)
 	}
 }
@@ -370,8 +409,12 @@ func TestTerminalCancellationIgnoresPermanentOutputRejection(t *testing.T) {
 	sandbox.EmitEvent = func(context.Context, agent.AdapterEvent) error {
 		return agent.ErrAdapterEventRejected
 	}
-	if err := (&Adapter{}).Cancel(context.Background(), agent.AdapterTask{ID: "run"}, sandbox); err != nil {
+	adapter := &Adapter{}
+	if err := adapter.Cancel(context.Background(), agent.AdapterTask{ID: "run"}, sandbox); err != nil {
 		t.Fatalf("Cancel() error = %v", err)
+	}
+	if len(adapter.pending) != 0 {
+		t.Fatalf("permanently rejected pending events retained after cancellation: %d", len(adapter.pending))
 	}
 }
 

--- a/internal/adapters/codex/adapter.go
+++ b/internal/adapters/codex/adapter.go
@@ -112,43 +112,43 @@ func (a *Adapter) Observe(ctx context.Context, task agent.AdapterTask, sandbox a
 	p, err := client.Get(ctx, &sandboxdv1.GetProcessRequest{Key: key(task)})
 	if err != nil {
 		if status.Code(err) == codes.NotFound {
-			return agent.AdapterObservationFailed, "Codex execution is absent in the current sandbox epoch", nil
+			return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 		}
 		return "", "", err
 	}
 	if err = a.forward(ctx, client, task, sandbox, p); err != nil {
 		if errors.Is(err, agent.ErrAdapterEventRejected) {
-			return agent.AdapterObservationFailed, "Codex transcript output was permanently rejected", nil
+			return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 		}
 		return "", "", err
 	}
 	switch p.State {
 	case sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, sandboxdv1.ProcessState_PROCESS_STATE_STOPPING:
-		return agent.AdapterObservationRunning, "Codex is running", nil
+		return agent.AdapterObservationRunning, agent.AdapterObservationRunning.StatusMessage(), nil
 	case sandboxdv1.ProcessState_PROCESS_STATE_FAILED:
-		return agent.AdapterObservationFailed, message("Codex failed to start", p.Error), nil
+		return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 	case sandboxdv1.ProcessState_PROCESS_STATE_EXITED:
 		if p.ExitCode == nil {
-			return agent.AdapterObservationFailed, "Codex exited without an exit code", nil
+			return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 		}
 		if p.GetExitCode() != 0 {
-			return agent.AdapterObservationFailed, fmt.Sprintf("Codex exited with code %d", p.GetExitCode()), nil
+			return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 		}
 		out, e := readOutput(ctx, client, key(task), p.ExecutionId)
 		if e != nil {
 			var truncated *outputTruncatedError
 			if errors.As(e, &truncated) {
-				return agent.AdapterObservationFailed, message("Codex stdout was truncated before terminal validation", truncated.Error()), nil
+				return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 			}
 			return "", "", e
 		}
-		thread, detail, ok := terminal(out)
+		_, _, ok := terminal(out)
 		if !ok {
-			return agent.AdapterObservationFailed, message("Codex exited without a coherent completed turn", detail), nil
+			return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 		}
-		return agent.AdapterObservationSucceeded, "Codex completed thread " + thread, nil
+		return agent.AdapterObservationSucceeded, agent.AdapterObservationSucceeded.StatusMessage(), nil
 	default:
-		return agent.AdapterObservationFailed, fmt.Sprintf("Codex returned invalid process state %s", p.State), nil
+		return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 	}
 }
 
@@ -295,15 +295,6 @@ func streamName(s sandboxdv1.OutputStream) string {
 		return "stderr"
 	}
 	return "stdout"
-}
-func message(a, b string) string {
-	if b == "" {
-		return a
-	}
-	if len(b) > 512 {
-		b = b[:512] + "…"
-	}
-	return a + ": " + b
 }
 func (a *Adapter) getCursor(c cursor) uint64 {
 	a.mu.Lock()

--- a/internal/adapters/codex/adapter_test.go
+++ b/internal/adapters/codex/adapter_test.go
@@ -269,6 +269,29 @@ func TestObservationOutcomes(t *testing.T) {
 	}
 }
 
+func TestObservationMessagesExcludeAgentControlledDetails(t *testing.T) {
+	const sentinel = "!!CODEX-STATUS-SECRET!!"
+	exit0 := int32(0)
+	tests := []struct {
+		name    string
+		process *sandboxdv1.Process
+		stdout  string
+		want    agent.AdapterObservation
+	}{
+		{"process failure", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_FAILED, Error: sentinel, ExecutionId: "e"}, "", agent.AdapterObservationFailed},
+		{"provider failure", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, `{"type":"thread.started","thread_id":"` + sentinel + `"}` + "\n" + `{"type":"turn.failed","error":{"message":"` + sentinel + `"}}`, agent.AdapterObservationFailed},
+		{"success result", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, `{"type":"thread.started","thread_id":"` + sentinel + `"}` + "\n" + `{"type":"turn.completed","usage":{}}`, agent.AdapterObservationSucceeded},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			observation, message, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, processSandbox(&fakeProcessClient{process: test.process, stdout: []byte(test.stdout)}, "epoch"))
+			if err != nil || observation != test.want || message != test.want.StatusMessage() || strings.Contains(message, sentinel) {
+				t.Fatalf("Observe = (%q, %q, %v), want fixed %q message", observation, message, err, test.want)
+			}
+		})
+	}
+}
+
 func TestTerminalObservationFailsOnRetainedOutputGap(t *testing.T) {
 	exit0 := int32(0)
 	client := &fakeProcessClient{
@@ -276,7 +299,7 @@ func TestTerminalObservationFailsOnRetainedOutputGap(t *testing.T) {
 		stdout:  []byte(`{"type":"turn.completed","usage":{}}`), retainedFrom: 1024,
 	}
 	got, detail, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, processSandbox(client, "epoch"))
-	if err != nil || got != agent.AdapterObservationFailed || !strings.Contains(detail, "retained from offset 1024") {
+	if err != nil || got != agent.AdapterObservationFailed || detail != got.StatusMessage() {
 		t.Fatalf("Observe = %q, %q, %v", got, detail, err)
 	}
 }
@@ -365,7 +388,7 @@ func TestPermanentOutputRejectionFailsObserveButNotTerminalCancel(t *testing.T) 
 	sandbox := processSandbox(client, "epoch")
 	sandbox.EmitEvent = func(context.Context, agent.AdapterEvent) error { return agent.ErrAdapterEventRejected }
 	got, message, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox)
-	if err != nil || got != agent.AdapterObservationFailed || !strings.Contains(message, "permanently rejected") {
+	if err != nil || got != agent.AdapterObservationFailed || message != got.StatusMessage() {
 		t.Fatalf("Observe = %q, %q, %v", got, message, err)
 	}
 	client.process.State, client.process.ExitCode = sandboxdv1.ProcessState_PROCESS_STATE_EXITED, &exit0

--- a/internal/adapters/pi/adapter.go
+++ b/internal/adapters/pi/adapter.go
@@ -112,43 +112,43 @@ func (a *Adapter) Observe(ctx context.Context, task agent.AdapterTask, sandbox a
 	p, err := c.Get(ctx, &sandboxdv1.GetProcessRequest{Key: key(task)})
 	if err != nil {
 		if status.Code(err) == codes.NotFound {
-			return agent.AdapterObservationFailed, "Pi execution is absent in the current sandbox epoch", nil
+			return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 		}
 		return "", "", err
 	}
 	if err = a.forward(ctx, c, task, sandbox, p); err != nil {
 		if errors.Is(err, agent.ErrAdapterEventRejected) {
-			return agent.AdapterObservationFailed, "Pi transcript output was permanently rejected", nil
+			return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 		}
 		return "", "", err
 	}
 	switch p.State {
 	case sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, sandboxdv1.ProcessState_PROCESS_STATE_STOPPING:
-		return agent.AdapterObservationRunning, "Pi is running", nil
+		return agent.AdapterObservationRunning, agent.AdapterObservationRunning.StatusMessage(), nil
 	case sandboxdv1.ProcessState_PROCESS_STATE_FAILED:
-		return agent.AdapterObservationFailed, message("Pi failed to start", p.Error), nil
+		return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 	case sandboxdv1.ProcessState_PROCESS_STATE_EXITED:
 		if p.ExitCode == nil {
-			return agent.AdapterObservationFailed, "Pi exited without an exit code", nil
+			return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 		}
 		if p.GetExitCode() != 0 {
-			return agent.AdapterObservationFailed, fmt.Sprintf("Pi exited with code %d", p.GetExitCode()), nil
+			return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 		}
 		out, e := readOutput(ctx, c, key(task), p.ExecutionId)
 		if e != nil {
 			var gap *outputTruncatedError
 			if errors.As(e, &gap) {
-				return agent.AdapterObservationFailed, message("Pi stdout was truncated before terminal validation", gap.Error()), nil
+				return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 			}
 			return "", "", e
 		}
-		detail, ok := terminal(out)
+		_, ok := terminal(out)
 		if !ok {
-			return agent.AdapterObservationFailed, message("Pi exited without a coherent final agent_end", detail), nil
+			return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 		}
-		return agent.AdapterObservationSucceeded, "Pi completed", nil
+		return agent.AdapterObservationSucceeded, agent.AdapterObservationSucceeded.StatusMessage(), nil
 	default:
-		return agent.AdapterObservationFailed, fmt.Sprintf("Pi returned invalid process state %s", p.State), nil
+		return agent.AdapterObservationFailed, agent.AdapterObservationFailed.StatusMessage(), nil
 	}
 }
 func terminal(out []byte) (string, bool) {
@@ -190,7 +190,7 @@ func terminal(out []byte) (string, bool) {
 	case "stop", "length", "toolUse":
 		return "", true
 	case "error", "aborted":
-		return message("final assistant stopReason is "+final.StopReason, final.Error), false
+		return "final assistant reported failure", false
 	default:
 		return "final assistant has invalid stopReason", false
 	}
@@ -283,15 +283,6 @@ func streamName(s sandboxdv1.OutputStream) string {
 		return "stderr"
 	}
 	return "stdout"
-}
-func message(a, b string) string {
-	if b == "" {
-		return a
-	}
-	if len(b) > 512 {
-		b = b[:512] + "…"
-	}
-	return a + ": " + b
 }
 func (a *Adapter) getCursor(c cursor) uint64 {
 	a.mu.Lock()

--- a/internal/adapters/pi/adapter_test.go
+++ b/internal/adapters/pi/adapter_test.go
@@ -219,11 +219,34 @@ func TestObservationOutcomes(t *testing.T) {
 	}
 }
 
+func TestObservationMessagesExcludeAgentControlledDetails(t *testing.T) {
+	const sentinel = "!!PI-STATUS-SECRET!!"
+	exit0 := int32(0)
+	tests := []struct {
+		name    string
+		process *sandboxdv1.Process
+		stdout  string
+		want    agent.AdapterObservation
+	}{
+		{"process failure", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_FAILED, Error: sentinel, ExecutionId: "e"}, "", agent.AdapterObservationFailed},
+		{"provider failure", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, `{"type":"agent_end","messages":[{"role":"assistant","stopReason":"error","errorMessage":"` + sentinel + `"}]}`, agent.AdapterObservationFailed},
+		{"success result", &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "e"}, `{"type":"agent_end","messages":[{"role":"assistant","stopReason":"stop","errorMessage":"` + sentinel + `"}]}`, agent.AdapterObservationSucceeded},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			observation, message, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, processSandbox(&processClient{process: test.process, stdout: []byte(test.stdout)}, "epoch"))
+			if err != nil || observation != test.want || message != test.want.StatusMessage() || strings.Contains(message, sentinel) {
+				t.Fatalf("Observe = (%q, %q, %v), want fixed %q message", observation, message, err, test.want)
+			}
+		})
+	}
+}
+
 func TestTerminalValidationFailsOnRetainedOutputGap(t *testing.T) {
 	exit0 := int32(0)
 	client := &processClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, stdout: []byte(`{"type":"agent_end","messages":[]}`), retainedFrom: 41}
 	got, detail, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, processSandbox(client, "epoch"))
-	if err != nil || got != agent.AdapterObservationFailed || !strings.Contains(detail, "retained from offset 41") {
+	if err != nil || got != agent.AdapterObservationFailed || detail != got.StatusMessage() {
 		t.Fatalf("Observe = %q, %q, %v", got, detail, err)
 	}
 }
@@ -306,7 +329,7 @@ func TestPermanentOutputRejectionFailsObserveButNotTerminalCancel(t *testing.T) 
 	sandbox := processSandbox(client, "epoch")
 	sandbox.EmitEvent = func(context.Context, agent.AdapterEvent) error { return agent.ErrAdapterEventRejected }
 	got, detail, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox)
-	if err != nil || got != agent.AdapterObservationFailed || !strings.Contains(detail, "permanently rejected") {
+	if err != nil || got != agent.AdapterObservationFailed || detail != got.StatusMessage() {
 		t.Fatalf("Observe = %q, %q, %v", got, detail, err)
 	}
 	client.process.State, client.process.ExitCode = sandboxdv1.ProcessState_PROCESS_STATE_EXITED, &exit0

--- a/internal/agent/adapter.go
+++ b/internal/agent/adapter.go
@@ -34,6 +34,26 @@ const (
 	AdapterObservationFailed     AdapterObservation = "Failed"
 )
 
+// StatusMessage returns the fixed platform-owned message for a normalized
+// observation. Adapter- and provider-controlled details belong only in opaque
+// transcript events and must never be included in normalized status.
+func (o AdapterObservation) StatusMessage() string {
+	switch o {
+	case AdapterObservationAccepted:
+		return "adapter accepted the task"
+	case AdapterObservationRunning:
+		return "adapter is running"
+	case AdapterObservationNeedsInput:
+		return "adapter needs input"
+	case AdapterObservationSucceeded:
+		return "adapter completed successfully"
+	case AdapterObservationFailed:
+		return "adapter reported failure"
+	default:
+		return ""
+	}
+}
+
 // AdapterTask contains immutable task identity and input. ID is the Run UID
 // and is the adapter's idempotency key across retries and controller restarts.
 type AdapterTask struct {
@@ -126,6 +146,8 @@ type AdapterSandbox struct {
 // ErrAdapterTaskRejected for permanent intent rejection; Cancel succeeds when
 // work is already absent or terminal and returns
 // ErrAdapterCancellationPending while its execution tree is still stopping.
+// Observe's message must equal observation.StatusMessage(); arbitrary process,
+// provider, result, or transcript bytes are forbidden from normalized status.
 type AdapterLifecycle interface {
 	EnsureAccepted(context.Context, AdapterTask, AdapterSandbox, *AdapterLaunchMaterial) error
 	Observe(context.Context, AdapterTask, AdapterSandbox) (AdapterObservation, string, error)

--- a/internal/agent/adapter_test.go
+++ b/internal/agent/adapter_test.go
@@ -42,3 +42,21 @@ func TestPrepareLaunchMaterialMergeCopyCleanupAndConflict(t *testing.T) {
 		t.Fatalf("duplicate conflict = %v", err)
 	}
 }
+
+func TestAdapterObservationStatusMessagesAreFixedPlatformVocabulary(t *testing.T) {
+	tests := map[AdapterObservation]string{
+		AdapterObservationAccepted:   "adapter accepted the task",
+		AdapterObservationRunning:    "adapter is running",
+		AdapterObservationNeedsInput: "adapter needs input",
+		AdapterObservationSucceeded:  "adapter completed successfully",
+		AdapterObservationFailed:     "adapter reported failure",
+	}
+	for observation, want := range tests {
+		if got := observation.StatusMessage(); got != want {
+			t.Errorf("%s status message = %q, want %q", observation, got, want)
+		}
+	}
+	if got := AdapterObservation("provider-controlled").StatusMessage(); got != "" {
+		t.Fatalf("unknown observation status message = %q, want empty", got)
+	}
+}

--- a/internal/cli/tui.go
+++ b/internal/cli/tui.go
@@ -52,7 +52,9 @@ type tuiModel struct {
 	detailInFlight        bool
 	detailRefreshPending  bool
 	detailNeedsRefresh    bool
+	detailRefreshBlocked  bool
 	envInFlight           bool
+	envRefreshBlocked     bool
 	mutationInFlight      bool
 	mutationID            uint64
 	cancelIdentity        runIdentity
@@ -119,6 +121,8 @@ type runLoadedMsg struct {
 
 type environmentLoadedMsg struct {
 	identity    runIdentity
+	name        string
+	expectedUID string
 	environment controlplane.Environment
 	err         error
 }
@@ -226,11 +230,11 @@ func (m *tuiModel) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		if (m.pollFallback || m.listNeedsRefresh) && !m.listInFlight {
 			commands = append(commands, m.loadRuns())
 		}
-		if (m.pollFallback || m.detailNeedsRefresh) && m.mode == tuiDetail && m.run != nil && !m.detailInFlight {
+		if (m.pollFallback || m.detailNeedsRefresh) && m.mode == tuiDetail && m.run != nil && !m.detailInFlight && !m.detailRefreshBlocked {
 			commands = append(commands, m.loadRun(m.run.Name))
 		}
-		if m.mode == tuiDetail && m.run != nil && m.run.Environment != nil && !m.envInFlight {
-			commands = append(commands, m.loadEnvironment(m.currentIdentity(), m.run.Environment.Name))
+		if m.mode == tuiDetail && m.run != nil && m.run.Environment != nil && !m.envInFlight && !m.detailRefreshBlocked && !m.envRefreshBlocked {
+			commands = append(commands, m.loadEnvironment(m.currentIdentity(), m.run.Environment.Name, m.run.Environment.UID))
 		}
 		return m, tea.Batch(commands...)
 	case runsLoadedMsg:
@@ -270,7 +274,9 @@ func (m *tuiModel) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		if m.cursor < 0 {
 			m.cursor = 0
 		}
-		if m.mode == tuiDetail && m.run != nil && msg.event.Run.Name == m.run.Name {
+		relevantDetailEvent := m.mode == tuiDetail && m.run != nil && msg.event.Run.Name == m.run.Name &&
+			(msg.event.Type != "DELETED" || msg.event.Run.UID == m.run.UID)
+		if relevantDetailEvent && !m.detailRefreshBlocked {
 			if m.detailInFlight {
 				m.detailRefreshPending = true
 			} else {
@@ -319,6 +325,16 @@ func (m *tuiModel) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if msg.err != nil {
 			m.err = safeError(msg.err)
+			if isProblemStatus(msg.err, http.StatusConflict) || isProblemStatus(msg.err, http.StatusNotFound) || errors.Is(msg.err, controlplaneclient.ErrRunIdentityMismatch) {
+				m.detailNeedsRefresh = false
+				m.detailRefreshBlocked = true
+				return m, nil
+			}
+			if !controlplaneclient.RetryableResourceError(msg.err) {
+				m.detailNeedsRefresh = false
+				m.detailRefreshBlocked = true
+				return m, nil
+			}
 			m.detailNeedsRefresh = true
 			if refreshAgain {
 				return m, m.loadRun(msg.name)
@@ -327,6 +343,7 @@ func (m *tuiModel) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.err = ""
 		m.detailNeedsRefresh = false
+		m.detailRefreshBlocked = false
 		identity := runIdentity{namespace: m.namespace, name: msg.run.Name, uid: msg.run.UID}
 		if identity != m.streamID {
 			m.stopStream()
@@ -335,11 +352,20 @@ func (m *tuiModel) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			m.streamRecoveryCount = 0
 			m.streamBlocked = false
 		}
+		associationChanged := m.run.Environment == nil != (msg.run.Environment == nil)
+		if m.run.Environment != nil && msg.run.Environment != nil {
+			associationChanged = m.run.Environment.Name != msg.run.Environment.Name || m.run.Environment.UID != msg.run.Environment.UID
+		}
+		if associationChanged {
+			m.env = nil
+			m.envRefreshBlocked = false
+			m.envInFlight = false
+		}
 		m.run = &msg.run
 		commands := []tea.Cmd{}
 		if msg.run.Environment != nil {
-			if !m.envInFlight {
-				commands = append(commands, m.loadEnvironment(identity, msg.run.Environment.Name))
+			if !m.envInFlight && !m.envRefreshBlocked {
+				commands = append(commands, m.loadEnvironment(identity, msg.run.Environment.Name, msg.run.Environment.UID))
 			}
 		} else {
 			m.env = nil
@@ -352,15 +378,20 @@ func (m *tuiModel) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, tea.Batch(commands...)
 	case environmentLoadedMsg:
-		m.envInFlight = false
-		if msg.identity != m.currentIdentity() {
+		if msg.identity != m.currentIdentity() || m.run == nil || m.run.Environment == nil ||
+			m.run.Environment.UID != msg.expectedUID || m.run.Environment.Name != msg.name {
 			return m, nil
 		}
+		m.envInFlight = false
 		if msg.err != nil {
 			m.env = nil
 			m.err = safeError(msg.err)
+			if !controlplaneclient.RetryableResourceError(msg.err) {
+				m.envRefreshBlocked = true
+			}
 		} else {
 			m.env = &msg.environment
+			m.envRefreshBlocked = false
 		}
 		return m, nil
 	case transcriptMsg:
@@ -468,6 +499,9 @@ func (m *tuiModel) handleKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if m.mode == tuiDetail && m.run != nil {
 			m.streamBlocked = false
 			m.streamRecoveryCount = 0
+			if m.detailRefreshBlocked {
+				return m, m.loadRuns()
+			}
 			return m, tea.Batch(m.loadRuns(), m.loadRun(m.run.Name))
 		}
 		return m, m.loadRuns()
@@ -496,6 +530,9 @@ func (m *tuiModel) handleKey(key tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.mode = tuiDetail
 				m.loading = true
 				m.err, m.status = "", ""
+				m.detailRefreshBlocked = false
+				m.envRefreshBlocked = false
+				m.env = nil
 				m.streamBlocked = false
 				m.streamRecoveryCount = 0
 				return m, m.loadRun(summary.Name)
@@ -683,28 +720,25 @@ func (m *tuiModel) loadRuns() tea.Cmd {
 }
 
 func (m *tuiModel) loadRun(name string) tea.Cmd {
-	if m.detailInFlight {
+	if m.detailInFlight || m.run == nil || m.run.Name != name || m.run.UID == "" {
 		return nil
 	}
 	m.detailInFlight = true
-	expectedUID := ""
-	if m.run != nil && m.run.Name == name {
-		expectedUID = m.run.UID
-	}
+	expectedUID := m.run.UID
 	return func() tea.Msg {
-		run, err := m.client.GetRun(m.ctx, m.namespace, name)
+		run, err := m.client.GetRunExact(m.ctx, m.namespace, name, expectedUID)
 		return runLoadedMsg{name: name, expectedUID: expectedUID, run: run, err: err}
 	}
 }
 
-func (m *tuiModel) loadEnvironment(identity runIdentity, name string) tea.Cmd {
+func (m *tuiModel) loadEnvironment(identity runIdentity, name, expectedUID string) tea.Cmd {
 	if m.envInFlight {
 		return nil
 	}
 	m.envInFlight = true
 	return func() tea.Msg {
-		environment, err := m.client.GetEnvironment(m.ctx, m.namespace, name)
-		return environmentLoadedMsg{identity: identity, environment: environment, err: err}
+		environment, err := m.client.GetEnvironmentExact(m.ctx, m.namespace, name, expectedUID)
+		return environmentLoadedMsg{identity: identity, name: name, expectedUID: expectedUID, environment: environment, err: err}
 	}
 }
 

--- a/internal/cli/tui_test.go
+++ b/internal/cli/tui_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -143,13 +144,139 @@ func TestTUIPollRecoversSnapshotAndExactDetailFailures(t *testing.T) {
 	model.mode = tuiDetail
 	model.run = &controlplane.Run{Name: "same", UID: "uid"}
 	model.detailInFlight = true
-	_, _ = model.Update(runLoadedMsg{name: "same", expectedUID: "uid", err: errors.New("temporary detail failure")})
+	_, _ = model.Update(runLoadedMsg{name: "same", expectedUID: "uid", err: &url.Error{Op: "Get", URL: "https://control-plane", Err: errors.New("temporary detail failure")}})
 	if !model.detailNeedsRefresh || model.detailInFlight {
 		t.Fatalf("failed detail state = needs refresh %t, inflight %t", model.detailNeedsRefresh, model.detailInFlight)
 	}
 	_, command = model.Update(pollMsg(time.Now()))
 	if command == nil || !model.detailInFlight {
 		t.Fatalf("detail recovery = command %v, inflight %t", command, model.detailInFlight)
+	}
+}
+
+func TestTUIExactDetailTerminalFailuresRemainBlockedUntilExplicitSelection(t *testing.T) {
+	terminalErrors := []error{
+		&controlplaneclient.ProblemError{Problem: controlplaneclient.Problem{Status: http.StatusNotFound}},
+		&controlplaneclient.ProblemError{Problem: controlplaneclient.Problem{Status: http.StatusConflict}},
+		fmt.Errorf("exact GET: %w", controlplaneclient.ErrRunIdentityMismatch),
+	}
+	for _, terminalErr := range terminalErrors {
+		model := newTUIModel(context.Background(), nil, "team-a")
+		model.mode = tuiDetail
+		model.run = &controlplane.Run{Name: "same", UID: "selected-uid", Environment: &controlplane.RunEnvironment{Name: "old-environment"}}
+		model.pollFallback = true
+		model.detailInFlight = true
+		_, command := model.Update(runLoadedMsg{name: "same", expectedUID: "selected-uid", err: terminalErr})
+		if command != nil || !model.detailRefreshBlocked || model.detailNeedsRefresh || model.detailInFlight {
+			t.Fatalf("terminal state for %v = command %v, blocked %t, needs refresh %t, inflight %t", terminalErr, command, model.detailRefreshBlocked, model.detailNeedsRefresh, model.detailInFlight)
+		}
+		_, _ = model.Update(pollMsg(time.Now()))
+		if model.detailInFlight || model.envInFlight {
+			t.Fatalf("fallback poll restarted blocked detail children for %v: detail %t, environment %t", terminalErr, model.detailInFlight, model.envInFlight)
+		}
+		_, _ = model.Update(keyMessage("r"))
+		if model.detailInFlight {
+			t.Fatalf("manual refresh restarted blocked selection for %v", terminalErr)
+		}
+		model.listInFlight = false
+		model.mode = tuiList
+		model.runs = []controlplane.RunSummary{{Name: "same", UID: "replacement-uid"}}
+		_, command = model.Update(keyMessage("enter"))
+		if command == nil || model.detailRefreshBlocked || !model.detailInFlight || model.run.UID != "replacement-uid" {
+			t.Fatalf("explicit selection state for %v = command %v, blocked %t, inflight %t, run %#v", terminalErr, command, model.detailRefreshBlocked, model.detailInFlight, model.run)
+		}
+	}
+}
+
+func TestTUIExactDetailTransientStatusesContinueRecovery(t *testing.T) {
+	for _, status := range []int{http.StatusRequestTimeout, http.StatusTooManyRequests, http.StatusInternalServerError, http.StatusServiceUnavailable} {
+		model := newTUIModel(context.Background(), nil, "team-a")
+		model.mode = tuiDetail
+		model.run = &controlplane.Run{Name: "run", UID: "uid"}
+		model.detailInFlight = true
+		err := &controlplaneclient.ProblemError{Problem: controlplaneclient.Problem{Status: status}}
+		_, _ = model.Update(runLoadedMsg{name: "run", expectedUID: "uid", err: err})
+		_, command := model.Update(pollMsg(time.Now()))
+		if model.detailRefreshBlocked || command == nil || !model.detailInFlight {
+			t.Fatalf("status %d recovery = blocked %t, command %v, inflight %t", status, model.detailRefreshBlocked, command, model.detailInFlight)
+		}
+	}
+}
+
+func TestTUIEnvironmentMismatchAndNotFoundStopOnlyEnvironmentPolling(t *testing.T) {
+	for _, terminalErr := range []error{
+		fmt.Errorf("exact Environment GET: %w", controlplaneclient.ErrEnvironmentIdentityMismatch),
+		&controlplaneclient.ProblemError{Problem: controlplaneclient.Problem{Status: http.StatusNotFound}},
+	} {
+		model := newTUIModel(context.Background(), nil, "team-a")
+		model.mode = tuiDetail
+		model.pollFallback = true
+		model.run = &controlplane.Run{Name: "run", UID: "run-uid", Environment: &controlplane.RunEnvironment{Name: "env", UID: "env-uid"}}
+		model.env = &controlplane.Environment{Name: "env", UID: "env-uid"}
+		model.envInFlight = true
+		_, _ = model.Update(environmentLoadedMsg{identity: model.currentIdentity(), name: "env", expectedUID: "env-uid", err: terminalErr})
+		if !model.envRefreshBlocked || model.env != nil || model.run == nil {
+			t.Fatalf("terminal Environment state for %v = blocked %t, env %#v, run %#v", terminalErr, model.envRefreshBlocked, model.env, model.run)
+		}
+		_, _ = model.Update(pollMsg(time.Now()))
+		if model.envInFlight {
+			t.Fatalf("terminal Environment error %v restarted polling", terminalErr)
+		}
+	}
+}
+
+func TestTUIEnvironmentTransient503RecoversOnPoll(t *testing.T) {
+	model := newTUIModel(context.Background(), nil, "team-a")
+	model.mode = tuiDetail
+	model.run = &controlplane.Run{Name: "run", UID: "run-uid", Environment: &controlplane.RunEnvironment{Name: "env", UID: "env-uid"}}
+	model.envInFlight = true
+	err := &controlplaneclient.ProblemError{Problem: controlplaneclient.Problem{Status: http.StatusServiceUnavailable}}
+	_, _ = model.Update(environmentLoadedMsg{identity: model.currentIdentity(), name: "env", expectedUID: "env-uid", err: err})
+	_, command := model.Update(pollMsg(time.Now()))
+	if model.envRefreshBlocked || command == nil || !model.envInFlight {
+		t.Fatalf("503 recovery = blocked %t, command %v, inflight %t", model.envRefreshBlocked, command, model.envInFlight)
+	}
+}
+
+func TestTUIEnvironmentAssociationChangeClearsTerminalBlock(t *testing.T) {
+	model := newTUIModel(context.Background(), nil, "team-a")
+	model.mode = tuiDetail
+	model.run = &controlplane.Run{Name: "run", UID: "run-uid", Environment: &controlplane.RunEnvironment{Name: "env", UID: "old-uid"}}
+	model.envRefreshBlocked = true
+	model.env = &controlplane.Environment{Name: "env", UID: "old-uid"}
+	replacement := controlplane.Run{Name: "run", UID: "run-uid", Environment: &controlplane.RunEnvironment{Name: "env", UID: "new-uid"}}
+	_, command := model.Update(runLoadedMsg{name: "run", expectedUID: "run-uid", run: replacement})
+	if model.envRefreshBlocked || model.env != nil || command == nil || !model.envInFlight {
+		t.Fatalf("association change = blocked %t, env %#v, command %v, inflight %t", model.envRefreshBlocked, model.env, command, model.envInFlight)
+	}
+}
+
+func TestTUIWatchDeleteReconcilesOnlySelectedUID(t *testing.T) {
+	model := newTUIModel(context.Background(), nil, "team-a")
+	model.mode = tuiDetail
+	model.run = &controlplane.Run{Name: "same", UID: "replacement-b"}
+	model.runs = []controlplane.RunSummary{{Name: "same", UID: "replacement-b"}}
+	model.resourceGeneration = 1
+	staleCommitted := make(chan struct{})
+	_, command := model.Update(runWatchMsg{generation: 1, event: controlplane.RunWatchEvent{Type: "DELETED", ResourceVersion: "2", Run: controlplane.RunSummary{Name: "same", UID: "old-a"}}, committed: staleCommitted})
+	if model.detailInFlight || model.detailRefreshPending {
+		t.Fatalf("stale delete refreshed replacement: command %v, inflight %t, pending %t", command, model.detailInFlight, model.detailRefreshPending)
+	}
+
+	model.run = &controlplane.Run{Name: "same", UID: "old-a"}
+	currentCommitted := make(chan struct{})
+	_, command = model.Update(runWatchMsg{generation: 1, event: controlplane.RunWatchEvent{Type: "DELETED", ResourceVersion: "3", Run: controlplane.RunSummary{Name: "same", UID: "old-a"}}, committed: currentCommitted})
+	if command == nil || !model.detailInFlight {
+		t.Fatalf("current delete did not settle exact identity once: command %v, inflight %t", command, model.detailInFlight)
+	}
+	notFound := &controlplaneclient.ProblemError{Problem: controlplaneclient.Problem{Status: http.StatusNotFound}}
+	_, command = model.Update(runLoadedMsg{name: "same", expectedUID: "old-a", err: notFound})
+	if command != nil || !model.detailRefreshBlocked || model.detailInFlight {
+		t.Fatalf("current delete settlement = command %v, blocked %t, inflight %t", command, model.detailRefreshBlocked, model.detailInFlight)
+	}
+	_, _ = model.Update(pollMsg(time.Now()))
+	if model.detailInFlight {
+		t.Fatal("settled current delete entered a refresh loop")
 	}
 }
 

--- a/internal/controllers/environment_resources_test.go
+++ b/internal/controllers/environment_resources_test.go
@@ -112,9 +112,39 @@ func TestRepositoryCloneCredentialRecoversBoundProvisioningLease(t *testing.T) {
 		t.Fatalf("recovered lease = %#v, %v", lease, err)
 	}
 	repositorycredential.ClearLease(lease)
-	delete(env.Annotations, repositoryProvisioningAnnotation)
-	if _, err := r.repositoryCloneCredential(context.Background(), env); !stderrors.Is(err, errRepositoryCredentialPending) {
-		t.Fatalf("bound lease without provisioning record error = %v", err)
+	for _, tc := range []struct {
+		name       string
+		annotation string
+	}{
+		{name: "missing provisioning record"},
+		{name: "revocation state present", annotation: repositorycredential.AnnotationRevocationState},
+		{name: "revocation disposition present", annotation: repositorycredential.AnnotationRevocationDisposition},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var currentSecret corev1.Secret
+			if err := c.Get(context.Background(), client.ObjectKeyFromObject(secret), &currentSecret); err != nil {
+				t.Fatal(err)
+			}
+			if tc.annotation != "" {
+				currentSecret.Annotations[tc.annotation] = ""
+				if err := c.Update(context.Background(), &currentSecret); err != nil {
+					t.Fatal(err)
+				}
+			}
+			currentEnv := env.DeepCopy()
+			if tc.annotation == "" {
+				delete(currentEnv.Annotations, repositoryProvisioningAnnotation)
+			}
+			if _, err := r.repositoryCloneCredential(context.Background(), currentEnv); err == nil || tc.annotation == "" && !stderrors.Is(err, errRepositoryCredentialPending) {
+				t.Fatalf("repositoryCloneCredential error = %v", err)
+			}
+			if tc.annotation != "" {
+				delete(currentSecret.Annotations, tc.annotation)
+				if err := c.Update(context.Background(), &currentSecret); err != nil {
+					t.Fatal(err)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/controllers/run_controller.go
+++ b/internal/controllers/run_controller.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -79,6 +80,22 @@ func repositoryRotation(run *platformv1alpha1.Run) (*repositoryRotationRecord, e
 	return parseRepositoryRotationRecord(run.Annotations[repositoryRefreshAnnotation])
 }
 
+func validateActiveRepositoryRotation(run *platformv1alpha1.Run, secretUID types.UID, tokenGeneration int64) error {
+	if run.Annotations[repositoryRefreshAnnotation] == "" {
+		return nil
+	}
+	record, err := repositoryRotation(run)
+	if err != nil {
+		return errors.New("repository credential cleanup blocked: rotation record is malformed")
+	}
+	old := secretUID == record.OldSecretUID && tokenGeneration+1 == record.TargetGeneration
+	replacement := secretUID != record.OldSecretUID && tokenGeneration == record.TargetGeneration
+	if !old && !replacement {
+		return errors.New("repository credential cleanup blocked: active Secret does not match rotation generation")
+	}
+	return nil
+}
+
 func (r *RunReconciler) persistRepositoryRotation(ctx context.Context, run *platformv1alpha1.Run, lease *repositorycredential.Lease, wake bool) error {
 	if lease.SecretUID == "" {
 		return errors.New("repository credential Secret has no UID")
@@ -100,15 +117,16 @@ func (r *RunReconciler) persistRepositoryRotation(ctx context.Context, run *plat
 // and declared-service processes inside the Environment.
 type RunReconciler struct {
 	client.Client
-	APIReader             client.Reader
-	Scheme                *runtime.Scheme
-	Scope                 *tenancy.ReconcileScope
-	Adapters              map[string]agent.AdapterLifecycle
-	EventSink             agent.AdapterEventSink
-	Connector             sandboxclient.Connector
-	Metrics               *OperatorMetrics
-	RepositoryCredentials repositorycredential.Provider
-	Now                   func() time.Time
+	APIReader               client.Reader
+	Scheme                  *runtime.Scheme
+	Scope                   *tenancy.ReconcileScope
+	Adapters                map[string]agent.AdapterLifecycle
+	EventSink               agent.AdapterEventSink
+	Connector               sandboxclient.Connector
+	Metrics                 *OperatorMetrics
+	RepositoryCredentials   repositorycredential.Provider
+	RepositoryCanonicalizer repositorycredential.Canonicalizer
+	Now                     func() time.Time
 }
 
 func (r *RunReconciler) now() time.Time {
@@ -153,6 +171,11 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		}
 	}
 
+	if normalized, err := r.normalizeAdapterStatusCondition(ctx, &run); err != nil {
+		return ctrl.Result{}, err
+	} else if normalized {
+		return ctrl.Result{Requeue: true}, nil
+	}
 	if !run.DeletionTimestamp.IsZero() {
 		return r.finalize(ctx, &run)
 	}
@@ -394,7 +417,7 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 				clear(value)
 			}
 		}()
-		acceptErr := adapter.EnsureAccepted(ctx, adapterTask(&run), r.adapterSandbox(&run, env, executionFence, fenceRejections), &agent.AdapterLaunchMaterial{AgentCredential: credential, RepositorySecretEnv: repositoryEnv})
+		acceptErr := adapter.EnsureAccepted(ctx, adapterTask(&run), r.adapterAcceptanceSandbox(&run, env, executionFence, fenceRejections), &agent.AdapterLaunchMaterial{AgentCredential: credential, RepositorySecretEnv: repositoryEnv})
 		r.Metrics.observeAdapter(run.Spec.Agent, adapterOperationEnsureAccepted, started, acceptErr)
 		current, err = r.allocatedExecutionCurrent(ctx, &run, env, execution, fenceRejections)
 		if err != nil {
@@ -405,7 +428,7 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		}
 		if acceptErr != nil {
 			if errors.Is(acceptErr, agent.ErrAdapterTaskRejected) {
-				return ctrl.Result{}, r.setRunState(ctx, &run, platformv1alpha1.RunStateFailed, "AdapterRejected", acceptErr.Error(), true)
+				return ctrl.Result{}, r.setRunState(ctx, &run, platformv1alpha1.RunStateFailed, "AdapterRejected", "adapter rejected the task", true)
 			}
 			return ctrl.Result{}, acceptErr
 		}
@@ -426,7 +449,7 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	}
 	executionFence := lifecycle.CaptureExecutionFence(env)
 	started := time.Now()
-	observation, message, err := adapter.Observe(ctx, adapterTask(&run), r.adapterSandbox(&run, env, executionFence, fenceRejections))
+	observation, _, err := adapter.Observe(ctx, adapterTask(&run), r.adapterSandbox(&run, env, executionFence, fenceRejections))
 	metricErr := err
 	if metricErr == nil {
 		switch observation {
@@ -460,7 +483,7 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	default:
 		return ctrl.Result{}, metricErr
 	}
-	err = r.setRunState(ctx, &run, state, string(observation), message, true)
+	err = r.setRunState(ctx, &run, state, string(observation), observation.StatusMessage(), true)
 	if err != nil || terminalRunState(state) {
 		return ctrl.Result{}, err
 	}
@@ -638,25 +661,46 @@ func (r *RunReconciler) repositoryForRun(ctx context.Context, run *platformv1alp
 	if run.Status.EnvironmentRef == nil {
 		return "", fmt.Errorf("%w: run has no frozen environment association", errRepositoryCredentialInvalid)
 	}
-	var env platformv1alpha1.Environment
-	if err := r.apiReader().Get(ctx, types.NamespacedName{Namespace: run.Namespace, Name: run.Status.EnvironmentRef.Name}, &env); err != nil {
+	env, err := getAllocatedEnvironment(ctx, r.apiReader(), run)
+	if err != nil {
+		if errors.Is(err, errAllocatedEnvironmentGone) {
+			return "", fmt.Errorf("%w: environment association is malformed: %v", errRepositoryCredentialInvalid, err)
+		}
 		return "", err
 	}
-	if env.UID != run.Status.EnvironmentRef.UID || !env.DeletionTimestamp.IsZero() {
-		return "", fmt.Errorf("%w: environment repository association is malformed", errRepositoryCredentialInvalid)
+	if !env.DeletionTimestamp.IsZero() {
+		return "", fmt.Errorf("%w: environment is deleting", errRepositoryCredentialInvalid)
 	}
-	if env.Status.Provisioning == nil || env.Status.Provisioning.Project == nil || platformv1alpha1.ValidateEnvironmentProvisioningSnapshot(&env, env.Status.Provisioning) != nil || !env.Status.Provisioning.ProjectVerified {
+	if env.Status.Provisioning == nil || env.Status.Provisioning.Project == nil || platformv1alpha1.ValidateEnvironmentProvisioningSnapshot(env, env.Status.Provisioning) != nil || !env.Status.Provisioning.ProjectVerified {
 		return "", errRepositoryCredentialPending
 	}
-	p := env.Status.Provisioning.Project
+	projectRef := env.Status.Provisioning.Project
 	var project platformv1alpha1.Project
-	if err := r.apiReader().Get(ctx, types.NamespacedName{Namespace: run.Namespace, Name: p.Name}, &project); err != nil {
+	if err := r.apiReader().Get(ctx, types.NamespacedName{Namespace: run.Namespace, Name: projectRef.Name}, &project); err != nil {
 		return "", err
 	}
-	if project.UID != p.UID || !project.DeletionTimestamp.IsZero() {
+	if project.UID != projectRef.UID || !project.DeletionTimestamp.IsZero() {
 		return "", fmt.Errorf("%w: environment project association was replaced", errRepositoryCredentialInvalid)
 	}
-	return p.Repository, nil
+	return projectRef.Repository, nil
+}
+
+func (r *RunReconciler) frozenRepositoryForRun(ctx context.Context, run *platformv1alpha1.Run) (string, *platformv1alpha1.EnvironmentProvisioningProject, error) {
+	if run.Status.EnvironmentRef == nil {
+		return "", nil, fmt.Errorf("%w: run has no frozen environment association", errRepositoryCredentialInvalid)
+	}
+	var env platformv1alpha1.Environment
+	if err := r.apiReader().Get(ctx, types.NamespacedName{Namespace: run.Namespace, Name: run.Status.EnvironmentRef.Name}, &env); err != nil {
+		return "", nil, err
+	}
+	if env.UID != run.Status.EnvironmentRef.UID || !env.DeletionTimestamp.IsZero() {
+		return "", nil, fmt.Errorf("%w: environment repository association is malformed", errRepositoryCredentialInvalid)
+	}
+	if env.Status.Provisioning == nil || env.Status.Provisioning.Project == nil || platformv1alpha1.ValidateEnvironmentProvisioningSnapshot(&env, env.Status.Provisioning) != nil || !env.Status.Provisioning.ProjectVerified {
+		return "", nil, errRepositoryCredentialPending
+	}
+	p := env.Status.Provisioning.Project
+	return p.Repository, p, nil
 }
 
 func (r *RunReconciler) readRepositoryLease(ctx context.Context, run *platformv1alpha1.Run) (*repositorycredential.Lease, error) {
@@ -680,7 +724,7 @@ func (r *RunReconciler) readRepositoryLease(ctx context.Context, run *platformv1
 	return repositorycredential.Parse(&secret, run.Name, run.UID)
 }
 
-func (r *RunReconciler) readPendingRepositoryRevocation(ctx context.Context, run *platformv1alpha1.Run) (*repositorycredential.Lease, error) {
+func (r *RunReconciler) readPendingRepositoryRevocation(ctx context.Context, run *platformv1alpha1.Run) (*repositorycredential.PendingRevocation, error) {
 	key := types.NamespacedName{Namespace: run.Namespace, Name: repositorycredential.PendingRevocationSecretName(run.UID)}
 	var secret corev1.Secret
 	if err := r.apiReader().Get(ctx, key, &secret); err != nil {
@@ -694,8 +738,8 @@ func (r *RunReconciler) readPendingRepositoryRevocation(ctx context.Context, run
 	return repositorycredential.ParsePendingRevocation(&secret, run.Name, run.UID)
 }
 
-func (r *RunReconciler) persistPendingRepositoryRevocation(ctx context.Context, run *platformv1alpha1.Run, source string, credential *repositorycredential.Credential, generation int64) error {
-	secret, err := repositorycredential.NewPendingRevocationSecret(run.Namespace, run.Name, run.UID, string(run.Spec.RepositoryCredential), source, credential, generation, r.now())
+func (r *RunReconciler) persistPendingRepositoryRevocation(ctx context.Context, run *platformv1alpha1.Run, source string, credential *repositorycredential.Credential, generation int64, disposition string) error {
+	secret, err := repositorycredential.NewPendingRevocationSecret(run.Namespace, run.Name, run.UID, string(run.Spec.RepositoryCredential), source, credential, generation, r.now(), disposition)
 	if err != nil {
 		return err
 	}
@@ -708,12 +752,123 @@ func (r *RunReconciler) persistPendingRepositoryRevocation(ctx context.Context, 
 	}
 	exact := persisted.Provider == string(run.Spec.RepositoryCredential) && persisted.SourceRepository == source &&
 		persisted.Repository == credential.Repository && persisted.InstallationID == credential.InstallationID &&
-		persisted.ExpiresAt.Equal(credential.ExpiresAt) && persisted.TokenGeneration == generation && bytes.Equal(persisted.Token, credential.Token)
-	repositorycredential.ClearLease(persisted)
+		persisted.ExpiresAt.Equal(credential.ExpiresAt) && persisted.TokenGeneration == generation && bytes.Equal(persisted.Token, credential.Token) &&
+		persisted.State == repositorycredential.RevocationStatePending && persisted.Disposition == disposition && !persisted.Legacy
+	repositorycredential.ClearPendingRevocation(persisted)
 	if !exact {
 		return err
 	}
 	return nil
+}
+
+func (r *RunReconciler) validatePendingRepositoryIdentity(ctx context.Context, run *platformv1alpha1.Run, pending *repositorycredential.PendingRevocation) error {
+	if pending.Provider != string(run.Spec.RepositoryCredential) {
+		return errors.New("pending repository credential cleanup blocked: provider identity does not match")
+	}
+	source, _, err := r.frozenRepositoryForRun(ctx, run)
+	if err != nil || source != pending.SourceRepository {
+		return errors.New("pending repository credential cleanup blocked: frozen provisioning source cannot be proven")
+	}
+	canonicalizer := r.repositoryCanonicalizer()
+	if canonicalizer == nil {
+		return errors.New("pending repository credential cleanup blocked: canonical repository identity cannot be proven")
+	}
+	canonical, err := canonicalizer.CanonicalRepository(source)
+	if err != nil || canonical != pending.Repository {
+		return errors.New("pending repository credential cleanup blocked: canonical repository identity does not match")
+	}
+	expected := int64(1)
+	if run.Annotations[repositoryRefreshAnnotation] != "" {
+		if record, recordErr := repositoryRotation(run); recordErr == nil {
+			expected = record.TargetGeneration
+		} else {
+			return errors.New("pending repository credential cleanup blocked: issuance generation cannot be proven")
+		}
+	}
+	if pending.TokenGeneration != expected {
+		return errors.New("pending repository credential cleanup blocked: issuance generation does not match")
+	}
+	return nil
+}
+
+func (r *RunReconciler) repositoryCanonicalizer() repositorycredential.Canonicalizer {
+	if r.RepositoryCanonicalizer != nil {
+		return r.RepositoryCanonicalizer
+	}
+	return r.RepositoryCredentials
+}
+
+func (r *RunReconciler) validateActiveRepositoryIdentity(ctx context.Context, run *platformv1alpha1.Run, lease *repositorycredential.Lease) error {
+	if lease.Provider != string(run.Spec.RepositoryCredential) {
+		return errors.New("repository credential cleanup blocked: provider identity does not match")
+	}
+	source, _, err := r.frozenRepositoryForRun(ctx, run)
+	if err != nil || source != lease.SourceRepository {
+		return errors.New("repository credential cleanup blocked: frozen provisioning source cannot be proven")
+	}
+	canonicalizer := r.repositoryCanonicalizer()
+	if canonicalizer == nil {
+		return errors.New("repository credential cleanup blocked: canonical repository identity cannot be proven")
+	}
+	canonical, err := canonicalizer.CanonicalRepository(source)
+	if err != nil || canonical != lease.Repository {
+		return errors.New("repository credential cleanup blocked: canonical repository identity does not match")
+	}
+	return nil
+}
+
+func (r *RunReconciler) blockPendingRepositoryCleanup(ctx context.Context, run *platformv1alpha1.Run, message string) (bool, ctrl.Result, error) {
+	if repositoryCredentialDispositionDurable(run, repositorycredential.DispositionProviderInvalidToken) {
+		return false, ctrl.Result{RequeueAfter: repositorycredential.DefaultRetryDelay}, nil
+	}
+	if err := r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionFalse, "ForeignPendingSecret", message); err != nil {
+		return false, ctrl.Result{}, err
+	}
+	return false, ctrl.Result{RequeueAfter: repositorycredential.DefaultRetryDelay}, nil
+}
+
+func samePendingLease(a, b *repositorycredential.PendingRevocation) bool {
+	return a.SecretUID == b.SecretUID && a.RunName == b.RunName && a.RunUID == b.RunUID && a.Provider == b.Provider &&
+		a.SourceRepository == b.SourceRepository && a.Repository == b.Repository && a.InstallationID == b.InstallationID &&
+		a.ExpiresAt.Equal(b.ExpiresAt) && a.TokenGeneration == b.TokenGeneration && a.Disposition == b.Disposition && bytes.Equal(a.Token, b.Token)
+}
+
+func repositoryCredentialDispositionDurable(run *platformv1alpha1.Run, disposition string) bool {
+	condition := apiMeta.FindStatusCondition(run.Status.Conditions, runConditionRepositoryCredentialReady)
+	return run.Status.State == platformv1alpha1.RunStateFailed && run.Status.ObservedGeneration == run.Generation &&
+		condition != nil && condition.Status == metav1.ConditionFalse && condition.Reason == disposition && condition.ObservedGeneration == run.Generation
+}
+
+func (r *RunReconciler) completePendingRepositoryRevocation(ctx context.Context, run *platformv1alpha1.Run, pending *repositorycredential.PendingRevocation) error {
+	key := types.NamespacedName{Namespace: run.Namespace, Name: repositorycredential.PendingRevocationSecretName(run.UID)}
+	var secret corev1.Secret
+	if err := r.apiReader().Get(ctx, key, &secret); err != nil {
+		return err
+	}
+	current, err := repositorycredential.ParsePendingRevocation(&secret, run.Name, run.UID)
+	if err != nil {
+		return err
+	}
+	defer repositorycredential.ClearPendingRevocation(current)
+	if current.ResourceVersion != pending.ResourceVersion || !samePendingLease(current, pending) || current.State != repositorycredential.RevocationStatePending || current.Legacy {
+		return errors.New("pending repository credential changed before completion")
+	}
+	secret.Annotations[repositorycredential.AnnotationRevocationState] = repositorycredential.RevocationStateComplete
+	if _, ok := secret.Annotations[repositorycredential.AnnotationRevocationDisposition]; !ok {
+		secret.Annotations[repositorycredential.AnnotationRevocationDisposition] = ""
+	}
+	if err = r.Update(ctx, &secret); err == nil {
+		return nil
+	}
+	// Update responses can be lost. Accept only the same immutable WAL record.
+	completed, readErr := r.readPendingRepositoryRevocation(ctx, run)
+	if readErr == nil {
+		defer repositorycredential.ClearPendingRevocation(completed)
+		if completed.State == repositorycredential.RevocationStateComplete && completed.Disposition == pending.Disposition && samePendingLease(completed, pending) {
+			return nil
+		}
+	}
+	return err
 }
 
 func (r *RunReconciler) cleanupPendingRepositoryRevocation(ctx context.Context, run *platformv1alpha1.Run) (bool, ctrl.Result, error) {
@@ -722,11 +877,80 @@ func (r *RunReconciler) cleanupPendingRepositoryRevocation(ctx context.Context, 
 		return true, ctrl.Result{}, nil
 	}
 	if err != nil {
-		return false, ctrl.Result{}, err
+		return r.blockPendingRepositoryCleanup(ctx, run, "pending repository credential cleanup blocked: Secret is foreign or malformed")
 	}
-	defer repositorycredential.ClearLease(pending)
-	if r.RepositoryCredentials == nil && r.now().Before(pending.ExpiresAt) {
-		return false, ctrl.Result{RequeueAfter: repositorycredential.DefaultRetryDelay}, r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionFalse, "RevocationPending", "repository credential revocation is pending")
+	defer repositorycredential.ClearPendingRevocation(pending)
+	if err := r.validatePendingRepositoryIdentity(ctx, run, pending); err != nil {
+		return r.blockPendingRepositoryCleanup(ctx, run, err.Error())
+	}
+	if pending.SecretUID == "" || pending.ResourceVersion == "" {
+		return r.blockPendingRepositoryCleanup(ctx, run, "pending repository credential cleanup blocked: exact Secret identity cannot be proven")
+	}
+	if pending.Legacy {
+		key := types.NamespacedName{Namespace: run.Namespace, Name: repositorycredential.PendingRevocationSecretName(run.UID)}
+		var secret corev1.Secret
+		if err := r.apiReader().Get(ctx, key, &secret); err != nil || secret.UID != pending.SecretUID || secret.ResourceVersion != pending.ResourceVersion {
+			return r.blockPendingRepositoryCleanup(ctx, run, "legacy pending repository credential changed before migration")
+		}
+		secret.Annotations[repositorycredential.AnnotationRevocationState] = repositorycredential.RevocationStatePending
+		secret.Annotations[repositorycredential.AnnotationRevocationDisposition] = ""
+		if err := r.Update(ctx, &secret); err != nil {
+			return false, ctrl.Result{}, err
+		}
+		return false, ctrl.Result{Requeue: true}, nil
+	}
+	if pending.State == repositorycredential.RevocationStateComplete {
+		if pending.Disposition == repositorycredential.DispositionProviderInvalidToken {
+			if !repositoryCredentialDispositionDurable(run, pending.Disposition) {
+				return false, ctrl.Result{Requeue: true}, r.failRepositoryCredential(ctx, run, repositorycredential.DispositionProviderInvalidToken)
+			}
+			var durable platformv1alpha1.Run
+			if err := r.apiReader().Get(ctx, client.ObjectKeyFromObject(run), &durable); err != nil {
+				return false, ctrl.Result{}, err
+			}
+			if durable.UID != run.UID || !repositoryCredentialDispositionDurable(&durable, pending.Disposition) {
+				return false, ctrl.Result{Requeue: true}, nil
+			}
+		}
+		active, activeErr := r.readRepositoryLease(ctx, run)
+		if activeErr == nil {
+			sameToken := active.Provider == pending.Provider && active.SourceRepository == pending.SourceRepository &&
+				active.Repository == pending.Repository && active.InstallationID == pending.InstallationID &&
+				active.ExpiresAt.Equal(pending.ExpiresAt) && active.TokenGeneration == pending.TokenGeneration && bytes.Equal(active.Token, pending.Token)
+			uid, rv := active.SecretUID, active.ResourceVersion
+			repositorycredential.ClearLease(active)
+			if !sameToken || uid == "" || rv == "" {
+				return r.blockPendingRepositoryCleanup(ctx, run, "pending repository credential cleanup blocked: active Secret does not match completed revocation")
+			}
+			deleteErr := r.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: run.Namespace, Name: repositorycredential.SecretName(run.UID), UID: uid, ResourceVersion: rv}}, &client.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid, ResourceVersion: &rv}})
+			if deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
+				var check corev1.Secret
+				if readErr := r.apiReader().Get(ctx, types.NamespacedName{Namespace: run.Namespace, Name: repositorycredential.SecretName(run.UID)}, &check); !apierrors.IsNotFound(readErr) {
+					return false, ctrl.Result{}, deleteErr
+				}
+			}
+			return false, ctrl.Result{Requeue: true}, nil
+		}
+		if !apierrors.IsNotFound(activeErr) {
+			return r.blockPendingRepositoryCleanup(ctx, run, "pending repository credential cleanup blocked: active Secret is foreign or malformed")
+		}
+		uid, rv := pending.SecretUID, pending.ResourceVersion
+		deleteErr := r.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: run.Namespace, Name: repositorycredential.PendingRevocationSecretName(run.UID), UID: uid, ResourceVersion: rv}}, &client.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid, ResourceVersion: &rv}})
+		if deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
+			// A lost delete response is safe only if the exact name is absent.
+			var check corev1.Secret
+			if readErr := r.apiReader().Get(ctx, types.NamespacedName{Namespace: run.Namespace, Name: repositorycredential.PendingRevocationSecretName(run.UID)}, &check); !apierrors.IsNotFound(readErr) {
+				return false, ctrl.Result{}, deleteErr
+			}
+		}
+		return false, ctrl.Result{Requeue: true}, nil
+	}
+	if r.RepositoryCredentials == nil {
+		now := r.now()
+		if now.Before(pending.ExpiresAt) {
+			delay := min(repositorycredential.DefaultRetryDelay, pending.ExpiresAt.Sub(now))
+			return false, ctrl.Result{RequeueAfter: delay}, r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionFalse, "RevocationPending", "repository credential revocation is pending")
+		}
 	}
 	if r.RepositoryCredentials != nil {
 		if revokeErr := r.RepositoryCredentials.Revoke(ctx, &pending.Credential); revokeErr != nil && r.now().Before(pending.ExpiresAt) {
@@ -736,22 +960,8 @@ func (r *RunReconciler) cleanupPendingRepositoryRevocation(ctx context.Context, 
 			return false, ctrl.Result{RequeueAfter: repositorycredential.RetryDelay(revokeErr)}, nil
 		}
 	}
-	active, activeErr := r.readRepositoryLease(ctx, run)
-	if activeErr == nil {
-		sameToken := active.Provider == pending.Provider && active.SourceRepository == pending.SourceRepository &&
-			active.Repository == pending.Repository && active.InstallationID == pending.InstallationID && active.ExpiresAt.Equal(pending.ExpiresAt) &&
-			active.TokenGeneration == pending.TokenGeneration && bytes.Equal(active.Token, pending.Token)
-		uid := active.SecretUID
-		repositorycredential.ClearLease(active)
-		if sameToken {
-			if deleteErr := r.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: run.Namespace, Name: repositorycredential.SecretName(run.UID), UID: uid}}, &client.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid}}); deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
-				return false, ctrl.Result{}, deleteErr
-			}
-		}
-	}
-	uid := pending.SecretUID
-	if deleteErr := r.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: run.Namespace, Name: repositorycredential.PendingRevocationSecretName(run.UID), UID: uid}}, &client.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid}}); deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
-		return false, ctrl.Result{}, deleteErr
+	if err := r.completePendingRepositoryRevocation(ctx, run, pending); err != nil {
+		return false, ctrl.Result{}, err
 	}
 	return false, ctrl.Result{Requeue: true}, nil
 }
@@ -854,8 +1064,18 @@ func (r *RunReconciler) ensureRepositoryCredential(ctx context.Context, run *pla
 			if revokeErr := r.RepositoryCredentials.Revoke(ctx, &lease.Credential); revokeErr != nil && r.now().Before(lease.ExpiresAt) {
 				return ctrl.Result{RequeueAfter: repositorycredential.RetryDelay(revokeErr)}, true, nil
 			}
-			uid := lease.SecretUID
-			if deleteErr := r.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: run.Namespace, Name: repositorycredential.SecretName(run.UID), UID: uid}}, &client.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid}}); deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
+			uid, rv := lease.SecretUID, lease.ResourceVersion
+			if uid == "" || rv == "" {
+				return ctrl.Result{}, true, errors.New("repository credential rotation exact Secret identity unavailable")
+			}
+			var current corev1.Secret
+			if readErr := r.apiReader().Get(ctx, types.NamespacedName{Namespace: run.Namespace, Name: repositorycredential.SecretName(run.UID)}, &current); readErr != nil {
+				return ctrl.Result{}, true, readErr
+			}
+			if current.UID != uid || current.ResourceVersion != rv {
+				return ctrl.Result{}, true, errors.New("repository credential secret changed during rotation")
+			}
+			if deleteErr := r.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: run.Namespace, Name: repositorycredential.SecretName(run.UID), UID: uid, ResourceVersion: rv}}, &client.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid, ResourceVersion: &rv}}); deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
 				return ctrl.Result{}, true, deleteErr
 			}
 			return ctrl.Result{Requeue: true}, true, r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionFalse, "Issuing", "repository credential lease is being issued")
@@ -916,6 +1136,25 @@ func (r *RunReconciler) ensureRepositoryCredential(ctx context.Context, run *pla
 	credential, issueErr := r.RepositoryCredentials.Issue(ctx, canonicalRepository)
 	if issueErr != nil {
 		reason := repositorycredential.Reason(issueErr)
+		if credential != nil && reason == repositorycredential.DispositionProviderInvalidToken {
+			defer clear(credential.Token)
+			generation := int64(1)
+			if rotation != nil {
+				generation = rotation.TargetGeneration
+			}
+			if err := r.persistPendingRepositoryRevocation(ctx, run, repository, credential, generation, repositorycredential.DispositionProviderInvalidToken); err != nil {
+				// The provider handle was returned but could not be made durable.
+				// Best-effort immediate revoke bounds this residual by token expiry.
+				_ = r.RepositoryCredentials.Revoke(ctx, credential)
+				return ctrl.Result{}, true, r.failRepositoryCredential(ctx, run, "SecretPersistenceFailed")
+			}
+			return ctrl.Result{Requeue: true}, true, nil
+		}
+		if credential == nil && reason == repositorycredential.DispositionProviderInvalidToken {
+			// ProviderInvalidToken is a WAL disposition, not authority to fail a
+			// Run when no cleanup-capable handle was returned.
+			reason = "ProviderInvalidResponse"
+		}
 		if repositorycredential.IsRetryable(issueErr) {
 			if err := r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionFalse, reason, "repository credential provider is temporarily unavailable"); err != nil {
 				return ctrl.Result{}, true, err
@@ -949,15 +1188,11 @@ func (r *RunReconciler) ensureRepositoryCredential(ctx context.Context, run *pla
 	}
 	if createErr != nil {
 		if credential != nil {
-			if revokeErr := r.RepositoryCredentials.Revoke(ctx, credential); revokeErr != nil {
-				if pendingErr := r.persistPendingRepositoryRevocation(ctx, run, repository, credential, generation); pendingErr != nil {
-					return ctrl.Result{}, true, r.failRepositoryCredential(ctx, run, "SecretPersistenceFailed")
-				}
-				if statusErr := r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionFalse, "RevocationPending", "repository credential revocation is pending"); statusErr != nil {
-					return ctrl.Result{}, true, statusErr
-				}
-				return ctrl.Result{RequeueAfter: repositorycredential.RetryDelay(revokeErr)}, true, nil
+			if pendingErr := r.persistPendingRepositoryRevocation(ctx, run, repository, credential, generation, ""); pendingErr != nil {
+				_ = r.RepositoryCredentials.Revoke(ctx, credential)
+				return ctrl.Result{}, true, r.failRepositoryCredential(ctx, run, "SecretPersistenceFailed")
 			}
+			return ctrl.Result{Requeue: true}, true, nil
 		}
 		if apierrors.IsAlreadyExists(createErr) {
 			return ctrl.Result{}, true, r.failRepositoryCredential(ctx, run, "SecretChanged")
@@ -1155,6 +1390,8 @@ func (r *RunReconciler) recoverEnvironmentReference(ctx context.Context, run *pl
 				if !current {
 					continue
 				}
+			} else if metav1.GetControllerOf(env) != nil {
+				continue
 			}
 			return &platformv1alpha1.RunEnvironmentReference{Name: env.Name, UID: env.UID, Ownership: platformv1alpha1.EnvironmentOwnershipClaimed}, nil
 		}
@@ -1607,7 +1844,9 @@ func (r *RunReconciler) cleanupRepositoryCredential(ctx context.Context, run *pl
 				return false, ctrl.Result{}, updateErr
 			}
 		}
-		_ = r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionTrue, "Revoked", "repository credential lifecycle is complete")
+		if !repositoryCredentialDispositionDurable(run, repositorycredential.DispositionProviderInvalidToken) {
+			_ = r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionTrue, "Revoked", "repository credential lifecycle is complete")
+		}
 		return true, ctrl.Result{}, nil
 	}
 	if err != nil {
@@ -1617,20 +1856,17 @@ func (r *RunReconciler) cleanupRepositoryCredential(ctx context.Context, run *pl
 		if getErr := r.apiReader().Get(ctx, key, &secret); getErr != nil {
 			return false, ctrl.Result{}, getErr
 		}
-		source, identityErr := r.repositoryForRun(ctx, run)
+		source, _, identityErr := r.frozenRepositoryForRun(ctx, run)
 		if identityErr != nil {
-			if !apierrors.IsNotFound(identityErr) {
-				return false, ctrl.Result{}, fmt.Errorf("repository credential cleanup identity unavailable: %w", identityErr)
-			}
-			source = secret.Annotations[repositorycredential.AnnotationSourceRepository]
+			return false, ctrl.Result{}, fmt.Errorf("repository credential cleanup identity unavailable: %w", identityErr)
 		}
-		canonical := secret.Annotations[repositorycredential.AnnotationRepository]
-		if r.RepositoryCredentials != nil {
-			var canonicalErr error
-			canonical, canonicalErr = r.RepositoryCredentials.CanonicalRepository(source)
-			if canonicalErr != nil {
-				return false, ctrl.Result{}, fmt.Errorf("repository credential cleanup canonical identity unavailable: %w", canonicalErr)
-			}
+		canonicalizer := r.repositoryCanonicalizer()
+		if canonicalizer == nil {
+			return false, ctrl.Result{}, errors.New("repository credential cleanup canonical identity unavailable")
+		}
+		canonical, canonicalErr := canonicalizer.CanonicalRepository(source)
+		if canonicalErr != nil {
+			return false, ctrl.Result{}, fmt.Errorf("repository credential cleanup canonical identity unavailable: %w", canonicalErr)
 		}
 		expires, parseErr := time.Parse(time.RFC3339Nano, secret.Annotations[repositorycredential.AnnotationExpiry])
 		if !repositorycredential.ExactManagedIdentity(&secret, run.Name, run.UID, string(run.Spec.RepositoryCredential), source, canonical) {
@@ -1639,13 +1875,32 @@ func (r *RunReconciler) cleanupRepositoryCredential(ctx context.Context, run *pl
 		if parseErr != nil || r.now().Before(expires) {
 			return false, ctrl.Result{}, err
 		}
-		uid := secret.UID
-		if deleteErr := r.Delete(ctx, &secret, &client.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid}}); deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
+		uid, rv := secret.UID, secret.ResourceVersion
+		if uid == "" || rv == "" {
+			return false, ctrl.Result{}, errors.New("repository credential cleanup exact Secret identity unavailable")
+		}
+		generation, generationErr := strconv.ParseInt(secret.Annotations[repositorycredential.AnnotationTokenGeneration], 10, 64)
+		if generationErr != nil || generation < 1 {
+			return false, ctrl.Result{}, errors.New("repository credential cleanup token generation unavailable")
+		}
+		if rotationErr := validateActiveRepositoryRotation(run, uid, generation); rotationErr != nil {
+			return false, ctrl.Result{}, rotationErr
+		}
+		if deleteErr := r.Delete(ctx, &secret, &client.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid, ResourceVersion: &rv}}); deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
 			return false, ctrl.Result{}, deleteErr
 		}
 		return true, ctrl.Result{}, nil
 	}
 	defer repositorycredential.ClearLease(lease)
+	if identityErr := r.validateActiveRepositoryIdentity(ctx, run, lease); identityErr != nil {
+		return false, ctrl.Result{}, identityErr
+	}
+	if lease.SecretUID == "" || lease.ResourceVersion == "" {
+		return false, ctrl.Result{}, errors.New("repository credential cleanup exact Secret identity unavailable")
+	}
+	if rotationErr := validateActiveRepositoryRotation(run, lease.SecretUID, lease.TokenGeneration); rotationErr != nil {
+		return false, ctrl.Result{}, rotationErr
+	}
 	if r.RepositoryCredentials == nil && r.now().Before(lease.ExpiresAt) {
 		_ = r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionFalse, "RevocationPending", "repository credential revocation is pending")
 		return false, ctrl.Result{RequeueAfter: repositorycredential.DefaultRetryDelay}, nil
@@ -1656,9 +1911,9 @@ func (r *RunReconciler) cleanupRepositoryCredential(ctx context.Context, run *pl
 			return false, ctrl.Result{RequeueAfter: repositorycredential.RetryDelay(revokeErr)}, nil
 		}
 	}
-	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: run.Namespace, Name: repositorycredential.SecretName(run.UID), UID: lease.SecretUID}}
-	uid := lease.SecretUID
-	if err := r.Delete(ctx, secret, &client.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid}}); err != nil && !apierrors.IsNotFound(err) {
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: run.Namespace, Name: repositorycredential.SecretName(run.UID), UID: lease.SecretUID, ResourceVersion: lease.ResourceVersion}}
+	uid, rv := lease.SecretUID, lease.ResourceVersion
+	if err := r.Delete(ctx, secret, &client.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid, ResourceVersion: &rv}}); err != nil && !apierrors.IsNotFound(err) {
 		return false, ctrl.Result{}, err
 	}
 	if run.Annotations[repositoryRefreshAnnotation] != "" {
@@ -1667,7 +1922,9 @@ func (r *RunReconciler) cleanupRepositoryCredential(ctx context.Context, run *pl
 			return false, ctrl.Result{}, err
 		}
 	}
-	_ = r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionTrue, "Revoked", "repository credential lifecycle is complete")
+	if !repositoryCredentialDispositionDurable(run, repositorycredential.DispositionProviderInvalidToken) {
+		_ = r.setRepositoryCredentialCondition(ctx, run, metav1.ConditionTrue, "Revoked", "repository credential lifecycle is complete")
+	}
 	return true, ctrl.Result{}, nil
 }
 
@@ -1706,6 +1963,27 @@ func (r *RunReconciler) setRunState(ctx context.Context, run *platformv1alpha1.R
 		return nil
 	}
 	return r.Status().Update(ctx, run)
+}
+
+func (r *RunReconciler) normalizeAdapterStatusCondition(ctx context.Context, run *platformv1alpha1.Run) (bool, error) {
+	condition := apiMeta.FindStatusCondition(run.Status.Conditions, runConditionAdapterAccepted)
+	if condition == nil {
+		return false, nil
+	}
+	var message string
+	switch condition.Reason {
+	case string(agent.AdapterObservationAccepted), string(agent.AdapterObservationRunning), string(agent.AdapterObservationNeedsInput), string(agent.AdapterObservationSucceeded), string(agent.AdapterObservationFailed):
+		message = agent.AdapterObservation(condition.Reason).StatusMessage()
+	case "AdapterRejected":
+		message = "adapter rejected the task"
+	default:
+		return false, nil
+	}
+	if condition.Message == message {
+		return false, nil
+	}
+	condition.Message = message
+	return true, r.Status().Update(ctx, run)
 }
 
 func (r *RunReconciler) setEnvironmentReadyCondition(ctx context.Context, run *platformv1alpha1.Run, ready bool, reason, message string) error {
@@ -1762,6 +2040,21 @@ func (r *RunReconciler) adapterSandbox(run *platformv1alpha1.Run, env *platformv
 		sandbox.EmitEvent = func(ctx context.Context, event agent.AdapterEvent) error {
 			return r.EventSink.Append(ctx, run.Namespace, run.Name, runUID, event)
 		}
+	}
+	return sandbox
+}
+
+func (r *RunReconciler) adapterAcceptanceSandbox(run *platformv1alpha1.Run, env *platformv1alpha1.Environment, fence lifecycle.ExecutionFence, fenceRejections *fenceRejectionRecorder) agent.AdapterSandbox {
+	sandbox := r.adapterSandbox(run, env, fence, fenceRejections)
+	dialProcess := sandbox.DialProcess
+	sandbox.DialProcess = func(ctx context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
+		// Acceptance can start a new process and deliver launch-only credentials.
+		// Revalidate at the process boundary so an active reconcile cannot start
+		// work after Project offboarding has revoked the active Namespace claim.
+		if _, err := r.Scope.Revalidate(ctx, run.Namespace, tenancy.LifecycleActive); err != nil {
+			return nil, nil, err
+		}
+		return dialProcess(ctx)
 	}
 	return sandbox
 }

--- a/internal/controllers/run_controller_test.go
+++ b/internal/controllers/run_controller_test.go
@@ -27,16 +27,19 @@ import (
 	"github.com/Chris-Cullins/swe-platform/internal/agent"
 	"github.com/Chris-Cullins/swe-platform/internal/lifecycle"
 	"github.com/Chris-Cullins/swe-platform/internal/repositorycredential"
+	"github.com/Chris-Cullins/swe-platform/internal/tenancy"
 )
 
 type fakeRepositoryCredentialProvider struct {
-	canonical string
-	issued    []string
-	revoked   [][]byte
-	issueErr  error
-	revokeErr error
-	now       time.Time
-	token     []byte
+	canonical       string
+	issued          []string
+	revoked         [][]byte
+	issueErr        error
+	revokeErr       error
+	onRevoke        func()
+	now             time.Time
+	token           []byte
+	issueCredential *repositorycredential.Credential
 }
 
 type lostRepositorySecretCreateClient struct {
@@ -77,15 +80,323 @@ func (f *fakeRepositoryCredentialProvider) CanonicalRepository(repository string
 func (f *fakeRepositoryCredentialProvider) Issue(_ context.Context, repository string) (*repositorycredential.Credential, error) {
 	f.issued = append(f.issued, repository)
 	if f.issueErr != nil {
-		return nil, f.issueErr
+		return f.issueCredential, f.issueErr
 	}
 	if f.token == nil {
 		f.token = []byte("fake-token")
 	}
 	return &repositorycredential.Credential{Token: f.token, Repository: f.canonical, InstallationID: 7, ExpiresAt: f.now.Add(time.Hour)}, nil
 }
+
+func TestRepositoryCredentialInvalidTokenWALDispositionIsDurable(t *testing.T) {
+	now := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "project-uid", Generation: 1}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/acme/repo"}}}
+	env, tmpl := frozenRepositoryEnvironment(project)
+	run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid", Generation: 1}, Spec: platformv1alpha1.RunSpec{ProjectRef: "p", RepositoryCredential: platformv1alpha1.RepositoryCredentialGitHubApp}, Status: platformv1alpha1.RunStatus{EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{Name: env.Name, UID: env.UID, Ownership: platformv1alpha1.EnvironmentOwnershipOwned}}}
+	issued := &repositorycredential.Credential{Token: []byte("rejected-token"), Repository: project.Spec.Repositories[0], InstallationID: 7, ExpiresAt: now.Add(time.Hour)}
+	provider := &fakeRepositoryCredentialProvider{canonical: issued.Repository, now: now, issueCredential: issued, issueErr: &repositorycredential.Error{Operation: "token", Reason: repositorycredential.DispositionProviderInvalidToken}}
+	r := reconciler(t, &scriptedAdapter{}, run, project, env, tmpl)
+	r.RepositoryCredentials, r.Now = provider, func() time.Time { return now }
+	key := client.ObjectKeyFromObject(run)
+	var current platformv1alpha1.Run
+	if err := r.Get(context.Background(), key, &current); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := r.ensureRepositoryCredential(context.Background(), &current); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Get(context.Background(), key, &current); err != nil {
+		t.Fatal(err)
+	}
+	lostPendingCreate := &lostRepositorySecretCreateClient{Client: r.Client}
+	r.Client = lostPendingCreate
+	if _, _, err := r.ensureRepositoryCredential(context.Background(), &current); err != nil {
+		t.Fatal(err)
+	}
+	if !lostPendingCreate.lost || len(provider.revoked) != 0 || current.Status.State == platformv1alpha1.RunStateFailed {
+		t.Fatalf("issuance recovery: lost=%t revoked=%d state=%s", lostPendingCreate.lost, len(provider.revoked), current.Status.State)
+	}
+	pendingKey := types.NamespacedName{Namespace: run.Namespace, Name: repositorycredential.PendingRevocationSecretName(run.UID)}
+	var pendingSecret corev1.Secret
+	if err := r.Get(context.Background(), pendingKey, &pendingSecret); err != nil {
+		t.Fatal(err)
+	}
+	pendingSecret.UID = "pending-secret-uid"
+	if err := r.Update(context.Background(), &pendingSecret); err != nil {
+		t.Fatal(err)
+	}
+	pending, err := repositorycredential.ParsePendingRevocation(&pendingSecret, run.Name, run.UID)
+	if err != nil || pending.State != repositorycredential.RevocationStatePending || pending.Disposition != repositorycredential.DispositionProviderInvalidToken {
+		t.Fatalf("pending WAL = %#v, %v", pending, err)
+	}
+	repositorycredential.ClearPendingRevocation(pending)
+	provider.issueErr, provider.issueCredential = nil, nil
+	if _, _, err := r.cleanupPendingRepositoryRevocation(context.Background(), &current); err != nil {
+		t.Fatal(err)
+	}
+	if len(provider.revoked) != 1 || string(provider.revoked[0]) != "rejected-token" {
+		t.Fatalf("revocations = %q", provider.revoked)
+	}
+	if err := r.Get(context.Background(), pendingKey, &pendingSecret); err != nil {
+		t.Fatal(err)
+	}
+	if pendingSecret.Annotations[repositorycredential.AnnotationRevocationState] != repositorycredential.RevocationStateComplete {
+		t.Fatalf("WAL state = %q", pendingSecret.Annotations[repositorycredential.AnnotationRevocationState])
+	}
+	// A restarted reconciler must apply the disposition without another provider call.
+	restarted := reconciler(t, &scriptedAdapter{}, &current, project, env, tmpl, &pendingSecret)
+	restarted.RepositoryCredentials, restarted.Now = provider, func() time.Time { return now }
+	if err := restarted.Get(context.Background(), key, &current); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := restarted.cleanupPendingRepositoryRevocation(context.Background(), &current); err != nil {
+		t.Fatal(err)
+	}
+	if len(provider.revoked) != 1 {
+		t.Fatalf("restart revoked again: %d", len(provider.revoked))
+	}
+	if err := restarted.Get(context.Background(), key, &current); err != nil {
+		t.Fatal(err)
+	}
+	if !repositoryCredentialDispositionDurable(&current, repositorycredential.DispositionProviderInvalidToken) {
+		t.Fatalf("disposition not durable: %#v", current.Status)
+	}
+	duplicateCredential := &repositorycredential.Credential{Token: []byte("rejected-token"), Repository: issued.Repository, InstallationID: issued.InstallationID, ExpiresAt: issued.ExpiresAt}
+	duplicate, err := repositorycredential.NewSecret(run.Namespace, run.Name, run.UID, string(run.Spec.RepositoryCredential), project.Spec.Repositories[0], duplicateCredential, 1, "", 0, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	duplicate.UID = "duplicate-active-uid"
+	if err := restarted.Create(context.Background(), duplicate); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := restarted.cleanupPendingRepositoryRevocation(context.Background(), &current); err != nil {
+		t.Fatal(err)
+	}
+	if err := restarted.Get(context.Background(), client.ObjectKeyFromObject(duplicate), &corev1.Secret{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("revoked active duplicate retained: %v", err)
+	}
+	if err := restarted.Get(context.Background(), pendingKey, &pendingSecret); err != nil {
+		t.Fatalf("WAL deleted before duplicate absence was observed: %v", err)
+	}
+	if _, _, err := restarted.cleanupPendingRepositoryRevocation(context.Background(), &current); err != nil {
+		t.Fatal(err)
+	}
+	if err := restarted.Get(context.Background(), pendingKey, &pendingSecret); !apierrors.IsNotFound(err) {
+		t.Fatalf("durable WAL was not deleted: %v", err)
+	}
+}
+
+func TestPendingRepositoryCredentialIdentityMismatchHasNoCleanupSideEffects(t *testing.T) {
+	now := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name   string
+		mutate func(*platformv1alpha1.Run, *corev1.Secret, *fakeRepositoryCredentialProvider)
+	}{
+		{name: "provider", mutate: func(_ *platformv1alpha1.Run, secret *corev1.Secret, _ *fakeRepositoryCredentialProvider) {
+			secret.Annotations[repositorycredential.AnnotationProvider] = "foreign"
+		}},
+		{name: "source", mutate: func(_ *platformv1alpha1.Run, secret *corev1.Secret, _ *fakeRepositoryCredentialProvider) {
+			secret.Annotations[repositorycredential.AnnotationSourceRepository] = "https://github.com/acme/other"
+		}},
+		{name: "canonical", mutate: func(_ *platformv1alpha1.Run, _ *corev1.Secret, provider *fakeRepositoryCredentialProvider) {
+			provider.canonical = "https://github.com/acme/other"
+		}},
+		{name: "generation", mutate: func(_ *platformv1alpha1.Run, secret *corev1.Secret, _ *fakeRepositoryCredentialProvider) {
+			secret.Annotations[repositorycredential.AnnotationTokenGeneration] = "2"
+		}},
+		{name: "rotation generation", mutate: func(run *platformv1alpha1.Run, _ *corev1.Secret, _ *fakeRepositoryCredentialProvider) {
+			run.Annotations = map[string]string{repositoryRefreshAnnotation: `{"oldSecretUID":"old","targetGeneration":2,"wake":false}`}
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "project-uid", Generation: 1}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/acme/repo"}}}
+			env, tmpl := frozenRepositoryEnvironment(project)
+			run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid", Generation: 1, Finalizers: []string{runFinalizer}}, Spec: platformv1alpha1.RunSpec{ProjectRef: "p", RepositoryCredential: platformv1alpha1.RepositoryCredentialGitHubApp}, Status: platformv1alpha1.RunStatus{EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{Name: env.Name, UID: env.UID, Ownership: platformv1alpha1.EnvironmentOwnershipOwned}}}
+			credential := &repositorycredential.Credential{Token: []byte("pending-token"), Repository: project.Spec.Repositories[0], InstallationID: 7, ExpiresAt: now.Add(time.Hour)}
+			pending, err := repositorycredential.NewPendingRevocationSecret(run.Namespace, run.Name, run.UID, string(run.Spec.RepositoryCredential), project.Spec.Repositories[0], credential, 1, now, repositorycredential.DispositionProviderInvalidToken)
+			if err != nil {
+				t.Fatal(err)
+			}
+			pending.UID, pending.ResourceVersion = "pending-uid", "1"
+			provider := &fakeRepositoryCredentialProvider{canonical: credential.Repository, now: now}
+			tc.mutate(run, pending, provider)
+			r := reconciler(t, &scriptedAdapter{}, run, project, env, tmpl, pending)
+			r.RepositoryCredentials, r.RepositoryCanonicalizer, r.Now = provider, provider, func() time.Time { return now }
+			var current platformv1alpha1.Run
+			if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil {
+				t.Fatal(err)
+			}
+			if done, result, err := r.cleanupPendingRepositoryRevocation(context.Background(), &current); err != nil || done || result.RequeueAfter == 0 {
+				t.Fatalf("blocked cleanup = (%#v, done %v, err %v)", result, done, err)
+			}
+			condition := apiMeta.FindStatusCondition(current.Status.Conditions, runConditionRepositoryCredentialReady)
+			if len(provider.revoked) != 0 || current.Status.State == platformv1alpha1.RunStateFailed || condition == nil || condition.Reason != "ForeignPendingSecret" {
+				t.Fatalf("side effects: revoked=%d state=%q condition=%#v", len(provider.revoked), current.Status.State, condition)
+			}
+			var retained corev1.Secret
+			if err := r.Get(context.Background(), client.ObjectKeyFromObject(pending), &retained); err != nil || retained.Annotations[repositorycredential.AnnotationRevocationState] != repositorycredential.RevocationStatePending {
+				t.Fatalf("pending Secret changed: %#v, %v", retained.Annotations, err)
+			}
+			if !controllerutil.ContainsFinalizer(&current, runFinalizer) {
+				t.Fatal("finalizer removed while cleanup identity was foreign")
+			}
+		})
+	}
+}
+
+func TestPendingRepositoryCredentialProviderNilHonorsExpiryBoundary(t *testing.T) {
+	now := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name      string
+		expires   time.Time
+		wantState string
+		advancing bool
+	}{
+		{name: "before", expires: now.Add(time.Second), wantState: repositorycredential.RevocationStatePending, advancing: true},
+		{name: "at", expires: now, wantState: repositorycredential.RevocationStateComplete},
+		{name: "after", expires: now.Add(-time.Second), wantState: repositorycredential.RevocationStateComplete},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "project-uid", Generation: 1}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/acme/repo"}}}
+			env, tmpl := frozenRepositoryEnvironment(project)
+			run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid", Generation: 1, Finalizers: []string{runFinalizer}}, Spec: platformv1alpha1.RunSpec{ProjectRef: "p", RepositoryCredential: platformv1alpha1.RepositoryCredentialGitHubApp}, Status: platformv1alpha1.RunStatus{EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{Name: env.Name, UID: env.UID, Ownership: platformv1alpha1.EnvironmentOwnershipOwned}}}
+			credential := &repositorycredential.Credential{Token: []byte("pending-token"), Repository: project.Spec.Repositories[0], InstallationID: 7, ExpiresAt: tc.expires}
+			pending, err := repositorycredential.NewPendingRevocationSecret(run.Namespace, run.Name, run.UID, string(run.Spec.RepositoryCredential), project.Spec.Repositories[0], credential, 1, now, repositorycredential.DispositionProviderInvalidToken)
+			if err != nil {
+				t.Fatal(err)
+			}
+			pending.UID, pending.ResourceVersion = "pending-uid", "1"
+			r := reconciler(t, &scriptedAdapter{}, run, project, env, tmpl, pending)
+			clockCalls := 0
+			r.RepositoryCanonicalizer, r.Now = &fakeRepositoryCredentialProvider{canonical: credential.Repository}, func() time.Time {
+				clockCalls++
+				if tc.advancing && clockCalls > 1 {
+					return tc.expires.Add(time.Second)
+				}
+				return now
+			}
+			var current platformv1alpha1.Run
+			if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil {
+				t.Fatal(err)
+			}
+			_, result, err := r.cleanupPendingRepositoryRevocation(context.Background(), &current)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.advancing && (clockCalls != 1 || result.RequeueAfter <= 0) {
+				t.Fatalf("advancing clock calls = %d, RequeueAfter = %v", clockCalls, result.RequeueAfter)
+			}
+			var got corev1.Secret
+			if err := r.Get(context.Background(), client.ObjectKeyFromObject(pending), &got); err != nil {
+				t.Fatal(err)
+			}
+			if state := got.Annotations[repositorycredential.AnnotationRevocationState]; state != tc.wantState {
+				t.Fatalf("state = %q, want %q", state, tc.wantState)
+			}
+			if current.Status.State == platformv1alpha1.RunStateFailed {
+				t.Fatal("pending/expiry completion applied disposition in the same pass")
+			}
+		})
+	}
+}
+
+func TestPendingRepositoryCredentialRecoversUpdateStatusAndDeleteAmbiguity(t *testing.T) {
+	now := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "project-uid", Generation: 1}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/acme/repo"}}}
+	env, tmpl := frozenRepositoryEnvironment(project)
+	run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid", Generation: 1, Finalizers: []string{runFinalizer}}, Spec: platformv1alpha1.RunSpec{ProjectRef: "p", RepositoryCredential: platformv1alpha1.RepositoryCredentialGitHubApp}, Status: platformv1alpha1.RunStatus{EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{Name: env.Name, UID: env.UID, Ownership: platformv1alpha1.EnvironmentOwnershipOwned}}}
+	credential := &repositorycredential.Credential{Token: []byte("pending-token"), Repository: project.Spec.Repositories[0], InstallationID: 7, ExpiresAt: now.Add(time.Hour)}
+	pending, err := repositorycredential.NewPendingRevocationSecret(run.Namespace, run.Name, run.UID, string(run.Spec.RepositoryCredential), project.Spec.Repositories[0], credential, 1, now, repositorycredential.DispositionProviderInvalidToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pending.UID, pending.ResourceVersion = "pending-uid", "1"
+	provider := &fakeRepositoryCredentialProvider{canonical: credential.Repository, now: now}
+	r := reconciler(t, &scriptedAdapter{}, run, project, env, tmpl, pending)
+	r.RepositoryCredentials, r.RepositoryCanonicalizer, r.Now = provider, provider, func() time.Time { return now }
+	base := r.Client
+	baseWithWatch := base.(client.WithWatch)
+	completionLost := false
+	r.Client = interceptor.NewClient(baseWithWatch, interceptor.Funcs{Update: func(ctx context.Context, underlying client.WithWatch, object client.Object, options ...client.UpdateOption) error {
+		if secret, ok := object.(*corev1.Secret); ok && secret.Name == pending.Name && secret.Annotations[repositorycredential.AnnotationRevocationState] == repositorycredential.RevocationStateComplete && !completionLost {
+			completionLost = true
+			if err := underlying.Update(ctx, object, options...); err != nil {
+				return err
+			}
+			return errors.New("completion update response lost")
+		}
+		return underlying.Update(ctx, object, options...)
+	}})
+	var current platformv1alpha1.Run
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := r.cleanupPendingRepositoryRevocation(context.Background(), &current); err != nil || !completionLost {
+		t.Fatalf("ambiguous completion = lost %t, err %v", completionLost, err)
+	}
+	if len(provider.revoked) != 1 {
+		t.Fatalf("revocations = %d", len(provider.revoked))
+	}
+
+	statusFailed := false
+	r.Client = interceptor.NewClient(baseWithWatch, interceptor.Funcs{SubResourceUpdate: func(ctx context.Context, underlying client.Client, subresource string, object client.Object, options ...client.SubResourceUpdateOption) error {
+		if _, ok := object.(*platformv1alpha1.Run); ok && subresource == "status" && !statusFailed {
+			statusFailed = true
+			return errors.New("status update failed")
+		}
+		return underlying.SubResource(subresource).Update(ctx, object, options...)
+	}})
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := r.cleanupPendingRepositoryRevocation(context.Background(), &current); err == nil || !statusFailed {
+		t.Fatalf("status failure = failed %t, err %v", statusFailed, err)
+	}
+	var retained corev1.Secret
+	if err := base.Get(context.Background(), client.ObjectKeyFromObject(pending), &retained); err != nil || retained.Annotations[repositorycredential.AnnotationRevocationState] != repositorycredential.RevocationStateComplete {
+		t.Fatalf("complete WAL after status failure = %#v, %v", retained.Annotations, err)
+	}
+	if len(provider.revoked) != 1 {
+		t.Fatal("complete WAL was revoked again after status failure")
+	}
+
+	r.Client = base
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := r.cleanupPendingRepositoryRevocation(context.Background(), &current); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil || !repositoryCredentialDispositionDurable(&current, repositorycredential.DispositionProviderInvalidToken) {
+		t.Fatalf("durable status = %#v, %v", current.Status, err)
+	}
+	deleteLost := false
+	r.Client = interceptor.NewClient(baseWithWatch, interceptor.Funcs{Delete: func(ctx context.Context, underlying client.WithWatch, object client.Object, options ...client.DeleteOption) error {
+		if object.GetName() == pending.Name && !deleteLost {
+			deleteLost = true
+			if err := underlying.Delete(ctx, object, options...); err != nil {
+				return err
+			}
+			return errors.New("delete response lost")
+		}
+		return underlying.Delete(ctx, object, options...)
+	}})
+	if _, _, err := r.cleanupPendingRepositoryRevocation(context.Background(), &current); err != nil || !deleteLost {
+		t.Fatalf("ambiguous delete = lost %t, err %v", deleteLost, err)
+	}
+	if err := base.Get(context.Background(), client.ObjectKeyFromObject(pending), &retained); !apierrors.IsNotFound(err) {
+		t.Fatalf("pending Secret after ambiguous delete = %v", err)
+	}
+	if len(provider.revoked) != 1 {
+		t.Fatal("complete WAL was revoked during deletion recovery")
+	}
+}
 func (f *fakeRepositoryCredentialProvider) Revoke(_ context.Context, credential *repositorycredential.Credential) error {
 	f.revoked = append(f.revoked, append([]byte(nil), credential.Token...))
+	if f.onRevoke != nil {
+		f.onRevoke()
+	}
 	return f.revokeErr
 }
 
@@ -122,6 +433,96 @@ func TestRepositoryCredentialIssueCanonicalizesAndClearsProviderToken(t *testing
 	}
 	if got := secret.Annotations[repositorycredential.AnnotationRepository]; got != provider.canonical {
 		t.Fatalf("lease repository = %q", got)
+	}
+}
+
+func TestRepositoryCredentialRejectsControllerOwnedClaim(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "project-uid", Generation: 1}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/acme/repo"}}}
+	env, tmpl := frozenRepositoryEnvironment(project)
+	run := &platformv1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid"},
+		Spec:       platformv1alpha1.RunSpec{ProjectRef: project.Name, RepositoryCredential: platformv1alpha1.RepositoryCredentialGitHubApp},
+		Status: platformv1alpha1.RunStatus{EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{
+			Name: env.Name, UID: env.UID, Ownership: platformv1alpha1.EnvironmentOwnershipClaimed,
+		}},
+	}
+	env.Status.ClaimedBy = &platformv1alpha1.RunReference{Name: run.Name, UID: run.UID}
+	env.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: platformv1alpha1.GroupVersion.String(), Kind: "Run", Name: "other", UID: "other-run-uid", Controller: ptr(true),
+	}}
+	r := reconciler(t, &scriptedAdapter{}, run, project, env, tmpl)
+	provider := &fakeRepositoryCredentialProvider{canonical: project.Spec.Repositories[0], now: now}
+	r.RepositoryCredentials, r.Now = provider, func() time.Time { return now }
+	var current platformv1alpha1.Run
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil {
+		t.Fatal(err)
+	}
+	if _, done, err := r.ensureRepositoryCredential(context.Background(), &current); err != nil || !done {
+		t.Fatalf("credential rejection = done %v, err %v", done, err)
+	}
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil {
+		t.Fatal(err)
+	}
+	if _, done, err := r.ensureRepositoryCredential(context.Background(), &current); err != nil || !done {
+		t.Fatalf("credential rejection after issuing marker = done %v, err %v", done, err)
+	}
+	if len(provider.issued) != 0 {
+		t.Fatalf("issued repository credentials for malformed claim: %v", provider.issued)
+	}
+	var secret corev1.Secret
+	if err := r.Get(context.Background(), types.NamespacedName{Namespace: run.Namespace, Name: repositorycredential.SecretName(run.UID)}, &secret); !apierrors.IsNotFound(err) {
+		t.Fatalf("repository credential Secret exists for malformed claim: %v", err)
+	}
+}
+
+func TestRepositoryCredentialTransientEnvironmentReadRetries(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "project-uid", Generation: 1}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/acme/repo"}}}
+	env, tmpl := frozenRepositoryEnvironment(project)
+	run := &platformv1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid"},
+		Spec:       platformv1alpha1.RunSpec{ProjectRef: project.Name, RepositoryCredential: platformv1alpha1.RepositoryCredentialGitHubApp},
+		Status: platformv1alpha1.RunStatus{EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{
+			Name: env.Name, UID: env.UID, Ownership: platformv1alpha1.EnvironmentOwnershipOwned,
+		}},
+	}
+	r := reconciler(t, &scriptedAdapter{}, run, project, env, tmpl)
+	provider := &fakeRepositoryCredentialProvider{canonical: project.Spec.Repositories[0], now: now}
+	r.RepositoryCredentials, r.Now = provider, func() time.Time { return now }
+	transientErr := errors.New("transient API read failure")
+	environmentReads := 0
+	r.APIReader = interceptor.NewClient(r.Client.(client.WithWatch), interceptor.Funcs{
+		Get: func(ctx context.Context, delegate client.WithWatch, key client.ObjectKey, object client.Object, options ...client.GetOption) error {
+			if _, ok := object.(*platformv1alpha1.Environment); ok && key == client.ObjectKeyFromObject(env) {
+				environmentReads++
+				return transientErr
+			}
+			return delegate.Get(ctx, key, object, options...)
+		},
+	})
+	var current platformv1alpha1.Run
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil {
+		t.Fatal(err)
+	}
+	if _, done, err := r.ensureRepositoryCredential(context.Background(), &current); !errors.Is(err, transientErr) || !done {
+		t.Fatalf("transient credential ensure = done %v, err %v", done, err)
+	}
+	if environmentReads != 1 {
+		t.Fatalf("transient Environment reads = %d, want 1", environmentReads)
+	}
+	if len(provider.issued) != 0 {
+		t.Fatalf("issued repository credentials after transient read: %v", provider.issued)
+	}
+	var secret corev1.Secret
+	if err := r.Get(context.Background(), types.NamespacedName{Namespace: run.Namespace, Name: repositorycredential.SecretName(run.UID)}, &secret); !apierrors.IsNotFound(err) {
+		t.Fatalf("repository credential Secret exists after transient read: %v", err)
+	}
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil {
+		t.Fatal(err)
+	}
+	if terminalRunState(current.Status.State) {
+		t.Fatalf("transient read made Run terminal: %s", current.Status.State)
 	}
 }
 
@@ -179,19 +580,19 @@ func TestRepositoryCredentialPersistsAndDrainsFailedImmediateRevocation(t *testi
 	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil {
 		t.Fatal(err)
 	}
-	if result, done, err := r.ensureRepositoryCredential(context.Background(), &current); err != nil || !done || result.RequeueAfter != time.Minute {
+	if result, done, err := r.ensureRepositoryCredential(context.Background(), &current); err != nil || !done || !result.Requeue {
 		t.Fatalf("persist pending revocation = (%#v, done %v, err %v)", result, done, err)
 	}
-	if !failingClient.failed || len(provider.issued) != 1 || len(provider.revoked) != 1 {
+	if !failingClient.failed || len(provider.issued) != 1 || len(provider.revoked) != 0 {
 		t.Fatalf("failed=%t issued=%d revoked=%d", failingClient.failed, len(provider.issued), len(provider.revoked))
-	}
-	condition := apiMeta.FindStatusCondition(current.Status.Conditions, runConditionRepositoryCredentialReady)
-	if condition == nil || condition.Reason != "RevocationPending" {
-		t.Fatalf("condition = %#v", condition)
 	}
 	var pendingSecret corev1.Secret
 	pendingKey := types.NamespacedName{Namespace: run.Namespace, Name: repositorycredential.PendingRevocationSecretName(run.UID)}
 	if err := r.Get(context.Background(), pendingKey, &pendingSecret); err != nil {
+		t.Fatal(err)
+	}
+	pendingSecret.UID = "pending-secret-uid"
+	if err := r.Update(context.Background(), &pendingSecret); err != nil {
 		t.Fatal(err)
 	}
 	pending, err := repositorycredential.ParsePendingRevocation(&pendingSecret, run.Name, run.UID)
@@ -203,11 +604,17 @@ func TestRepositoryCredentialPersistsAndDrainsFailedImmediateRevocation(t *testi
 	if result, done, err := r.ensureRepositoryCredential(context.Background(), &current); err != nil || !done || !result.Requeue {
 		t.Fatalf("drain pending revocation = (%#v, done %v, err %v)", result, done, err)
 	}
-	if len(provider.issued) != 1 || len(provider.revoked) != 2 {
+	if len(provider.issued) != 1 || len(provider.revoked) != 1 {
 		t.Fatalf("pending drain issued=%d revoked=%d", len(provider.issued), len(provider.revoked))
 	}
+	if err := r.Get(context.Background(), pendingKey, &pendingSecret); err != nil || pendingSecret.Annotations[repositorycredential.AnnotationRevocationState] != repositorycredential.RevocationStateComplete {
+		t.Fatalf("completed pending Secret = %#v, %v", pendingSecret.Annotations, err)
+	}
+	if result, done, err := r.ensureRepositoryCredential(context.Background(), &current); err != nil || !done || !result.Requeue {
+		t.Fatalf("delete completed revocation = (%#v, done %v, err %v)", result, done, err)
+	}
 	if err := r.Get(context.Background(), pendingKey, &pendingSecret); !apierrors.IsNotFound(err) {
-		t.Fatalf("pending Secret after drain = %v", err)
+		t.Fatalf("pending Secret after durable completion = %v", err)
 	}
 }
 
@@ -246,6 +653,49 @@ func TestRepositoryRotationRecordStrictJSON(t *testing.T) {
 		if _, err := parseRepositoryRotationRecord(value); err == nil {
 			t.Errorf("parseRepositoryRotationRecord(%q) succeeded", value)
 		}
+	}
+}
+
+func TestRepositoryCredentialRotationDeleteIsResourceVersionFenced(t *testing.T) {
+	now := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "project-uid", Generation: 1}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/acme/repo"}}}
+	env, tmpl := frozenRepositoryEnvironment(project)
+	run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid", Annotations: map[string]string{repositoryRefreshAnnotation: `{"oldSecretUID":"old-secret-uid","targetGeneration":2,"wake":false}`}}, Spec: platformv1alpha1.RunSpec{ProjectRef: project.Name, RepositoryCredential: platformv1alpha1.RepositoryCredentialGitHubApp}, Status: platformv1alpha1.RunStatus{EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{Name: env.Name, UID: env.UID, Ownership: platformv1alpha1.EnvironmentOwnershipOwned}}}
+	credential := &repositorycredential.Credential{Token: []byte("old-token"), Repository: project.Spec.Repositories[0], InstallationID: 7, ExpiresAt: now.Add(time.Hour)}
+	secret, err := repositorycredential.NewSecret(run.Namespace, run.Name, run.UID, string(run.Spec.RepositoryCredential), credential.Repository, credential, 1, "", 0, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secret.UID = "old-secret-uid"
+	r := reconciler(t, &scriptedAdapter{}, run, project, env, tmpl, secret)
+	provider := &fakeRepositoryCredentialProvider{canonical: credential.Repository, now: now}
+	provider.onRevoke = func() {
+		var changed corev1.Secret
+		if getErr := r.Get(context.Background(), client.ObjectKeyFromObject(secret), &changed); getErr != nil {
+			t.Fatal(getErr)
+		}
+		changed.Annotations["test.swe.dev/concurrent-update"] = "true"
+		if updateErr := r.Update(context.Background(), &changed); updateErr != nil {
+			t.Fatal(updateErr)
+		}
+	}
+	r.RepositoryCredentials, r.Now = provider, func() time.Time { return now }
+	var current platformv1alpha1.Run
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil {
+		t.Fatal(err)
+	}
+	if _, done, ensureErr := r.ensureRepositoryCredential(context.Background(), &current); ensureErr == nil || !done {
+		t.Fatalf("rotation after concurrent update = done %t, err %v", done, ensureErr)
+	}
+	if len(provider.revoked) != 1 {
+		t.Fatalf("revocations = %d, want 1", len(provider.revoked))
+	}
+	var retained corev1.Secret
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(secret), &retained); err != nil {
+		t.Fatalf("concurrently updated Secret removed: %v", err)
+	}
+	if retained.Annotations["test.swe.dev/concurrent-update"] != "true" {
+		t.Fatalf("concurrent update missing: %#v", retained.Annotations)
 	}
 }
 
@@ -350,6 +800,31 @@ func TestRepositoryCredentialPendingFrozenSnapshotIsBounded(t *testing.T) {
 	}
 }
 
+func TestRepositoryLaunchMaterialRejectsPendingOnlyAnnotations(t *testing.T) {
+	now := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "project-uid", Generation: 1}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/acme/repo"}}}
+	env, tmpl := frozenRepositoryEnvironment(project)
+	env.Status.ExecutionGeneration = 1
+	run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid"}, Spec: platformv1alpha1.RunSpec{RepositoryCredential: platformv1alpha1.RepositoryCredentialGitHubApp}}
+	credential := &repositorycredential.Credential{Token: []byte("active-token"), Repository: project.Spec.Repositories[0], InstallationID: 7, ExpiresAt: now.Add(time.Hour)}
+	for _, annotation := range []string{repositorycredential.AnnotationRevocationState, repositorycredential.AnnotationRevocationDisposition} {
+		t.Run(annotation, func(t *testing.T) {
+			secret, err := repositorycredential.NewSecret(run.Namespace, run.Name, run.UID, string(run.Spec.RepositoryCredential), credential.Repository, credential, 1, env.UID, 1, now)
+			if err != nil {
+				t.Fatal(err)
+			}
+			secret.UID = "secret-uid"
+			secret.Annotations[annotation] = ""
+			r := reconciler(t, &scriptedAdapter{}, run.DeepCopy(), project.DeepCopy(), env.DeepCopy(), tmpl.DeepCopy(), secret)
+			r.RepositoryCredentials, r.Now = &fakeRepositoryCredentialProvider{canonical: credential.Repository, now: now}, func() time.Time { return now }
+			environment, lease, launchErr := r.repositoryLaunchMaterial(context.Background(), run, env)
+			if launchErr == nil || environment != nil || lease != nil {
+				t.Fatalf("repositoryLaunchMaterial = %#v, %#v, %v", environment, lease, launchErr)
+			}
+		})
+	}
+}
+
 func TestExpiredMalformedRepositoryCredentialCleanupRequiresExactIdentity(t *testing.T) {
 	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
 	mutations := map[string]func(*corev1.Secret){
@@ -364,11 +839,123 @@ func TestExpiredMalformedRepositoryCredentialCleanupRequiresExactIdentity(t *tes
 		t.Run(name, func(t *testing.T) { testExpiredMalformedCleanup(t, now, mutate, false) })
 	}
 	t.Run("exact expired malformed token", func(t *testing.T) { testExpiredMalformedCleanup(t, now, func(*corev1.Secret) {}, true) })
+	t.Run("rotation mismatch", func(t *testing.T) {
+		project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "project-uid", Generation: 1}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/acme/repo"}}}
+		env, tmpl := frozenRepositoryEnvironment(project)
+		run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid", Annotations: map[string]string{repositoryRefreshAnnotation: `{"oldSecretUID":"secret-uid","targetGeneration":3,"wake":false}`}}, Spec: platformv1alpha1.RunSpec{RepositoryCredential: platformv1alpha1.RepositoryCredentialGitHubApp}, Status: platformv1alpha1.RunStatus{EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{Name: env.Name, UID: env.UID}}}
+		credential := &repositorycredential.Credential{Token: []byte("token"), Repository: project.Spec.Repositories[0], InstallationID: 7, ExpiresAt: now.Add(time.Hour)}
+		secret, err := repositorycredential.NewSecret(run.Namespace, run.Name, run.UID, string(run.Spec.RepositoryCredential), credential.Repository, credential, 3, "", 0, now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		secret.UID = "secret-uid"
+		secret.Annotations[repositorycredential.AnnotationExpiry] = now.Add(-time.Minute).Format(time.RFC3339Nano)
+		secret.Data[repositorycredential.TokenKey] = nil
+		provider := &fakeRepositoryCredentialProvider{canonical: credential.Repository, now: now}
+		r := reconciler(t, &scriptedAdapter{}, run, env, tmpl, secret)
+		r.RepositoryCredentials, r.Now = provider, func() time.Time { return now }
+		var current platformv1alpha1.Run
+		if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil {
+			t.Fatal(err)
+		}
+		if done, _, cleanupErr := r.cleanupRepositoryCredential(context.Background(), &current, nil); cleanupErr == nil || done || len(provider.revoked) != 0 {
+			t.Fatalf("malformed fallback = done %t, revocations %d, err %v", done, len(provider.revoked), cleanupErr)
+		}
+		if err := r.Get(context.Background(), client.ObjectKeyFromObject(secret), &corev1.Secret{}); err != nil {
+			t.Fatalf("mismatched malformed Secret removed: %v", err)
+		}
+	})
+}
+
+func TestExpiredMalformedRepositoryCredentialCleanupUsesManagedIdentityAfterClaimLoss(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "project-uid", Generation: 1}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/acme/repo"}}}
+	env, tmpl := frozenRepositoryEnvironment(project)
+	run := &platformv1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid"},
+		Spec:       platformv1alpha1.RunSpec{RepositoryCredential: platformv1alpha1.RepositoryCredentialGitHubApp},
+		Status: platformv1alpha1.RunStatus{EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{
+			Name: env.Name, UID: env.UID, Ownership: platformv1alpha1.EnvironmentOwnershipClaimed,
+		}},
+	}
+	env.Status.ClaimedBy = &platformv1alpha1.RunReference{Name: run.Name, UID: run.UID}
+	env.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: platformv1alpha1.GroupVersion.String(), Kind: "Run", Name: "other", UID: "other-run-uid", Controller: ptr(true),
+	}}
+	credential := &repositorycredential.Credential{Token: []byte("token"), Repository: project.Spec.Repositories[0], InstallationID: 7, ExpiresAt: now.Add(time.Hour)}
+	secret, err := repositorycredential.NewSecret(run.Namespace, run.Name, run.UID, string(run.Spec.RepositoryCredential), project.Spec.Repositories[0], credential, 1, "", 0, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secret.UID = "secret-uid"
+	secret.Annotations[repositorycredential.AnnotationExpiry] = now.Add(-time.Minute).Format(time.RFC3339Nano)
+	secret.Data[repositorycredential.TokenKey] = nil
+	r := reconciler(t, &scriptedAdapter{}, run, project, env, tmpl, secret)
+	r.RepositoryCredentials, r.Now = &fakeRepositoryCredentialProvider{canonical: credential.Repository, now: now}, func() time.Time { return now }
+	var current platformv1alpha1.Run
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil {
+		t.Fatal(err)
+	}
+	if done, _, err := r.cleanupRepositoryCredential(context.Background(), &current, nil); err != nil || !done {
+		t.Fatalf("expired malformed cleanup after claim loss = done %v, err %v", done, err)
+	}
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(secret), &corev1.Secret{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("expired exact-managed Secret retained after claim loss: %v", err)
+	}
+}
+
+func TestExpiredMalformedRepositoryCredentialCleanupRetriesTransientEnvironmentRead(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "project-uid", Generation: 1}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/acme/repo"}}}
+	env, tmpl := frozenRepositoryEnvironment(project)
+	run := &platformv1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid"},
+		Spec:       platformv1alpha1.RunSpec{RepositoryCredential: platformv1alpha1.RepositoryCredentialGitHubApp},
+		Status: platformv1alpha1.RunStatus{EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{
+			Name: env.Name, UID: env.UID, Ownership: platformv1alpha1.EnvironmentOwnershipOwned,
+		}},
+	}
+	credential := &repositorycredential.Credential{Token: []byte("token"), Repository: project.Spec.Repositories[0], InstallationID: 7, ExpiresAt: now.Add(time.Hour)}
+	secret, err := repositorycredential.NewSecret(run.Namespace, run.Name, run.UID, string(run.Spec.RepositoryCredential), project.Spec.Repositories[0], credential, 1, "", 0, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secret.UID = "secret-uid"
+	secret.Annotations[repositorycredential.AnnotationExpiry] = now.Add(-time.Minute).Format(time.RFC3339Nano)
+	secret.Data[repositorycredential.TokenKey] = nil
+	r := reconciler(t, &scriptedAdapter{}, run, project, env, tmpl, secret)
+	r.RepositoryCredentials, r.Now = &fakeRepositoryCredentialProvider{canonical: credential.Repository, now: now}, func() time.Time { return now }
+	transientErr := errors.New("transient Environment read failure")
+	environmentReads := 0
+	r.APIReader = interceptor.NewClient(r.Client.(client.WithWatch), interceptor.Funcs{
+		Get: func(ctx context.Context, delegate client.WithWatch, key client.ObjectKey, object client.Object, options ...client.GetOption) error {
+			if _, ok := object.(*platformv1alpha1.Environment); ok && key == client.ObjectKeyFromObject(env) {
+				environmentReads++
+				return transientErr
+			}
+			return delegate.Get(ctx, key, object, options...)
+		},
+	})
+	var current platformv1alpha1.Run
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil {
+		t.Fatal(err)
+	}
+	if done, _, err := r.cleanupRepositoryCredential(context.Background(), &current, nil); !errors.Is(err, transientErr) || done {
+		t.Fatalf("transient expired cleanup = done %v, err %v", done, err)
+	}
+	if environmentReads != 1 {
+		t.Fatalf("transient cleanup Environment reads = %d, want 1", environmentReads)
+	}
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(secret), &corev1.Secret{}); err != nil {
+		t.Fatalf("transient cleanup removed exact-managed Secret: %v", err)
+	}
 }
 
 func TestExpiredRepositoryCredentialsCleanUpWithoutProvider(t *testing.T) {
 	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
-	run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid"}, Spec: platformv1alpha1.RunSpec{RepositoryCredential: platformv1alpha1.RepositoryCredentialGitHubApp}}
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "project-uid", Generation: 1}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/acme/repo"}}}
+	env, tmpl := frozenRepositoryEnvironment(project)
+	run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid"}, Spec: platformv1alpha1.RunSpec{ProjectRef: "p", RepositoryCredential: platformv1alpha1.RepositoryCredentialGitHubApp}, Status: platformv1alpha1.RunStatus{EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{Name: env.Name, UID: env.UID, Ownership: platformv1alpha1.EnvironmentOwnershipOwned}}}
 	credential := &repositorycredential.Credential{Token: []byte("expired-token"), Repository: "https://github.com/acme/repo", InstallationID: 7, ExpiresAt: now.Add(time.Hour)}
 	active, err := repositorycredential.NewSecret(run.Namespace, run.Name, run.UID, string(run.Spec.RepositoryCredential), credential.Repository, credential, 1, "", 0, now)
 	if err != nil {
@@ -376,8 +963,11 @@ func TestExpiredRepositoryCredentialsCleanUpWithoutProvider(t *testing.T) {
 	}
 	active.UID = "active-uid"
 	active.Annotations[repositorycredential.AnnotationExpiry] = now.Add(-time.Minute).Format(time.RFC3339Nano)
-	r := reconciler(t, &scriptedAdapter{}, run, active)
+	// Cleanup authority is the verified frozen snapshot; the live Project may
+	// already be absent after issuance.
+	r := reconciler(t, &scriptedAdapter{}, run, env, tmpl, active)
 	r.RepositoryCredentials, r.Now = nil, func() time.Time { return now }
+	r.RepositoryCanonicalizer = &fakeRepositoryCredentialProvider{canonical: credential.Repository}
 	var current platformv1alpha1.Run
 	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil {
 		t.Fatal(err)
@@ -389,7 +979,7 @@ func TestExpiredRepositoryCredentialsCleanUpWithoutProvider(t *testing.T) {
 		t.Fatalf("expired active Secret retained: %v", err)
 	}
 
-	pending, err := repositorycredential.NewPendingRevocationSecret(run.Namespace, run.Name, run.UID, string(run.Spec.RepositoryCredential), credential.Repository, credential, 1, now)
+	pending, err := repositorycredential.NewPendingRevocationSecret(run.Namespace, run.Name, run.UID, string(run.Spec.RepositoryCredential), credential.Repository, credential, 1, now, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -401,8 +991,91 @@ func TestExpiredRepositoryCredentialsCleanUpWithoutProvider(t *testing.T) {
 	if done, result, err := r.cleanupPendingRepositoryRevocation(context.Background(), &current); err != nil || done || !result.Requeue {
 		t.Fatalf("expired pending cleanup = (%#v, done %t, err %v)", result, done, err)
 	}
+	if done, result, err := r.cleanupPendingRepositoryRevocation(context.Background(), &current); err != nil || done || !result.Requeue {
+		t.Fatalf("completed pending deletion = (%#v, done %t, err %v)", result, done, err)
+	}
 	if err := r.Get(context.Background(), client.ObjectKeyFromObject(pending), &corev1.Secret{}); !apierrors.IsNotFound(err) {
 		t.Fatalf("expired pending Secret retained: %v", err)
+	}
+}
+
+func TestActiveRepositoryCredentialCleanupRejectsForeignIdentityBeforeRevoke(t *testing.T) {
+	now := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "project-uid", Generation: 1}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/acme/repo"}}}
+	env, tmpl := frozenRepositoryEnvironment(project)
+	run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid", Finalizers: []string{runFinalizer}}, Spec: platformv1alpha1.RunSpec{ProjectRef: "p", RepositoryCredential: platformv1alpha1.RepositoryCredentialGitHubApp}, Status: platformv1alpha1.RunStatus{EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{Name: env.Name, UID: env.UID, Ownership: platformv1alpha1.EnvironmentOwnershipOwned}}}
+	credential := &repositorycredential.Credential{Token: []byte("foreign-token"), Repository: project.Spec.Repositories[0], InstallationID: 7, ExpiresAt: now.Add(time.Hour)}
+	secret, err := repositorycredential.NewSecret(run.Namespace, run.Name, run.UID, string(run.Spec.RepositoryCredential), project.Spec.Repositories[0], credential, 1, "", 0, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secret.UID, secret.ResourceVersion = "active-uid", "1"
+	secret.Annotations[repositorycredential.AnnotationSourceRepository] = "https://github.com/acme/other"
+	provider := &fakeRepositoryCredentialProvider{canonical: credential.Repository, now: now}
+	r := reconciler(t, &scriptedAdapter{}, run, project, env, tmpl, secret)
+	r.RepositoryCredentials, r.RepositoryCanonicalizer, r.Now = provider, provider, func() time.Time { return now }
+	var current platformv1alpha1.Run
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil {
+		t.Fatal(err)
+	}
+	if done, _, err := r.cleanupRepositoryCredential(context.Background(), &current, nil); err == nil || done {
+		t.Fatalf("foreign cleanup = done %t, err %v", done, err)
+	}
+	if len(provider.revoked) != 0 {
+		t.Fatalf("foreign token revoked: %d", len(provider.revoked))
+	}
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(secret), &corev1.Secret{}); err != nil {
+		t.Fatalf("foreign active Secret removed: %v", err)
+	}
+}
+
+func TestActiveRepositoryCredentialCleanupFencesRotation(t *testing.T) {
+	now := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		annotation string
+		uid        types.UID
+		generation int64
+		accepted   bool
+	}{
+		{name: "old", annotation: `{"oldSecretUID":"old-uid","targetGeneration":3,"wake":false}`, uid: "old-uid", generation: 2, accepted: true},
+		{name: "replacement", annotation: `{"oldSecretUID":"old-uid","targetGeneration":3,"wake":false}`, uid: "new-uid", generation: 3, accepted: true},
+		{name: "wrong old generation", annotation: `{"oldSecretUID":"old-uid","targetGeneration":3,"wake":false}`, uid: "old-uid", generation: 3},
+		{name: "wrong replacement generation", annotation: `{"oldSecretUID":"old-uid","targetGeneration":3,"wake":false}`, uid: "new-uid", generation: 2},
+		{name: "malformed", annotation: `{"oldSecretUID":`, uid: "old-uid", generation: 2},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "project-uid", Generation: 1}, Spec: platformv1alpha1.ProjectSpec{Repositories: []string{"https://github.com/acme/repo"}}}
+			env, tmpl := frozenRepositoryEnvironment(project)
+			run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid", Annotations: map[string]string{repositoryRefreshAnnotation: tc.annotation}}, Spec: platformv1alpha1.RunSpec{RepositoryCredential: platformv1alpha1.RepositoryCredentialGitHubApp}, Status: platformv1alpha1.RunStatus{EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{Name: env.Name, UID: env.UID}}}
+			credential := &repositorycredential.Credential{Token: []byte("token"), Repository: project.Spec.Repositories[0], InstallationID: 7, ExpiresAt: now.Add(time.Hour)}
+			secret, err := repositorycredential.NewSecret(run.Namespace, run.Name, run.UID, string(run.Spec.RepositoryCredential), credential.Repository, credential, tc.generation, "", 0, now)
+			if err != nil {
+				t.Fatal(err)
+			}
+			secret.UID = tc.uid
+			provider := &fakeRepositoryCredentialProvider{canonical: credential.Repository, now: now}
+			r := reconciler(t, &scriptedAdapter{}, run, env, tmpl, secret)
+			r.RepositoryCredentials, r.Now = provider, func() time.Time { return now }
+			var current platformv1alpha1.Run
+			if err := r.Get(context.Background(), client.ObjectKeyFromObject(run), &current); err != nil {
+				t.Fatal(err)
+			}
+			done, _, cleanupErr := r.cleanupRepositoryCredential(context.Background(), &current, nil)
+			if tc.accepted {
+				if cleanupErr != nil || !done || len(provider.revoked) != 1 {
+					t.Fatalf("accepted cleanup = done %t, revocations %d, err %v", done, len(provider.revoked), cleanupErr)
+				}
+			} else {
+				if cleanupErr == nil || done || len(provider.revoked) != 0 {
+					t.Fatalf("blocked cleanup = done %t, revocations %d, err %v", done, len(provider.revoked), cleanupErr)
+				}
+				if err := r.Get(context.Background(), client.ObjectKeyFromObject(secret), &corev1.Secret{}); err != nil {
+					t.Fatalf("blocked Secret removed: %v", err)
+				}
+			}
+		})
 	}
 }
 
@@ -451,6 +1124,7 @@ func frozenRepositoryEnvironment(project *platformv1alpha1.Project) (*platformv1
 
 type scriptedAdapter struct {
 	observations          []agent.AdapterObservation
+	observationMessage    string
 	accepted, observed    int
 	cancelled             int
 	acceptErr             error
@@ -466,6 +1140,24 @@ type blockingObserveAdapter struct {
 	observation agent.AdapterObservation
 	started     chan struct{}
 	release     chan struct{}
+}
+
+type fencingDialAdapter struct {
+	mutate func()
+}
+
+func (a *fencingDialAdapter) EnsureAccepted(ctx context.Context, _ agent.AdapterTask, sandbox agent.AdapterSandbox, _ *agent.AdapterLaunchMaterial) error {
+	a.mutate()
+	_, _, err := sandbox.DialProcess(ctx)
+	return err
+}
+
+func (*fencingDialAdapter) Observe(context.Context, agent.AdapterTask, agent.AdapterSandbox) (agent.AdapterObservation, string, error) {
+	return agent.AdapterObservationRunning, "running", nil
+}
+
+func (*fencingDialAdapter) Cancel(context.Context, agent.AdapterTask, agent.AdapterSandbox) error {
+	return nil
 }
 
 func (*blockingObserveAdapter) EnsureAccepted(context.Context, agent.AdapterTask, agent.AdapterSandbox, *agent.AdapterLaunchMaterial) error {
@@ -570,7 +1262,11 @@ func (a *scriptedAdapter) Observe(context.Context, agent.AdapterTask, agent.Adap
 	if len(a.observations) > 1 {
 		a.observations = a.observations[1:]
 	}
-	return o, string(o), nil
+	message := a.observationMessage
+	if message == "" {
+		message = string(o)
+	}
+	return o, message, nil
 }
 
 func runScheme(t *testing.T) *runtime.Scheme {
@@ -928,6 +1624,65 @@ func TestWarmClaimRecoveryRejectsRecreatedTemplateOwner(t *testing.T) {
 	}
 	if retained.Status.ClaimedBy == nil || retained.Status.ClaimedBy.UID != run.UID || retained.Labels[warmPoolLabel] != template.Name {
 		t.Fatalf("recovery mutated rejected member: %#v", retained)
+	}
+}
+
+func TestClaimRecoveryRejectsControllerOwnedEnvironment(t *testing.T) {
+	run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid"}, Spec: platformv1alpha1.RunSpec{TemplateRef: "small", Agent: "test"}}
+	env := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foreign", Namespace: "ns", UID: "env-uid",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: platformv1alpha1.GroupVersion.String(), Kind: "Run", Name: "other", UID: "other-run-uid", Controller: ptr(true),
+			}},
+		},
+		Status: platformv1alpha1.EnvironmentStatus{
+			ClaimedBy: &platformv1alpha1.RunReference{Name: run.Name, UID: run.UID},
+		},
+	}
+	r := reconciler(t, &scriptedAdapter{}, run, env)
+	recovered, err := r.recoverEnvironmentReference(context.Background(), run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recovered != nil {
+		t.Fatalf("recovered controller-owned Environment as a claim: %#v", recovered)
+	}
+	var retained platformv1alpha1.Environment
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(env), &retained); err != nil {
+		t.Fatal(err)
+	}
+	if retained.Status.ClaimedBy == nil || retained.Status.ClaimedBy.UID != run.UID || !metav1.IsControlledBy(&retained, &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "other", UID: "other-run-uid"}}) {
+		t.Fatalf("recovery mutated rejected Environment: %#v", retained)
+	}
+}
+
+func TestInterruptedWarmPromotionRecoveryPromotesClaim(t *testing.T) {
+	run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid", Finalizers: []string{runFinalizer}}, Spec: platformv1alpha1.RunSpec{TemplateRef: "small", ProjectRef: "project", Agent: "test"}}
+	template := &platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: "ns", UID: "template-uid"}}
+	warm := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "warm-small", Namespace: "ns", UID: "warm-uid", Labels: map[string]string{warmPoolLabel: template.Name},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: platformv1alpha1.GroupVersion.String(), Kind: "EnvironmentTemplate", Name: template.Name, UID: template.UID, Controller: ptr(true),
+			}},
+		},
+		Spec: platformv1alpha1.EnvironmentSpec{TemplateRef: template.Name},
+		Status: platformv1alpha1.EnvironmentStatus{
+			Phase: platformv1alpha1.EnvironmentPhaseReady, ClaimedBy: &platformv1alpha1.RunReference{Name: run.Name, UID: run.UID},
+		},
+	}
+	r := reconciler(t, &scriptedAdapter{}, run, template, warm)
+	got := reconcileRun(t, r, run.Name)
+	if got.Status.EnvironmentRef == nil || got.Status.EnvironmentRef.Name != warm.Name || got.Status.EnvironmentRef.UID != warm.UID || got.Status.EnvironmentRef.Ownership != platformv1alpha1.EnvironmentOwnershipClaimed {
+		t.Fatalf("interrupted warm recovery = %#v", got.Status.EnvironmentRef)
+	}
+	var recovered platformv1alpha1.Environment
+	if err := r.Get(context.Background(), client.ObjectKeyFromObject(warm), &recovered); err != nil {
+		t.Fatal(err)
+	}
+	if recovered.Labels[warmPoolLabel] != "" || metav1.GetControllerOf(&recovered) != nil || recovered.Spec.ProjectRef != run.Spec.ProjectRef || recovered.Status.ClaimedBy == nil || recovered.Status.ClaimedBy.UID != run.UID || recovered.Status.Phase != platformv1alpha1.EnvironmentPhaseSetup {
+		t.Fatalf("recovered warm claim was not promoted safely: %#v", recovered)
 	}
 }
 
@@ -1482,8 +2237,63 @@ func TestPermanentAdapterAcceptanceRejectionFailsRun(t *testing.T) {
 	r := reconciler(t, adapter, run, env)
 	got := reconcileRun(t, r, run.Name)
 	condition := apiMeta.FindStatusCondition(got.Status.Conditions, runConditionAdapterAccepted)
-	if got.Status.State != platformv1alpha1.RunStateFailed || condition == nil || condition.Status != metav1.ConditionFalse || condition.Reason != "AdapterRejected" || !strings.Contains(condition.Message, "unsupported task configuration") || adapter.accepted != 1 {
+	if got.Status.State != platformv1alpha1.RunStateFailed || condition == nil || condition.Status != metav1.ConditionFalse || condition.Reason != "AdapterRejected" || condition.Message != "adapter rejected the task" || adapter.accepted != 1 {
 		t.Fatalf("Run status = %#v, AdapterAccepted = %#v, accepts = %d", got.Status, condition, adapter.accepted)
+	}
+}
+
+func TestAdapterObservationDetailCannotEnterPersistedRunStatus(t *testing.T) {
+	const sentinel = "!!ARBITRARY-ADAPTER-STATUS-SECRET!!"
+	run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "uid", Finalizers: []string{runFinalizer}}, Spec: platformv1alpha1.RunSpec{Agent: "test"}, Status: platformv1alpha1.RunStatus{
+		State:          platformv1alpha1.RunStateAdapterAccepted,
+		EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{Name: "e", UID: "euid", Ownership: platformv1alpha1.EnvironmentOwnershipOwned},
+		Conditions:     []metav1.Condition{{Type: runConditionAdapterAccepted, Status: metav1.ConditionTrue, Reason: "AdapterAccepted"}},
+	}}
+	env := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "e", Namespace: "ns", UID: "euid"}, Status: platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhaseReady}}
+	r := reconciler(t, &scriptedAdapter{observations: []agent.AdapterObservation{agent.AdapterObservationFailed}, observationMessage: sentinel}, run, env)
+	got := reconcileRun(t, r, run.Name)
+	condition := apiMeta.FindStatusCondition(got.Status.Conditions, runConditionAdapterAccepted)
+	statusJSON, err := json.Marshal(got.Status)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if condition == nil || condition.Reason != string(agent.AdapterObservationFailed) || condition.Message != agent.AdapterObservationFailed.StatusMessage() || strings.Contains(string(statusJSON), sentinel) {
+		t.Fatalf("persisted Run status = %s", statusJSON)
+	}
+}
+
+func TestExistingAdapterStatusDetailIsNormalizedBeforeTerminalOrDeletionCleanup(t *testing.T) {
+	const sentinel = "!!PREEXISTING-ADAPTER-STATUS-SECRET!!"
+	now := metav1.Now()
+	tests := []struct {
+		name      string
+		state     platformv1alpha1.RunState
+		reason    string
+		want      string
+		deleting  bool
+		condition metav1.ConditionStatus
+	}{
+		{name: "succeeded", state: platformv1alpha1.RunStateSucceeded, reason: string(agent.AdapterObservationSucceeded), want: agent.AdapterObservationSucceeded.StatusMessage(), condition: metav1.ConditionTrue},
+		{name: "failed", state: platformv1alpha1.RunStateFailed, reason: string(agent.AdapterObservationFailed), want: agent.AdapterObservationFailed.StatusMessage(), condition: metav1.ConditionTrue},
+		{name: "rejected", state: platformv1alpha1.RunStateFailed, reason: "AdapterRejected", want: "adapter rejected the task", condition: metav1.ConditionFalse},
+		{name: "deleting", state: platformv1alpha1.RunStateRunning, reason: string(agent.AdapterObservationRunning), want: agent.AdapterObservationRunning.StatusMessage(), deleting: true, condition: metav1.ConditionTrue},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "uid", Finalizers: []string{runFinalizer}}, Spec: platformv1alpha1.RunSpec{Agent: "test"}, Status: platformv1alpha1.RunStatus{
+				State:      test.state,
+				Conditions: []metav1.Condition{{Type: runConditionAdapterAccepted, Status: test.condition, Reason: test.reason, Message: sentinel, LastTransitionTime: now}},
+			}}
+			if test.deleting {
+				run.DeletionTimestamp = &now
+			}
+			r := reconciler(t, &scriptedAdapter{}, run)
+			got := reconcileRun(t, r, run.Name)
+			condition := apiMeta.FindStatusCondition(got.Status.Conditions, runConditionAdapterAccepted)
+			if condition == nil || condition.Reason != test.reason || condition.Message != test.want || condition.LastTransitionTime.Time.Unix() != now.Time.Unix() {
+				t.Fatalf("normalized AdapterAccepted condition = %#v", condition)
+			}
+		})
 	}
 }
 
@@ -3304,6 +4114,75 @@ func TestAdapterSandboxEmitEventSendsExactRunUID(t *testing.T) {
 	}
 	if gotNamespace != "ns" || gotName != "r" || gotUID != "run-uid" {
 		t.Fatalf("sink received namespace/name/uid = %q/%q/%q, want ns/r/run-uid", gotNamespace, gotName, gotUID)
+	}
+}
+
+func TestAdapterAcceptanceDialRevalidatesActiveTenancyClaim(t *testing.T) {
+	installation := &platformv1alpha1.Installation{ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "system", UID: "installation-uid"}}
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns", UID: "namespace-uid", Annotations: map[string]string{
+		tenancy.InstallationNamespaceAnnotation: "system",
+		tenancy.InstallationNameAnnotation:      "main",
+		tenancy.InstallationUIDAnnotation:       "installation-uid",
+		tenancy.ProjectNameAnnotation:           "project",
+		tenancy.ProjectUIDAnnotation:            "project-uid",
+		tenancy.LifecycleAnnotation:             string(tenancy.LifecycleActive),
+	}}}
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "project", Namespace: "ns", UID: "project-uid"}}
+	run := &platformv1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid", Finalizers: []string{runFinalizer}},
+		Spec:       platformv1alpha1.RunSpec{Agent: "test"},
+		Status: platformv1alpha1.RunStatus{
+			State:          platformv1alpha1.RunStateEnvironmentReady,
+			EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{Name: "env", UID: "env-uid", Ownership: platformv1alpha1.EnvironmentOwnershipOwned},
+			Conditions:     []metav1.Condition{{Type: runConditionAdapterAcceptanceAttempted, Status: metav1.ConditionTrue, Reason: "AcceptancePending"}},
+		},
+	}
+	env := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "env", Namespace: "ns", UID: "env-uid"},
+		Status:     platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhaseReady},
+	}
+	adapter := &fencingDialAdapter{}
+	r := reconciler(t, adapter, installation, namespace, project, run, env)
+	baseClient := r.Client
+	verifier := &tenancy.Verifier{
+		Reader:       baseClient,
+		Installation: tenancy.InstallationIdentity{Key: types.NamespacedName{Namespace: "system", Name: "main"}, UID: installation.UID},
+		Mode:         tenancy.ModeScoped,
+	}
+	r.Scope = &tenancy.ReconcileScope{Verifier: verifier}
+	r.Client = tenancy.GuardedClient{Client: baseClient, Verifier: verifier}
+	adapter.mutate = func() {
+		var currentNamespace corev1.Namespace
+		if err := baseClient.Get(context.Background(), client.ObjectKey{Name: "ns"}, &currentNamespace); err != nil {
+			t.Fatal(err)
+		}
+		currentNamespace.Annotations[tenancy.LifecycleAnnotation] = string(tenancy.LifecycleFencing)
+		currentNamespace.Annotations[tenancy.LifecycleOperationAnnotation] = tenancy.OperationOffboarding
+		if err := baseClient.Update(context.Background(), &currentNamespace); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)})
+	if !errors.Is(err, tenancy.ErrOutOfScope) {
+		t.Fatalf("acceptance reconcile after offboarding claim = %v, want ErrOutOfScope", err)
+	}
+	var retained platformv1alpha1.Run
+	if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(run), &retained); err != nil {
+		t.Fatal(err)
+	}
+	if !acceptanceAttempted(&retained) || runAccepted(&retained) {
+		t.Fatalf("acceptance fence lost conservative marker or published acceptance: %#v", retained.Status.Conditions)
+	}
+
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)}); err != nil {
+		t.Fatalf("offboarding cancellation reconcile: %v", err)
+	}
+	if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(run), &retained); err != nil {
+		t.Fatal(err)
+	}
+	if !retained.Spec.Cancel {
+		t.Fatal("offboarding cancellation was blocked by the acceptance fence")
 	}
 }
 

--- a/internal/controlplane/portal.go
+++ b/internal/controlplane/portal.go
@@ -41,6 +41,7 @@ const (
 	portalAdmissionTimeout         = 2 * time.Minute
 	portalAdmissionHeartbeat       = time.Second
 	portalLeasePollInterval        = 2 * time.Second
+	portalLeaseCheckTimeout        = 2 * time.Second
 )
 
 // PortalResolver is the narrow durable route authority used by the gateway.
@@ -1009,9 +1010,12 @@ func (g *portalGateway) revalidatePortalLease(ctx context.Context, request *http
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			checkContext, cancel := context.WithTimeout(ctx, portalLeaseCheckTimeout)
 			var env platformv1alpha1.Environment
-			authRequest := request.Clone(ctx)
-			if g.resolver.Get(ctx, key, &env) != nil || fence.Validate(&env) != nil || !snapshot.Matches(&env) || portalPolicyError(&env) != nil || !env.DeletionTimestamp.IsZero() || !activeExactRoute(&env, route) || g.authorize(authRequest, env.Namespace, env.Name, route.Name, &env) != nil || lifecycle.RecordActivity(ctx, g.resolver, fence, platformv1alpha1.EnvironmentActivitySourcePortal, fmt.Sprintf("portal/lease/%d", time.Now().UnixNano())) != nil {
+			authRequest := request.Clone(checkContext)
+			invalid := g.resolver.Get(checkContext, key, &env) != nil || fence.Validate(&env) != nil || !snapshot.Matches(&env) || portalPolicyError(&env) != nil || !env.DeletionTimestamp.IsZero() || !activeExactRoute(&env, route) || g.authorize(authRequest, env.Namespace, env.Name, route.Name, &env) != nil || lifecycle.RecordActivity(checkContext, g.resolver, fence, platformv1alpha1.EnvironmentActivitySourcePortal, fmt.Sprintf("portal/lease/%d", time.Now().UnixNano())) != nil
+			cancel()
+			if invalid {
 				_ = conn.Close()
 				return
 			}

--- a/internal/controlplane/portal_test.go
+++ b/internal/controlplane/portal_test.go
@@ -108,6 +108,7 @@ func (w statusDenyingWriter) Update(context.Context, client.Object, ...client.Su
 
 type headerPortalAccess struct {
 	projectCalls atomic.Int64
+	denied       atomic.Bool
 }
 
 func (a *headerPortalAccess) Authorize(r *http.Request, _ ResourceAccess, _ bool) error {
@@ -125,6 +126,9 @@ func (a *headerPortalAccess) AuthorizePrincipal(r *http.Request, access Resource
 func (a *headerPortalAccess) AuthenticatePrincipal(r *http.Request, _ bool) (string, error) {
 	if r.Header.Get("Authorization") != "Bearer portal-user" {
 		return "", errUnauthenticated
+	}
+	if a.denied.Load() {
+		return "", errForbidden
 	}
 	return "portal-user", nil
 }
@@ -1183,6 +1187,30 @@ func TestPortalWebSocketSurvivesLeaseRevalidationThenClosesOnRouteRevocation(t *
 	_ = connection.SetReadDeadline(time.Now().Add(time.Second))
 	if _, _, err := connection.ReadMessage(); err == nil {
 		t.Fatal("revoked portal route retained its WebSocket")
+	}
+	waitPortalSlotsReleased(t, fixture)
+}
+
+func TestPortalWebSocketClosesOnLeaseAuthorizationRevocation(t *testing.T) {
+	fixture := newPortalWebSocketFixture(t, 20*time.Millisecond)
+	connection, response, err := websocket.DefaultDialer.DialContext(context.Background(), fixture.webSocketURL, fixture.requestHeader)
+	if err != nil {
+		if response != nil {
+			t.Fatalf("dial websocket: %v (%s)", err, response.Status)
+		}
+		t.Fatal(err)
+	}
+	defer connection.Close()
+	select {
+	case <-fixture.dialer.opened:
+	case <-time.After(time.Second):
+		t.Fatal("portal tunnel did not open")
+	}
+
+	fixture.access.denied.Store(true)
+	_ = connection.SetReadDeadline(time.Now().Add(time.Second))
+	if _, _, err := connection.ReadMessage(); err == nil {
+		t.Fatal("portal WebSocket remained open after authorization revocation")
 	}
 	waitPortalSlotsReleased(t, fixture)
 }

--- a/internal/controlplane/postgres_transcript.go
+++ b/internal/controlplane/postgres_transcript.go
@@ -471,12 +471,15 @@ func (s *PostgresTranscriptStore) pollBatch(ctx context.Context, run RunIdentity
 		return nil, 0, 0, err
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
+	var databaseNamespaceUID *string
 	var databaseHighWater int64
-	err = tx.QueryRow(ctx, `SELECT high_water FROM transcript_runs WHERE namespace = $1 AND namespace_uid = $2 AND run_uid = $3`, run.Namespace, string(run.NamespaceUID), string(run.UID)).Scan(&databaseHighWater)
+	err = tx.QueryRow(ctx, `SELECT namespace_uid, high_water FROM transcript_runs WHERE namespace = $1 AND run_uid = $2`, run.Namespace, string(run.UID)).Scan(&databaseNamespaceUID, &databaseHighWater)
 	if errors.Is(err, pgx.ErrNoRows) {
 		databaseHighWater = 0
 	} else if err != nil {
 		return nil, 0, 0, err
+	} else if databaseNamespaceUID == nil || *databaseNamespaceUID != string(run.NamespaceUID) {
+		return nil, 0, 0, ErrTranscriptIdentity
 	}
 	highWater := uint64(databaseHighWater)
 	earliest := highWater + 1

--- a/internal/controlplane/postgres_transcript_test.go
+++ b/internal/controlplane/postgres_transcript_test.go
@@ -171,6 +171,26 @@ func TestPostgresTranscriptStoreContract(t *testing.T) {
 		}
 	})
 
+	t.Run("empty subscription rejects a later conflicting Namespace identity", func(t *testing.T) {
+		current := RunIdentity{Namespace: "replacement-race", NamespaceUID: "namespace-uid-new", UID: "shared-run-uid"}
+		subscription, err := store.Subscribe(ctx, current, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer subscription.Unsubscribe()
+
+		stale := current
+		stale.NamespaceUID = "namespace-uid-old"
+		appendStoreEvent(t, store, stale, "stale")
+		select {
+		case event := <-subscription.Events:
+			t.Fatalf("conflicting Namespace identity delivered event: %#v", event)
+		case <-subscription.Dropped:
+		case <-time.After(2 * time.Second):
+			t.Fatal("conflicting Namespace identity did not close the subscription")
+		}
+	})
+
 	t.Run("opaque bytes and uint64 source sequence round trip", func(t *testing.T) {
 		run := RunIdentity{Namespace: "project-a", NamespaceUID: testNamespaceUID("project-a"), UID: "opaque-run"}
 		maximum := ^uint64(0)

--- a/internal/controlplane/resource_handlers.go
+++ b/internal/controlplane/resource_handlers.go
@@ -122,8 +122,28 @@ func (s *Server) handleGetRun(w http.ResponseWriter, r *http.Request, namespace,
 		writeProblem(w, http.StatusServiceUnavailable, "resource-service-unavailable", "Resource service unavailable", "Run resources are not configured")
 		return
 	}
-	run, err := s.resources.GetRun(r.Context(), namespace, name)
+	_, uidHeaderPresent := r.Header[http.CanonicalHeaderKey(RunUIDHeader)]
+	expectedUID := strings.TrimSpace(r.Header.Get(RunUIDHeader))
+	if uidHeaderPresent && expectedUID == "" {
+		writeProblem(w, http.StatusPreconditionRequired, "run-uid-required", "Run UID required", "a present "+RunUIDHeader+" header must contain an exact Run UID")
+		return
+	}
+	if len(expectedUID) > maxRunUIDLength {
+		writeProblem(w, http.StatusBadRequest, "invalid-request", "Invalid request", errRunUIDTooLong.Error())
+		return
+	}
+	var run Run
+	var err error
+	if uidHeaderPresent {
+		run, err = s.resources.GetRunExact(r.Context(), namespace, name, expectedUID)
+	} else {
+		run, err = s.resources.GetRun(r.Context(), namespace, name)
+	}
 	if err != nil {
+		if errors.Is(err, errRunUIDConflict) {
+			writeProblem(w, http.StatusConflict, "run-uid-conflict", "Run identity conflict", "the Run name now identifies a different Run")
+			return
+		}
 		s.writeResourceError(w, "get run", namespace, name, err)
 		return
 	}

--- a/internal/controlplane/resource_handlers_test.go
+++ b/internal/controlplane/resource_handlers_test.go
@@ -74,6 +74,10 @@ func (f *fakeResources) GetRun(_ context.Context, n, x string) (Run, error) {
 	f.calls = append(f.calls, "get")
 	return f.existing, f.errorGet
 }
+func (f *fakeResources) GetRunExact(_ context.Context, n, x, uid string) (Run, error) {
+	f.calls = append(f.calls, "get-exact:"+uid)
+	return f.existing, f.errorGet
+}
 func (f *fakeResources) CancelRun(_ context.Context, n, x, uid string) (Run, error) {
 	f.calls = append(f.calls, "cancel")
 	f.cancelUID = uid
@@ -421,5 +425,38 @@ func TestKubernetesResourceErrorsAreProblems(t *testing.T) {
 		if w.Code != tc.status || w.Header().Get("Content-Type") != "application/problem+json" {
 			t.Errorf("err=%v response=%d/%q", tc.err, w.Code, w.Header().Get("Content-Type"))
 		}
+	}
+}
+
+func TestGetRunOptionalUIDPrecondition(t *testing.T) {
+	resources := &fakeResources{existing: Run{Name: "run", UID: "current-uid"}}
+	server := NewServer(nil, ServerOptions{Access: &recordingAccess{}, Resources: resources})
+	request := func(header *string) *httptest.ResponseRecorder {
+		r := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/ns/runs/run", nil)
+		if header != nil {
+			r.Header.Set(RunUIDHeader, *header)
+		}
+		w := httptest.NewRecorder()
+		server.Handler().ServeHTTP(w, r)
+		return w
+	}
+	if response := request(nil); response.Code != http.StatusOK || !reflect.DeepEqual(resources.calls, []string{"get"}) {
+		t.Fatalf("headerless response/calls = %d/%v", response.Code, resources.calls)
+	}
+	resources.calls = nil
+	uid := "current-uid"
+	if response := request(&uid); response.Code != http.StatusOK || !reflect.DeepEqual(resources.calls, []string{"get-exact:current-uid"}) {
+		t.Fatalf("exact response/calls = %d/%v", response.Code, resources.calls)
+	}
+	resources.calls = nil
+	resources.errorGet = errRunUIDConflict
+	uid = "stale-uid"
+	if response := request(&uid); response.Code != http.StatusConflict || !strings.Contains(response.Body.String(), `/run-uid-conflict"`) {
+		t.Fatalf("stale response/body = %d/%s", response.Code, response.Body.String())
+	}
+	resources.calls = nil
+	uid = " "
+	if response := request(&uid); response.Code != http.StatusPreconditionRequired || len(resources.calls) != 0 {
+		t.Fatalf("blank response/calls = %d/%v", response.Code, resources.calls)
 	}
 }

--- a/internal/controlplane/resource_service.go
+++ b/internal/controlplane/resource_service.go
@@ -38,6 +38,7 @@ type ResourceService interface {
 	CreateRun(ctx context.Context, namespace string, request CreateRunRequest) (Run, error)
 	ResolveRunCreateCollision(ctx context.Context, namespace string, request CreateRunRequest) (Run, error)
 	GetRun(ctx context.Context, namespace, name string) (Run, error)
+	GetRunExact(ctx context.Context, namespace, name, expectedUID string) (Run, error)
 	CancelRun(ctx context.Context, namespace, name, expectedUID string) (Run, error)
 	GetEnvironment(ctx context.Context, namespace, name string) (Environment, error)
 	ResolveRunTerminal(ctx context.Context, namespace, name, expectedRunUID, expectedEnvironmentUID string) (RunTerminalAssociation, error)
@@ -121,9 +122,26 @@ func (s *KubernetesResourceService) ResolveRunCreateCollision(ctx context.Contex
 }
 
 func (s *KubernetesResourceService) GetRun(ctx context.Context, namespace, name string) (Run, error) {
+	return s.getRun(ctx, namespace, name, "")
+}
+
+func (s *KubernetesResourceService) GetRunExact(ctx context.Context, namespace, name, expectedUID string) (Run, error) {
+	if expectedUID == "" {
+		return Run{}, errRunUIDRequired
+	}
+	if len(expectedUID) > maxRunUIDLength {
+		return Run{}, errRunUIDTooLong
+	}
+	return s.getRun(ctx, namespace, name, expectedUID)
+}
+
+func (s *KubernetesResourceService) getRun(ctx context.Context, namespace, name, expectedUID string) (Run, error) {
 	var run platformv1alpha1.Run
 	if err := s.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &run); err != nil {
 		return Run{}, err
+	}
+	if expectedUID != "" && string(run.UID) != expectedUID {
+		return Run{}, errRunUIDConflict
 	}
 	result := runDTO(&run)
 	if run.Status.EnvironmentRef != nil {
@@ -241,7 +259,7 @@ func runOwnsOrClaimsEnvironment(run *platformv1alpha1.Run, environment *platform
 	}
 	switch run.Status.EnvironmentRef.Ownership {
 	case platformv1alpha1.EnvironmentOwnershipClaimed:
-		return environment.Status.ClaimedBy != nil && environment.Status.ClaimedBy.Name == run.Name && environment.Status.ClaimedBy.UID == run.UID
+		return metav1.GetControllerOf(environment) == nil && environment.Status.ClaimedBy != nil && environment.Status.ClaimedBy.Name == run.Name && environment.Status.ClaimedBy.UID == run.UID
 	case platformv1alpha1.EnvironmentOwnershipOwned:
 		owner := metav1.GetControllerOf(environment)
 		return owner != nil && owner.APIVersion == platformv1alpha1.GroupVersion.String() && owner.Kind == "Run" && owner.Name == run.Name && owner.UID == run.UID

--- a/internal/controlplane/resource_service_test.go
+++ b/internal/controlplane/resource_service_test.go
@@ -264,6 +264,28 @@ func TestResourceServiceGetRunPublishesOnlyExactAttachableEnvironmentUID(t *test
 	}
 }
 
+func TestResourceServiceGetRunExactRejectsSameNameReplacementBeforeEnvironmentRead(t *testing.T) {
+	run := &platformv1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{Name: "run", Namespace: "ns", UID: "replacement-uid"},
+		Status: platformv1alpha1.RunStatus{EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{
+			Name: "environment", UID: "environment-uid",
+		}},
+	}
+	gets := 0
+	base := fake.NewClientBuilder().WithScheme(resourceScheme(t)).WithObjects(run).Build()
+	wrapped := interceptor.NewClient(base, interceptor.Funcs{Get: func(ctx context.Context, underlying client.WithWatch, key client.ObjectKey, object client.Object, options ...client.GetOption) error {
+		gets++
+		return underlying.Get(ctx, key, object, options...)
+	}})
+	service := &KubernetesResourceService{Client: wrapped}
+	if _, err := service.GetRunExact(context.Background(), "ns", "run", "original-uid"); !errors.Is(err, errRunUIDConflict) || gets != 1 {
+		t.Fatalf("stale exact GET error/reads = %v/%d", err, gets)
+	}
+	if got, err := service.GetRun(context.Background(), "ns", "run"); err != nil || got.UID != "replacement-uid" {
+		t.Fatalf("ordinary current GET = %#v, %v", got, err)
+	}
+}
+
 func TestResourceServiceRunDTOMapsLifecycleTimestamps(t *testing.T) {
 	startedAt := metav1.NewTime(time.Date(2026, 7, 19, 18, 5, 0, 0, time.UTC))
 	finishedAt := metav1.NewTime(time.Date(2026, 7, 19, 18, 10, 0, 0, time.UTC))

--- a/internal/controlplane/run_watch.go
+++ b/internal/controlplane/run_watch.go
@@ -19,9 +19,10 @@ import (
 )
 
 const (
-	maxRunWatchRV = 4096
-	maxRunEvent   = 64 << 10
-	runWatchLife  = 5 * time.Minute
+	maxRunWatchRV          = 4096
+	maxRunEvent            = 64 << 10
+	runWatchLife           = 5 * time.Minute
+	runWatchReauthorizeMax = 15 * time.Second
 )
 
 type runWatchService interface {
@@ -153,9 +154,19 @@ func (s *Server) watchRuns(w http.ResponseWriter, r *http.Request, namespace str
 	defer cleanup()
 	ctx, cancel := context.WithTimeout(r.Context(), runWatchLife)
 	defer cancel()
+	reauthorize := func() bool {
+		checkCtx, checkCancel := context.WithTimeout(ctx, runWatchReauthorizeMax)
+		defer checkCancel()
+		request := r.Clone(checkCtx)
+		if pa, ok := s.access.(principalAccessController); ok {
+			current, err := pa.AuthorizePrincipal(request, access, true)
+			return err == nil && current == principal
+		}
+		return s.access != nil && s.access.Authorize(request, access, true) == nil
+	}
 	upstream, err := service.WatchRuns(ctx, namespace, rv, time.Duration(240+rand.Intn(40))*time.Second)
 	if err != nil {
-		if apierrors.IsResourceExpired(err) {
+		if apierrors.IsResourceExpired(err) || apierrors.IsGone(err) {
 			writeProblem(w, 410, "run-relist", "Run relist required", "resourceVersion is no longer available")
 		} else {
 			s.writeResourceError(w, "watch runs", namespace, "", err)
@@ -223,10 +234,13 @@ func (s *Server) watchRuns(w http.ResponseWriter, r *http.Request, namespace str
 		case <-ctx.Done():
 			return
 		case event, open := <-upstream.ResultChan():
-			if !open || !process(event) {
+			if !open || !reauthorize() || !process(event) {
 				return
 			}
 		case <-heartbeat.C:
+			if !reauthorize() {
+				return
+			}
 			_ = controller.SetWriteDeadline(time.Now().Add(15 * time.Second))
 			if _, err := w.Write([]byte(": heartbeat\n\n")); err != nil {
 				return

--- a/internal/controlplane/run_watch_test.go
+++ b/internal/controlplane/run_watch_test.go
@@ -2,9 +2,11 @@ package controlplane
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -40,6 +42,58 @@ func (a *principalAccess) Authorize(*http.Request, ResourceAccess, bool) error {
 func (a *principalAccess) AuthorizePrincipal(_ *http.Request, access ResourceAccess, _ bool) (string, error) {
 	a.access = access
 	return a.key, a.err
+}
+
+type revocableWatchAccess struct {
+	mu     sync.Mutex
+	denied bool
+}
+
+func (a *revocableWatchAccess) Authorize(*http.Request, ResourceAccess, bool) error {
+	_, err := a.AuthorizePrincipal(nil, ResourceAccess{}, true)
+	return err
+}
+
+func (a *revocableWatchAccess) AuthorizePrincipal(*http.Request, ResourceAccess, bool) (string, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.denied {
+		return "", errForbidden
+	}
+	return "uid", nil
+}
+
+func (a *revocableWatchAccess) revoke() {
+	a.mu.Lock()
+	a.denied = true
+	a.mu.Unlock()
+}
+
+type blockingReauthAccess struct {
+	calls           atomic.Int32
+	initialDeadline chan bool
+	reauthDeadline  chan time.Duration
+	reauthCanceled  chan struct{}
+}
+
+func (a *blockingReauthAccess) Authorize(*http.Request, ResourceAccess, bool) error {
+	return errors.New("unexpected non-principal authorization")
+}
+
+func (a *blockingReauthAccess) AuthorizePrincipal(r *http.Request, _ ResourceAccess, _ bool) (string, error) {
+	deadline, hasDeadline := r.Context().Deadline()
+	if a.calls.Add(1) == 1 {
+		a.initialDeadline <- hasDeadline
+		return "uid", nil
+	}
+	if hasDeadline {
+		a.reauthDeadline <- time.Until(deadline)
+	} else {
+		a.reauthDeadline <- 0
+	}
+	<-r.Context().Done()
+	close(a.reauthCanceled)
+	return "", r.Context().Err()
 }
 
 func TestRunWatchQueryRequiresExactOpaqueCursorAndLastEventIDWins(t *testing.T) {
@@ -95,6 +149,73 @@ func TestRunWatchStreamsBoundedSummaryAndExactWatchSAR(t *testing.T) {
 	}
 }
 
+func TestRunWatchReauthorizesBeforeForwardingEvents(t *testing.T) {
+	upstream := watch.NewRaceFreeFake()
+	access := &revocableWatchAccess{}
+	started := make(chan struct{})
+	server := NewServer(nil, ServerOptions{Access: access, Resources: &watchResources{fakeResources: &fakeResources{}, watch: upstream, started: started}})
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/ns/runs?watch=true&view=summary&resourceVersion=10", nil)
+	request.Header.Set("Accept", "text/event-stream")
+	response := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		server.Handler().ServeHTTP(response, request)
+		close(done)
+	}()
+	<-started
+	access.revoke()
+	upstream.Add(&platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "private", Namespace: "ns", UID: "uid", ResourceVersion: "11"}})
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("authorization loss did not close the watch")
+	}
+	if strings.Contains(response.Body.String(), "private") {
+		t.Fatalf("event was forwarded after authorization loss: %q", response.Body.String())
+	}
+}
+
+func TestRunWatchBoundsAndCancelsStalledReauthorization(t *testing.T) {
+	requestCtx, cancelRequest := context.WithCancel(context.Background())
+	defer cancelRequest()
+	upstream := &stoppedWatch{result: make(chan watch.Event, 1)}
+	upstream.result <- watch.Event{Type: watch.Added, Object: &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: "private", Namespace: "ns", UID: "uid", ResourceVersion: "11"}}}
+	access := &blockingReauthAccess{initialDeadline: make(chan bool, 1), reauthDeadline: make(chan time.Duration, 1), reauthCanceled: make(chan struct{})}
+	server := NewServer(nil, ServerOptions{Access: access, Resources: &watchResources{fakeResources: &fakeResources{}, watch: upstream}})
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/ns/runs?watch=true&view=summary&resourceVersion=10", nil).WithContext(requestCtx)
+	request.Header.Set("Accept", "text/event-stream")
+	response := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		server.Handler().ServeHTTP(response, request)
+		close(done)
+	}()
+	if <-access.initialDeadline {
+		t.Fatal("initial authorization was unexpectedly bounded by the watch lifetime")
+	}
+	deadline := <-access.reauthDeadline
+	if deadline <= 0 || deadline > runWatchReauthorizeMax {
+		t.Fatalf("reauthorization deadline = %v, want within (0, %v]", deadline, runWatchReauthorizeMax)
+	}
+	cancelRequest()
+	select {
+	case <-access.reauthCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("watch cancellation did not cancel stalled reauthorization")
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("stalled reauthorization retained the watch handler")
+	}
+	if !upstream.stopped.Load() {
+		t.Fatal("stalled reauthorization retained the upstream watch")
+	}
+	if strings.Contains(response.Body.String(), "private") {
+		t.Fatalf("event was forwarded while reauthorization stalled: %q", response.Body.String())
+	}
+}
+
 func TestRunWatchStaleBeforeAndAfterHeaders(t *testing.T) {
 	request := func() *http.Request {
 		r := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/ns/runs?watch=true&view=summary&resourceVersion=old", nil)
@@ -102,10 +223,17 @@ func TestRunWatchStaleBeforeAndAfterHeaders(t *testing.T) {
 		return r
 	}
 	t.Run("startup", func(t *testing.T) {
-		w := httptest.NewRecorder()
-		NewServer(nil, ServerOptions{Access: &principalAccess{key: "uid"}, Resources: &watchResources{fakeResources: &fakeResources{}, err: apierrors.NewResourceExpired("old")}}).Handler().ServeHTTP(w, request())
-		if w.Code != http.StatusGone || strings.Contains(w.Body.String(), "old") {
-			t.Fatalf("response = %d %q", w.Code, w.Body.String())
+		for name, err := range map[string]error{
+			"resource expired": apierrors.NewResourceExpired("old"),
+			"gone":             apierrors.NewGone("old"),
+		} {
+			t.Run(name, func(t *testing.T) {
+				w := httptest.NewRecorder()
+				NewServer(nil, ServerOptions{Access: &principalAccess{key: "uid"}, Resources: &watchResources{fakeResources: &fakeResources{}, err: err}}).Handler().ServeHTTP(w, request())
+				if w.Code != http.StatusGone || strings.Contains(w.Body.String(), "old") {
+					t.Fatalf("response = %d %q", w.Code, w.Body.String())
+				}
+			})
 		}
 	})
 	t.Run("streamed", func(t *testing.T) {

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -24,6 +24,7 @@ import (
 const (
 	namespacedPathPrefix               = "/api/v1/namespaces/"
 	defaultTranscriptHeartbeatInterval = 15 * time.Second
+	streamAuthorizationTimeout         = 5 * time.Second
 )
 
 type appendTranscriptRequest struct {
@@ -47,6 +48,7 @@ type Server struct {
 	trustProxy            bool
 	allowInsecureSessions bool
 	heartbeat             time.Duration
+	terminalAuthPoll      time.Duration
 	streams               context.Context
 	watchAdmission        *watchAdmission
 	terminalOpenTimeout   time.Duration
@@ -124,6 +126,7 @@ func NewServer(log *slog.Logger, options ServerOptions) *Server {
 		trustProxy:            options.TrustProxy,
 		allowInsecureSessions: options.AllowInsecureSessions,
 		heartbeat:             heartbeat,
+		terminalAuthPoll:      terminalPolicyPollInterval,
 		streams:               streams,
 		watchAdmission:        processWatchAdmission,
 		terminalOpenTimeout:   terminalHandshakeTimeout,
@@ -405,7 +408,7 @@ func (s *Server) handleTranscript(w http.ResponseWriter, r *http.Request, namesp
 
 	switch r.Method {
 	case http.MethodGet:
-		s.streamTranscript(w, r, identity)
+		s.streamTranscript(w, r, identity, ResourceAccess{Namespace: namespace, Verb: "get", Resource: "runs", Subresource: "transcript", Name: run})
 	case http.MethodPost:
 		s.appendTranscript(w, r, identity)
 	}
@@ -495,13 +498,44 @@ func (s *Server) appendTranscript(w http.ResponseWriter, r *http.Request, run Ru
 	_ = json.NewEncoder(w).Encode(result.Event)
 }
 
-func (s *Server) streamTranscript(w http.ResponseWriter, r *http.Request, run RunIdentity) {
+func (s *Server) streamTranscript(w http.ResponseWriter, r *http.Request, run RunIdentity, authorization ResourceAccess) {
 	if s.store == nil {
 		http.Error(w, "transcript store is unavailable", http.StatusServiceUnavailable)
 		return
 	}
 	r, cancelStream := s.withStreamLifecycle(r)
 	defer cancelStream()
+	authorizationDeadline := time.Now().Add(s.heartbeat)
+	reauthorize := func() error {
+		timeout := streamAuthorizationTimeout
+		if s.heartbeat < timeout {
+			timeout = s.heartbeat
+		}
+		authContext, cancel := context.WithTimeout(r.Context(), timeout)
+		defer cancel()
+		authRequest := r.Clone(authContext)
+		if err := s.access.Authorize(authRequest, authorization, true); err != nil {
+			return err
+		}
+		if namespaceUIDFromRequest(authRequest) != run.NamespaceUID {
+			return ErrTranscriptIdentity
+		}
+		uid, err := s.runs.ResolveRun(authContext, run.Namespace, authorization.Name)
+		if err != nil {
+			return err
+		}
+		if uid != run.UID {
+			return ErrTranscriptIdentity
+		}
+		authorizationDeadline = time.Now().Add(s.heartbeat)
+		return nil
+	}
+	ensureAuthorization := func() error {
+		if time.Now().Before(authorizationDeadline) {
+			return nil
+		}
+		return reauthorize()
+	}
 	cursor := r.Header.Get("Last-Event-ID")
 	if cursor == "" {
 		cursor = r.URL.Query().Get("after")
@@ -529,7 +563,11 @@ func (s *Server) streamTranscript(w http.ResponseWriter, r *http.Request, run Ru
 
 	controller := http.NewResponseController(w)
 	write := func(payload string) error {
-		if err := controller.SetWriteDeadline(time.Now().Add(15 * time.Second)); err != nil && !errors.Is(err, http.ErrNotSupported) {
+		writeDeadline := time.Now().Add(15 * time.Second)
+		if authorizationDeadline.Before(writeDeadline) {
+			writeDeadline = authorizationDeadline
+		}
+		if err := controller.SetWriteDeadline(writeDeadline); err != nil && !errors.Is(err, http.ErrNotSupported) {
 			return err
 		}
 		if _, err := io.WriteString(w, payload); err != nil {
@@ -544,6 +582,9 @@ func (s *Server) streamTranscript(w http.ResponseWriter, r *http.Request, run Ru
 		return nil
 	}
 	writeEvent := func(event TranscriptEvent) error {
+		if err := ensureAuthorization(); err != nil {
+			return err
+		}
 		payload, err := json.Marshal(event)
 		if err != nil {
 			return err
@@ -554,6 +595,9 @@ func (s *Server) streamTranscript(w http.ResponseWriter, r *http.Request, run Ru
 		return nil
 	}
 	if subscription.Gap != nil {
+		if err := ensureAuthorization(); err != nil {
+			return
+		}
 		payload, marshalErr := json.Marshal(subscription.Gap)
 		if marshalErr != nil {
 			s.metrics.observeDelivery("gap", "error", nil)
@@ -577,26 +621,39 @@ func (s *Server) streamTranscript(w http.ResponseWriter, r *http.Request, run Ru
 	if err := controller.Flush(); err != nil {
 		return
 	}
-	heartbeats := time.NewTicker(s.heartbeat)
-	defer heartbeats.Stop()
-
 	for {
+		if err := ensureAuthorization(); err != nil {
+			return
+		}
+		authorizationTimer := time.NewTimer(time.Until(authorizationDeadline))
 		select {
 		case event := <-subscription.Events:
+			if !authorizationTimer.Stop() {
+				<-authorizationTimer.C
+			}
 			if err := writeEvent(event); err != nil {
 				s.metrics.observeDelivery("live", "error", nil)
 				return
 			}
 			s.metrics.observeDelivery("live", "delivered", &event)
 		case <-subscription.Dropped:
+			if !authorizationTimer.Stop() {
+				<-authorizationTimer.C
+			}
 			s.metrics.observeDelivery("live", "dropped", nil)
 			s.log.Warn("closing dropped transcript subscriber", "namespace", run.Namespace, "runUID", run.UID)
 			return
-		case <-heartbeats.C:
+		case <-authorizationTimer.C:
+			if err := reauthorize(); err != nil {
+				return
+			}
 			if err := write(": ping\n\n"); err != nil {
 				return
 			}
 		case <-r.Context().Done():
+			if !authorizationTimer.Stop() {
+				<-authorizationTimer.C
+			}
 			return
 		}
 	}

--- a/internal/controlplane/server_test.go
+++ b/internal/controlplane/server_test.go
@@ -128,6 +128,144 @@ func TestTranscriptStreamSendsHeartbeat(t *testing.T) {
 	}
 }
 
+func TestTranscriptStreamClosesWhenHeartbeatReauthorizationFails(t *testing.T) {
+	access := &fakeAccess{}
+	api := NewServer(nil, ServerOptions{
+		Access:                      access,
+		Runs:                        &fakeRunResolver{},
+		TranscriptStore:             NewMemoryTranscriptStore(MemoryTranscriptStoreOptions{}),
+		TranscriptHeartbeatInterval: 10 * time.Millisecond,
+	})
+	server := httptest.NewServer(api.Handler())
+	defer server.Close()
+
+	request, err := http.NewRequest(http.MethodGet, server.URL+transcriptURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set(RunUIDHeader, "run-1-uid")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	access.setError(errForbidden)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := io.Copy(io.Discard, response.Body)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("read reauthorization-closed SSE stream: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("SSE stream remained open after authorization revocation")
+	}
+	if got := access.callCount(); got < 2 {
+		t.Fatalf("authorization calls = %d, want establishment plus lease check", got)
+	}
+}
+
+func TestTranscriptStreamClosesAfterBrowserLogout(t *testing.T) {
+	store := NewMemorySessionStore(MemorySessionStoreOptions{})
+	sessionID, err := store.Create(context.Background(), "kubernetes-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	api := NewServer(nil, ServerOptions{
+		Access:                      sessionResolvingAccess{store: store},
+		Sessions:                    KubernetesAccessController{Sessions: store},
+		Runs:                        &fakeRunResolver{},
+		TranscriptStore:             NewMemoryTranscriptStore(MemoryTranscriptStoreOptions{}),
+		TranscriptHeartbeatInterval: 10 * time.Millisecond,
+		AllowInsecureSessions:       true,
+	})
+	server := httptest.NewServer(api.Handler())
+	defer server.Close()
+
+	request, err := http.NewRequest(http.MethodGet, server.URL+transcriptURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set(RunUIDHeader, "run-1-uid")
+	request.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sessionID})
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+
+	logout, err := http.NewRequest(http.MethodDelete, server.URL+"/api/v1/session", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logout.Header.Set("Origin", server.URL)
+	logout.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sessionID})
+	logoutResponse, err := http.DefaultClient.Do(logout)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logoutResponse.Body.Close()
+	if logoutResponse.StatusCode != http.StatusNoContent {
+		t.Fatalf("logout status = %d, want %d", logoutResponse.StatusCode, http.StatusNoContent)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := io.Copy(io.Discard, response.Body)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("read logout-closed SSE stream: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("SSE stream remained open after browser logout")
+	}
+}
+
+func TestTranscriptStreamClosesWhenRunIdentityChangesAtRenewal(t *testing.T) {
+	resolver := &mutableRunResolver{uid: "run-1-uid"}
+	api := NewServer(nil, ServerOptions{
+		Access:                      &fakeAccess{},
+		Runs:                        resolver,
+		TranscriptStore:             NewMemoryTranscriptStore(MemoryTranscriptStoreOptions{}),
+		TranscriptHeartbeatInterval: 10 * time.Millisecond,
+	})
+	server := httptest.NewServer(api.Handler())
+	defer server.Close()
+
+	request, err := http.NewRequest(http.MethodGet, server.URL+transcriptURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set(RunUIDHeader, "run-1-uid")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	resolver.setUID("replacement-run-uid")
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := io.Copy(io.Discard, response.Body)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("read identity-closed SSE stream: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("SSE stream remained open after Run replacement")
+	}
+}
+
 func TestMetricsHandlerDoesNotExposeApplicationRoutes(t *testing.T) {
 	registry := prometheus.NewRegistry()
 	NewMetrics(registry)
@@ -608,12 +746,60 @@ func (a *fakeAccess) Authorize(request *http.Request, access ResourceAccess, _ b
 	return nil
 }
 
+func (a *fakeAccess) setError(err error) {
+	a.mu.Lock()
+	a.err = err
+	a.mu.Unlock()
+}
+
+func (a *fakeAccess) callCount() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.calls)
+}
+
+type sessionResolvingAccess struct {
+	store SessionStore
+}
+
+func (a sessionResolvingAccess) Authorize(request *http.Request, access ResourceAccess, allowSession bool) error {
+	if !allowSession {
+		return errUnauthenticated
+	}
+	cookie, err := request.Cookie(sessionCookieName)
+	if err != nil {
+		return errUnauthenticated
+	}
+	if _, err := a.store.Resolve(request.Context(), cookie.Value); err != nil {
+		return errUnauthenticated
+	}
+	*request = *request.WithContext(context.WithValue(request.Context(), namespaceUIDContextKey{}, testNamespaceUID(access.Namespace)))
+	return nil
+}
+
 func testNamespaceUID(namespace string) types.UID { return types.UID("namespace-uid-" + namespace) }
 
 type fakeRunResolver struct {
 	calls int
 	err   error
 	uid   types.UID
+}
+
+type mutableRunResolver struct {
+	mu  sync.Mutex
+	uid types.UID
+}
+
+func (r *mutableRunResolver) ResolveRun(_ context.Context, _, _ string) (types.UID, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.uid, nil
+}
+
+func (r *mutableRunResolver) setUID(uid types.UID) {
+	r.mu.Lock()
+	r.uid = uid
+	r.mu.Unlock()
 }
 
 func (r *fakeRunResolver) ResolveRun(_ context.Context, _, name string) (types.UID, error) {

--- a/internal/controlplane/terminal.go
+++ b/internal/controlplane/terminal.go
@@ -27,6 +27,7 @@ const (
 	wakeTimeout                   = 2 * time.Minute
 	wakePollInterval              = 250 * time.Millisecond
 	terminalPolicyPollInterval    = 5 * time.Second
+	terminalAuthorizationTimeout  = 5 * time.Second
 	terminalHealthTimeout         = 5 * time.Second
 	terminalHandshakeTimeout      = 5 * time.Second
 	terminalStreamingWriteTimeout = 15 * time.Second
@@ -513,7 +514,10 @@ func (s *Server) handleTerminal(w http.ResponseWriter, r *http.Request, namespac
 		writeProblem(w, http.StatusBadRequest, "terminal-identity-required", "Terminal identity required", "an exact Environment UID is required")
 		return
 	}
-	s.serveTerminal(w, r, namespace, environment, func(ctx context.Context) (sandboxdv1.TerminalServiceClient, sandboxdv1.HealthServiceClient, io.Closer, error) {
+	authorization := func(ctx context.Context) error {
+		return s.access.Authorize(r.Clone(ctx), ResourceAccess{Namespace: namespace, Verb: "get", Resource: "environments", Subresource: "terminal", Name: environment}, true)
+	}
+	s.serveTerminal(w, r, namespace, environment, authorization, func(ctx context.Context) (sandboxdv1.TerminalServiceClient, sandboxdv1.HealthServiceClient, io.Closer, error) {
 		return s.terminalDialer.DialTerminal(ctx, namespace, environment, expectedEnvironmentUID)
 	})
 }
@@ -570,14 +574,22 @@ func (s *Server) handleRunTerminalWithIdentity(w http.ResponseWriter, r *http.Re
 		writeAccessError(w, err)
 		return
 	}
-	s.serveTerminal(w, r, namespace, association.EnvironmentName, func(ctx context.Context) (sandboxdv1.TerminalServiceClient, sandboxdv1.HealthServiceClient, io.Closer, error) {
+	authorization := func(ctx context.Context) error {
+		authRequest := r.Clone(ctx)
+		if err := s.access.Authorize(authRequest, ResourceAccess{Namespace: namespace, Verb: "get", Resource: "runs", Name: runName}, true); err != nil {
+			return err
+		}
+		return s.access.Authorize(authRequest, ResourceAccess{Namespace: namespace, Verb: "get", Resource: "environments", Subresource: "terminal", Name: association.EnvironmentName}, true)
+	}
+	s.serveTerminal(w, r, namespace, association.EnvironmentName, authorization, func(ctx context.Context) (sandboxdv1.TerminalServiceClient, sandboxdv1.HealthServiceClient, io.Closer, error) {
 		return s.terminalDialer.DialRunTerminal(ctx, namespace, association)
 	})
 }
 
 type terminalBackendDial func(context.Context) (sandboxdv1.TerminalServiceClient, sandboxdv1.HealthServiceClient, io.Closer, error)
+type terminalAuthorization func(context.Context) error
 
-func (s *Server) serveTerminal(w http.ResponseWriter, r *http.Request, namespace, environment string, dial terminalBackendDial) {
+func (s *Server) serveTerminal(w http.ResponseWriter, r *http.Request, namespace, environment string, authorize terminalAuthorization, dial terminalBackendDial) {
 	if !websocket.IsWebSocketUpgrade(r) {
 		http.Error(w, "websocket upgrade is required", http.StatusBadRequest)
 		return
@@ -613,16 +625,47 @@ func (s *Server) serveTerminal(w http.ResponseWriter, r *http.Request, namespace
 		http.Error(w, "environment terminal is unavailable", http.StatusBadGateway)
 		return
 	}
+	authorizeOnce := func(ctx context.Context) error {
+		authContext, cancel := context.WithTimeout(ctx, terminalAuthorizationTimeout)
+		defer cancel()
+		return authorize(authContext)
+	}
+	if err := authorizeOnce(r.Context()); err != nil {
+		writeAccessError(w, err)
+		return
+	}
 
 	connection, err := terminalUpgrader.Upgrade(w, r, nil)
 	if err != nil {
 		return
 	}
 	defer connection.Close()
-	stopCloseOnCancel := context.AfterFunc(r.Context(), func() { _ = connection.Close() })
+	bridgeContext, cancelBridge := context.WithCancel(r.Context())
+	defer cancelBridge()
+	stopCloseOnCancel := context.AfterFunc(bridgeContext, func() { _ = connection.Close() })
 	defer stopCloseOnCancel()
+	authPoll := s.terminalAuthPoll
+	if authPoll <= 0 {
+		authPoll = terminalPolicyPollInterval
+	}
+	go func() {
+		ticker := time.NewTicker(authPoll)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-bridgeContext.Done():
+				return
+			case <-ticker.C:
+				if authorizeOnce(bridgeContext) != nil {
+					cancelBridge()
+					_ = connection.Close()
+					return
+				}
+			}
+		}
+	}()
 	connection.SetReadLimit(1 << 20)
-	if err := bridgeWebTerminalWithTimeouts(r.Context(), connection, terminal, s.terminalOpenTimeout, s.terminalWriteTimeout); err != nil {
+	if err := bridgeWebTerminalWithTimeouts(bridgeContext, connection, terminal, s.terminalOpenTimeout, s.terminalWriteTimeout); err != nil {
 		if r.Context().Err() == nil {
 			s.log.Debug("web terminal closed", "namespace", namespace, "environment", environment, "error", err)
 		}

--- a/internal/controlplane/terminal_test.go
+++ b/internal/controlplane/terminal_test.go
@@ -233,6 +233,50 @@ func TestWebTerminalOpenTimeoutReleasesStreamAndBackend(t *testing.T) {
 	}
 }
 
+func TestWebTerminalClosesWhenLeaseReauthorizationFails(t *testing.T) {
+	backend := &terminalLivenessServer{started: make(chan struct{}), stopped: make(chan struct{})}
+	backendConnection := newTerminalTestConnection(t, backend)
+	access := &fakeAccess{}
+	controlPlane := NewServer(nil, ServerOptions{
+		Access: access,
+		TerminalDialer: &terminalTestDialer{
+			client: sandboxdv1.NewTerminalServiceClient(backendConnection),
+		},
+	})
+	controlPlane.terminalAuthPoll = 10 * time.Millisecond
+	server := httptest.NewServer(controlPlane.Handler())
+	t.Cleanup(server.Close)
+
+	websocketURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/v1/namespaces/project-1/environments/env-1/terminal"
+	connection, _, err := websocket.DefaultDialer.Dial(websocketURL, http.Header{"Authorization": []string{"Bearer reader"}, EnvironmentUIDHeader: []string{"env-uid"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = connection.Close() })
+	if err := connection.WriteJSON(terminalControl{Type: "open", Cols: 80, Rows: 24}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-backend.started:
+	case <-time.After(time.Second):
+		t.Fatal("sandboxd terminal stream did not open")
+	}
+
+	access.setError(errForbidden)
+	_ = connection.SetReadDeadline(time.Now().Add(time.Second))
+	if _, _, err := connection.ReadMessage(); err == nil {
+		t.Fatal("terminal WebSocket remained open after authorization revocation")
+	}
+	select {
+	case <-backend.stopped:
+	case <-time.After(time.Second):
+		t.Fatal("sandboxd terminal stream remained open after authorization revocation")
+	}
+	if got := access.callCount(); got < 2 {
+		t.Fatalf("authorization calls = %d, want establishment plus lease check", got)
+	}
+}
+
 func TestWebTerminalValidOpenClearsReadDeadline(t *testing.T) {
 	backend := &terminalIdleServer{opened: make(chan struct{})}
 	backendConnection := newTerminalTestConnection(t, backend)
@@ -1193,6 +1237,9 @@ func TestResolveRunTerminalRequiresExactCurrentAssociation(t *testing.T) {
 		{name: "released claim", runUID: "run-uid", environmentUID: "env-uid", mutate: func(_ *platformv1alpha1.Run, e *platformv1alpha1.Environment) { e.Status.ClaimedBy = nil }, want: errRunTerminalAssociation},
 		{name: "reclaimed by another Run", runUID: "run-uid", environmentUID: "env-uid", mutate: func(_ *platformv1alpha1.Run, e *platformv1alpha1.Environment) {
 			e.Status.ClaimedBy = &platformv1alpha1.RunReference{Name: "other", UID: "other-uid"}
+		}, want: errRunTerminalAssociation},
+		{name: "claimed with foreign controller owner", runUID: "run-uid", environmentUID: "env-uid", mutate: func(_ *platformv1alpha1.Run, e *platformv1alpha1.Environment) {
+			e.OwnerReferences = []metav1.OwnerReference{{APIVersion: platformv1alpha1.GroupVersion.String(), Kind: "Run", Name: "other", UID: "other-uid", Controller: &controller}}
 		}, want: errRunTerminalAssociation},
 		{name: "foreign owner", runUID: "run-uid", environmentUID: "env-uid", mutate: func(r *platformv1alpha1.Run, e *platformv1alpha1.Environment) {
 			r.Status.EnvironmentRef.Ownership = platformv1alpha1.EnvironmentOwnershipOwned

--- a/internal/controlplaneclient/resources.go
+++ b/internal/controlplaneclient/resources.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/Chris-Cullins/swe-platform/internal/controlplane"
 )
@@ -51,7 +52,28 @@ func (c *Client) GetPortalRoute(ctx context.Context, namespace, environment, ser
 	return route, nil
 }
 
-var ErrRunRelist = errors.New("Run watch requires a full relist")
+var (
+	// ErrRunRelist reports that a Run watch must restart from a fresh snapshot.
+	ErrRunRelist = errors.New("Run watch requires a full relist")
+	// ErrRunIdentityMismatch reports that an exact Run GET returned another UID.
+	ErrRunIdentityMismatch = errors.New("control plane returned a different Run identity")
+	// ErrEnvironmentIdentityMismatch reports that an exact Environment GET returned another UID.
+	ErrEnvironmentIdentityMismatch = errors.New("control plane returned a different Environment identity")
+)
+
+// RetryableResourceError reports bounded automatic-recovery failures for exact
+// resource reads. Response decoding and local validation failures are terminal.
+func RetryableResourceError(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	var problem *ProblemError
+	if errors.As(err, &problem) {
+		return retryableHTTPStatus(problem.Problem.Status)
+	}
+	var transport *url.Error
+	return errors.As(err, &transport)
+}
 
 type initialRunWatchCompatibilityError struct{ error }
 
@@ -199,6 +221,36 @@ func (c *Client) GetRun(ctx context.Context, namespace, name string) (controlpla
 	return run, err
 }
 
+// GetRunExact returns the Run only while name identifies expectedUID.
+func (c *Client) GetRunExact(ctx context.Context, namespace, name, expectedUID string) (controlplane.Run, error) {
+	expectedUID = strings.TrimSpace(expectedUID)
+	if expectedUID == "" {
+		return controlplane.Run{}, fmt.Errorf("expected Run UID is required")
+	}
+	if len(expectedUID) > 128 {
+		return controlplane.Run{}, fmt.Errorf("expected Run UID exceeds 128 bytes")
+	}
+	var run controlplane.Run
+	request, err := c.NewRequest(ctx, http.MethodGet, c.Endpoint("api", "v1", "namespaces", namespace, "runs", name), nil)
+	if err != nil {
+		return run, err
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set(controlplane.RunUIDHeader, expectedUID)
+	response, err := c.Do(request)
+	if err != nil {
+		return run, err
+	}
+	defer response.Body.Close()
+	if err := decodeJSON(response.Body, &run, maxExactResourceResponse); err != nil {
+		return run, err
+	}
+	if run.UID != expectedUID {
+		return controlplane.Run{}, fmt.Errorf("%w: returned Run UID %q, expected %q", ErrRunIdentityMismatch, run.UID, expectedUID)
+	}
+	return run, nil
+}
+
 // CreateRun creates a Run or returns the existing Run when the server accepts
 // an exact immutable-intent retry under the same name.
 func (c *Client) CreateRun(ctx context.Context, namespace string, value controlplane.CreateRunRequest) (controlplane.Run, error) {
@@ -220,6 +272,25 @@ func (c *Client) GetEnvironment(ctx context.Context, namespace, name string) (co
 	var environment controlplane.Environment
 	err := c.getJSON(ctx, c.Endpoint("api", "v1", "namespaces", namespace, "environments", name), &environment)
 	return environment, err
+}
+
+// GetEnvironmentExact returns the Environment only while name identifies expectedUID.
+func (c *Client) GetEnvironmentExact(ctx context.Context, namespace, name, expectedUID string) (controlplane.Environment, error) {
+	expectedUID = strings.TrimSpace(expectedUID)
+	if expectedUID == "" {
+		return controlplane.Environment{}, fmt.Errorf("expected Environment UID is required")
+	}
+	if len(expectedUID) > 128 {
+		return controlplane.Environment{}, fmt.Errorf("expected Environment UID exceeds 128 bytes")
+	}
+	environment, err := c.GetEnvironment(ctx, namespace, name)
+	if err != nil {
+		return environment, err
+	}
+	if environment.UID != expectedUID {
+		return controlplane.Environment{}, fmt.Errorf("%w: returned Environment UID %q, expected %q", ErrEnvironmentIdentityMismatch, environment.UID, expectedUID)
+	}
+	return environment, nil
 }
 
 func (c *Client) getJSON(ctx context.Context, endpoint string, destination any) error {

--- a/internal/controlplaneclient/resources_test.go
+++ b/internal/controlplaneclient/resources_test.go
@@ -107,6 +107,66 @@ func TestResourceClientAlwaysSendsCancelUIDPrecondition(t *testing.T) {
 	}
 }
 
+func TestResourceClientGetRunExactValidatesLocallyAndResponseIdentity(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.Header.Get(controlplane.RunUIDHeader) != "stale-uid" {
+			t.Errorf("Run UID header = %q", r.Header.Get(controlplane.RunUIDHeader))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		writeTestRun(w, "run", false)
+	}))
+	defer server.Close()
+	client, _ := New(server.URL, "token", server.Client())
+	if _, err := client.GetRunExact(context.Background(), "ns", "run", " "); err == nil || requests != 0 {
+		t.Fatalf("blank exact error/requests = %v/%d", err, requests)
+	}
+	if _, err := client.GetRunExact(context.Background(), "ns", "run", "stale-uid"); !errors.Is(err, ErrRunIdentityMismatch) || !strings.Contains(err.Error(), `returned Run UID "uid-one"`) || requests != 1 {
+		t.Fatalf("mismatch error/requests = %v/%d", err, requests)
+	}
+}
+
+func TestResourceClientGetEnvironmentExactValidatesLocallyAndResponseIdentity(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"name":"env","uid":"replacement-uid","createdAt":"2026-07-24T00:00:00Z"}`)
+	}))
+	defer server.Close()
+	client, _ := New(server.URL, "token", server.Client())
+	if _, err := client.GetEnvironmentExact(context.Background(), "ns", "env", " "); err == nil || requests != 0 {
+		t.Fatalf("blank exact error/requests = %v/%d", err, requests)
+	}
+	if _, err := client.GetEnvironmentExact(context.Background(), "ns", "env", "expected-uid"); !errors.Is(err, ErrEnvironmentIdentityMismatch) || !strings.Contains(err.Error(), `returned Environment UID "replacement-uid"`) || requests != 1 {
+		t.Fatalf("mismatch error/requests = %v/%d", err, requests)
+	}
+}
+
+func TestRetryableResourceErrorClassifiesOnlyTransportAndRetryableStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "transport", err: &url.Error{Op: "Get", URL: "https://control-plane", Err: errors.New("network unavailable")}, want: true},
+		{name: "request timeout", err: &ProblemError{Problem: Problem{Status: http.StatusRequestTimeout}}, want: true},
+		{name: "rate limited", err: &ProblemError{Problem: Problem{Status: http.StatusTooManyRequests}}, want: true},
+		{name: "unavailable", err: &ProblemError{Problem: Problem{Status: http.StatusServiceUnavailable}}, want: true},
+		{name: "conflict", err: &ProblemError{Problem: Problem{Status: http.StatusConflict}}},
+		{name: "decode", err: errors.New("invalid JSON")},
+		{name: "canceled transport", err: &url.Error{Op: "Get", URL: "https://control-plane", Err: context.Canceled}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := RetryableResourceError(test.err); got != test.want {
+				t.Fatalf("RetryableResourceError(%v) = %t, want %t", test.err, got, test.want)
+			}
+		})
+	}
+}
+
 func TestResourceClientSurfacesAPIStatusesWithoutCredentialDisclosure(t *testing.T) {
 	statuses := []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusConflict, http.StatusServiceUnavailable}
 	for _, status := range statuses {

--- a/internal/repositorycredential/githubapp/provider.go
+++ b/internal/repositorycredential/githubapp/provider.go
@@ -81,6 +81,13 @@ func canonical(repository string) (string, string, string, error) {
 }
 
 func (p *Provider) CanonicalRepository(repository string) (string, error) {
+	return Canonicalizer{}.CanonicalRepository(repository)
+}
+
+// Canonicalizer performs no I/O and holds no provider credentials.
+type Canonicalizer struct{}
+
+func (Canonicalizer) CanonicalRepository(repository string) (string, error) {
 	canonicalURL, _, _, err := canonical(repository)
 	if err != nil {
 		return "", &repositorycredential.Error{Operation: "repository", Reason: "RepositoryUnsupported"}
@@ -198,7 +205,7 @@ func (p *Provider) Issue(ctx context.Context, repository string) (*repositorycre
 	}
 	var token struct {
 		Token               string            `json:"token"`
-		ExpiresAt           time.Time         `json:"expires_at"`
+		ExpiresAt           json.RawMessage   `json:"expires_at"`
 		RepositorySelection string            `json:"repository_selection"`
 		Permissions         map[string]string `json:"permissions"`
 		Repositories        []struct {
@@ -209,6 +216,15 @@ func (p *Provider) Issue(ctx context.Context, repository string) (*repositorycre
 	if err = p.request(ctx, http.MethodPost, fmt.Sprintf("/app/installations/%d/access_tokens", installation.ID), j, body, &token); err != nil {
 		return nil, err
 	}
+	cleanupNow := p.Now()
+	cleanupDeadline := cleanupNow.Add(time.Hour)
+	var expiresAt time.Time
+	var expiresText string
+	expiryTrusted := json.Unmarshal(token.ExpiresAt, &expiresText) == nil
+	if expiryTrusted {
+		expiresAt, err = time.Parse(time.RFC3339Nano, expiresText)
+		expiryTrusted = err == nil && expiresAt.After(cleanupNow.Add(repositorycredential.MinimumValidity)) && !expiresAt.After(cleanupDeadline)
+	}
 	validPermissions := len(token.Permissions) >= 1 && len(token.Permissions) <= 2 && token.Permissions["contents"] == "write"
 	for name, access := range token.Permissions {
 		if name != "contents" && (name != "metadata" || access != "read") {
@@ -216,10 +232,17 @@ func (p *Provider) Issue(ctx context.Context, repository string) (*repositorycre
 		}
 	}
 	validRepositories := len(token.Repositories) == 0 || len(token.Repositories) == 1 && strings.EqualFold(token.Repositories[0].FullName, owner+"/"+repo)
-	if token.Token == "" || len(token.Token) > repositorycredential.MaxTokenBytes || strings.IndexByte(token.Token, 0) >= 0 || !token.ExpiresAt.After(p.Now().Add(repositorycredential.MinimumValidity)) || token.RepositorySelection != "selected" || !validPermissions || !validRepositories {
+	credential := &repositorycredential.Credential{Token: []byte(token.Token), Repository: canonicalURL, InstallationID: installation.ID, ExpiresAt: cleanupDeadline}
+	if token.Token == "" || len(token.Token) > repositorycredential.MaxTokenBytes || strings.ContainsAny(token.Token, "\x00\r\n") {
 		return nil, &repositorycredential.Error{Operation: "token", Reason: "ProviderInvalidToken"}
 	}
-	return &repositorycredential.Credential{Token: []byte(token.Token), Repository: canonicalURL, InstallationID: installation.ID, ExpiresAt: token.ExpiresAt}, nil
+	if expiryTrusted {
+		credential.ExpiresAt = expiresAt
+	}
+	if !expiryTrusted || token.RepositorySelection != "selected" || !validPermissions || !validRepositories {
+		return credential, &repositorycredential.Error{Operation: "token", Reason: "ProviderInvalidToken"}
+	}
+	return credential, nil
 }
 
 func (p *Provider) Revoke(ctx context.Context, credential *repositorycredential.Credential) error {

--- a/internal/repositorycredential/githubapp/provider_test.go
+++ b/internal/repositorycredential/githubapp/provider_test.go
@@ -157,6 +157,70 @@ func TestIssueAndRevokeGitHubContract(t *testing.T) {
 	}
 }
 
+func TestIssueValidatesExactTokenBoundaryAndScope(t *testing.T) {
+	now := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name           string
+		expires        any
+		selection      string
+		permissions    map[string]string
+		repositories   []string
+		token          string
+		wantCredential bool
+		wantError      bool
+		wantDeadline   time.Time
+	}{
+		{name: "missing expiry", expires: nil, selection: "selected", permissions: map[string]string{"contents": "write"}, repositories: []string{"acme/widget"}, token: "token", wantCredential: true, wantError: true, wantDeadline: now.Add(time.Hour)},
+		{name: "malformed expiry", expires: "not-a-time", selection: "selected", permissions: map[string]string{"contents": "write"}, repositories: []string{"acme/widget"}, token: "token", wantCredential: true, wantError: true, wantDeadline: now.Add(time.Hour)},
+		{name: "zero expiry", expires: time.Time{}, selection: "selected", permissions: map[string]string{"contents": "write"}, repositories: []string{"acme/widget"}, token: "token", wantCredential: true, wantError: true, wantDeadline: now.Add(time.Hour)},
+		{name: "past expiry", expires: now.Add(-time.Minute), selection: "selected", permissions: map[string]string{"contents": "write"}, repositories: []string{"acme/widget"}, token: "token", wantCredential: true, wantError: true, wantDeadline: now.Add(time.Hour)},
+		{name: "exact minimum", expires: now.Add(repositorycredential.MinimumValidity), selection: "selected", permissions: map[string]string{"contents": "write"}, repositories: []string{"acme/widget"}, token: "token", wantCredential: true, wantError: true, wantDeadline: now.Add(time.Hour)},
+		{name: "below minimum", expires: now.Add(repositorycredential.MinimumValidity - time.Nanosecond), selection: "selected", permissions: map[string]string{"contents": "write"}, repositories: []string{"acme/widget"}, token: "token", wantCredential: true, wantError: true, wantDeadline: now.Add(time.Hour)},
+		{name: "above exact scope", expires: now.Add(repositorycredential.MinimumValidity + time.Nanosecond), selection: "selected", permissions: map[string]string{"contents": "write"}, repositories: []string{"acme/widget"}, token: "token", wantCredential: true},
+		{name: "beyond maximum", expires: now.Add(time.Hour + time.Nanosecond), selection: "selected", permissions: map[string]string{"contents": "write"}, repositories: []string{"acme/widget"}, token: "token", wantCredential: true, wantError: true, wantDeadline: now.Add(time.Hour)},
+		{name: "wrong selection", expires: now.Add(time.Hour), selection: "all", permissions: map[string]string{"contents": "write"}, repositories: []string{"acme/widget"}, token: "token", wantCredential: true, wantError: true},
+		{name: "broader permissions", expires: now.Add(time.Hour), selection: "selected", permissions: map[string]string{"contents": "write", "issues": "write"}, repositories: []string{"acme/widget"}, token: "token", wantCredential: true, wantError: true},
+		{name: "returned repository mismatch", expires: now.Add(time.Hour), selection: "selected", permissions: map[string]string{"contents": "write"}, repositories: []string{"acme/other"}, token: "token", wantCredential: true, wantError: true},
+		{name: "empty token", expires: now.Add(time.Hour), selection: "selected", permissions: map[string]string{"contents": "write"}, token: "", wantError: true},
+		{name: "NUL token", expires: now.Add(time.Hour), selection: "selected", permissions: map[string]string{"contents": "write"}, token: "bad\x00token", wantError: true},
+		{name: "oversize token", expires: now.Add(time.Hour), selection: "selected", permissions: map[string]string{"contents": "write"}, token: strings.Repeat("x", repositorycredential.MaxTokenBytes+1), wantError: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			p := &Provider{ClientID: "client", Key: key, Now: func() time.Time { return now }}
+			p.Client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				calls++
+				var body []byte
+				if calls == 1 {
+					body, _ = json.Marshal(map[string]any{"id": 42})
+				} else {
+					repositories := make([]map[string]string, len(tc.repositories))
+					for i, repository := range tc.repositories {
+						repositories[i] = map[string]string{"full_name": repository}
+					}
+					body, _ = json.Marshal(map[string]any{"token": tc.token, "expires_at": tc.expires, "repository_selection": tc.selection, "permissions": tc.permissions, "repositories": repositories})
+				}
+				return &http.Response{StatusCode: 200, Header: make(http.Header), Body: io.NopCloser(bytes.NewReader(body))}, nil
+			})}
+			credential, issueErr := p.Issue(context.Background(), "https://github.com/acme/widget")
+			if (credential != nil) != tc.wantCredential || (issueErr != nil) != tc.wantError {
+				t.Fatalf("Issue credential=%#v error=%v", credential, issueErr)
+			}
+			if tc.wantError && repositorycredential.Reason(issueErr) != "ProviderInvalidToken" {
+				t.Fatalf("reason = %q, error %v", repositorycredential.Reason(issueErr), issueErr)
+			}
+			if tc.wantDeadline.IsZero() == false && (credential == nil || !credential.ExpiresAt.Equal(tc.wantDeadline)) {
+				t.Fatalf("cleanup deadline = %#v, want %v", credential, tc.wantDeadline)
+			}
+		})
+	}
+}
+
 func TestRevokeTreatsUnauthorizedAsAlreadyInactive(t *testing.T) {
 	p := &Provider{Client: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 		body, _ := json.Marshal(map[string]string{"message": "Bad credentials"})

--- a/internal/repositorycredential/provider.go
+++ b/internal/repositorycredential/provider.go
@@ -24,8 +24,16 @@ type Credential struct {
 
 type Provider interface {
 	CanonicalRepository(string) (string, error)
+	// Issue returns both a credential and an error only when the credential is
+	// cleanup-capable but must not be delivered.
 	Issue(context.Context, string) (*Credential, error)
 	Revoke(context.Context, *Credential) error
+}
+
+// Canonicalizer is the stateless provider identity operation needed even when
+// issuance and revocation are disabled.
+type Canonicalizer interface {
+	CanonicalRepository(string) (string, error)
 }
 
 type Error struct {

--- a/internal/repositorycredential/secret.go
+++ b/internal/repositorycredential/secret.go
@@ -13,18 +13,23 @@ import (
 )
 
 const (
-	SecretType                    corev1.SecretType = "swe.dev/repository-credential"
-	TokenKey                                        = "token"
-	AnnotationRunName                               = "swe.dev/repository-credential-run-name"
-	AnnotationRunUID                                = "swe.dev/repository-credential-run-uid"
-	AnnotationProvider                              = "swe.dev/repository-credential-provider"
-	AnnotationRepository                            = "swe.dev/repository-credential-repository"
-	AnnotationSourceRepository                      = "swe.dev/repository-credential-source-repository"
-	AnnotationInstallationID                        = "swe.dev/repository-credential-installation-id"
-	AnnotationExpiry                                = "swe.dev/repository-credential-expiry"
-	AnnotationEnvironmentUID                        = "swe.dev/repository-credential-environment-uid"
-	AnnotationExecutionGeneration                   = "swe.dev/repository-credential-execution-generation"
-	AnnotationTokenGeneration                       = "swe.dev/repository-credential-token-generation"
+	SecretType                      corev1.SecretType = "swe.dev/repository-credential"
+	TokenKey                                          = "token"
+	AnnotationRunName                                 = "swe.dev/repository-credential-run-name"
+	AnnotationRunUID                                  = "swe.dev/repository-credential-run-uid"
+	AnnotationProvider                                = "swe.dev/repository-credential-provider"
+	AnnotationRepository                              = "swe.dev/repository-credential-repository"
+	AnnotationSourceRepository                        = "swe.dev/repository-credential-source-repository"
+	AnnotationInstallationID                          = "swe.dev/repository-credential-installation-id"
+	AnnotationExpiry                                  = "swe.dev/repository-credential-expiry"
+	AnnotationEnvironmentUID                          = "swe.dev/repository-credential-environment-uid"
+	AnnotationExecutionGeneration                     = "swe.dev/repository-credential-execution-generation"
+	AnnotationTokenGeneration                         = "swe.dev/repository-credential-token-generation"
+	AnnotationRevocationState                         = "swe.dev/repository-credential-revocation-state"
+	AnnotationRevocationDisposition                   = "swe.dev/repository-credential-revocation-disposition"
+	RevocationStatePending                            = "pending"
+	RevocationStateComplete                           = "complete"
+	DispositionProviderInvalidToken                   = "ProviderInvalidToken"
 )
 
 func SecretName(runUID types.UID) string { return "run-repository-credential-" + string(runUID) }
@@ -39,6 +44,12 @@ func ExactManagedIdentity(secret *corev1.Secret, runName string, runUID types.UI
 		return false
 	}
 	a := secret.Annotations
+	if _, ok := a[AnnotationRevocationState]; ok {
+		return false
+	}
+	if _, ok := a[AnnotationRevocationDisposition]; ok {
+		return false
+	}
 	return a[AnnotationRunName] == runName && a[AnnotationRunUID] == string(runUID) && a[AnnotationProvider] == provider && a[AnnotationSourceRepository] == source && a[AnnotationRepository] == canonical
 }
 
@@ -55,11 +66,33 @@ type Lease struct {
 	TokenGeneration     int64
 }
 
+// PendingRevocation is cleanup authority held in the revocation WAL. Keeping it
+// distinct from Lease prevents pending-only state from entering active paths.
+type PendingRevocation struct {
+	Credential
+	SecretUID        types.UID
+	ResourceVersion  string
+	RunName          string
+	RunUID           types.UID
+	Provider         string
+	SourceRepository string
+	TokenGeneration  int64
+	State            string
+	Disposition      string
+	Legacy           bool
+}
+
 func Parse(secret *corev1.Secret, runName string, runUID types.UID) (*Lease, error) {
 	if secret == nil || !secret.DeletionTimestamp.IsZero() || secret.Name != SecretName(runUID) || secret.Type != SecretType || len(secret.OwnerReferences) != 0 {
 		return nil, errors.New("foreign repository credential secret")
 	}
 	a := secret.Annotations
+	if _, ok := a[AnnotationRevocationState]; ok {
+		return nil, errors.New("foreign repository credential secret")
+	}
+	if _, ok := a[AnnotationRevocationDisposition]; ok {
+		return nil, errors.New("foreign repository credential secret")
+	}
 	if a[AnnotationRunName] != runName || a[AnnotationRunUID] != string(runUID) || a[AnnotationProvider] == "" || a[AnnotationRepository] == "" || a[AnnotationSourceRepository] == "" {
 		return nil, errors.New("foreign repository credential secret")
 	}
@@ -74,18 +107,31 @@ func Parse(secret *corev1.Secret, runName string, runUID types.UID) (*Lease, err
 	return &Lease{Credential: Credential{Token: append([]byte(nil), token...), Repository: a[AnnotationRepository], InstallationID: installation, ExpiresAt: expiry}, SecretUID: secret.UID, ResourceVersion: secret.ResourceVersion, RunName: runName, RunUID: runUID, Provider: a[AnnotationProvider], SourceRepository: a[AnnotationSourceRepository], EnvironmentUID: types.UID(a[AnnotationEnvironmentUID]), ExecutionGeneration: execution, TokenGeneration: generation}, nil
 }
 
-func ParsePendingRevocation(secret *corev1.Secret, runName string, runUID types.UID) (*Lease, error) {
-	if secret == nil || secret.Name != PendingRevocationSecretName(runUID) {
+func ParsePendingRevocation(secret *corev1.Secret, runName string, runUID types.UID) (*PendingRevocation, error) {
+	if secret == nil || !secret.DeletionTimestamp.IsZero() || secret.Name != PendingRevocationSecretName(runUID) || secret.Type != SecretType || len(secret.OwnerReferences) != 0 {
 		return nil, errors.New("foreign pending repository credential revocation")
 	}
-	copy := secret.DeepCopy()
-	defer func() {
-		for _, value := range copy.Data {
-			clear(value)
-		}
-	}()
-	copy.Name = SecretName(runUID)
-	return Parse(copy, runName, runUID)
+	a := secret.Annotations
+	state, hasState := a[AnnotationRevocationState]
+	disposition, hasDisposition := a[AnnotationRevocationDisposition]
+	// Records created before the WAL state annotations are migrated as pending.
+	if !hasState && !hasDisposition {
+		state = RevocationStatePending
+	} else if !hasState || !hasDisposition || (state != RevocationStatePending && state != RevocationStateComplete) || (disposition != "" && disposition != DispositionProviderInvalidToken) {
+		return nil, errors.New("malformed pending repository credential revocation")
+	}
+	if a[AnnotationRunName] != runName || a[AnnotationRunUID] != string(runUID) || a[AnnotationProvider] == "" || a[AnnotationRepository] == "" || a[AnnotationSourceRepository] == "" {
+		return nil, errors.New("foreign pending repository credential revocation")
+	}
+	installation, e1 := strconv.ParseInt(a[AnnotationInstallationID], 10, 64)
+	expiry, e2 := time.Parse(time.RFC3339Nano, a[AnnotationExpiry])
+	execution, e3 := strconv.ParseInt(a[AnnotationExecutionGeneration], 10, 64)
+	generation, e4 := strconv.ParseInt(a[AnnotationTokenGeneration], 10, 64)
+	token, ok := secret.Data[TokenKey]
+	if e1 != nil || e2 != nil || e3 != nil || e4 != nil || installation < 1 || execution != 0 || generation < 1 || !ok || len(secret.Data) != 1 || len(token) == 0 || len(token) > MaxTokenBytes || bytes.IndexByte(token, 0) >= 0 {
+		return nil, errors.New("malformed pending repository credential revocation")
+	}
+	return &PendingRevocation{Credential: Credential{Token: append([]byte(nil), token...), Repository: a[AnnotationRepository], InstallationID: installation, ExpiresAt: expiry}, SecretUID: secret.UID, ResourceVersion: secret.ResourceVersion, RunName: runName, RunUID: runUID, Provider: a[AnnotationProvider], SourceRepository: a[AnnotationSourceRepository], TokenGeneration: generation, State: state, Disposition: disposition, Legacy: !hasState && !hasDisposition}, nil
 }
 
 func NewSecret(namespace, runName string, runUID types.UID, provider, sourceRepository string, c *Credential, generation int64, envUID types.UID, execution int64, now time.Time) (*corev1.Secret, error) {
@@ -95,11 +141,15 @@ func NewSecret(namespace, runName string, runUID types.UID, provider, sourceRepo
 	return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: SecretName(runUID), Annotations: map[string]string{AnnotationRunName: runName, AnnotationRunUID: string(runUID), AnnotationProvider: provider, AnnotationRepository: c.Repository, AnnotationSourceRepository: sourceRepository, AnnotationInstallationID: strconv.FormatInt(c.InstallationID, 10), AnnotationExpiry: c.ExpiresAt.Format(time.RFC3339Nano), AnnotationEnvironmentUID: string(envUID), AnnotationExecutionGeneration: strconv.FormatInt(execution, 10), AnnotationTokenGeneration: strconv.FormatInt(generation, 10)}}, Type: SecretType, Data: map[string][]byte{TokenKey: append([]byte(nil), c.Token...)}}, nil
 }
 
-func NewPendingRevocationSecret(namespace, runName string, runUID types.UID, provider, sourceRepository string, c *Credential, generation int64, now time.Time) (*corev1.Secret, error) {
-	secret, err := NewSecret(namespace, runName, runUID, provider, sourceRepository, c, generation, "", 0, now)
-	if err != nil {
-		return nil, err
+func NewPendingRevocationSecret(namespace, runName string, runUID types.UID, provider, sourceRepository string, c *Credential, generation int64, now time.Time, disposition string) (*corev1.Secret, error) {
+	if sourceRepository == "" || c == nil || c.Repository == "" || c.InstallationID < 1 || c.ExpiresAt.IsZero() || len(c.Token) == 0 || len(c.Token) > MaxTokenBytes || bytes.IndexByte(c.Token, 0) >= 0 || generation < 1 {
+		return nil, fmt.Errorf("invalid issued repository credential")
 	}
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: SecretName(runUID), Annotations: map[string]string{AnnotationRunName: runName, AnnotationRunUID: string(runUID), AnnotationProvider: provider, AnnotationRepository: c.Repository, AnnotationSourceRepository: sourceRepository, AnnotationInstallationID: strconv.FormatInt(c.InstallationID, 10), AnnotationExpiry: c.ExpiresAt.Format(time.RFC3339Nano), AnnotationEnvironmentUID: "", AnnotationExecutionGeneration: "0", AnnotationTokenGeneration: strconv.FormatInt(generation, 10), AnnotationRevocationState: RevocationStatePending, AnnotationRevocationDisposition: ""}}, Type: SecretType, Data: map[string][]byte{TokenKey: append([]byte(nil), c.Token...)}}
+	if disposition != "" && disposition != DispositionProviderInvalidToken {
+		return nil, fmt.Errorf("invalid repository credential disposition")
+	}
+	secret.Annotations[AnnotationRevocationDisposition] = disposition
 	secret.Name = PendingRevocationSecretName(runUID)
 	return secret, nil
 }
@@ -107,5 +157,11 @@ func NewPendingRevocationSecret(namespace, runName string, runUID types.UID, pro
 func ClearLease(l *Lease) {
 	if l != nil {
 		clear(l.Token)
+	}
+}
+
+func ClearPendingRevocation(p *PendingRevocation) {
+	if p != nil {
+		clear(p.Token)
 	}
 }

--- a/internal/repositorycredential/secret_test.go
+++ b/internal/repositorycredential/secret_test.go
@@ -1,0 +1,100 @@
+package repositorycredential
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestActiveSecretRejectsPendingMetadataPresence(t *testing.T) {
+	now := time.Date(2026, 8, 8, 0, 0, 0, 0, time.UTC)
+	uid := types.UID("run-uid")
+	c := &Credential{Token: []byte("token"), Repository: "https://github.com/acme/repo", InstallationID: 7, ExpiresAt: now.Add(time.Hour)}
+	for _, annotation := range []string{AnnotationRevocationState, AnnotationRevocationDisposition} {
+		t.Run(annotation, func(t *testing.T) {
+			s, err := NewSecret("ns", "run", uid, "github-app", c.Repository, c, 1, "", 0, now)
+			if err != nil {
+				t.Fatal(err)
+			}
+			s.Annotations[annotation] = ""
+			if _, err := Parse(s, "run", uid); err == nil {
+				t.Fatal("Parse accepted pending-only annotation presence")
+			}
+			if ExactManagedIdentity(s, "run", uid, "github-app", c.Repository, c.Repository) {
+				t.Fatal("ExactManagedIdentity accepted pending-only annotation presence")
+			}
+		})
+	}
+}
+
+func TestPendingRevocationStateAndDispositionAreStrict(t *testing.T) {
+	now := time.Date(2026, 8, 8, 0, 0, 0, 0, time.UTC)
+	uid := types.UID("run-uid")
+	c := &Credential{Token: []byte("token"), Repository: "https://github.com/acme/repo", InstallationID: 7, ExpiresAt: now.Add(time.Hour)}
+	s, err := NewPendingRevocationSecret("ns", "run", uid, "github-app", c.Repository, c, 1, now, DispositionProviderInvalidToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, err := ParsePendingRevocation(s, "run", uid)
+	if err != nil || p.State != RevocationStatePending || p.Disposition != DispositionProviderInvalidToken || p.Legacy {
+		t.Fatalf("pending parse = %#v, %v", p, err)
+	}
+	for _, name := range []string{"missing state", "missing disposition", "unknown state", "unknown disposition"} {
+		t.Run(name, func(t *testing.T) {
+			copy := s.DeepCopy()
+			// Apply the named mutation independently to avoid shared table state.
+			switch name {
+			case "missing state":
+				delete(copy.Annotations, AnnotationRevocationState)
+			case "missing disposition":
+				delete(copy.Annotations, AnnotationRevocationDisposition)
+			case "unknown state":
+				copy.Annotations[AnnotationRevocationState] = "unknown"
+			case "unknown disposition":
+				copy.Annotations[AnnotationRevocationDisposition] = "unknown"
+			}
+			if _, err := ParsePendingRevocation(copy, "run", uid); err == nil {
+				t.Fatal("malformed pending metadata accepted")
+			}
+		})
+	}
+	legacy := s.DeepCopy()
+	delete(legacy.Annotations, AnnotationRevocationState)
+	delete(legacy.Annotations, AnnotationRevocationDisposition)
+	p, err = ParsePendingRevocation(legacy, "run", uid)
+	if err != nil || !p.Legacy || p.State != RevocationStatePending || p.Disposition != "" {
+		t.Fatalf("legacy parse = %#v, %v", p, err)
+	}
+	if _, err := NewPendingRevocationSecret("ns", "run", uid, "github-app", c.Repository, c, 1, now, "unknown"); err == nil {
+		t.Fatal("constructor accepted unknown disposition")
+	}
+}
+
+func TestSecretConstructorsEnforceActiveValidityBoundaryOnly(t *testing.T) {
+	now := time.Date(2026, 8, 8, 0, 0, 0, 0, time.UTC)
+	base := Credential{Token: []byte("token"), Repository: "https://github.com/acme/repo", InstallationID: 7}
+	for _, tc := range []struct {
+		name     string
+		expires  time.Time
+		activeOK bool
+	}{
+		{name: "short", expires: now.Add(time.Minute)},
+		{name: "exact minimum", expires: now.Add(MinimumValidity)},
+		{name: "above minimum", expires: now.Add(MinimumValidity + time.Nanosecond), activeOK: true},
+		{name: "expired", expires: now.Add(-time.Second)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			credential := base
+			credential.ExpiresAt = tc.expires
+			active, activeErr := NewSecret("ns", "run", "uid", "github-app", credential.Repository, &credential, 1, "", 0, now)
+			if (active != nil) != tc.activeOK || (activeErr == nil) != tc.activeOK {
+				t.Fatalf("active = %#v, %v", active, activeErr)
+			}
+			pending, pendingErr := NewPendingRevocationSecret("ns", "run", "uid", "github-app", credential.Repository, &credential, 1, now, "")
+			if pendingErr != nil || pending == nil {
+				t.Fatalf("pending = %#v, %v", pending, pendingErr)
+			}
+		})
+	}
+}

--- a/internal/tenancy/reconcile.go
+++ b/internal/tenancy/reconcile.go
@@ -73,6 +73,29 @@ func (s *ReconcileScope) Begin(ctx context.Context, namespace string, permitted 
 	return context.WithValue(ctx, mutationLeaseKey{}, lease), claim, nil
 }
 
+// Revalidate proves that the complete claim captured by Begin remains current
+// immediately before a privileged operation outside the Kubernetes client.
+func (s *ReconcileScope) Revalidate(ctx context.Context, namespace string, permitted ...Lifecycle) (Claim, error) {
+	if s == nil || s.Verifier == nil {
+		return Claim{Lifecycle: LifecycleActive}, nil
+	}
+	lease, ok := ctx.Value(mutationLeaseKey{}).(mutationLease)
+	if !ok || lease.fenceOnly || lease.namespace != namespace {
+		return Claim{}, errors.New("tenancy scope refuses operation without a matching reconcile lease")
+	}
+	claim, err := s.Verifier.VerifyNamespace(ctx, namespace)
+	if err != nil {
+		return Claim{}, err
+	}
+	if claim != lease.claim {
+		return Claim{}, fmt.Errorf("%w: Namespace %q claim changed during reconciliation", ErrOutOfScope, namespace)
+	}
+	if !permitsLifecycle(claim.Lifecycle, permitted) {
+		return Claim{}, fmt.Errorf("%w: Namespace %q lifecycle is %s", ErrOutOfScope, namespace, claim.Lifecycle)
+	}
+	return claim, nil
+}
+
 type GuardedClient struct {
 	client.Client
 	Verifier *Verifier

--- a/sandboxd/internal/server/portal.go
+++ b/sandboxd/internal/server/portal.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net"
@@ -15,16 +16,20 @@ import (
 
 const portalMaxFrame = 64 * 1024
 
+var portalLoopbacks = []string{"127.0.0.1", "::1"}
+
 // PortalServer tunnels bytes only to logical loopback. The semaphore bounds
 // daemon-wide tunnel concurrency and is deliberately independent of HTTP.
 type PortalServer struct {
 	sandboxdv1.UnimplementedPortalServiceServer
 	controlPort uint32
 	active      chan struct{}
+	dialContext dialContextFunc
 }
 
 func NewPortalServer(controlPort uint32) *PortalServer {
-	return &PortalServer{controlPort: controlPort, active: make(chan struct{}, 64)}
+	dialer := &net.Dialer{}
+	return &PortalServer{controlPort: controlPort, active: make(chan struct{}, 64), dialContext: dialer.DialContext}
 }
 
 func (s *PortalServer) Tunnel(stream sandboxdv1.PortalService_TunnelServer) error {
@@ -41,12 +46,16 @@ func (s *PortalServer) Tunnel(stream sandboxdv1.PortalService_TunnelServer) erro
 	if first.TargetPort == 0 || first.TargetPort > 65535 || first.TargetPort == s.controlPort || len(first.Data) > portalMaxFrame || first.Opened {
 		return status.Error(codes.InvalidArgument, "invalid portal target or frame")
 	}
-	dialer := net.Dialer{Timeout: 2 * time.Second}
-	conn, err := dialer.DialContext(stream.Context(), "tcp", net.JoinHostPort("localhost", strconv.Itoa(int(first.TargetPort))))
+	conn, err := s.dialLoopback(stream.Context(), first.TargetPort)
 	if err != nil {
 		return status.Error(codes.Unavailable, "portal target unavailable")
 	}
 	defer conn.Close()
+	// A target that stops reading can block a synchronous write. Closing the
+	// connection is the portable way to unblock both directions on cancellation
+	// and ensures the bounded tunnel slot is released.
+	stopCloseOnCancel := context.AfterFunc(stream.Context(), func() { _ = conn.Close() })
+	defer stopCloseOnCancel()
 	// This acknowledgement is the open handshake: clients must not expose a
 	// connection before receiving it.
 	if err := stream.Send(&sandboxdv1.PortalFrame{Opened: true}); err != nil {
@@ -132,6 +141,23 @@ func (s *PortalServer) Tunnel(stream sandboxdv1.PortalService_TunnelServer) erro
 			}
 		}
 	}
+}
+
+func (s *PortalServer) dialLoopback(ctx context.Context, port uint32) (net.Conn, error) {
+	dialCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	var lastErr error
+	for _, loopback := range portalLoopbacks {
+		conn, err := s.dialContext(dialCtx, "tcp", net.JoinHostPort(loopback, strconv.Itoa(int(port))))
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+		if dialCtx.Err() != nil {
+			break
+		}
+	}
+	return nil, lastErr
 }
 
 func closeWrite(conn net.Conn) {

--- a/sandboxd/internal/server/portal_test.go
+++ b/sandboxd/internal/server/portal_test.go
@@ -2,8 +2,10 @@ package server
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -137,6 +139,124 @@ func TestPortalCancellationReleasesSilentTargetAndTunnelSlot(t *testing.T) {
 		t.Fatal("portal cancellation did not close the silent target connection")
 	}
 }
+
+func TestPortalCancellationUnblocksTargetWriteAndReleasesTunnelSlot(t *testing.T) {
+	client, portalServer := portalTestHarness(t, 50051)
+	target := newBlockingPortalConn()
+	portalServer.dialContext = func(context.Context, string, string) (net.Conn, error) {
+		return target, nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	stream, err := client.Tunnel(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := stream.Send(&sandboxdv1.PortalFrame{TargetPort: 8080, Data: []byte("blocked")}); err != nil {
+		t.Fatal(err)
+	}
+	ack, err := stream.Recv()
+	if err != nil || !ack.Opened {
+		t.Fatalf("ack = %#v, %v", ack, err)
+	}
+	select {
+	case <-target.writeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("portal target write did not start")
+	}
+	if len(portalServer.active) != 1 {
+		t.Fatalf("active tunnels during blocked write = %d, want 1", len(portalServer.active))
+	}
+	cancel()
+	deadline := time.Now().Add(time.Second)
+	for len(portalServer.active) != 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if len(portalServer.active) != 0 {
+		t.Fatalf("active tunnels after cancellation = %d, want 0", len(portalServer.active))
+	}
+	select {
+	case <-target.closed:
+	case <-time.After(time.Second):
+		t.Fatal("portal cancellation did not close the blocked target connection")
+	}
+}
+
+func TestPortalDialsOnlyLiteralLoopbacksWithDualStackFallback(t *testing.T) {
+	client, portalServer := portalTestHarness(t, 50051)
+	var addresses []string
+	portalServer.dialContext = func(_ context.Context, _, address string) (net.Conn, error) {
+		addresses = append(addresses, address)
+		host, _, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, err
+		}
+		ip := net.ParseIP(host)
+		if ip == nil || !ip.IsLoopback() {
+			return nil, errors.New("portal attempted a non-loopback address")
+		}
+		if ip.To4() != nil {
+			return nil, errors.New("IPv4 target unavailable")
+		}
+		server, target := net.Pipe()
+		t.Cleanup(func() { _ = target.Close() })
+		return server, nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stream, err := client.Tunnel(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := stream.Send(&sandboxdv1.PortalFrame{TargetPort: 8080}); err != nil {
+		t.Fatal(err)
+	}
+	ack, err := stream.Recv()
+	if err != nil || !ack.Opened {
+		t.Fatalf("ack = %#v, %v", ack, err)
+	}
+	want := []string{"127.0.0.1:8080", "[::1]:8080"}
+	if len(addresses) != len(want) || addresses[0] != want[0] || addresses[1] != want[1] {
+		t.Fatalf("dial addresses = %v, want %v", addresses, want)
+	}
+}
+
+type blockingPortalConn struct {
+	writeStarted chan struct{}
+	closed       chan struct{}
+	writeOnce    sync.Once
+	closeOnce    sync.Once
+}
+
+func newBlockingPortalConn() *blockingPortalConn {
+	return &blockingPortalConn{writeStarted: make(chan struct{}), closed: make(chan struct{})}
+}
+
+func (c *blockingPortalConn) Read([]byte) (int, error) {
+	<-c.closed
+	return 0, net.ErrClosed
+}
+
+func (c *blockingPortalConn) Write([]byte) (int, error) {
+	c.writeOnce.Do(func() { close(c.writeStarted) })
+	<-c.closed
+	return 0, net.ErrClosed
+}
+
+func (c *blockingPortalConn) Close() error {
+	c.closeOnce.Do(func() { close(c.closed) })
+	return nil
+}
+
+func (*blockingPortalConn) LocalAddr() net.Addr              { return portalTestAddr("local") }
+func (*blockingPortalConn) RemoteAddr() net.Addr             { return portalTestAddr("remote") }
+func (*blockingPortalConn) SetDeadline(time.Time) error      { return nil }
+func (*blockingPortalConn) SetReadDeadline(time.Time) error  { return nil }
+func (*blockingPortalConn) SetWriteDeadline(time.Time) error { return nil }
+
+type portalTestAddr string
+
+func (a portalTestAddr) Network() string { return "test" }
+func (a portalTestAddr) String() string  { return string(a) }
 
 func TestPortalRejectsInvalidControlUnavailableAndOversizedFrames(t *testing.T) {
 	closed, err := net.Listen("tcp", "127.0.0.1:0")

--- a/sandboxd/internal/server/process.go
+++ b/sandboxd/internal/server/process.go
@@ -17,8 +17,6 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"google.golang.org/protobuf/proto"
-
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -30,6 +28,14 @@ const (
 	defaultOutputCapacity     = 1024 * 1024
 	defaultMaxRecords         = 1024
 	defaultReadMax            = 64 * 1024
+	maxManagedServices        = 32
+	maxManagedOwnerBytes      = 256
+	maxManagedRoleBytes       = 32
+	maxManagedArgs            = 64
+	maxManagedArgBytes        = 4096
+	maxManagedArgvBytes       = 16 * 1024
+	maxManagedCWDBytes        = 4096
+	maxManagedEnvEntries      = 64
 	maxLaunchMaterialEntries  = 64
 	maxLaunchMaterialName     = 256
 	maxLaunchMaterialValue    = 64 * 1024
@@ -108,8 +114,8 @@ type ProcessServer struct {
 type managedOwner struct {
 	revision      uint64
 	routeRevision uint64
-	wire          []byte
 	desired       map[string]*sandboxdv1.ProcessSpec
+	restarts      map[string]*time.Timer
 	gen           uint64
 }
 
@@ -119,6 +125,13 @@ func NewProcessServer(workspace string, supervisors ...*Supervisor) *ProcessServ
 		sup = supervisors[0]
 	}
 	return &ProcessServer{Workspace: workspace, processes: make(map[processKey]*managedProcess), managedOwners: make(map[string]*managedOwner), OutputCapacity: defaultOutputCapacity, MaxRecords: defaultMaxRecords, supervisor: sup, restartInitial: 25 * time.Millisecond, restartMax: 5 * time.Second, restartStable: 30 * time.Second}
+}
+
+func (s *ProcessServer) maxRecords() int {
+	if s.MaxRecords > 0 {
+		return s.MaxRecords
+	}
+	return defaultMaxRecords
 }
 
 func validTimeout(ms uint64) bool { return ms <= uint64((time.Duration(1<<63-1))/time.Millisecond) }
@@ -260,34 +273,40 @@ func (s *ProcessServer) ReconcileManagedServices(_ context.Context, req *sandbox
 	if req == nil || req.OwnerId == "" || req.IntentRevision == 0 {
 		return nil, status.Error(codes.InvalidArgument, "owner_id and positive intent_revision are required")
 	}
+	if len(req.OwnerId) > maxManagedOwnerBytes || !utf8.ValidString(req.OwnerId) || strings.ContainsRune(req.OwnerId, 0) {
+		return nil, status.Errorf(codes.InvalidArgument, "owner_id must be valid UTF-8 without NUL and at most %d bytes", maxManagedOwnerBytes)
+	}
+	if len(req.Services) > maxManagedServices {
+		return nil, status.Errorf(codes.InvalidArgument, "services exceeds maximum of %d", maxManagedServices)
+	}
+	if !s.reconcileMu.TryLock() {
+		return nil, status.Error(codes.ResourceExhausted, "managed service reconciliation is busy")
+	}
+	defer s.reconcileMu.Unlock()
 	desired := make(map[string]*sandboxdv1.ProcessSpec, len(req.Services))
 	roles := make([]string, 0, len(req.Services))
 	for _, service := range req.Services {
-		if service == nil || service.Role == "" {
-			return nil, status.Error(codes.InvalidArgument, "service role must not be empty")
+		if service == nil || service.Role == "" || len(service.Role) > maxManagedRoleBytes || !utf8.ValidString(service.Role) || strings.ContainsRune(service.Role, 0) {
+			return nil, status.Errorf(codes.InvalidArgument, "service role must be valid UTF-8 without NUL and 1-%d bytes", maxManagedRoleBytes)
 		}
 		if _, exists := desired[service.Role]; exists {
 			return nil, status.Error(codes.InvalidArgument, "service roles must be unique")
+		}
+		if err := validateManagedSpec(service.Spec); err != nil {
+			return nil, err
 		}
 		spec, err := s.normalizeSpec(service.Spec)
 		if err != nil {
 			return nil, err
 		}
+		if len(spec.Env) == 0 {
+			spec.Env = nil
+		}
 		desired[service.Role] = spec
 		roles = append(roles, service.Role)
 	}
 	sort.Strings(roles)
-	canonical := &sandboxdv1.ReconcileManagedServicesRequest{OwnerId: req.OwnerId, IntentRevision: req.IntentRevision, RouteRevision: req.RouteRevision}
-	for _, role := range roles {
-		canonical.Services = append(canonical.Services, &sandboxdv1.ManagedServiceSpec{Role: role, Spec: desired[role]})
-	}
-	wire, err := proto.MarshalOptions{Deterministic: true}.Marshal(canonical)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "encode desired services: %v", err)
-	}
 
-	s.reconcileMu.Lock()
-	defer s.reconcileMu.Unlock()
 	s.mu.Lock()
 	if s.closed {
 		s.mu.Unlock()
@@ -300,7 +319,7 @@ func (s *ProcessServer) ReconcileManagedServices(_ context.Context, req *sandbox
 			return nil, status.Error(codes.FailedPrecondition, "managed service revision is stale")
 		}
 		if req.IntentRevision == owner.revision && req.RouteRevision == owner.routeRevision {
-			if !bytes.Equal(wire, owner.wire) {
+			if !reflect.DeepEqual(desired, owner.desired) {
 				s.mu.Unlock()
 				return nil, status.Error(codes.FailedPrecondition, "intent_revision has a different desired set")
 			}
@@ -309,11 +328,27 @@ func (s *ProcessServer) ReconcileManagedServices(_ context.Context, req *sandbox
 			return resp, nil
 		}
 	}
+	maxRecords := s.maxRecords()
+	if owner == nil && len(s.managedOwners) >= maxRecords {
+		s.mu.Unlock()
+		return nil, status.Error(codes.ResourceExhausted, "managed service owner limit reached")
+	}
+	desiredRecords := len(desired)
+	for ownerID, existing := range s.managedOwners {
+		if ownerID != req.OwnerId {
+			desiredRecords += len(existing.desired)
+		}
+	}
+	if desiredRecords > maxRecords {
+		s.mu.Unlock()
+		return nil, status.Error(codes.ResourceExhausted, "managed service desired record limit reached")
+	}
 	gen := uint64(1)
 	if owner != nil {
 		gen = owner.gen + 1
+		s.cancelManagedRestartsLocked(owner)
 	}
-	owner = &managedOwner{revision: req.IntentRevision, routeRevision: req.RouteRevision, wire: wire, desired: desired, gen: gen}
+	owner = &managedOwner{revision: req.IntentRevision, routeRevision: req.RouteRevision, desired: desired, restarts: make(map[string]*time.Timer), gen: gen}
 	s.managedOwners[req.OwnerId] = owner
 	var stop []*managedProcess
 	toStart := make(map[string]struct{}, len(desired))
@@ -353,6 +388,42 @@ func (s *ProcessServer) ReconcileManagedServices(_ context.Context, req *sandbox
 	return resp, nil
 }
 
+func validateManagedSpec(spec *sandboxdv1.ProcessSpec) error {
+	if spec == nil || len(spec.Argv) == 0 {
+		return status.Error(codes.InvalidArgument, "managed service spec argv must not be empty")
+	}
+	if len(spec.Argv) > maxManagedArgs {
+		return status.Errorf(codes.InvalidArgument, "managed service argv exceeds maximum of %d arguments", maxManagedArgs)
+	}
+	argvBytes := 0
+	for _, arg := range spec.Argv {
+		if arg == "" || len(arg) > maxManagedArgBytes || !utf8.ValidString(arg) || strings.ContainsRune(arg, 0) {
+			return status.Errorf(codes.InvalidArgument, "managed service argument must be valid UTF-8 without NUL and 1-%d bytes", maxManagedArgBytes)
+		}
+		argvBytes += len(arg)
+	}
+	if argvBytes > maxManagedArgvBytes {
+		return status.Errorf(codes.InvalidArgument, "managed service argv exceeds %d aggregate bytes", maxManagedArgvBytes)
+	}
+	if len(spec.Cwd) > maxManagedCWDBytes || !utf8.ValidString(spec.Cwd) || strings.ContainsRune(spec.Cwd, 0) {
+		return status.Errorf(codes.InvalidArgument, "managed service cwd must be valid UTF-8 without NUL and at most %d bytes", maxManagedCWDBytes)
+	}
+	if len(spec.Env) > maxManagedEnvEntries {
+		return status.Errorf(codes.InvalidArgument, "managed service environment exceeds maximum of %d entries", maxManagedEnvEntries)
+	}
+	envBytes := 0
+	for name, value := range spec.Env {
+		if len(name) > maxLaunchMaterialName || !utf8.ValidString(name) || len(value) > maxLaunchMaterialValue || !utf8.ValidString(value) {
+			return status.Error(codes.InvalidArgument, "managed service environment entry exceeds portable size or encoding limits")
+		}
+		envBytes += len(name) + len(value)
+	}
+	if envBytes > maxLaunchMaterialTotal {
+		return status.Errorf(codes.InvalidArgument, "managed service environment exceeds %d aggregate bytes", maxLaunchMaterialTotal)
+	}
+	return nil
+}
+
 func (s *ProcessServer) managedResponseLocked(ownerID string, owner *managedOwner) *sandboxdv1.ReconcileManagedServicesResponse {
 	resp := &sandboxdv1.ReconcileManagedServicesResponse{OwnerId: ownerID, IntentRevision: owner.revision, RouteRevision: owner.routeRevision}
 	roles := make([]string, 0, len(owner.desired))
@@ -368,12 +439,6 @@ func (s *ProcessServer) managedResponseLocked(ownerID string, owner *managedOwne
 		resp.Services = append(resp.Services, &sandboxdv1.ManagedServiceStatus{Role: role, Process: process})
 	}
 	return resp
-}
-
-func (s *ProcessServer) ensureManaged(ownerID, role string, gen uint64, attempt uint) {
-	s.reconcileMu.Lock()
-	defer s.reconcileMu.Unlock()
-	s.ensureManagedUnderReconcile(ownerID, role, gen, attempt)
 }
 
 // ensureManagedUnderReconcile is called only while reconcileMu is held. The
@@ -408,7 +473,7 @@ func (s *ProcessServer) ensureManagedUnderReconcile(ownerID, role string, gen ui
 	if startErr != nil {
 		if owner == s.managedOwners[ownerID] && owner.gen == gen && owner.desired[role] != nil && !s.closed {
 			delay := s.managedRestartDelay(attempt)
-			time.AfterFunc(delay, func() { s.ensureManaged(ownerID, role, gen, attempt+1) })
+			s.scheduleManagedEnsureLocked(ownerID, role, owner, attempt+1, delay)
 		}
 		s.mu.Unlock()
 		return
@@ -435,8 +500,51 @@ func (s *ProcessServer) scheduleManagedRestartLocked(key processKey, p *managedP
 		attempt = 0
 	}
 	delay := s.managedRestartDelay(attempt)
-	gen := owner.gen
-	time.AfterFunc(delay, func() { s.ensureManaged(key.ownerID, key.role, gen, attempt+1) })
+	s.scheduleManagedEnsureLocked(key.ownerID, key.role, owner, attempt+1, delay)
+}
+
+func (s *ProcessServer) scheduleManagedEnsureLocked(ownerID, role string, owner *managedOwner, attempt uint, delay time.Duration) {
+	if timer := owner.restarts[role]; timer != nil {
+		timer.Stop()
+	}
+	var timer *time.Timer
+	timer = time.AfterFunc(delay, func() {
+		s.mu.Lock()
+		current := s.managedOwners[ownerID]
+		valid := current == owner && !s.closed && current.restarts[role] == timer && current.desired[role] != nil
+		s.mu.Unlock()
+		if !valid {
+			return
+		}
+		if !s.reconcileMu.TryLock() {
+			s.mu.Lock()
+			current = s.managedOwners[ownerID]
+			if current == owner && !s.closed && current.restarts[role] == timer && current.desired[role] != nil {
+				s.scheduleManagedEnsureLocked(ownerID, role, owner, attempt, s.restartInitial)
+			}
+			s.mu.Unlock()
+			return
+		}
+		defer s.reconcileMu.Unlock()
+		s.mu.Lock()
+		current = s.managedOwners[ownerID]
+		valid = current == owner && !s.closed && current.restarts[role] == timer && current.desired[role] != nil
+		if valid {
+			delete(current.restarts, role)
+		}
+		s.mu.Unlock()
+		if valid {
+			s.ensureManagedUnderReconcile(ownerID, role, owner.gen, attempt)
+		}
+	})
+	owner.restarts[role] = timer
+}
+
+func (s *ProcessServer) cancelManagedRestartsLocked(owner *managedOwner) {
+	for role, timer := range owner.restarts {
+		timer.Stop()
+		delete(owner.restarts, role)
+	}
 }
 
 func (s *ProcessServer) managedRestartDelay(attempt uint) time.Duration {
@@ -554,10 +662,7 @@ func (s *ProcessServer) start(keyRequest *sandboxdv1.ProcessKey, specRequest *sa
 		}
 		return processResponse(p), nil
 	}
-	maxRecords := s.MaxRecords
-	if maxRecords <= 0 {
-		maxRecords = defaultMaxRecords
-	}
+	maxRecords := s.maxRecords()
 	if len(s.processes) >= maxRecords {
 		return nil, status.Error(codes.ResourceExhausted, "process record limit reached")
 	}
@@ -771,8 +876,7 @@ func (s *ProcessServer) finishLocked(p *managedProcess) {
 		if p.managed {
 			s.scheduleManagedRestartLocked(key, p)
 		} else if owner := s.managedOwners[key.ownerID]; owner != nil && owner.desired[key.role] != nil && !p.managedSuppressed && !s.closed {
-			gen := owner.gen
-			time.AfterFunc(0, func() { s.ensureManaged(key.ownerID, key.role, gen, 0) })
+			s.scheduleManagedEnsureLocked(key.ownerID, key.role, owner, 0, 0)
 		}
 	}
 }
@@ -1004,6 +1108,9 @@ func (s *ProcessServer) CloseContext(ctx context.Context) error {
 		return s.supervisor.Close(ctx)
 	}
 	s.closed = true
+	for _, owner := range s.managedOwners {
+		s.cancelManagedRestartsLocked(owner)
+	}
 	s.mu.Unlock()
 	return s.supervisor.Close(ctx)
 }

--- a/sandboxd/internal/server/process_managed_test.go
+++ b/sandboxd/internal/server/process_managed_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -94,6 +95,233 @@ func TestManagedRestartDelayProgressionAndCap(t *testing.T) {
 	}
 	if got := s.managedRestartDelay(^uint(0)); got != 40*time.Millisecond {
 		t.Fatalf("overflow-scale attempt delay = %s, want cap", got)
+	}
+}
+
+func TestManagedServiceAdmissionBounds(t *testing.T) {
+	t.Run("maximum services accepted", func(t *testing.T) {
+		s := NewProcessServer(t.TempDir())
+		defer s.Close()
+		request := &sandboxdv1.ReconcileManagedServicesRequest{OwnerId: "uid", IntentRevision: 1}
+		for i := 0; i < maxManagedServices; i++ {
+			request.Services = append(request.Services, &sandboxdv1.ManagedServiceSpec{Role: fmt.Sprintf("service-%02d", i), Spec: &sandboxdv1.ProcessSpec{Argv: []string{"never-admitted"}}})
+		}
+		response, err := s.ReconcileManagedServices(context.Background(), request)
+		if err != nil {
+			t.Fatalf("maximum desired set: %v", err)
+		}
+		if len(response.Services) != maxManagedServices {
+			t.Fatalf("maximum desired set = %d services, want %d", len(response.Services), maxManagedServices)
+		}
+	})
+
+	t.Run("services per set", func(t *testing.T) {
+		s := NewProcessServer(t.TempDir())
+		defer s.Close()
+		request := &sandboxdv1.ReconcileManagedServicesRequest{OwnerId: "uid", IntentRevision: 1}
+		for i := 0; i <= maxManagedServices; i++ {
+			request.Services = append(request.Services, &sandboxdv1.ManagedServiceSpec{Role: fmt.Sprintf("service-%02d", i), Spec: &sandboxdv1.ProcessSpec{Argv: []string{"never-admitted"}}})
+		}
+		if _, err := s.ReconcileManagedServices(context.Background(), request); status.Code(err) != codes.InvalidArgument {
+			t.Fatalf("oversized desired set = %v, want InvalidArgument", err)
+		}
+		if len(s.managedOwners) != 0 || len(s.processes) != 0 {
+			t.Fatalf("oversized desired set mutated state: owners=%d processes=%d", len(s.managedOwners), len(s.processes))
+		}
+	})
+
+	t.Run("owners retain bounded tombstones", func(t *testing.T) {
+		s := NewProcessServer(t.TempDir())
+		s.MaxRecords = 2
+		defer s.Close()
+		for _, owner := range []string{"one", "two"} {
+			if _, err := s.ReconcileManagedServices(context.Background(), managedRequest(owner, 1, "", "", "", nil)); err != nil {
+				t.Fatalf("owner %q: %v", owner, err)
+			}
+		}
+		if _, err := s.ReconcileManagedServices(context.Background(), managedRequest("three", 1, "", "", "", nil)); status.Code(err) != codes.ResourceExhausted {
+			t.Fatalf("third owner = %v, want ResourceExhausted", err)
+		}
+		if _, err := s.ReconcileManagedServices(context.Background(), managedRequest("one", 1, "", "", "", nil)); err != nil {
+			t.Fatalf("exact retry at owner limit: %v", err)
+		}
+	})
+
+	t.Run("aggregate desired slots", func(t *testing.T) {
+		s := NewProcessServer(t.TempDir())
+		s.MaxRecords = 1
+		defer s.Close()
+		missing := &sandboxdv1.ProcessSpec{Argv: []string{filepath.Join(t.TempDir(), "missing")}}
+		first := &sandboxdv1.ReconcileManagedServicesRequest{OwnerId: "one", IntentRevision: 1, Services: []*sandboxdv1.ManagedServiceSpec{{Role: "svc", Spec: missing}}}
+		if _, err := s.ReconcileManagedServices(context.Background(), first); err != nil {
+			t.Fatal(err)
+		}
+		second := &sandboxdv1.ReconcileManagedServicesRequest{OwnerId: "one", IntentRevision: 2, Services: []*sandboxdv1.ManagedServiceSpec{{Role: "svc", Spec: missing}, {Role: "second", Spec: missing}}}
+		if _, err := s.ReconcileManagedServices(context.Background(), second); status.Code(err) != codes.ResourceExhausted {
+			t.Fatalf("second desired slot = %v, want ResourceExhausted", err)
+		}
+		if s.managedOwners["one"].revision != 1 || len(s.managedOwners["one"].desired) != 1 {
+			t.Fatal("rejected desired set mutated the accepted owner")
+		}
+	})
+}
+
+func TestConcurrentManagedReconcileReturnsResourceExhausted(t *testing.T) {
+	s := NewProcessServer(t.TempDir())
+	defer s.Close()
+	entered, release := make(chan struct{}), make(chan struct{})
+	s.beforeManagedStart = func() {
+		close(entered)
+		<-release
+	}
+	request := &sandboxdv1.ReconcileManagedServicesRequest{OwnerId: "uid", IntentRevision: 1, Services: []*sandboxdv1.ManagedServiceSpec{{Role: "svc", Spec: &sandboxdv1.ProcessSpec{Argv: []string{"never-admitted"}}}}}
+	done := make(chan error, 1)
+	go func() {
+		_, err := s.ReconcileManagedServices(context.Background(), request)
+		done <- err
+	}()
+	<-entered
+	_, concurrentErr := s.ReconcileManagedServices(context.Background(), request)
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	if status.Code(concurrentErr) != codes.ResourceExhausted {
+		t.Fatalf("concurrent reconcile = %v, want ResourceExhausted", concurrentErr)
+	}
+}
+
+func TestManagedServiceFieldBoundsPreserveAcceptedIntent(t *testing.T) {
+	tests := map[string]func(*sandboxdv1.ReconcileManagedServicesRequest){
+		"owner": func(request *sandboxdv1.ReconcileManagedServicesRequest) {
+			request.OwnerId = strings.Repeat("o", maxManagedOwnerBytes+1)
+		},
+		"owner NUL": func(request *sandboxdv1.ReconcileManagedServicesRequest) {
+			request.OwnerId = "uid\x00other"
+		},
+		"role": func(request *sandboxdv1.ReconcileManagedServicesRequest) {
+			request.Services[0].Role = strings.Repeat("r", maxManagedRoleBytes+1)
+		},
+		"role NUL": func(request *sandboxdv1.ReconcileManagedServicesRequest) {
+			request.Services[0].Role = "svc\x00other"
+		},
+		"argument count": func(request *sandboxdv1.ReconcileManagedServicesRequest) {
+			request.Services[0].Spec.Argv = make([]string, maxManagedArgs+1)
+			for i := range request.Services[0].Spec.Argv {
+				request.Services[0].Spec.Argv[i] = "x"
+			}
+		},
+		"argument bytes": func(request *sandboxdv1.ReconcileManagedServicesRequest) {
+			request.Services[0].Spec.Argv = []string{strings.Repeat("x", maxManagedArgBytes+1)}
+		},
+		"argv bytes": func(request *sandboxdv1.ReconcileManagedServicesRequest) {
+			request.Services[0].Spec.Argv = []string{strings.Repeat("x", maxManagedArgBytes), strings.Repeat("y", maxManagedArgBytes), strings.Repeat("z", maxManagedArgBytes), strings.Repeat("w", maxManagedArgBytes), "overflow"}
+		},
+		"cwd": func(request *sandboxdv1.ReconcileManagedServicesRequest) {
+			request.Services[0].Spec.Cwd = strings.Repeat("c", maxManagedCWDBytes+1)
+		},
+		"environment count": func(request *sandboxdv1.ReconcileManagedServicesRequest) {
+			request.Services[0].Spec.Env = make(map[string]string, maxManagedEnvEntries+1)
+			for i := 0; i <= maxManagedEnvEntries; i++ {
+				request.Services[0].Spec.Env[string(rune('a'+i))] = "x"
+			}
+		},
+		"environment value": func(request *sandboxdv1.ReconcileManagedServicesRequest) {
+			request.Services[0].Spec.Env = map[string]string{"VALUE": strings.Repeat("x", maxLaunchMaterialValue+1)}
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			s := NewProcessServer(t.TempDir())
+			s.restartInitial = 10 * time.Second
+			defer s.Close()
+			accepted := &sandboxdv1.ReconcileManagedServicesRequest{OwnerId: "uid", IntentRevision: 1, Services: []*sandboxdv1.ManagedServiceSpec{{Role: "svc", Spec: &sandboxdv1.ProcessSpec{Argv: []string{filepath.Join(t.TempDir(), "missing")}}}}}
+			if _, err := s.ReconcileManagedServices(context.Background(), accepted); err != nil {
+				t.Fatal(err)
+			}
+			owner := s.managedOwners["uid"]
+			timer := owner.restarts["svc"]
+			candidate := &sandboxdv1.ReconcileManagedServicesRequest{OwnerId: "uid", IntentRevision: 2, Services: []*sandboxdv1.ManagedServiceSpec{{Role: "svc", Spec: &sandboxdv1.ProcessSpec{Argv: []string{"valid"}}}}}
+			mutate(candidate)
+			if _, err := s.ReconcileManagedServices(context.Background(), candidate); status.Code(err) != codes.InvalidArgument {
+				t.Fatalf("invalid field = %v, want InvalidArgument", err)
+			}
+			if len(s.managedOwners) != 1 || s.managedOwners["uid"] != owner || owner.revision != 1 || owner.restarts["svc"] != timer {
+				t.Fatal("invalid field mutated accepted intent or its retry")
+			}
+		})
+	}
+}
+
+func TestManagedRetryDoesNotWaitBehindReconcile(t *testing.T) {
+	s := NewProcessServer(t.TempDir())
+	s.MaxRecords = 1
+	s.restartInitial = 30 * time.Millisecond
+	s.restartMax = 60 * time.Millisecond
+	defer s.Close()
+	occupied := &sandboxdv1.ProcessSpec{Argv: []string{os.Args[0], "-test.run=TestSetManagedProcessHelper"}, EnvMode: sandboxdv1.EnvironmentMode_ENVIRONMENT_MODE_REPLACE, Env: map[string]string{"SANDBOXD_MANAGED_HELPER": "1", "MARKER": filepath.Join(t.TempDir(), "occupied"), "VALUE": "occupied", "WAIT": "1"}}
+	if _, err := s.Start(context.Background(), &sandboxdv1.StartProcessRequest{Key: &sandboxdv1.ProcessKey{OwnerId: "ordinary", Role: "slot"}, Spec: occupied}); err != nil {
+		t.Fatal(err)
+	}
+	attempted := make(chan struct{}, 2)
+	s.beforeManagedStart = func() { attempted <- struct{}{} }
+	request := &sandboxdv1.ReconcileManagedServicesRequest{OwnerId: "uid", IntentRevision: 1, Services: []*sandboxdv1.ManagedServiceSpec{{Role: "svc", Spec: &sandboxdv1.ProcessSpec{Argv: []string{"never-admitted"}}}}}
+	if _, err := s.ReconcileManagedServices(context.Background(), request); err != nil {
+		t.Fatal(err)
+	}
+	<-attempted
+	s.mu.Lock()
+	originalTimer := s.managedOwners["uid"].restarts["svc"]
+	s.mu.Unlock()
+	s.reconcileMu.Lock()
+	time.Sleep(75 * time.Millisecond)
+	s.mu.Lock()
+	if len(s.managedOwners["uid"].restarts) != 1 {
+		t.Fatalf("pending retries = %d, want one", len(s.managedOwners["uid"].restarts))
+	}
+	if s.managedOwners["uid"].restarts["svc"] == originalTimer {
+		t.Fatal("expired retry waited behind reconciliation instead of re-arming")
+	}
+	s.mu.Unlock()
+	select {
+	case <-attempted:
+		t.Fatal("retry crossed held reconciliation admission")
+	default:
+	}
+	s.reconcileMu.Unlock()
+	select {
+	case <-attempted:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("re-armed retry did not run after reconciliation admission released")
+	}
+}
+
+func TestManagedRemovalCancelsExhaustedRecordRetry(t *testing.T) {
+	s := NewProcessServer(t.TempDir())
+	s.MaxRecords = 1
+	s.restartInitial = 100 * time.Millisecond
+	s.restartMax = 100 * time.Millisecond
+	defer s.Close()
+	occupied := &sandboxdv1.ProcessSpec{Argv: []string{os.Args[0], "-test.run=TestSetManagedProcessHelper"}, EnvMode: sandboxdv1.EnvironmentMode_ENVIRONMENT_MODE_REPLACE, Env: map[string]string{"SANDBOXD_MANAGED_HELPER": "1", "MARKER": filepath.Join(t.TempDir(), "occupied"), "VALUE": "occupied", "WAIT": "1"}}
+	if _, err := s.Start(context.Background(), &sandboxdv1.StartProcessRequest{Key: &sandboxdv1.ProcessKey{OwnerId: "ordinary", Role: "slot"}, Spec: occupied}); err != nil {
+		t.Fatal(err)
+	}
+
+	attempted := make(chan struct{}, 2)
+	s.beforeManagedStart = func() { attempted <- struct{}{} }
+	request := &sandboxdv1.ReconcileManagedServicesRequest{OwnerId: "uid", IntentRevision: 1, Services: []*sandboxdv1.ManagedServiceSpec{{Role: "svc", Spec: &sandboxdv1.ProcessSpec{Argv: []string{"never-admitted"}}}}}
+	if _, err := s.ReconcileManagedServices(context.Background(), request); err != nil {
+		t.Fatal(err)
+	}
+	<-attempted
+	if _, err := s.ReconcileManagedServices(context.Background(), managedRequest("uid", 2, "", "", "", nil)); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(200 * time.Millisecond)
+	select {
+	case <-attempted:
+		t.Fatal("removed service retained an exhausted-record retry")
+	default:
 	}
 }
 
@@ -322,19 +550,21 @@ func TestManagedRestartAdmissionSerializesNewerRemoval(t *testing.T) {
 		t.Fatal("restart did not reach managed admission hook")
 	}
 
-	done := make(chan error, 1)
-	go func() {
-		_, err := s.ReconcileManagedServices(context.Background(), managedRequest("uid", 2, "", marker, "", nil))
-		done <- err
-	}()
-	select {
-	case err := <-done:
-		t.Fatalf("newer removal crossed in-flight admission: %v", err)
-	case <-time.After(25 * time.Millisecond):
+	removal := managedRequest("uid", 2, "", marker, "", nil)
+	if _, err := s.ReconcileManagedServices(context.Background(), removal); status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("concurrent newer removal = %v, want ResourceExhausted", err)
 	}
 	close(release)
-	if err := <-done; err != nil {
-		t.Fatal(err)
+	deadline := time.Now().Add(time.Second)
+	for {
+		_, err := s.ReconcileManagedServices(context.Background(), removal)
+		if err == nil {
+			break
+		}
+		if status.Code(err) != codes.ResourceExhausted || time.Now().After(deadline) {
+			t.Fatal(err)
+		}
+		time.Sleep(time.Millisecond)
 	}
 	s.beforeManagedStart = nil
 	time.Sleep(100 * time.Millisecond)

--- a/sandboxd/proto/sandboxd/v1/PROCESS_LIFECYCLE.md
+++ b/sandboxd/proto/sandboxd/v1/PROCESS_LIFECYCLE.md
@@ -24,6 +24,18 @@ current pair, fails without mutation. A greater pair
 atomically replaces desired intent: removed roles are stopped, changed roles are
 stopped before replacement, and new roles are started. Responses report each desired
 logical role's current `Process` state and opaque execution ID, never an OS identity.
+One set contains at most 32 services. Owner IDs are at most 256 NUL-free UTF-8 bytes;
+roles use the platform declaration limit of 32 NUL-free UTF-8 bytes. Managed argv
+retains at most 64 arguments, 4,096 UTF-8 bytes per argument, and 16 KiB aggregate; cwd and public
+environment are likewise explicitly size- and encoding-bounded: cwd is at most 4,096
+UTF-8 bytes, and environment is at most 64 entries, 256 UTF-8 bytes per name, 64 KiB
+per UTF-8 value, and 256 KiB aggregate. Across one daemon epoch, retained
+managed-owner tombstones and aggregate desired managed-service slots are each bounded
+by the process record limit (1,024 by default); a new owner or desired set that would
+exceed those daemon resources fails with `RESOURCE_EXHAUSTED` without mutation.
+Tombstones preserve revision and exact-retry fencing, including after a complete-set
+removal. Only one reconciliation is admitted at a time; a concurrent call receives
+`RESOURCE_EXHAUSTED` rather than retaining another queued request.
 
 Every unrequested exit, including exit zero and start failure, is restarted with
 bounded exponential backoff. Backoff is capped and resets after stable operation. A
@@ -33,7 +45,9 @@ close suppress the old execution's restart. Restart admission is serialized with
 reconciliation and explicit Stop. Revision/generation fencing applies to delayed restart work,
 so stale reconciliation cannot resurrect a removed service or
 overwrite newer intent. Managed services use only `ProcessSpec.env`; launch material
-is deliberately unsupported.
+is deliberately unsupported. At most one delayed restart is retained per desired
+owner/role; replacement, removal, and daemon close cancel obsolete delayed work, and
+a retry never waits in a goroutine behind reconciliation.
 
 Committed states include natural `RUNNING -> EXITED` and controlled
 `RUNNING -> STOPPING -> EXITED`, with `FAILED` terminal for a

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -2246,9 +2246,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3244,9 +3244,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -3394,9 +3394,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -3414,7 +3414,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/ui/src/App.test.tsx
+++ b/ui/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { focusManager, onlineManager, QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, useLocation } from 'react-router'
@@ -19,14 +19,14 @@ function LocationProbe() {
   const location = useLocation()
   return <output data-testid="location">{`${location.pathname}${location.search}${location.hash}`}</output>
 }
-function show(path: string, state?: unknown) {
-  const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+function show(path: string, state?: unknown, providedClient?: QueryClient) {
+  const client = providedClient || new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
   const location = new URL(path, 'https://console.test')
   const entry = { pathname: location.pathname, search: location.search, hash: location.hash, state }
   return { client, ...render(<QueryClientProvider client={client}><MemoryRouter initialEntries={[entry]}><LocationProbe /><App /></MemoryRouter></QueryClientProvider>) }
 }
 
-afterEach(() => { vi.useRealTimers(); vi.restoreAllMocks(); vi.unstubAllGlobals() })
+afterEach(() => { focusManager.setFocused(undefined); onlineManager.setOnline(true); vi.useRealTimers(); vi.restoreAllMocks(); vi.unstubAllGlobals() })
 describe('App frozen API integration', () => {
   it('lands on the default namespace Run feed from the root route', async () => {
     const fetch = vi.spyOn(globalThis, 'fetch').mockImplementation(async path => path === '/api/v1/session' ? response({ authenticated: true, username: 'alex' }) : response({ items: [] }))
@@ -144,6 +144,29 @@ describe('App frozen API integration', () => {
     expect(fetch).toHaveBeenCalledWith(expect.stringContaining('watch=true'), expect.anything())
   })
 
+  it('hides retained namespace data and actions when a watch reconnect loses authorization', async () => {
+    vi.useFakeTimers()
+    let watches = 0
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async path => {
+      if (String(path).includes('watch=true')) {
+        watches += 1
+        if (watches === 1) return new Response(new ReadableStream({ start: controller => controller.close() }), { headers: { 'Content-Type': 'text/event-stream' } })
+        return response({ type: 'https://swe-platform.dev/problems/forbidden', title: 'Access denied', status: 403 }, 403)
+      }
+      throw new Error(`Unexpected request: ${path}`)
+    })
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Infinity } } })
+    client.setQueryData(queryKeys.session, { authenticated: true, username: 'alex' })
+    client.setQueryData(queryKeys.runs('default'), { items: [run], resourceVersion: '2' })
+    render(<QueryClientProvider client={client}><MemoryRouter initialEntries={['/namespaces/default/runs']}><App /></MemoryRouter></QueryClientProvider>)
+    expect(screen.getByText('repair-ui')).toBeInTheDocument()
+    await act(async () => { await vi.advanceTimersByTimeAsync(1001) })
+    expect(screen.getByRole('alert')).toHaveTextContent('Run watch failed (403)')
+    expect(screen.queryByText('repair-ui')).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'New run' })).not.toBeInTheDocument()
+    expect(client.getQueryData(queryKeys.runs('default'))).toEqual(expect.objectContaining({ items: [expect.objectContaining({ uid: 'run-uid' })] }))
+  })
+
   it('polls exact Run detail only while the summary feed uses compatibility fallback', async () => {
     vi.useFakeTimers()
     let details = 0
@@ -152,7 +175,7 @@ describe('App frozen API integration', () => {
     vi.spyOn(globalThis, 'fetch').mockImplementation(async path => {
       if (path === '/api/v1/session') return response({ authenticated: true, username: 'alex' })
       if (path === '/api/v1/namespaces/default/runs?limit=200&view=summary') return response({ items: [initial] })
-      if (path === '/api/v1/namespaces/default/runs/repair-ui') { details += 1; return response(details === 1 ? initial : updated) }
+      if (path === '/api/v1/namespaces/default/runs/repair-ui') { details += 1; return response(details <= 2 ? initial : updated) }
       throw new Error(`Unexpected request: ${path}`)
     })
     const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
@@ -162,7 +185,102 @@ describe('App frozen API integration', () => {
     expect(screen.getByText('Running', { selector: '.pill' })).toBeInTheDocument()
     await act(async () => { await vi.advanceTimersByTimeAsync(4001); await Promise.resolve(); await Promise.resolve() })
     expect(screen.getByText('Succeeded', { selector: '.pill' })).toBeInTheDocument()
+    expect(details).toBe(3)
+  })
+
+  it('treats headerless discovery as non-renderable until exact identity confirmation', async () => {
+    let resolveDiscovery!: (value: Response) => void
+    let resolveExact!: (value: Response) => void
+    const childRequests: string[] = []
+    const headers: Array<string | null> = []
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (path, init) => {
+      if (path === '/api/v1/session') return response({ authenticated: true, username: 'alex' })
+      if (path === '/api/v1/namespaces/default/runs?limit=200&view=summary') return response({ title: 'Forbidden', status: 403 }, 403)
+      if (path === '/api/v1/namespaces/default/runs/repair-ui') {
+        const uid = (init?.headers as Headers).get('SWE-Run-UID')
+        headers.push(uid)
+        if (!uid) return new Promise<Response>(resolve => { resolveDiscovery = resolve })
+        return new Promise<Response>(resolve => { resolveExact = resolve })
+      }
+      childRequests.push(String(path))
+      return response({})
+    })
+    const seededClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } })
+    seededClient.setQueryData(queryKeys.run('default', 'repair-ui', 'uid-a'), { ...run, uid: 'uid-a' })
+    const { client } = show('/namespaces/default/runs/repair-ui/overview', undefined, seededClient)
+    expect(await screen.findByText('Loading run…')).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'repair-ui' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Cancel run' })).not.toBeInTheDocument()
+
+    resolveDiscovery(response({ ...run, uid: 'uid-a' }))
+    await waitFor(() => expect(headers).toEqual([null, 'uid-a']))
+    expect(client.getQueryCache().findAll({ queryKey: ['run-bootstrap', 'default', 'repair-ui'] }).map(query => query.state.data)).toEqual(['uid-a'])
+    expect(screen.queryByRole('heading', { name: 'repair-ui' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('navigation', { name: 'Run sections' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Cancel run' })).not.toBeInTheDocument()
+    expect(childRequests).toEqual([])
+
+    resolveExact(response({ title: 'Run identity conflict', status: 409, detail: 'the Run name now identifies UID B' }, 409))
+    expect(await screen.findByRole('alert')).toHaveTextContent('UID B')
+    expect(screen.queryByRole('navigation', { name: 'Run sections' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Cancel run' })).not.toBeInTheDocument()
+    expect(childRequests).toEqual([])
+    act(() => { focusManager.setFocused(false); focusManager.setFocused(true); onlineManager.setOnline(false); onlineManager.setOnline(true) })
+    await Promise.resolve()
+    expect(headers).toEqual([null, 'uid-a'])
+  })
+
+  it('recovers exact Run detail from a transient 503', async () => {
+    vi.useFakeTimers()
+    let details = 0
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async path => {
+      if (path === '/api/v1/session') return response({ authenticated: true, username: 'alex' })
+      if (path === '/api/v1/namespaces/default/runs?limit=200&view=summary') return response({ items: [] })
+      if (path === '/api/v1/namespaces/default/runs/repair-ui') {
+        details += 1
+        return details === 1 ? response({ title: 'Unavailable', status: 503 }, 503) : response(run)
+      }
+      throw new Error(`Unexpected request: ${path}`)
+    })
+    show('/namespaces/default/runs/repair-ui/overview', { runUID: 'run-uid' })
+    await act(async () => { await vi.advanceTimersByTimeAsync(1100); await Promise.resolve() })
+    expect(screen.getByRole('heading', { name: 'repair-ui' })).toBeInTheDocument()
     expect(details).toBe(2)
+  })
+
+  it('recovers an exact Run after a network failure but does not loop on malformed JSON', async () => {
+    vi.useFakeTimers()
+    let details = 0
+    const fetch = vi.spyOn(globalThis, 'fetch').mockImplementation(async path => {
+      if (path === '/api/v1/session') return response({ authenticated: true, username: 'alex' })
+      if (path === '/api/v1/namespaces/default/runs?limit=200&view=summary') return response({ items: [] })
+      if (path === '/api/v1/namespaces/default/runs/repair-ui') {
+        details += 1
+        if (details === 1) throw new TypeError('network unavailable')
+        return response(run)
+      }
+      throw new Error(`Unexpected request: ${path}`)
+    })
+    const first = show('/namespaces/default/runs/repair-ui/overview', { runUID: 'run-uid' })
+    await act(async () => { await vi.advanceTimersByTimeAsync(1100); await Promise.resolve() })
+    expect(screen.getByRole('heading', { name: 'repair-ui' })).toBeInTheDocument()
+    expect(details).toBe(2)
+    first.unmount()
+
+    details = 0
+    fetch.mockImplementation(async path => {
+      if (path === '/api/v1/session') return response({ authenticated: true, username: 'alex' })
+      if (path === '/api/v1/namespaces/default/runs?limit=200&view=summary') return response({ items: [] })
+      if (path === '/api/v1/namespaces/default/runs/repair-ui') { details += 1; return new Response('{') }
+      throw new Error(`Unexpected request: ${path}`)
+    })
+    show('/namespaces/default/runs/repair-ui/overview', { runUID: 'run-uid' })
+    await act(async () => { await vi.advanceTimersByTimeAsync(1100); await Promise.resolve() })
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    const settled = details
+    act(() => { focusManager.setFocused(false); focusManager.setFocused(true); onlineManager.setOnline(false); onlineManager.setOnline(true) })
+    await act(async () => { await vi.advanceTimersByTimeAsync(8001); await Promise.resolve() })
+    expect(details).toBe(settled)
   })
 
   it('keeps the transcript stream mounted when cancellation only advances Run generation', async () => {
@@ -180,8 +298,8 @@ describe('App frozen API integration', () => {
     })
     const { client } = show('/namespaces/default/runs/repair-ui/transcript')
     await waitFor(() => expect(transcriptRequests).toHaveLength(1))
-    act(() => client.setQueryData(queryKeys.run('default', 'repair-ui'), { ...detail, generation: 2, cancelRequested: true }))
-    await waitFor(() => expect(client.getQueryData<Run>(queryKeys.run('default', 'repair-ui'))?.generation).toBe(2))
+    act(() => client.setQueryData(queryKeys.run('default', 'repair-ui', 'run-uid'), { ...detail, generation: 2, cancelRequested: true }))
+    await waitFor(() => expect(client.getQueryData<Run>(queryKeys.run('default', 'repair-ui', 'run-uid'))?.generation).toBe(2))
     expect(transcriptRequests).toHaveLength(1)
     expect((transcriptRequests[0].signal as AbortSignal).aborted).toBe(false)
   })
@@ -259,6 +377,33 @@ describe('App frozen API integration', () => {
     expect(screen.queryByRole('link', { name: /changes/i })).not.toBeInTheDocument()
   })
 
+  it('recovers Environment detail from 503 but stops on identity mismatch', async () => {
+    vi.useFakeTimers()
+    let environments = 0
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async path => {
+      if (path === '/api/v1/session') return response({ authenticated: true, username: 'alex' })
+      if (path === '/api/v1/namespaces/default/runs?limit=200&view=summary') return response({ items: [] })
+      if (path === '/api/v1/namespaces/default/runs/repair-ui') return response(run)
+      if (String(path).includes('/environments/')) {
+        environments += 1
+        if (environments === 1) return response({ title: 'Unavailable', status: 503 }, 503)
+        if (environments === 2) return response(environment)
+        return response({ ...environment, uid: 'replacement-env-uid' })
+      }
+      throw new Error(`Unexpected request: ${path}`)
+    })
+    const { client } = show('/namespaces/default/runs/repair-ui/overview', { runUID: 'run-uid' })
+    await act(async () => { await vi.advanceTimersByTimeAsync(1100); await Promise.resolve() })
+    expect(screen.getByText('Ready, active')).toBeInTheDocument()
+    act(() => { void client.invalidateQueries({ queryKey: queryKeys.environment('default', 'repair-env', 'env-uid') }) })
+    await act(async () => { await vi.advanceTimersByTimeAsync(1); await Promise.resolve() })
+    expect(screen.getByRole('alert')).toHaveTextContent('different Environment identity')
+    const settled = environments
+    act(() => { focusManager.setFocused(false); focusManager.setFocused(true); onlineManager.setOnline(false); onlineManager.setOnline(true) })
+    await act(async () => { await vi.advanceTimersByTimeAsync(8001); await Promise.resolve() })
+    expect(environments).toBe(settled)
+  })
+
   it('hides and revokes terminal navigation when the exact association is unavailable', async () => {
     const released = { ...run, terminalAvailable: false, environment: { name: 'repair-env', ownership: 'Owned' as const } }
     vi.spyOn(globalThis, 'fetch').mockImplementation(async path => {
@@ -316,6 +461,34 @@ describe('App frozen API integration', () => {
     })
     show('/namespaces/default/runs/repair-ui/portals')
     expect(await screen.findByText('No authorized declared services.')).toHaveAttribute('role', 'status')
+  })
+
+  it('retries transient portal failures but stops polling an exact identity conflict', async () => {
+    vi.useFakeTimers()
+    const portalPath = '/api/v1/namespaces/default/runs/repair-ui/portals/run-uid/env-uid'
+    let portals = 0
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async path => {
+      if (path === '/api/v1/session') return response({ authenticated: true, username: 'alex' })
+      if (path === '/api/v1/namespaces/default/runs?limit=200&view=summary') return response({ items: [] })
+      if (path === '/api/v1/namespaces/default/runs/repair-ui') return response(run)
+      if (path === portalPath) {
+        portals += 1
+        if (portals === 1) return response({ title: 'Unavailable', status: 503 }, 503)
+        if (portals === 2) return response({ items: [] })
+        return response({ title: 'Run identity conflict', status: 409, detail: 'different Run' }, 409)
+      }
+      throw new Error(`Unexpected request: ${path}`)
+    })
+    const { client } = show('/namespaces/default/runs/repair-ui/portals', { runUID: 'run-uid' })
+    await act(async () => { await vi.advanceTimersByTimeAsync(1100); await Promise.resolve() })
+    expect(screen.getByText('No authorized declared services.')).toBeInTheDocument()
+    act(() => { void client.invalidateQueries({ queryKey: queryKeys.portals('default', 'repair-ui', 'run-uid', 'env-uid') }) })
+    await act(async () => { await vi.advanceTimersByTimeAsync(1); await Promise.resolve() })
+    expect(screen.getByRole('alert')).toHaveTextContent('different Run')
+    const settled = portals
+    act(() => { focusManager.setFocused(false); focusManager.setFocused(true); onlineManager.setOnline(false); onlineManager.setOnline(true) })
+    await act(async () => { await vi.advanceTimersByTimeAsync(8001); await Promise.resolve() })
+    expect(portals).toBe(settled)
   })
 
   it('clears login token after an error and never accesses browser storage', async () => {
@@ -399,7 +572,7 @@ describe('App frozen API integration', () => {
     await waitFor(() => expect(fetch).toHaveBeenCalledWith('/api/v1/namespaces/default/runs/repair-ui/cancel', expect.objectContaining({ method: 'POST' })))
     const cancelInit = fetch.mock.calls.find(call => String(call[0]).endsWith('/cancel'))?.[1]
     expect(JSON.parse(String(cancelInit?.body))).toEqual({ runUID: 'run-uid' })
-    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['run', 'default', 'repair-ui'] })
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['run', 'default', 'repair-ui', 'run-uid'], exact: true })
     expect(invalidate).not.toHaveBeenCalledWith({ queryKey: ['runs', 'default'] })
   })
 })

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -6,8 +6,9 @@ import {
 } from 'react-router'
 import {
   api, ApiProblem, fallbackPollInterval, isTerminal, onUnauthorized, queryKeys,
+  retryTransientResourceError, transientResourceError,
 } from './api'
-import type { CreateRun, Run, Selector } from './contracts'
+import type { CreateRun, Environment, PortalServiceList, Run, Selector } from './contracts'
 import { useRunFeed } from './runFeed'
 import { Transcript } from './Transcript'
 
@@ -58,6 +59,9 @@ const useActiveRunFeed = () => {
 
 function RunFeedOutlet({ namespace }: { namespace: string }) {
   const feed = useRunFeed(namespace)
+  if (feed.watchError instanceof ApiProblem && feed.watchError.status === 403) {
+    return <main><Failure error={feed.watchError} /></main>
+  }
   return <RunFeedContext.Provider value={feed}><Outlet /></RunFeedContext.Provider>
 }
 const age = (createdAt: string) => {
@@ -154,7 +158,7 @@ function RunList() {
     {query.fallback && <p className="hint" role="status">Live updates unavailable; refreshing every 4 seconds.</p>}
     {!query.fallback && query.watchError && <p className="hint" role="status">Live updates disconnected; reconnecting…</p>}
     {query.isPending ? <Busy label="Loading runs" /> : query.error ? <Failure error={query.error} /> : !query.data.items.length ? <p role="status">No runs found.</p> :
-      <div className="cards">{query.data.items.map(run => <Link className="card" key={run.uid} to={`${encodeURIComponent(run.name)}/overview`}>
+      <div className="cards">{query.data.items.map(run => <Link className="card" key={run.uid} to={`${encodeURIComponent(run.name)}/overview`} state={{ runUID: run.uid }}>
         <div><strong>{run.name}</strong><span className="pill">{run.state}</span></div>
         <p>{run.promptPreview}</p><dl><dt>Agent</dt><dd>{run.agent}</dd><dt>Environment</dt><dd>{run.environment?.name || 'Allocating'}</dd><dt>Age</dt><dd title={run.createdAt}>{age(run.createdAt)}</dd></dl>
       </Link>)}</div>}
@@ -182,7 +186,7 @@ function NewRun() {
     const value: CreateRun = { name: form.name.trim(), agent: form.agent.trim(), prompt: form.prompt, selector, ...(credentialProfile ? { credentialProfile } : {}), ...(repositoryCredential ? { repositoryCredential: repositoryCredential as 'GitHubApp' } : {}) }
     const error = validateCreateRun(value)
     setValidation(error || '')
-    if (!error) mutation.mutate(value, { onSuccess: run => navigate(`/namespaces/${encodeURIComponent(namespace)}/runs/${encodeURIComponent(run.name)}/overview`) })
+    if (!error) mutation.mutate(value, { onSuccess: run => navigate(`/namespaces/${encodeURIComponent(namespace)}/runs/${encodeURIComponent(run.name)}/overview`, { state: { runUID: run.uid } }) })
   }}>
     {field('name', 'Name')}{field('agent', 'Agent')}{field('credentialProfile', 'Credential profile')}
     <label>Git credential<select value={form.repositoryCredential} onChange={event => setForm({ ...form, repositoryCredential: event.target.value })}><option value="">None</option><option value="GitHubApp">GitHub App</option></select></label>{field('prompt', 'Prompt / task', true)}
@@ -196,11 +200,41 @@ function NewRun() {
 function useRun() {
   const { namespace = '', run = '' } = useParams()
   const feed = useActiveRunFeed()
-  return useQuery({
-    queryKey: queryKeys.run(namespace, run),
-    queryFn: ({ signal }) => api.run(namespace, run, signal),
-    refetchInterval: feed.fallback ? fallbackPollInterval : false,
+  const location = useLocation()
+  const bootstrapRequest = React.useId()
+  const selectedUID = location.state && typeof location.state === 'object' && 'runUID' in location.state && typeof location.state.runUID === 'string' && location.state.runUID
+    ? location.state.runUID
+    : undefined
+  const [locked, setLocked] = React.useState<{ namespace: string; name: string; uid: string } | undefined>(
+    selectedUID ? { namespace, name: run, uid: selectedUID } : undefined,
+  )
+  const [confirmed, setConfirmed] = React.useState<{ namespace: string; name: string; uid: string }>()
+  const matchingLockedUID = locked?.namespace === namespace && locked.name === run ? locked.uid : undefined
+  const runUID = selectedUID || matchingLockedUID
+  React.useEffect(() => {
+    if (selectedUID) setLocked({ namespace, name: run, uid: selectedUID })
+  }, [namespace, run, selectedUID])
+  const query = useQuery<Run | string, Error>({
+    queryKey: runUID ? queryKeys.run(namespace, run, runUID) : queryKeys.runBootstrap(namespace, run, bootstrapRequest),
+    queryFn: async ({ signal }) => {
+      if (runUID) {
+        const exact = await api.runExact(namespace, run, runUID, signal)
+        setConfirmed({ namespace, name: run, uid: runUID })
+        return exact
+      }
+      const discovered = await api.run(namespace, run, signal)
+      setLocked({ namespace, name: run, uid: discovered.uid })
+      return discovered.uid
+    },
+    retry: retryTransientResourceError,
+    refetchInterval: current => feed.fallback && !!runUID && (!current.state.error || transientResourceError(current.state.error)) ? fallbackPollInterval : false,
+    refetchOnWindowFocus: current => !current.state.error || transientResourceError(current.state.error),
+    refetchOnReconnect: current => !current.state.error || transientResourceError(current.state.error),
   })
+  const confirmedRun = runUID && confirmed?.namespace === namespace && confirmed.name === run && confirmed.uid === runUID && typeof query.data !== 'string'
+    ? query.data
+    : undefined
+  return { ...query, isPending: !query.error && (!confirmedRun || query.isPending), data: confirmedRun }
 }
 
 function Detail() {
@@ -208,6 +242,7 @@ function Detail() {
   const query = useRun()
   if (query.isPending) return <main><Busy label="Loading run" /></main>
   if (query.error) return <main><Failure error={query.error} /></main>
+  if (!query.data) return <main><Busy label="Confirming run identity" /></main>
   return <main><div className="title"><div><Link to={`/namespaces/${encodeURIComponent(namespace)}/runs`}>← Runs</Link><h1>{run}</h1></div><span className="pill">{query.data.state}</span></div>
     <nav aria-label="Run sections"><NavLink to="overview">Overview</NavLink><NavLink to="transcript">Transcript</NavLink>{query.data.environment?.uid && <NavLink to="portals">Portals</NavLink>}{query.data.terminalAvailable && query.data.environment?.uid && <NavLink to="terminal">Terminal</NavLink>}</nav>
     <Outlet context={query.data} />
@@ -220,17 +255,22 @@ function Overview() {
   const run = useOutletRun()
   const { namespace = '' } = useParams()
   const queryClient = useQueryClient()
-  const environment = useQuery({
-    queryKey: queryKeys.environment(namespace, run.environment?.name || ''),
-    queryFn: () => api.environment(namespace, run.environment!.name),
-    enabled: !!run.environment,
-    refetchInterval: () => !isTerminal(run.state) ? 4000 : false,
+  const environmentUID = run.environment?.uid || ''
+  const environment = useQuery<Environment, Error>({
+    queryKey: queryKeys.environment(namespace, run.environment?.name || '', environmentUID),
+    queryFn: ({ signal }) => api.environmentExact(namespace, run.environment!.name, environmentUID, signal),
+    enabled: !!environmentUID,
+    retry: retryTransientResourceError,
+    refetchInterval: current => !isTerminal(run.state) && (!current.state.error || transientResourceError(current.state.error)) ? 4000 : false,
+    refetchOnWindowFocus: current => !current.state.error || transientResourceError(current.state.error),
+    refetchOnReconnect: current => !current.state.error || transientResourceError(current.state.error),
   })
   const cancel = useMutation({
     mutationFn: () => api.cancelRun(namespace, run.name, run.uid),
     onSuccess: updated => {
-      queryClient.setQueryData<Run>(queryKeys.run(namespace, run.name), current => current?.uid === run.uid && updated.uid === run.uid ? updated : current)
-      queryClient.invalidateQueries({ queryKey: queryKeys.run(namespace, run.name) })
+      const key = queryKeys.run(namespace, run.name, run.uid)
+      queryClient.setQueryData<Run>(key, current => current?.uid === run.uid && updated.uid === run.uid ? updated : current)
+      queryClient.invalidateQueries({ queryKey: key, exact: true })
     },
   })
   const env = environment.data
@@ -240,9 +280,9 @@ function Overview() {
     <h2>Operational conditions</h2><table><thead><tr><th>Exposed fact</th><th>Status</th></tr></thead><tbody>
       <tr><td>Cancellation requested</td><td>{run.cancelRequested ? 'Yes' : 'No'}</td></tr>
       <tr><td>Environment allocated</td><td>{run.environment ? 'Yes' : 'No'}</td></tr>
-      {run.environment && <><tr><td>Environment ready</td><td>{environment.isPending ? 'Loading…' : env?.ready ? 'Yes' : 'No'}</td></tr><tr><td>Environment paused</td><td>{environment.isPending ? 'Loading…' : env?.paused ? 'Yes' : 'No'}</td></tr></>}
+      {environmentUID && <><tr><td>Environment ready</td><td>{environment.isPending ? 'Loading…' : env?.ready ? 'Yes' : 'No'}</td></tr><tr><td>Environment paused</td><td>{environment.isPending ? 'Loading…' : env?.paused ? 'Yes' : 'No'}</td></tr></>}
     </tbody></table>
-    <h2>Environment</h2>{run.environment ? environment.error ? <Failure error={environment.error} /> : <dl className="facts"><dt>Name</dt><dd>{run.environment.name}</dd><dt>Ownership</dt><dd>{run.environment.ownership}</dd><dt>Phase</dt><dd>{env?.phase || 'Loading…'}</dd><dt>Backend</dt><dd>{env?.backend || 'Loading…'}</dd><dt>Template</dt><dd>{env?.template || 'Loading…'}</dd><dt>Status</dt><dd>{env ? `${env.ready ? 'Ready' : 'Not ready'}, ${env.paused ? 'paused' : 'active'}` : 'Loading…'}</dd></dl> : <p>Not allocated.</p>}
+    <h2>Environment</h2>{!run.environment ? <p>Not allocated.</p> : !environmentUID ? <p role="status">Exact Environment identity unavailable.</p> : environment.error ? <Failure error={environment.error} /> : <dl className="facts"><dt>Name</dt><dd>{run.environment.name}</dd><dt>Ownership</dt><dd>{run.environment.ownership}</dd><dt>Phase</dt><dd>{env?.phase || 'Loading…'}</dd><dt>Backend</dt><dd>{env?.backend || 'Loading…'}</dd><dt>Template</dt><dd>{env?.template || 'Loading…'}</dd><dt>Status</dt><dd>{env ? `${env.ready ? 'Ready' : 'Not ready'}, ${env.paused ? 'paused' : 'active'}` : 'Loading…'}</dd></dl>}
     {!isTerminal(run.state) && <button className="danger" disabled={cancel.isPending} onClick={() => cancel.mutate()}>Cancel run</button>}{cancel.isError && <Failure error={cancel.error} />}
   </section>
 }
@@ -262,11 +302,14 @@ function Portals() {
   const run = useOutletRun()
   const { namespace = '' } = useParams()
   const environmentUID = run.environment?.uid || ''
-  const query = useQuery({
+  const query = useQuery<PortalServiceList, Error>({
     queryKey: queryKeys.portals(namespace, run.name, run.uid, environmentUID),
     queryFn: () => api.portals(namespace, run.name, run.uid, environmentUID),
     enabled: !!environmentUID,
-    refetchInterval: 4000,
+    retry: retryTransientResourceError,
+    refetchInterval: current => !current.state.error || transientResourceError(current.state.error) ? 4000 : false,
+    refetchOnWindowFocus: current => !current.state.error || transientResourceError(current.state.error),
+    refetchOnReconnect: current => !current.state.error || transientResourceError(current.state.error),
   })
   if (!environmentUID) return <p role="status">Portals unavailable for this Run identity.</p>
   if (query.isPending) return <Busy label="Loading portals" />

--- a/ui/src/Transcript.test.tsx
+++ b/ui/src/Transcript.test.tsx
@@ -1,7 +1,7 @@
 import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { Transcript } from './Transcript'
+import { SSEFramer, Transcript } from './Transcript'
 import { MAX_TRANSCRIPT_ITEMS } from './TranscriptTimeline'
 
 const reducerCalls = vi.hoisted(() => vi.fn())
@@ -238,6 +238,129 @@ describe('Transcript', () => {
     await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Transcript event exceeds'))
     expect(stream.cancel).toHaveBeenCalledOnce()
     expect(Events.instances).toHaveLength(1)
+  })
+
+  it('accepts an exact byte-limit frame body and rejects one byte over', async () => {
+    mockStreams()
+    render(<Transcript namespace="n" run="limit" identity="uid-exact" />)
+    await waitFor(() => expect(Events.instances).toHaveLength(1))
+    const exact = new Uint8Array((8 << 20) + 2).fill(32)
+    exact.set(new TextEncoder().encode('data:'), 0)
+    exact.set([10, 10], exact.length - 2)
+    act(() => Events.current.write(exact))
+    expect(screen.getByRole('status')).toHaveTextContent('Connected')
+    act(() => Events.current.write(new Uint8Array((8 << 20) + 1).fill(120)))
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Transcript event exceeds'))
+    expect(Events.instances).toHaveLength(1)
+  })
+
+  it('recognizes all nine line-ending pairs at every delimiter byte boundary', () => {
+    const encoder = new TextEncoder()
+    const decoder = new TextDecoder()
+    const body = encoder.encode('event:transcript\ndata:{"sequence":1,"data":"combinations"}')
+    const endings = [[10], [13], [13, 10]]
+    for (const first of endings) for (const second of endings) {
+      const delimiter = Uint8Array.from([...first, ...second])
+      for (let split = 0; split <= delimiter.length; split += 1) {
+        const frames: Uint8Array[] = []
+        const framer = new SSEFramer()
+        const consume = (frame: Uint8Array) => frames.push(frame.slice())
+        framer.push(body, consume)
+        framer.push(delimiter.slice(0, split), consume)
+        framer.push(delimiter.slice(split), consume)
+        framer.finish(consume)
+        expect(frames.map(frame => decoder.decode(frame)), `${first}+${second} split ${split}`).toEqual([decoder.decode(body)])
+      }
+    }
+  })
+
+  it('preserves CRLF fields under deterministic randomized chunking', () => {
+    const encoder = new TextEncoder()
+    const decoder = new TextDecoder()
+    const bodies = Array.from({ length: 24 }, (_, index) => `event:transcript\r\ndata:first-${index}\r\ndata:second-${index}\r\nid:${index}`)
+    const delimiters = ['\n\n', '\n\r', '\n\r\n', '\r\r', '\r\r\n', '\r\n\n', '\r\n\r', '\r\n\r\n']
+    const source = encoder.encode(bodies.map((body, index) => body + delimiters[index % delimiters.length]).join(''))
+    for (let seed = 1; seed <= 32; seed += 1) {
+      const frames: string[] = []
+      const framer = new SSEFramer()
+      let state = seed
+      let offset = 0
+      while (offset < source.length) {
+        state = (state * 1664525 + 1013904223) >>> 0
+        const end = Math.min(source.length, offset + 1 + state % 19)
+        framer.push(source.slice(offset, end), frame => frames.push(decoder.decode(frame)))
+        offset = end
+      }
+      framer.finish(frame => frames.push(decoder.decode(frame)))
+      expect(frames, `seed ${seed}`).toEqual(bodies)
+    }
+  })
+
+  it('parses ordinary CRLF field lines before a CRLF-delimited blank line', async () => {
+    mockStreams()
+    render(<Transcript namespace="n" run="crlf-fields" identity="uid-exact" />)
+    await waitFor(() => expect(Events.instances).toHaveLength(1))
+    act(() => Events.current.write(new TextEncoder().encode('event:transcript\r\nid:1\r\ndata:{"sequence":1,"data":"crlf-fields"}\r\n\r\n')))
+    expect(await screen.findByText('crlf-fields')).toBeInTheDocument()
+  })
+
+  it('handles a split UTF-8 scalar, colonless data, and many frames in one source chunk', async () => {
+    mockStreams()
+    render(<Transcript namespace="n" run="bytes" identity="uid-exact" />)
+    await waitFor(() => expect(Events.instances).toHaveLength(1))
+    const encoder = new TextEncoder()
+    const snowman = encoder.encode('event:transcript\ndata:{"sequence":1,"data":"snowman ☃"}\n\n')
+    const scalar = snowman.indexOf(0xe2)
+    act(() => {
+      Events.current.write(snowman.slice(0, scalar + 1))
+      Events.current.write(snowman.slice(scalar + 1))
+      const frames = Array.from({ length: 100 }, (_, index) => `event:transcript\ndata\ndata:{"sequence":${index + 2},"data":"many-${index}"}\n\n`).join('')
+      Events.current.write(encoder.encode(frames))
+    })
+    expect(await screen.findByText('snowman ☃')).toBeInTheDocument()
+    await waitFor(() => expect(screen.getAllByRole('listitem')).toHaveLength(101))
+    expect(screen.getByText('many-99')).toBeInTheDocument()
+  })
+
+  it('counts colonless data and its inserted newline in the retained byte budget', async () => {
+    mockStreams()
+    render(<Transcript namespace="n" run="colonless-budget" identity="uid-exact" />)
+    await waitFor(() => expect(Events.instances).toHaveLength(1))
+    const payload = 'x'.repeat(2 * 1024 * 1024)
+    act(() => Events.current.write(new TextEncoder().encode(`id:1\nevent:transcript\ndata\ndata:${payload}\n\n`)))
+    expect(await screen.findByText(/approximately 2,097,153 raw bytes/)).toBeInTheDocument()
+  })
+
+  it('copies only a tiny unresolved suffix after processing a large source chunk', async () => {
+    mockStreams()
+    render(<Transcript namespace="n" run="suffix" identity="uid-exact" />)
+    await waitFor(() => expect(Events.instances).toHaveLength(1))
+    const frames = Array.from({ length: 1000 }, (_, index) => `event:transcript\ndata:{"sequence":${index + 1},"data":"bulk-${index}"}\n\n`).join('')
+    act(() => {
+      Events.current.write(new TextEncoder().encode(`${frames}event:trans`))
+      Events.current.write(new TextEncoder().encode('cript\ndata:{"sequence":1001,"data":"suffix-complete"}\n\n'))
+    })
+    expect(await screen.findByText('suffix-complete')).toBeInTheDocument()
+  })
+
+  it('terminates malformed UTF-8 and unresolved EOF without reconnecting', async () => {
+    mockStreams()
+    const firstView = render(<Transcript namespace="n" run="utf8" identity="uid-utf8" />)
+    await waitFor(() => expect(Events.instances).toHaveLength(1))
+    act(() => Events.current.write(Uint8Array.from([100, 97, 116, 97, 58, 0xc3, 10, 10])))
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Malformed UTF-8'))
+    expect(Events.instances).toHaveLength(1)
+    firstView.unmount()
+
+    render(<Transcript namespace="n" run="eof" identity="uid-eof" />)
+    await waitFor(() => expect(Events.instances).toHaveLength(2))
+    act(() => {
+      Events.current.write(new TextEncoder().encode('data:unfinished'))
+      Events.current.close()
+    })
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Malformed transcript event stream at EOF'))
+    await new Promise(resolve => setTimeout(resolve, 300))
+    expect(Events.instances).toHaveLength(2)
   })
 
   it('cancels a retryable error response before reconnecting with the same UID', async () => {

--- a/ui/src/Transcript.tsx
+++ b/ui/src/Transcript.tsx
@@ -78,10 +78,123 @@ interface TranscriptState {
 }
 
 const MAX_SSE_BUFFER = 8 << 20
+const INITIAL_SSE_BUFFER = 4096
 
-function sseBoundary(buffer: string): { index: number; length: number } | undefined {
-  const match = /\r\n\r\n|\n\n|\r\r/.exec(buffer)
-  return match ? { index: match.index, length: match[0].length } : undefined
+class TerminalStreamError extends Error {}
+
+// CRLF has greedy precedence over the byte-identical CR + LF combination
+// while streaming. The ambiguous CR + LF delimiter is accepted only at EOF.
+// Completed frames are consumed synchronously, and large accumulators shrink
+// after dispatch so an unresolved suffix never retains a large source buffer.
+// Exported for deterministic chunk-boundary/property tests.
+export class SSEFramer {
+  private bytes = new Uint8Array(INITIAL_SSE_BUFFER)
+  private length = 0
+  private scan = 0
+  private previousEndingStart = -1
+  private previousEndingEnd = -1
+
+  push(chunk: Uint8Array, consume: (frame: Uint8Array) => void) {
+    for (const byte of chunk) {
+      this.append(byte)
+      this.scanAvailable(consume, false)
+      this.checkBodyLimit()
+    }
+  }
+
+  finish(consume: (frame: Uint8Array) => void) {
+    this.scanAvailable(consume, true)
+    if (this.length && this.previousEndingEnd === this.length && this.previousEndingEnd-this.previousEndingStart === 2 &&
+      this.bytes[this.previousEndingStart] === 13 && this.bytes[this.previousEndingStart + 1] === 10) {
+      // At EOF only, resolve the otherwise ambiguous CRLF as CR + LF.
+      this.consumeFrame(this.previousEndingStart, this.length, consume)
+    }
+    if (this.length !== 0) throw new TerminalStreamError('Malformed transcript event stream at EOF')
+  }
+
+  private append(byte: number) {
+    if (this.length === MAX_SSE_BUFFER + 4) throw new TerminalStreamError(`Transcript event exceeds ${MAX_SSE_BUFFER} bytes`)
+    if (this.length === this.bytes.length) {
+      const grown = new Uint8Array(Math.min(MAX_SSE_BUFFER + 4, this.bytes.length * 2))
+      grown.set(this.bytes)
+      this.bytes = grown
+    }
+    this.bytes[this.length++] = byte
+  }
+
+  private checkBodyLimit() {
+    let bodyBytes = this.length
+    if (this.scan < this.length) {
+      bodyBytes = this.previousEndingEnd === this.scan ? this.previousEndingStart : this.scan
+    } else if (this.previousEndingEnd === this.length) {
+      bodyBytes = this.previousEndingStart
+    }
+    if (bodyBytes > MAX_SSE_BUFFER) throw new TerminalStreamError(`Transcript event exceeds ${MAX_SSE_BUFFER} bytes`)
+  }
+
+  private consumeFrame(bodyLength: number, consumedEnd: number, consume: (frame: Uint8Array) => void) {
+    if (bodyLength > MAX_SSE_BUFFER) throw new TerminalStreamError(`Transcript event exceeds ${MAX_SSE_BUFFER} bytes`)
+    consume(this.bytes.subarray(0, bodyLength))
+    const suffixLength = this.length - consumedEnd
+    if (this.bytes.length > INITIAL_SSE_BUFFER) {
+      const compact = new Uint8Array(Math.max(INITIAL_SSE_BUFFER, suffixLength))
+      compact.set(this.bytes.subarray(consumedEnd, this.length))
+      this.bytes = compact
+    } else if (suffixLength) {
+      this.bytes.copyWithin(0, consumedEnd, this.length)
+    }
+    this.length = suffixLength
+    this.scan = 0
+    this.previousEndingStart = -1
+    this.previousEndingEnd = -1
+  }
+
+  private scanAvailable(consume: (frame: Uint8Array) => void, eof: boolean) {
+    while (this.scan < this.length) {
+      const start = this.scan
+      const byte = this.bytes[start]
+      let endingLength = 0
+      if (byte === 10) endingLength = 1
+      else if (byte === 13) {
+        if (start + 1 === this.length && !eof) return
+        endingLength = start + 1 < this.length && this.bytes[start + 1] === 10 ? 2 : 1
+      } else {
+        this.scan += 1
+        continue
+      }
+      const end = start + endingLength
+      if (this.previousEndingEnd === start) {
+        this.consumeFrame(this.previousEndingStart, end, consume)
+        continue
+      }
+      this.previousEndingStart = start
+      this.previousEndingEnd = end
+      this.scan = end
+    }
+  }
+}
+
+function dataPayloadBytes(bytes: Uint8Array): number {
+  let fields = 0
+  let total = 0
+  for (let start = 0; start <= bytes.length;) {
+    let end = start
+    while (end < bytes.length && bytes[end] !== 10 && bytes[end] !== 13) end += 1
+    const length = end - start
+    if (length >= 4 && bytes[start] === 100 && bytes[start + 1] === 97 && bytes[start + 2] === 116 && bytes[start + 3] === 97 && (length === 4 || bytes[start + 4] === 58)) {
+      let valueStart = start + 4
+      if (length > 4) {
+        valueStart += 1
+        if (valueStart < end && bytes[valueStart] === 32) valueStart += 1
+      }
+      total += end - valueStart
+      fields += 1
+    }
+    if (end === bytes.length) break
+    if (bytes[end] === 13 && bytes[end + 1] === 10) end += 1
+    start = end + 1
+  }
+  return total + Math.max(0, fields - 1)
 }
 
 function emptyTranscriptState(): TranscriptState {
@@ -132,23 +245,23 @@ export function Transcript({ namespace, run, identity }: { namespace: string; ru
         timer = window.setTimeout(flushTimeline, 16)
       }
     }
-    const onTranscript = (raw: Event) => {
+    const onTranscript = (raw: Event, rawBytes: number) => {
       if (disposed) return
       const entry = parseEntry(raw as MessageEvent)
       if (!entry) return
       if (queuedTimeline.some(item => item.kind === 'event' && (item.entry.id === entry.id || item.entry.sequence === entry.sequence))) return
-      const next: TranscriptRenderItem = { kind: 'event', entry, position: entry.sequence, rawBytes: (raw as MessageEvent).data.length }
+      const next: TranscriptRenderItem = { kind: 'event', entry, position: entry.sequence, rawBytes }
       queuedTimeline = appendTimelineItem(queuedTimeline, next)
       scheduleTimelineFlush()
     }
-    const onGap = (raw: Event) => {
+    const onGap = (raw: Event, rawBytes: number) => {
       if (disposed) return
       const gap = parseGap(raw as MessageEvent)
       if (!gap) return
       if (queuedTimeline.some(item => item.kind === 'gap' && item.gap.resumeAfter === gap.resumeAfter && item.gap.earliestSequence === gap.earliestSequence && item.gap.latestSequence === gap.latestSequence)) return
       const lastPosition = queuedTimeline.reduce((latest, item) => Math.max(latest, item.position), 0)
       const position = gap.earliestSequence ?? lastPosition + 0.5
-      const next: TranscriptRenderItem = { kind: 'gap', gap, position, rawBytes: (raw as MessageEvent).data.length }
+      const next: TranscriptRenderItem = { kind: 'gap', gap, position, rawBytes }
       queuedTimeline = appendTimelineItem(queuedTimeline, next)
       scheduleTimelineFlush()
     }
@@ -192,40 +305,38 @@ export function Transcript({ namespace, run, identity }: { namespace: string; ru
           freshRecoveryUsed = false
           setStatus('Connected')
           const reader = response.body.getReader()
-          const decoder = new TextDecoder()
-          let buffer = ''
+          const decoder = new TextDecoder('utf-8', { fatal: true })
+          const framer = new SSEFramer()
+          const consumeFrame = (frameBytes: Uint8Array) => {
+            let block: string
+            try { block = decoder.decode(frameBytes) } catch { throw new TerminalStreamError('Malformed UTF-8 in transcript event stream') }
+            let type = 'message'
+            let id = ''
+            let hasID = false
+            const data: string[] = []
+            for (const line of block.split(/\r\n|\n|\r/)) {
+              if (!line || line.startsWith(':')) continue
+              const colon = line.indexOf(':')
+              const field = colon < 0 ? line : line.slice(0, colon)
+              const fieldValue = colon < 0 ? '' : line.slice(colon + 1).replace(/^ /, '')
+              if (field === 'event') type = fieldValue
+              else if (field === 'id' && !fieldValue.includes('\0')) { id = fieldValue; hasID = true }
+              else if (field === 'data') data.push(fieldValue)
+              else if (field === 'retry' && /^\d+$/.test(fieldValue)) reconnectWait = Math.min(Number(fieldValue), 30_000)
+            }
+            if (hasID) lastEventID = id
+            if (!data.length) return
+            const event = new MessageEvent(type, { data: data.join('\n'), lastEventId: lastEventID })
+            const rawBytes = dataPayloadBytes(frameBytes)
+            if (type === 'transcript') onTranscript(event, rawBytes)
+            else if (type === 'transcript-gap') onGap(event, rawBytes)
+          }
           try {
             while (!disposed) {
               const { value, done } = await reader.read()
-              if (value) buffer += decoder.decode(value, { stream: true })
-              let boundary: { index: number; length: number } | undefined
-              while ((boundary = sseBoundary(buffer)) !== undefined) {
-                if (boundary.index > MAX_SSE_BUFFER) throw new Error(`Transcript event exceeds ${MAX_SSE_BUFFER} bytes`)
-                const block = buffer.slice(0, boundary.index)
-                buffer = buffer.slice(boundary.index + boundary.length)
-                let type = 'message'
-                let id = ''
-                let hasID = false
-                const data: string[] = []
-                for (const line of block.split(/\r\n|\n|\r/)) {
-                  if (!line || line.startsWith(':')) continue
-                  const colon = line.indexOf(':')
-                  const field = colon < 0 ? line : line.slice(0, colon)
-                  const fieldValue = colon < 0 ? '' : line.slice(colon + 1).replace(/^ /, '')
-                  if (field === 'event') type = fieldValue
-                  else if (field === 'id' && !fieldValue.includes('\0')) { id = fieldValue; hasID = true }
-                  else if (field === 'data') data.push(fieldValue)
-                  else if (field === 'retry' && /^\d+$/.test(fieldValue)) reconnectWait = Math.min(Number(fieldValue), 30_000)
-                }
-                if (hasID) lastEventID = id
-                if (!data.length) continue
-                const event = new MessageEvent(type, { data: data.join('\n'), lastEventId: lastEventID })
-                if (type === 'transcript') onTranscript(event)
-                else if (type === 'transcript-gap') onGap(event)
-              }
-              if (buffer.length > MAX_SSE_BUFFER) throw new Error(`Transcript event exceeds ${MAX_SSE_BUFFER} bytes`)
+              if (value) framer.push(value, consumeFrame)
               if (done) {
-                decoder.decode()
+                framer.finish(consumeFrame)
                 break
               }
             }
@@ -238,7 +349,7 @@ export function Transcript({ namespace, run, identity }: { namespace: string; ru
           }
         } catch (error) {
           if (disposed || controller.signal.aborted) return
-          if (!(error instanceof Error && error.message.startsWith('Transcript event exceeds'))) {
+          if (!(error instanceof TerminalStreamError)) {
             setStatus('Reconnecting')
             await reconnectDelay()
             continue

--- a/ui/src/api.test.ts
+++ b/ui/src/api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { ApiProblem, api, fallbackPollInterval, listAllRuns, onUnauthorized } from './api'
+import { ApiProblem, api, fallbackPollInterval, listAllRuns, onUnauthorized, ResourceTransportError, retryTransientResourceError, transientResourceError } from './api'
 import type { Run } from './contracts'
 
 afterEach(() => vi.restoreAllMocks())
@@ -7,7 +7,19 @@ describe('API boundary', () => {
   it('encodes namespace and names and sends credentials', async () => { const fetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ items: [] }))); await api.runs('team/a'); expect(fetch).toHaveBeenCalledWith('/api/v1/namespaces/team%2Fa/runs', expect.objectContaining({ credentials: 'same-origin' })) })
   it('uses bearer authorization only for login and never puts it in the body', async () => { const fetch = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => new Response(JSON.stringify({ authenticated: true }))); await api.login('secret'); const [, init] = fetch.mock.calls[0]; expect((init?.headers as Headers).get('Authorization')).toBe('Bearer secret'); expect(init?.body).toBeUndefined(); await api.session(); expect((fetch.mock.calls[1][1]?.headers as Headers).has('Authorization')).toBe(false) })
   it('sends cancel with an immutable UID fence', async () => { const fetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}')); await api.cancelRun('n', 'r', 'uid'); const [path, init] = fetch.mock.calls[0]; expect(path).toBe('/api/v1/namespaces/n/runs/r/cancel'); expect(init?.method).toBe('POST'); expect(JSON.parse(String(init?.body))).toEqual({ runUID: 'uid' }) })
-  it('passes exact Run cancellation through to fetch', async () => { const fetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}')); const controller = new AbortController(); await api.run('n', 'r', controller.signal); expect(fetch).toHaveBeenCalledWith('/api/v1/namespaces/n/runs/r', expect.objectContaining({ signal: controller.signal })) })
+  it('keeps discovery headerless and validates exact Run and Environment responses', async () => {
+    const fetch = vi.spyOn(globalThis, 'fetch').mockImplementation(async path => new Response(String(path).includes('/environments/') ? '{"uid":"env-uid"}' : '{"uid":"run-uid"}'))
+    const controller = new AbortController()
+    await api.run('n', 'r', controller.signal)
+    expect((fetch.mock.calls[0][1]?.headers as Headers).has('SWE-Run-UID')).toBe(false)
+    await api.runExact('n', 'r', 'run-uid', controller.signal)
+    expect((fetch.mock.calls[1][1]?.headers as Headers).get('SWE-Run-UID')).toBe('run-uid')
+    await api.environmentExact('n', 'e', 'env-uid', controller.signal)
+    fetch.mockResolvedValueOnce(new Response('{"uid":"replacement"}'))
+    await expect(api.runExact('n', 'r', 'run-uid')).rejects.toThrow('different Run identity')
+    fetch.mockResolvedValueOnce(new Response('{"uid":"replacement"}'))
+    await expect(api.environmentExact('n', 'e', 'env-uid')).rejects.toThrow('different Environment identity')
+  })
   it('notifies authentication state when a transcript session expires', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 401, statusText: 'Unauthorized' }))
     const listener = vi.fn()
@@ -18,6 +30,17 @@ describe('API boundary', () => {
   })
   it('builds optional list pagination with URLSearchParams and validates limit', async () => { const fetch = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{"items":[]}')); await api.runs('n', { limit: 200, continue: 'a+b' }); expect(fetch.mock.calls[0][0]).toBe('/api/v1/namespaces/n/runs?limit=200&continue=a%2Bb'); expect(() => api.runs('n', { limit: 201 })).toThrow(RangeError) })
   it('safely normalizes malformed errors into a typed problem', async () => { vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('not json', { status: 500, statusText: 'Oops' })); await expect(api.session()).rejects.toEqual(expect.objectContaining({ name: 'ApiProblem', status: 500, message: 'Oops', problem: { type: 'about:blank', title: 'Oops', status: 500 } })); await api.session().catch(error => expect(error).toBeInstanceOf(ApiProblem)) })
+  it('retries typed network and retryable HTTP failures but not client-side errors', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValueOnce(new TypeError('network unavailable'))
+    const network = await api.session().catch(error => error)
+    expect(network).toBeInstanceOf(ResourceTransportError)
+    expect(transientResourceError(network)).toBe(true)
+    expect(retryTransientResourceError(0, new ApiProblem({ type: 'busy', title: 'busy', status: 429 }, 429))).toBe(true)
+    expect(retryTransientResourceError(1, new ApiProblem({ type: 'unavailable', title: 'unavailable', status: 503 }, 503))).toBe(true)
+    expect(retryTransientResourceError(2, network)).toBe(false)
+    expect(transientResourceError(new Error('invalid response shape'))).toBe(false)
+    expect(transientResourceError(new SyntaxError('malformed JSON'))).toBe(false)
+  })
   it('follows list continuation cursors and aggregates pages', async () => {
     const first = { name: 'first' } as Run
     const second = { name: 'second' } as Run

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -7,6 +7,38 @@ export class ApiProblem extends Error {
   }
 }
 
+export class ResourceIdentityMismatch extends Error {
+  constructor(resource: 'Run' | 'Environment') {
+    super(`Control plane returned a different ${resource} identity`)
+    this.name = 'ResourceIdentityMismatch'
+  }
+}
+
+export class ResourceTransportError extends Error {
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : 'Resource transport failed', { cause })
+    this.name = 'ResourceTransportError'
+  }
+}
+
+export function terminalRunIdentityError(error: unknown) {
+  return error instanceof ResourceIdentityMismatch || error instanceof ApiProblem && (error.status === 404 || error.status === 409)
+}
+
+export function terminalEnvironmentIdentityError(error: unknown) {
+  return error instanceof ResourceIdentityMismatch || error instanceof ApiProblem && error.status === 404
+}
+
+export function transientResourceError(error: unknown) {
+  if (error instanceof ResourceTransportError) return true
+  if (error instanceof ApiProblem) return error.status === 408 || error.status === 429 || error.status >= 500
+  return false
+}
+
+export function retryTransientResourceError(failureCount: number, error: unknown) {
+  return transientResourceError(error) && failureCount < 2
+}
+
 type UnauthorizedListener = () => void
 const unauthorizedListeners = new Set<UnauthorizedListener>()
 export const onUnauthorized = (listener: UnauthorizedListener) => {
@@ -36,7 +68,13 @@ async function request<T>(path: string, init: RequestInit = {}, options?: { toke
   const headers = new Headers(init.headers)
   if (init.body !== undefined) headers.set('Content-Type', 'application/json')
   if (options?.token !== undefined) headers.set('Authorization', `Bearer ${options.token}`)
-  const response = await fetch(path, { ...init, headers, credentials: 'same-origin' })
+  let response: Response
+  try {
+    response = await fetch(path, { ...init, headers, credentials: 'same-origin' })
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') throw error
+    throw new ResourceTransportError(error)
+  }
   if (!response.ok) {
     let body: unknown
     try { body = await response.json() } catch { body = undefined }
@@ -82,9 +120,19 @@ export const api = {
     })
   },
   run: (namespace: string, name: string, signal?: AbortSignal) => request<Run>(`${base(namespace)}/runs/${encodeURIComponent(name)}`, { signal }),
+  runExact: async (namespace: string, name: string, runUID: string, signal?: AbortSignal) => {
+    const run = await request<Run>(`${base(namespace)}/runs/${encodeURIComponent(name)}`, { headers: { 'SWE-Run-UID': runUID }, signal })
+    if (run.uid !== runUID) throw new ResourceIdentityMismatch('Run')
+    return run
+  },
   createRun: (namespace: string, value: CreateRun) => request<Run>(`${base(namespace)}/runs`, { method: 'POST', body: JSON.stringify(value) }),
   cancelRun: (namespace: string, name: string, runUID: string) => request<Run>(`${base(namespace)}/runs/${encodeURIComponent(name)}/cancel`, { method: 'POST', body: JSON.stringify({ runUID }) }),
   environment: (namespace: string, name: string) => request<Environment>(`${base(namespace)}/environments/${encodeURIComponent(name)}`),
+  environmentExact: async (namespace: string, name: string, environmentUID: string, signal?: AbortSignal) => {
+    const environment = await request<Environment>(`${base(namespace)}/environments/${encodeURIComponent(name)}`, { signal })
+    if (environment.uid !== environmentUID) throw new ResourceIdentityMismatch('Environment')
+    return environment
+  },
   portals: (namespace: string, run: string, runUID: string, environmentUID: string) => request<PortalServiceList>(`${base(namespace)}/runs/${encodeURIComponent(run)}/portals/${encodeURIComponent(runUID)}/${encodeURIComponent(environmentUID)}`),
   transcriptUrl: (namespace: string, name: string) => `${base(namespace)}/runs/${encodeURIComponent(name)}/transcript`,
   transcript: async (namespace: string, name: string, runUID: string, signal: AbortSignal, lastEventID?: string) => {
@@ -120,7 +168,9 @@ export const fallbackPollInterval = 4000
 export const queryKeys = {
   session: ['session'] as const,
   runs: (namespace: string) => ['runs', namespace] as const,
-  run: (namespace: string, name: string) => ['run', namespace, name] as const,
-  environment: (namespace: string, name: string) => ['environment', namespace, name] as const,
+  runPrefix: (namespace: string, name: string) => ['run', namespace, name] as const,
+  run: (namespace: string, name: string, uid: string) => ['run', namespace, name, uid] as const,
+  runBootstrap: (namespace: string, name: string, request: string) => ['run-bootstrap', namespace, name, request] as const,
+  environment: (namespace: string, name: string, uid: string) => ['environment', namespace, name, uid] as const,
   portals: (namespace: string, run: string, runUID: string, environmentUID: string) => ['portals', namespace, run, runUID, environmentUID] as const,
 }

--- a/ui/src/runFeed.test.ts
+++ b/ui/src/runFeed.test.ts
@@ -2,7 +2,7 @@ import { QueryClient, QueryObserver } from '@tanstack/react-query'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { api, ApiProblem } from './api'
 import type { RunSummary, RunSummaryList, RunWatchEvent } from './contracts'
-import { applyRunEvent, consumeSSE, listRunSnapshot, refreshMatchingDetail, waitForRunFeedRetry } from './runFeed'
+import { applyRunEvent, consumeSSE, listRunSnapshot, reconcileRunSnapshot, reconcileRunWatchPublication, refreshMatchingDetail, waitForRunFeedRetry } from './runFeed'
 
 afterEach(() => vi.restoreAllMocks())
 
@@ -73,15 +73,104 @@ describe('Run summary watch', () => {
       }
       return Promise.resolve({ uid: 'one-uid', generation: 1 })
     })
-    const observer = new QueryObserver(client, { queryKey: ['run', 'ns', 'one'], queryFn, retry: false })
+    const key = ['run', 'ns', 'one', 'one-uid']
+    const observer = new QueryObserver(client, { queryKey: key, queryFn, retry: false })
     const unsubscribe = observer.subscribe(() => undefined)
     await vi.waitFor(() => expect(queryFn).toHaveBeenCalledOnce())
     refreshMatchingDetail(client, 'ns', summary('one'))
     await vi.waitFor(() => expect(queryFn).toHaveBeenCalledTimes(2))
     expect(firstSignal?.aborted).toBe(true)
     resolveFirst({ uid: 'stale-uid', generation: 0 })
-    await vi.waitFor(() => expect(client.getQueryData(['run', 'ns', 'one'])).toEqual({ uid: 'one-uid', generation: 1 }))
+    await vi.waitFor(() => expect(client.getQueryData(key)).toEqual({ uid: 'one-uid', generation: 1 }))
     unsubscribe()
+  })
+
+  it('uses distinct live and fallback snapshot publication semantics on concrete UID keys', async () => {
+    const client = new QueryClient()
+    const match = vi.fn().mockResolvedValue({ uid: 'one-uid', generation: 1 })
+    const replaced = vi.fn().mockResolvedValue({ uid: 'old-uid', generation: 1 })
+    const matchObserver = new QueryObserver(client, { queryKey: ['run', 'ns', 'one', 'one-uid'], queryFn: match, retry: false, staleTime: Infinity })
+    const replacedObserver = new QueryObserver(client, { queryKey: ['run', 'ns', 'old', 'old-uid'], queryFn: replaced, retry: false, staleTime: Infinity })
+    const unsubscribeMatch = matchObserver.subscribe(() => undefined)
+    const unsubscribeReplaced = replacedObserver.subscribe(() => undefined)
+    await vi.waitFor(() => expect(match).toHaveBeenCalledOnce())
+    await vi.waitFor(() => expect(replaced).toHaveBeenCalledOnce())
+    match.mockClear(); replaced.mockClear()
+    replaced.mockRejectedValue(new ApiProblem({ type: 'conflict', title: 'replacement', status: 409 }, 409))
+
+    reconcileRunSnapshot(client, 'ns', { items: [summary('one')], resourceVersion: undefined }, false)
+    await vi.waitFor(() => expect(replaced).toHaveBeenCalledOnce())
+    expect(match).not.toHaveBeenCalled()
+
+    reconcileRunSnapshot(client, 'ns', { items: [summary('one')], resourceVersion: '2' }, true)
+    await vi.waitFor(() => expect(match).toHaveBeenCalledOnce())
+    expect(client.getQueryData(['run', 'ns', 'one'])).toBeUndefined()
+    unsubscribeMatch(); unsubscribeReplaced()
+  })
+
+  it('settles current deletes once while a stale delete never touches the replacement UID', async () => {
+    const client = new QueryClient()
+    const old = vi.fn().mockRejectedValue(new ApiProblem({ type: 'gone', title: 'gone', status: 404 }, 404))
+    const replacement = vi.fn().mockResolvedValue({ uid: 'replacement-uid', generation: 1 })
+    const oldObserver = new QueryObserver(client, { queryKey: ['run', 'ns', 'one', 'old-uid'], queryFn: old, retry: false })
+    const replacementObserver = new QueryObserver(client, { queryKey: ['run', 'ns', 'one', 'replacement-uid'], queryFn: replacement, retry: false })
+    const unsubscribeOld = oldObserver.subscribe(() => undefined)
+    const unsubscribeReplacement = replacementObserver.subscribe(() => undefined)
+    await vi.waitFor(() => expect(old).toHaveBeenCalledOnce())
+    await vi.waitFor(() => expect(replacement).toHaveBeenCalledOnce())
+    old.mockClear(); replacement.mockClear()
+    replacement.mockRejectedValue(new ApiProblem({ type: 'gone', title: 'gone', status: 404 }, 404))
+
+    const staleDelete: RunWatchEvent = { type: 'DELETED', resourceVersion: '3', run: summary('one', 'old-uid') }
+    reconcileRunWatchPublication(client, 'ns', staleDelete, { items: [summary('one', 'replacement-uid')], resourceVersion: '3' })
+    await Promise.resolve()
+    expect(old).not.toHaveBeenCalled()
+    expect(replacement).not.toHaveBeenCalled()
+
+    const currentDelete: RunWatchEvent = { type: 'DELETED', resourceVersion: '4', run: summary('one', 'replacement-uid') }
+    reconcileRunWatchPublication(client, 'ns', currentDelete, { items: [], resourceVersion: '4' })
+    await vi.waitFor(() => expect(replacement).toHaveBeenCalledOnce())
+    reconcileRunWatchPublication(client, 'ns', currentDelete, { items: [], resourceVersion: '4' })
+    await Promise.resolve()
+    expect(replacement).toHaveBeenCalledOnce()
+    unsubscribeOld(); unsubscribeReplacement()
+  })
+
+  it('serializes a delete behind an in-flight modification and settles the deleted identity', async () => {
+    const client = new QueryClient()
+    let resolveModified!: (value: { uid: string; generation: number }) => void
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({ uid: 'one-uid', generation: 1 })
+      .mockImplementationOnce(() => new Promise(resolve => { resolveModified = resolve }))
+      .mockRejectedValueOnce(new ApiProblem({ type: 'gone', title: 'gone', status: 404 }, 404))
+    const key = ['run', 'ns', 'one', 'one-uid'] as const
+    const observer = new QueryObserver(client, { queryKey: key, queryFn, retry: false })
+    const unsubscribe = observer.subscribe(() => undefined)
+    await vi.waitFor(() => expect(queryFn).toHaveBeenCalledOnce())
+
+    const modified: RunWatchEvent = { type: 'MODIFIED', resourceVersion: '2', run: { ...summary('one'), generation: 2 } }
+    reconcileRunWatchPublication(client, 'ns', modified, { items: [modified.run], resourceVersion: '2' })
+    await vi.waitFor(() => expect(queryFn).toHaveBeenCalledTimes(2))
+    const deleted: RunWatchEvent = { type: 'DELETED', resourceVersion: '3', run: modified.run }
+    reconcileRunWatchPublication(client, 'ns', deleted, { items: [], resourceVersion: '3' })
+    await Promise.resolve()
+    expect(queryFn).toHaveBeenCalledTimes(2)
+
+    resolveModified({ uid: 'one-uid', generation: 2 })
+    await vi.waitFor(() => expect(queryFn).toHaveBeenCalledTimes(3))
+    await vi.waitFor(() => expect(client.getQueryState(key)?.error).toBeInstanceOf(ApiProblem))
+    reconcileRunWatchPublication(client, 'ns', deleted, { items: [], resourceVersion: '3' })
+    await Promise.resolve()
+    expect(queryFn).toHaveBeenCalledTimes(3)
+    unsubscribe()
+  })
+
+  it('does not refresh a newer detail from an older generation', () => {
+    const client = new QueryClient()
+    client.setQueryData(['run', 'ns', 'one', 'one-uid'], { uid: 'one-uid', generation: 2 })
+    const cancel = vi.spyOn(client, 'cancelQueries')
+    refreshMatchingDetail(client, 'ns', { ...summary('one'), generation: 1 })
+    expect(cancel).not.toHaveBeenCalled()
   })
 
   it('settles a pending reconnect delay immediately when its feed is aborted', async () => {

--- a/ui/src/runFeed.ts
+++ b/ui/src/runFeed.ts
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useQuery, useQueryClient, type QueryClient } from '@tanstack/react-query'
-import { api, ApiProblem, fallbackPollInterval, notifyUnauthorized, queryKeys } from './api'
+import { api, ApiProblem, fallbackPollInterval, notifyUnauthorized, queryKeys, terminalRunIdentityError, transientResourceError } from './api'
 import type { Run, RunSummary, RunSummaryList, RunWatchEvent } from './contracts'
 
 const MAX_PAGES = 100
@@ -103,17 +103,76 @@ export function applyRunEvent(snapshot: RunSummaryList, event: RunWatchEvent): R
 }
 
 export function refreshMatchingDetail(queryClient: QueryClient, namespace: string, summary: RunSummary) {
-  const detail = queryClient.getQueryData<Run>(queryKeys.run(namespace, summary.name))
-  if (!detail) {
-    void queryClient.resetQueries({ queryKey: queryKeys.run(namespace, summary.name), exact: true })
+  const key = queryKeys.run(namespace, summary.name, summary.uid)
+  const state = queryClient.getQueryState(key)
+  if (!state || terminalRunIdentityError(state.error)) return
+  const detail = queryClient.getQueryData<Run>(key)
+  if (detail?.generation !== undefined && summary.generation !== undefined && detail.generation > summary.generation) return
+  settleExactDetail(queryClient, key)
+}
+
+type Settlement = { dirty: boolean }
+const settlements = new WeakMap<QueryClient, Map<string, Settlement>>()
+
+function settleExactDetail(queryClient: QueryClient, key: readonly [string, string, string, string]) {
+  const state = queryClient.getQueryState(key)
+  if (!state || state.error && !transientResourceError(state.error)) return
+  let active = settlements.get(queryClient)
+  if (!active) {
+    active = new Map()
+    settlements.set(queryClient, active)
+  }
+  const identity = JSON.stringify(key)
+  const existing = active.get(identity)
+  if (existing) {
+    existing.dirty = true
     return
   }
-  if (detail.uid !== summary.uid) {
-    void queryClient.invalidateQueries({ queryKey: queryKeys.run(namespace, summary.name), exact: true })
+  const settlement: Settlement = { dirty: false }
+  active.set(identity, settlement)
+  void (async () => {
+    try {
+      do {
+        settlement.dirty = false
+        await queryClient.cancelQueries({ queryKey: key, exact: true })
+        await queryClient.refetchQueries({ queryKey: key, exact: true, type: 'active' })
+      } while (settlement.dirty && (() => {
+        const error = queryClient.getQueryState(key)?.error
+        return !error || transientResourceError(error)
+      })())
+    } finally {
+      active?.delete(identity)
+    }
+  })()
+}
+
+export function reconcileRunSnapshot(queryClient: QueryClient, namespace: string, snapshot: RunSummaryList, refreshMatches: boolean) {
+  const summaries = new Map(snapshot.items.map(summary => [summary.name, summary]))
+  for (const query of queryClient.getQueryCache().findAll({ queryKey: ['run', namespace] })) {
+    const [, queryNamespace, name, uid] = query.queryKey
+    if (query.queryKey.length !== 4 || queryNamespace !== namespace || typeof name !== 'string' || typeof uid !== 'string') continue
+    const summary = summaries.get(name)
+    if (summary?.uid === uid) {
+      if (refreshMatches) refreshMatchingDetail(queryClient, namespace, summary)
+    } else {
+      settleExactDetail(queryClient, query.queryKey as [string, string, string, string])
+    }
+  }
+}
+
+export function reconcileRunWatchPublication(queryClient: QueryClient, namespace: string, event: RunWatchEvent, snapshot: RunSummaryList) {
+  const published = snapshot.items.find(run => run.uid === event.run.uid)
+  if (event.type === 'DELETED') {
+    const key = queryKeys.run(namespace, event.run.name, event.run.uid)
+    if (!published) settleExactDetail(queryClient, key)
     return
   }
-  if (detail.generation !== undefined && summary.generation !== undefined && detail.generation > summary.generation) return
-  void queryClient.invalidateQueries({ queryKey: queryKeys.run(namespace, summary.name), exact: true })
+  for (const query of queryClient.getQueryCache().findAll({ queryKey: queryKeys.runPrefix(namespace, event.run.name) })) {
+    const uid = query.queryKey[3]
+    if (query.queryKey.length !== 4 || typeof uid !== 'string') continue
+    if (uid === event.run.uid && published) refreshMatchingDetail(queryClient, namespace, published)
+    else settleExactDetail(queryClient, query.queryKey as [string, string, string, string])
+  }
 }
 
 export function useRunFeed(namespace: string) {
@@ -121,7 +180,11 @@ export function useRunFeed(namespace: string) {
   const [fallback, setFallback] = React.useState(false)
   const [watchError, setWatchError] = React.useState<Error>()
   const query = useQuery({
-    queryKey: queryKeys.runs(namespace), queryFn: ({ signal }) => listRunSnapshot(namespace, signal),
+    queryKey: queryKeys.runs(namespace), queryFn: async ({ signal }) => {
+      const snapshot = await listRunSnapshot(namespace, signal)
+      reconcileRunSnapshot(queryClient, namespace, snapshot, !!snapshot.resourceVersion)
+      return snapshot
+    },
     refetchInterval: current => fallback || current.state.status === 'error' ? fallbackPollInterval : false,
     staleTime: fallback ? 0 : Infinity,
     refetchOnMount: false,
@@ -149,6 +212,7 @@ export function useRunFeed(namespace: string) {
       if (!snapshot.resourceVersion) { setFallback(true); controller.abort(); return false }
       if (controller.signal.aborted) return false
       queryClient.setQueryData(queryKeys.runs(namespace), snapshot)
+      reconcileRunSnapshot(queryClient, namespace, snapshot, true)
       cursor = snapshot.resourceVersion
       watchStart = snapshot.resourceVersion
       return true
@@ -181,8 +245,12 @@ export function useRunFeed(namespace: string) {
             if (message.event !== 'run') return
             const event = JSON.parse(message.data) as RunWatchEvent
             if (!message.id || event.resourceVersion !== message.id) throw new Error('Invalid Run watch event cursor.')
-            queryClient.setQueryData<RunSummaryList>(queryKeys.runs(namespace), old => old ? applyRunEvent(old, event) : old)
-            refreshMatchingDetail(queryClient, namespace, event.run)
+            let published: RunSummaryList | undefined
+            queryClient.setQueryData<RunSummaryList>(queryKeys.runs(namespace), old => {
+              published = old ? applyRunEvent(old, event) : old
+              return published
+            })
+            if (published) reconcileRunWatchPublication(queryClient, namespace, event, published)
             cursor = event.resourceVersion
           }, controller.signal)
         } catch (error) {


### PR DESCRIPTION
## Summary

- fence repository credentials, Environment ownership, and console resources to immutable UIDs
- durably revoke rejected GitHub App tokens and prevent adapter/provider detail from entering Run status
- reauthorize Run watches, terminals, transcript SSE, and portal streams on bounded leases
- enforce reciprocal Environment intent/status ownership with admission policies
- bound sandboxd managed-service retention, retries, and concurrent reconciliation
- preserve exact retry/idempotency behavior while dropping permanently rejected Claude events
- allow autonomous local commits in `AGENTS.md` so MVP work can keep moving

## Validation

- `make test`
- `make vet`
- `make check-chart-crds`
- `git diff --check`
- `go test -race ./internal/controlplane -count=1`
- `go test -race ./internal/adapters/claudecode -count=1`
- UI: `npm test -- --run` (100 tests), `npm run typecheck`, `npm run lint`, `npm run build`

All passed locally. Full live kind E2E was not run in the orb.
