### PR TITLE
Define fail-closed egress policy and protocol foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,9 @@ Pi deliberately supports no credential profiles or credential injection.
 
 - **Language:** Go for control plane, operator, `sandboxd`, and CLI.
 - **Layout:** kubebuilder conventions — `api/v1alpha1/` for types,
-  `internal/controllers/`, `cmd/{operator,swe}`. The exact adapter contract boundary is
+  `internal/controllers/`, and `cmd/{operator,control-plane,swe,egress-proxy}` for root-module
+  binaries. The egress proxy command is a disabled protocol foundation and intentionally remains
+  outside `make build` and image publishing until the fail-closed runtime is enabled. The exact adapter contract boundary is
   `internal/agent/`. Shared fenced Environment intent
   publication and validation belongs in `internal/lifecycle/`; controllers remain
   the sole owners of observed lifecycle transitions. Environment reconciliation is split

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -77,7 +77,7 @@ All current CRDs are namespaced:
 | Resource | Current contract |
 |---|---|
 | `Installation` | Empty-spec identity object in the system namespace. Its immutable Kubernetes UID is the stable installation identity used by namespace claims, catalog sources, managed Template copies, and baseline resources. |
-| `Project` | One repository URL (represented as a one-item list), a same-namespace default Template reference, changes-workflow metadata, and a reserved egress allowlist. A non-empty allowlist is rejected when an Environment uses the Project. |
+| `Project` | One repository URL (represented as a one-item list), a same-namespace default Template reference, changes-workflow metadata, and up to 64 exact lowercase-ASCII FQDN egress selections. The selection contract is admitted, but a non-empty selection remains rejected when an Environment uses the Project because runtime egress enforcement is not enabled. |
 | `EnvironmentTemplate` | Pod image, size/resources, disk, runtime class, idle timeout, warm-pool minimum, and backend. Admission currently permits only the `pod` backend. Chart-owned system-namespace objects are inert catalog sources; execution accepts only installation-managed same-namespace copies bound to exact Installation, source, and Project identities. |
 | `Environment` | Immutable Template selection, an immutable optional backend override, one-way empty-to-nonempty Project binding, explicit hold policy, bounded wake/suspend/activity intents, and up to 32 API- or Repository-owned service declarations. New declarations have an immutable-per-incarnation random `instanceID`; upgrade-retained legacy declarations may omit it, receive no portal route, and can add it only with a higher revision. Omitted legacy service ownership defaults only to `API` and is immutable thereafter. Controller-owned status includes the immutable resolved `provisioning` snapshot, readiness, lifecycle/execution, claim, observations, activity, and nested backend-neutral recovery state; recovery records attempts, exhaustion, the exact failed execution generation being accounted, and the next allowed attempt time, while generation zero means no recovery identity. The gateway owns bounded `portalRoutes` and monotonic `nextPortalRouteGeneration`; inactive routes are denial tombstones preserved by other status writers. |
 | `Run` | Immutable agent task and Environment/Project/Template/agent-credential/repository-credential selection plus monotonic cancellation; status records normalized lifecycle, exact Environment name/UID and ownership, exact credential profile identity, repository credential readiness, accepted lifecycle epoch, and accepted execution generation. `notify` and `parentRef` are schema placeholders without an implemented inbox. |
@@ -210,7 +210,8 @@ runtime-class name, and effective backend plus the Project repository are frozen
 inputs. Template generation and Project generation are recorded for diagnosis but live edits do
 not rewrite the snapshot. Template `idleTimeout` remains live lifecycle policy;
 `warmPool.min` remains live pool policy; and Project egress allowlist remains live security
-policy (currently any non-empty list fences execution as unsupported). Project-less warm members
+policy (currently any non-empty list fences execution as unsupported, even though its bounded v1
+selection grammar is admitted). Project-less warm members
 are current only when Template name/UID and the resolved provisioning projection match; generation
 alone is not compared because it can contain policy-only edits. A provisioning edit makes old
 members unclaimable and quarantined while bounded replacement members roll out; the existing
@@ -757,7 +758,7 @@ Hold, Requested suspension, stale association/declaration/route/execution, and u
 the same 404 as an unknown locator. Idle requests wake and await a fresh execution. The proxy
 strips credentials, session cookies, and hop-by-hop headers and supports WebSocket upgrade.
 
-### Fail-closed proxy-only egress
+### Approved fail-closed proxy-only egress contract
 
 The maintainer approved the [outbound-network contract in #68](https://github.com/Chris-Cullins/swe-platform/issues/68#issuecomment-5078805740):
 
@@ -780,8 +781,37 @@ The maintainer approved the [outbound-network contract in #68](https://github.co
 - required Git, package, provider, and CDN traffic is explicit and observable, and denials
   provide useful operator evidence.
 
-The current non-empty Project allowlist rejection remains until identity, proxy readiness, and
-path forcing ship together after Project namespace claims.
+The [approved v1 implementation package](https://github.com/Chris-Cullins/swe-platform/issues/68#issuecomment-5231375346)
+defines `Project.spec.egressAllowlist` as a tenant selection, not a grant. It is a set of 0–64
+exact lowercase ASCII FQDNs, each 1–253 bytes with at least two 1–63 byte labels matching
+`[a-z0-9]([a-z0-9-]*[a-z0-9])?`. Uppercase, trailing dots, `xn--`, non-ASCII, wildcards,
+schemes, ports, paths, queries, fragments, userinfo, percent encoding, whitespace/control bytes,
+NUL, and every IP literal form are invalid and are rejected rather than normalized. Each entry
+means only TLS-over-CONNECT to that exact FQDN on TCP 443; redirects require independent policy.
+The CRD enforces bounded expressible shape, while `internal/egresspolicy` is the sole complete Go
+grammar and canonicalization authority.
+
+The future immutable administrator-owned policy has a maximum 256-entry ceiling and maximum
+64-entry baseline using the same grammar. Baseline and Project selection must each be subsets of
+the ceiling; an invalid or out-of-ceiling value fails closed rather than being silently
+intersected. Effective v1 policy is `baseline ∪ Project selection`; the platform baseline is
+empty, so two empty sets mean deny-all under the future restricted runtime. Administrators must
+explicitly list repository, provider, package, CDN, redirect, and WebSocket destinations. The
+platform infers none. EnvironmentTemplates neither grant nor narrow egress, and Project-less warm
+Environments receive no egress identity or external egress in the approved runtime design.
+
+The canonical runtime revision is SHA-256 over deterministic canonical bytes containing the
+revision domain, exact Installation UID, immutable policy ConfigMap UID and content SHA-256,
+sorted ceiling and baseline, exact Project UID, and sorted Project selection. Later operator and
+proxy integration must independently recompute this from authoritative uncached reads. Helm
+rendering is not runtime authority.
+
+Only this API and canonical-policy foundation is implemented. The current non-empty Project
+allowlist rejection remains unchanged until per-execution identity, proxy readiness, technical
+path forcing, Calico v3.32.1-only enforcement proof, and acceptance land together. There is
+currently no default-deny egress, proxy deployment, runtime policy ConfigMap, restricted profile,
+or production egress-enforcement claim; generic Kubernetes, k3s, GKE, and EKS restricted profiles
+remain deferred. Issue #68 is not runtime-complete.
 
 ## Remaining decisions and open work
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -117,11 +117,29 @@ kind fixture, with an allowed connection as a positive control. The operator doe
 that a production cluster's CNI enforces NetworkPolicy, and Environment status does not claim
 effective CNI enforcement.
 
-Default-deny egress and the per-project egress proxy are not implemented. The
-`Project.spec.egressAllowlist` field is reserved for that future contract; the operator rejects
-non-empty values and fences any existing Environment execution rather than running with an
-unenforced allowlist. Empty or omitted allowlists do not restrict environment egress, which is
-subject to the cluster's network configuration.
+Default-deny egress and the per-project egress proxy are not implemented. The admitted v1
+`Project.spec.egressAllowlist` contract is a set of at most 64 exact lowercase ASCII FQDN tenant
+selections, not an autonomous grant. Each entry is 1–253 bytes, has at least two labels, uses only
+1–63 byte `[a-z0-9]([a-z0-9-]*[a-z0-9])?` labels, and means only TLS-over-CONNECT to that exact
+name on TCP 443. Uppercase, trailing dots, `xn--`, non-ASCII, wildcards, URL components, percent
+encoding, whitespace/control bytes, NUL, and all IP forms are rejected rather than normalized.
+The CRD enforces expressible bounds and shape; `internal/egresspolicy` is the sole complete Go
+authority for parsing and canonical policy composition.
+
+The approved but not wired administrator policy has a 256-entry ceiling and a 64-entry baseline
+using the same grammar. Baseline and Project selection must both be subsets of the ceiling, and
+the future effective set is their union. Invalid or out-of-ceiling input fails closed rather than
+being silently intersected. The platform baseline is empty and no repository, provider, package,
+CDN, redirect, or WebSocket host is inferred. Templates neither grant nor narrow egress. The
+canonical future runtime revision binds the revision domain, exact Installation UID, immutable
+policy ConfigMap UID and content SHA-256, sorted ceiling/baseline, exact Project UID, and sorted
+selection.
+
+The operator still rejects every non-empty Project selection and fences any existing Environment
+execution rather than running with unenforced intent. Empty or omitted selections do not restrict
+Environment egress today, which remains subject to cluster network configuration. No policy
+ConfigMap, proxy, identity, path forcing, restricted NetworkPolicy, or enforcement proof is wired;
+the approved restricted runtime is Calico v3.32.1-only and remains later issue #68 work.
 
 When an EnvironmentTemplate explicitly names a RuntimeClass, the operator verifies that the
 cluster-scoped RuntimeClass object exists before execution and fences exact-owned execution if

--- a/api/v1alpha1/project_crd_schema_test.go
+++ b/api/v1alpha1/project_crd_schema_test.go
@@ -1,0 +1,115 @@
+package v1alpha1
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsvalidation "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation"
+	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema/cel"
+	apiservervalidation "k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/yaml"
+)
+
+func TestGeneratedProjectEgressAllowlistSchema(t *testing.T) {
+	data, err := os.ReadFile("../../config/crd/bases/swe.dev_projects.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var crd apiextensionsv1.CustomResourceDefinition
+	if err := yaml.Unmarshal(data, &crd); err != nil {
+		t.Fatal(err)
+	}
+	var internalCRD apiextensions.CustomResourceDefinition
+	if err := apiextensionsv1.Convert_v1_CustomResourceDefinition_To_apiextensions_CustomResourceDefinition(&crd, &internalCRD, nil); err != nil {
+		t.Fatal(err)
+	}
+	for _, version := range internalCRD.Spec.Versions {
+		if version.Storage {
+			internalCRD.Status.StoredVersions = append(internalCRD.Status.StoredVersions, version.Name)
+		}
+	}
+	if errs := apiextensionsvalidation.ValidateCustomResourceDefinition(context.Background(), &internalCRD); len(errs) != 0 {
+		t.Fatalf("generated Project CRD is not establishable: %v", errs)
+	}
+
+	version := crd.Spec.Versions[0]
+	for i := range crd.Spec.Versions {
+		if crd.Spec.Versions[i].Name == GroupVersion.Version {
+			version = crd.Spec.Versions[i]
+		}
+	}
+	allowlist := version.Schema.OpenAPIV3Schema.Properties["spec"].Properties["egressAllowlist"]
+	if allowlist.MaxItems == nil || *allowlist.MaxItems != 64 || allowlist.XListType == nil || *allowlist.XListType != "set" || allowlist.Items == nil || allowlist.Items.Schema == nil {
+		t.Fatalf("generated allowlist collection bounds are incomplete: %#v", allowlist)
+	}
+	item := allowlist.Items.Schema
+	if item.MinLength == nil || *item.MinLength != 1 || item.MaxLength == nil || *item.MaxLength != 253 || item.Pattern == "" {
+		t.Fatalf("generated allowlist item bounds are incomplete: %#v", item)
+	}
+
+	var internal apiextensions.JSONSchemaProps
+	if err := apiextensionsv1.Convert_v1_JSONSchemaProps_To_apiextensions_JSONSchemaProps(version.Schema.OpenAPIV3Schema, &internal, nil); err != nil {
+		t.Fatal(err)
+	}
+	structural, err := structuralschema.NewStructural(&internal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	openAPI, _, err := apiservervalidation.NewSchemaValidator(&internal)
+	if err != nil {
+		t.Fatal(err)
+	}
+	celValidator := cel.NewValidator(structural, true, 1_000_000)
+	base := map[string]interface{}{
+		"apiVersion": GroupVersion.String(), "kind": "Project",
+		"metadata": map[string]interface{}{"name": "project", "namespace": "default"},
+		"spec":     map[string]interface{}{"repositories": []interface{}{"https://example.com/repo.git"}},
+	}
+	tests := []struct {
+		name      string
+		allowlist []interface{}
+		valid     bool
+	}{
+		{name: "omitted", valid: true},
+		{name: "empty", allowlist: []interface{}{}, valid: true},
+		{name: "exact FQDN", allowlist: []interface{}{"api.example.com"}, valid: true},
+		{name: "uppercase", allowlist: []interface{}{"API.example.com"}},
+		{name: "trailing dot", allowlist: []interface{}{"api.example.com."}},
+		{name: "IDNA", allowlist: []interface{}{"xn--bcher-kva.example"}},
+		{name: "inner IDNA", allowlist: []interface{}{"www.xn--bcher-kva.example"}},
+		{name: "IPv4", allowlist: []interface{}{"127.0.0.1"}},
+		{name: "invalid octal is a hostname", allowlist: []interface{}{"09.0.0.1"}, valid: true},
+		// Legacy IP forms pass the expressible CRD shape and are rejected by the
+		// authoritative egresspolicy parser before any later runtime use.
+		{name: "legacy IPv4 requires Go authority", allowlist: []interface{}{"0x7f.0x0.0x0.0x1"}, valid: true},
+		{name: "one label", allowlist: []interface{}{"localhost"}},
+		{name: "too many", allowlist: projectSchemaHosts(65)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			object := runtime.DeepCopyJSONValue(base).(map[string]interface{})
+			if test.allowlist != nil {
+				object["spec"].(map[string]interface{})["egressAllowlist"] = test.allowlist
+			}
+			errs := apiservervalidation.ValidateCustomResource(nil, object, openAPI)
+			celErrs, _ := celValidator.Validate(context.Background(), nil, structural, object, nil, 10_000_000)
+			errs = append(errs, celErrs...)
+			if test.valid != (len(errs) == 0) {
+				t.Fatalf("valid=%t errors=%v", test.valid, errs)
+			}
+		})
+	}
+}
+
+func projectSchemaHosts(count int) []interface{} {
+	result := make([]interface{}, count)
+	for i := range result {
+		result[i] = "host-" + string(rune('a'+i%26)) + ".example.com"
+	}
+	return result
+}

--- a/api/v1alpha1/project_types.go
+++ b/api/v1alpha1/project_types.go
@@ -29,10 +29,16 @@ type ProjectSpec struct {
 	// +optional
 	ChangesWorkflow ChangesWorkflow `json:"changesWorkflow,omitempty"`
 
-	// EgressAllowlist is reserved for future per-project egress enforcement.
-	// Non-empty values are currently unsupported and cause referenced Environments
-	// to fail validation until the egress proxy is implemented.
+	// EgressAllowlist selects exact HTTPS FQDN destinations from an administrator-owned
+	// ceiling. Runtime enforcement is not enabled yet: non-empty values still cause
+	// referenced Environments to fail validation until the egress proxy is implemented.
 	// +optional
+	// +kubebuilder:validation:MaxItems=64
+	// +kubebuilder:validation:items:MinLength=1
+	// +kubebuilder:validation:items:MaxLength=253
+	// +kubebuilder:validation:items:Pattern=`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$`
+	// +kubebuilder:validation:XValidation:rule="self.all(host, !host.startsWith('xn--') && !host.contains('.xn--'))",message="egress allowlist entries must not contain IDNA A-labels"
+	// +kubebuilder:validation:XValidation:rule="self.all(host, !(host.split('.').size() == 4 && host.split('.').all(part, part.matches('^(0|[1-9][0-9]{0,2})$') && int(part) <= 255)))",message="egress allowlist entries must not be IPv4 literals"
 	// +listType=set
 	EgressAllowlist []string `json:"egressAllowlist,omitempty"`
 }

--- a/charts/swe-platform/crds/swe.dev_projects.yaml
+++ b/charts/swe-platform/crds/swe.dev_projects.yaml
@@ -50,13 +50,23 @@ spec:
                 type: string
               egressAllowlist:
                 description: |-
-                  EgressAllowlist is reserved for future per-project egress enforcement.
-                  Non-empty values are currently unsupported and cause referenced Environments
-                  to fail validation until the egress proxy is implemented.
+                  EgressAllowlist selects exact HTTPS FQDN destinations from an administrator-owned
+                  ceiling. Runtime enforcement is not enabled yet: non-empty values still cause
+                  referenced Environments to fail validation until the egress proxy is implemented.
                 items:
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$
                   type: string
+                maxItems: 64
                 type: array
                 x-kubernetes-list-type: set
+                x-kubernetes-validations:
+                - message: egress allowlist entries must not contain IDNA A-labels
+                  rule: self.all(host, !host.startsWith('xn--') && !host.contains('.xn--'))
+                - message: egress allowlist entries must not be IPv4 literals
+                  rule: self.all(host, !(host.split('.').size() == 4 && host.split('.').all(part,
+                    part.matches('^(0|[1-9][0-9]{0,2})$') && int(part) <= 255)))
               repositories:
                 description: |-
                   Repositories contains the single git repository URL this project works on.

--- a/cmd/egress-proxy/main.go
+++ b/cmd/egress-proxy/main.go
@@ -1,0 +1,102 @@
+// egress-proxy is operationally disabled: serve mode always denies authorization.
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"flag"
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/Chris-Cullins/swe-platform/internal/egressproxy"
+)
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+}
+func run(args []string) error {
+	if len(args) < 1 {
+		return errors.New("usage: egress-proxy serve|forward")
+	}
+	fs := flag.NewFlagSet(args[0], flag.ContinueOnError)
+	addr := fs.String("address", "", "listen address")
+	cert := fs.String("cert", "", "certificate PEM")
+	key := fs.String("key", "", "private key PEM")
+	ca := fs.String("ca", "", "peer CA PEM")
+	server := fs.String("server", "", "serve address (forward mode)")
+	serverName := fs.String("server-name", "", "TLS server name")
+	var resolvers stringList
+	fs.Var(&resolvers, "resolver", "DNS resolver IP/address (repeatable; port defaults to 53)")
+	if err := fs.Parse(args[1:]); err != nil {
+		return err
+	}
+	if *addr == "" || *cert == "" || *key == "" {
+		return errors.New("--address, --cert and --key are required")
+	}
+	pair, err := tls.LoadX509KeyPair(*cert, *key)
+	if err != nil {
+		return err
+	}
+	switch args[0] {
+	case "serve":
+		if *ca != "" || *server != "" || *serverName != "" {
+			return errors.New("serve does not accept --ca, --server, or --server-name")
+		}
+		if len(resolvers) == 0 {
+			return errors.New("at least one --resolver is required")
+		}
+		l, e := net.Listen("tcp", *addr)
+		if e != nil {
+			return e
+		}
+		defer l.Close()
+		resolver, e := egressproxy.NewDNSClient(resolvers)
+		if e != nil {
+			return e
+		}
+		return (&egressproxy.Server{TLSConfig: &tls.Config{Certificates: []tls.Certificate{pair}, ClientAuth: tls.RequireAnyClientCert, MinVersion: tls.VersionTLS13, MaxVersion: tls.VersionTLS13, SessionTicketsDisabled: true}, Authorizer: egressproxy.DisabledAuthorizer{}, Resolver: resolver}).Serve(l)
+	case "forward":
+		if *server == "" || *serverName == "" || *ca == "" || len(resolvers) != 0 {
+			return errors.New("forward requires --server, --server-name and --ca, and does not accept --resolver")
+		}
+		pool, err := loadPool(*ca)
+		if err != nil {
+			return err
+		}
+		l, e := net.Listen("tcp", *addr)
+		if e != nil {
+			return e
+		}
+		defer l.Close()
+		return (&egressproxy.Forwarder{ServerAddress: *server, TLSConfig: &tls.Config{Certificates: []tls.Certificate{pair}, RootCAs: pool, ServerName: *serverName, MinVersion: tls.VersionTLS13, MaxVersion: tls.VersionTLS13, SessionTicketsDisabled: true}}).Serve(l)
+	default:
+		return errors.New("usage: egress-proxy serve|forward")
+	}
+}
+
+type stringList []string
+
+func (s *stringList) String() string { return fmt.Sprint([]string(*s)) }
+func (s *stringList) Set(v string) error {
+	if v == "" {
+		return errors.New("empty resolver")
+	}
+	*s = append(*s, v)
+	return nil
+}
+func loadPool(path string) (*x509.CertPool, error) {
+	b, e := os.ReadFile(path)
+	if e != nil {
+		return nil, e
+	}
+	p := x509.NewCertPool()
+	if !p.AppendCertsFromPEM(b) {
+		return nil, errors.New("CA contains no certificates")
+	}
+	return p, nil
+}

--- a/config/crd/bases/swe.dev_projects.yaml
+++ b/config/crd/bases/swe.dev_projects.yaml
@@ -50,13 +50,23 @@ spec:
                 type: string
               egressAllowlist:
                 description: |-
-                  EgressAllowlist is reserved for future per-project egress enforcement.
-                  Non-empty values are currently unsupported and cause referenced Environments
-                  to fail validation until the egress proxy is implemented.
+                  EgressAllowlist selects exact HTTPS FQDN destinations from an administrator-owned
+                  ceiling. Runtime enforcement is not enabled yet: non-empty values still cause
+                  referenced Environments to fail validation until the egress proxy is implemented.
                 items:
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$
                   type: string
+                maxItems: 64
                 type: array
                 x-kubernetes-list-type: set
+                x-kubernetes-validations:
+                - message: egress allowlist entries must not contain IDNA A-labels
+                  rule: self.all(host, !host.startsWith('xn--') && !host.contains('.xn--'))
+                - message: egress allowlist entries must not be IPv4 literals
+                  rule: self.all(host, !(host.split('.').size() == 4 && host.split('.').all(part,
+                    part.matches('^(0|[1-9][0-9]{0,2})$') && int(part) <= 255)))
               repositories:
                 description: |-
                   Repositories contains the single git repository URL this project works on.

--- a/go.mod
+++ b/go.mod
@@ -16,10 +16,11 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/spf13/cobra v1.10.2
-	gopkg.in/yaml.v3 v3.0.1
+	golang.org/x/net v0.56.0
 	golang.org/x/term v0.44.0
 	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.36.2
 	k8s.io/apiextensions-apiserver v0.36.0
 	k8s.io/apimachinery v0.36.2
@@ -104,7 +105,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/exp v0.0.0-20251219203646-944ab1f22d93 // indirect
-	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect

--- a/internal/egresspolicy/policy.go
+++ b/internal/egresspolicy/policy.go
@@ -1,0 +1,272 @@
+// Package egresspolicy is the sole authority for the v1 egress destination
+// grammar, policy composition, and runtime policy revision.
+package egresspolicy
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/netip"
+	"sort"
+	"strconv"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	MaxProjectEntries  = 64
+	MaxCeilingEntries  = 256
+	MaxBaselineEntries = 64
+	MaxHostnameBytes   = 253
+	MaxLabelBytes      = 63
+
+	// RuntimeRevisionDomain changes whenever canonical revision semantics or a
+	// security-relevant policy input changes.
+	RuntimeRevisionDomain = "swe.dev/egress-policy/runtime-revision/v1"
+)
+
+// Hostname is an exact lowercase ASCII FQDN accepted by ParseHostname.
+// Its implicit and only v1 destination is TLS-over-CONNECT on TCP port 443.
+type Hostname string
+
+// Policy is a validated, sorted v1 policy. Each slice is an independent copy.
+type Policy struct {
+	Ceiling          []Hostname
+	Baseline         []Hostname
+	ProjectSelection []Hostname
+	Effective        []Hostname
+}
+
+// RuntimeRevisionInputs are the authoritative immutable identities and policy
+// content needed by later operator and proxy integrations. ConfigMapContentSHA256
+// is the digest of the immutable administrator-owned ConfigMap content.
+type RuntimeRevisionInputs struct {
+	InstallationUID        types.UID
+	ConfigMapUID           types.UID
+	ConfigMapContentSHA256 [sha256.Size]byte
+	ProjectUID             types.UID
+	Ceiling                []string
+	Baseline               []string
+	ProjectSelection       []string
+}
+
+// RuntimeRevision is the SHA-256 digest of canonical runtime policy inputs.
+type RuntimeRevision [sha256.Size]byte
+
+func (r RuntimeRevision) String() string { return hex.EncodeToString(r[:]) }
+
+// ParseHostname validates an exact v1 destination. It never normalizes input.
+func ParseHostname(value string) (Hostname, error) {
+	if len(value) == 0 || len(value) > MaxHostnameBytes {
+		return "", fmt.Errorf("hostname length must be 1-%d bytes", MaxHostnameBytes)
+	}
+	for i := 0; i < len(value); i++ {
+		if value[i] > 0x7f {
+			return "", errors.New("hostname must contain lowercase ASCII only")
+		}
+	}
+
+	labels := strings.Split(value, ".")
+	if len(labels) < 2 {
+		return "", errors.New("hostname must contain at least two labels")
+	}
+	for _, label := range labels {
+		if err := validateLabel(label); err != nil {
+			return "", fmt.Errorf("invalid hostname %q: %w", value, err)
+		}
+	}
+	if isIPLiteral(value, labels) {
+		return "", errors.New("IP literals are not egress hostnames")
+	}
+	return Hostname(value), nil
+}
+
+func validateLabel(label string) error {
+	if len(label) == 0 || len(label) > MaxLabelBytes {
+		return fmt.Errorf("label length must be 1-%d bytes", MaxLabelBytes)
+	}
+	if strings.HasPrefix(label, "xn--") {
+		return errors.New("IDNA A-labels are not supported")
+	}
+	if label[0] == '-' || label[len(label)-1] == '-' {
+		return errors.New("label must start and end with a letter or digit")
+	}
+	for i := 0; i < len(label); i++ {
+		c := label[i]
+		if !((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-') {
+			return errors.New("label must match [a-z0-9]([a-z0-9-]*[a-z0-9])?")
+		}
+	}
+	return nil
+}
+
+func isIPLiteral(value string, labels []string) bool {
+	if _, err := netip.ParseAddr(value); err == nil {
+		return true
+	}
+	if len(labels) > 4 {
+		return false
+	}
+	parts := make([]uint64, len(labels))
+	for i, label := range labels {
+		part, ok := parseIPv4Number(label)
+		if !ok {
+			return false
+		}
+		parts[i] = part
+	}
+	switch len(parts) {
+	case 1:
+		return parts[0] <= 0xffffffff
+	case 2:
+		return parts[0] <= 0xff && parts[1] <= 0xffffff
+	case 3:
+		return parts[0] <= 0xff && parts[1] <= 0xff && parts[2] <= 0xffff
+	case 4:
+		return parts[0] <= 0xff && parts[1] <= 0xff && parts[2] <= 0xff && parts[3] <= 0xff
+	default:
+		return false
+	}
+}
+
+func parseIPv4Number(value string) (uint64, bool) {
+	base, digits := 10, value
+	if value == "0x" {
+		return 0, true
+	}
+	if len(value) > 2 && value[0:2] == "0x" {
+		base, digits = 16, value[2:]
+	} else if len(value) > 1 && value[0] == '0' {
+		base = 8
+	}
+	if digits == "" {
+		return 0, false
+	}
+	result, err := strconv.ParseUint(digits, base, 32)
+	return result, err == nil
+}
+
+// Evaluate validates the administrator ceiling and baseline, validates the
+// Project selection as a subset of that ceiling, and returns baseline union
+// selection. Invalid entries and out-of-ceiling selections fail rather than
+// being normalized or silently intersected.
+func Evaluate(ceiling, baseline, projectSelection []string) (Policy, error) {
+	canonicalCeiling, err := parseSet("ceiling", ceiling, MaxCeilingEntries)
+	if err != nil {
+		return Policy{}, err
+	}
+	canonicalBaseline, err := parseSet("baseline", baseline, MaxBaselineEntries)
+	if err != nil {
+		return Policy{}, err
+	}
+	canonicalSelection, err := parseSet("project selection", projectSelection, MaxProjectEntries)
+	if err != nil {
+		return Policy{}, err
+	}
+	ceilingSet := hostnameSet(canonicalCeiling)
+	if err := requireSubset("baseline", canonicalBaseline, ceilingSet); err != nil {
+		return Policy{}, err
+	}
+	if err := requireSubset("project selection", canonicalSelection, ceilingSet); err != nil {
+		return Policy{}, err
+	}
+	effectiveSet := hostnameSet(canonicalBaseline)
+	for _, hostname := range canonicalSelection {
+		effectiveSet[hostname] = struct{}{}
+	}
+	effective := make([]Hostname, 0, len(effectiveSet))
+	for hostname := range effectiveSet {
+		effective = append(effective, hostname)
+	}
+	sort.Slice(effective, func(i, j int) bool { return effective[i] < effective[j] })
+	return Policy{
+		Ceiling:          canonicalCeiling,
+		Baseline:         canonicalBaseline,
+		ProjectSelection: canonicalSelection,
+		Effective:        effective,
+	}, nil
+}
+
+func parseSet(name string, values []string, maximum int) ([]Hostname, error) {
+	if len(values) > maximum {
+		return nil, fmt.Errorf("%s has %d entries, maximum is %d", name, len(values), maximum)
+	}
+	result := make([]Hostname, 0, len(values))
+	seen := make(map[Hostname]struct{}, len(values))
+	for i, value := range values {
+		hostname, err := ParseHostname(value)
+		if err != nil {
+			return nil, fmt.Errorf("%s entry %d: %w", name, i, err)
+		}
+		if _, exists := seen[hostname]; exists {
+			return nil, fmt.Errorf("%s contains duplicate hostname %q", name, hostname)
+		}
+		seen[hostname] = struct{}{}
+		result = append(result, hostname)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i] < result[j] })
+	return result, nil
+}
+
+func hostnameSet(values []Hostname) map[Hostname]struct{} {
+	result := make(map[Hostname]struct{}, len(values))
+	for _, value := range values {
+		result[value] = struct{}{}
+	}
+	return result
+}
+
+func requireSubset(name string, values []Hostname, ceiling map[Hostname]struct{}) error {
+	for _, value := range values {
+		if _, allowed := ceiling[value]; !allowed {
+			return fmt.Errorf("%s hostname %q is outside the administrator ceiling", name, value)
+		}
+	}
+	return nil
+}
+
+// CanonicalBytes validates and serializes revision inputs deterministically.
+func (in RuntimeRevisionInputs) CanonicalBytes() ([]byte, error) {
+	if in.InstallationUID == "" || in.ConfigMapUID == "" || in.ProjectUID == "" {
+		return nil, errors.New("installation, ConfigMap, and Project UIDs are required")
+	}
+	if in.ConfigMapContentSHA256 == ([sha256.Size]byte{}) {
+		return nil, errors.New("ConfigMap content SHA-256 is required")
+	}
+	policy, err := Evaluate(in.Ceiling, in.Baseline, in.ProjectSelection)
+	if err != nil {
+		return nil, err
+	}
+	type canonicalInputs struct {
+		Domain                 string     `json:"domain"`
+		InstallationUID        types.UID  `json:"installationUID"`
+		ConfigMapUID           types.UID  `json:"configMapUID"`
+		ConfigMapContentSHA256 string     `json:"configMapContentSHA256"`
+		Ceiling                []Hostname `json:"ceiling"`
+		Baseline               []Hostname `json:"baseline"`
+		ProjectUID             types.UID  `json:"projectUID"`
+		ProjectSelection       []Hostname `json:"projectSelection"`
+	}
+	return json.Marshal(canonicalInputs{
+		Domain:                 RuntimeRevisionDomain,
+		InstallationUID:        in.InstallationUID,
+		ConfigMapUID:           in.ConfigMapUID,
+		ConfigMapContentSHA256: hex.EncodeToString(in.ConfigMapContentSHA256[:]),
+		Ceiling:                policy.Ceiling,
+		Baseline:               policy.Baseline,
+		ProjectUID:             in.ProjectUID,
+		ProjectSelection:       policy.ProjectSelection,
+	})
+}
+
+// Revision returns SHA-256 over CanonicalBytes.
+func (in RuntimeRevisionInputs) Revision() (RuntimeRevision, error) {
+	canonical, err := in.CanonicalBytes()
+	if err != nil {
+		return RuntimeRevision{}, err
+	}
+	return sha256.Sum256(canonical), nil
+}

--- a/internal/egresspolicy/policy_fuzz_test.go
+++ b/internal/egresspolicy/policy_fuzz_test.go
@@ -1,0 +1,37 @@
+package egresspolicy
+
+import (
+	"strings"
+	"testing"
+)
+
+func FuzzParseHostname(f *testing.F) {
+	for _, seed := range []string{
+		"example.com", "api-2.example.com", "Example.com", "example.com.",
+		"xn--bcher-kva.example", "bücher.example", "*.example.com", "https://example.com",
+		"example.com:443", "user@example.com", "example%2ecom", "example.com\x00",
+		"127.0.0.1", "127.1", "0177.0.0.1", "0x7f.0x0.0x0.0x1", "0x.0x", "0x.1", "0x.0x.0x.1", "::ffff:127.0.0.1",
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, value string) {
+		hostname, err := ParseHostname(value)
+		if err != nil {
+			return
+		}
+		if string(hostname) != value {
+			t.Fatalf("parser normalized %q to %q", value, hostname)
+		}
+		if len(value) == 0 || len(value) > MaxHostnameBytes || strings.ToLower(value) != value || strings.Count(value, ".") < 1 {
+			t.Fatalf("accepted value violates canonical bounds: %q", value)
+		}
+		for i := 0; i < len(value); i++ {
+			if value[i] > 0x7f {
+				t.Fatalf("accepted non-ASCII value %q", value)
+			}
+		}
+		if reparsed, reparseErr := ParseHostname(string(hostname)); reparseErr != nil || reparsed != hostname {
+			t.Fatalf("accepted hostname is not stable: %q, %v", reparsed, reparseErr)
+		}
+	})
+}

--- a/internal/egresspolicy/policy_test.go
+++ b/internal/egresspolicy/policy_test.go
@@ -1,0 +1,212 @@
+package egresspolicy
+
+import (
+	"crypto/sha256"
+	"strconv"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestParseHostname(t *testing.T) {
+	label63 := strings.Repeat("a", 63)
+	tests := []struct {
+		name  string
+		value string
+		valid bool
+	}{
+		{name: "two labels", value: "example.com", valid: true},
+		{name: "digits and hyphens", value: "api-2.example123.com", valid: true},
+		{name: "maximum labels", value: label63 + "." + label63 + "." + label63 + "." + strings.Repeat("a", 61), valid: true},
+		{name: "empty"},
+		{name: "one label", value: "localhost"},
+		{name: "uppercase", value: "Example.com"},
+		{name: "trailing dot", value: "example.com."},
+		{name: "empty label", value: "example..com"},
+		{name: "leading hyphen", value: "-api.example.com"},
+		{name: "trailing hyphen", value: "api-.example.com"},
+		{name: "long label", value: strings.Repeat("a", 64) + ".com"},
+		{name: "long name", value: label63 + "." + label63 + "." + label63 + "." + label63},
+		{name: "idna", value: "xn--bcher-kva.example"},
+		{name: "idna inner label", value: "www.xn--bcher-kva.example"},
+		{name: "unicode", value: "bücher.example"},
+		{name: "wildcard", value: "*.example.com"},
+		{name: "scheme", value: "https://example.com"},
+		{name: "port", value: "example.com:443"},
+		{name: "path", value: "example.com/path"},
+		{name: "query", value: "example.com?x=y"},
+		{name: "fragment", value: "example.com#x"},
+		{name: "userinfo", value: "user@example.com"},
+		{name: "percent encoding", value: "example%2ecom"},
+		{name: "space", value: "example .com"},
+		{name: "tab", value: "example.com\t"},
+		{name: "newline", value: "example.com\n"},
+		{name: "nul", value: "example.com\x00"},
+		{name: "IPv4", value: "127.0.0.1"},
+		{name: "IPv4 short", value: "127.1"},
+		{name: "IPv4 octal", value: "0177.0.0.1"},
+		{name: "IPv4 hex", value: "0x7f.0x0.0x0.0x1"},
+		{name: "IPv4 mixed", value: "0x7f.01"},
+		{name: "IPv4 empty hex components", value: "0x.0x"},
+		{name: "IPv4 empty hex then decimal", value: "0x.1"},
+		{name: "IPv4 empty hex components and decimal", value: "0x.0x.0x.1"},
+		{name: "IPv4 integer", value: "2130706433"},
+		{name: "invalid octal remains hostname", value: "09.0.0.1", valid: true},
+		{name: "IPv6", value: "2001:db8::1"},
+		{name: "mapped IPv6", value: "::ffff:127.0.0.1"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := ParseHostname(test.value)
+			if test.valid && (err != nil || string(got) != test.value) {
+				t.Fatalf("ParseHostname(%q) = %q, %v", test.value, got, err)
+			}
+			if !test.valid && err == nil {
+				t.Fatalf("ParseHostname(%q) unexpectedly accepted", test.value)
+			}
+		})
+	}
+}
+
+func TestEvaluate(t *testing.T) {
+	tests := []struct {
+		name      string
+		ceiling   []string
+		baseline  []string
+		selection []string
+		want      []Hostname
+		wantErr   bool
+	}{
+		{name: "deny all", want: []Hostname{}},
+		{name: "baseline union selection", ceiling: []string{"z.example.com", "api.example.com", "git.example.com"}, baseline: []string{"git.example.com"}, selection: []string{"z.example.com", "git.example.com"}, want: []Hostname{"git.example.com", "z.example.com"}},
+		{name: "empty selection gets baseline", ceiling: []string{"git.example.com"}, baseline: []string{"git.example.com"}, want: []Hostname{"git.example.com"}},
+		{name: "baseline outside ceiling", ceiling: []string{"api.example.com"}, baseline: []string{"git.example.com"}, wantErr: true},
+		{name: "selection outside ceiling", ceiling: []string{"api.example.com"}, selection: []string{"git.example.com"}, wantErr: true},
+		{name: "invalid ceiling", ceiling: []string{"API.example.com"}, wantErr: true},
+		{name: "invalid baseline", ceiling: []string{"api.example.com"}, baseline: []string{"API.example.com"}, wantErr: true},
+		{name: "invalid selection", ceiling: []string{"api.example.com"}, selection: []string{"API.example.com"}, wantErr: true},
+		{name: "duplicate ceiling", ceiling: []string{"api.example.com", "api.example.com"}, wantErr: true},
+		{name: "duplicate baseline", ceiling: []string{"api.example.com"}, baseline: []string{"api.example.com", "api.example.com"}, wantErr: true},
+		{name: "duplicate selection", ceiling: []string{"api.example.com"}, selection: []string{"api.example.com", "api.example.com"}, wantErr: true},
+		{name: "ceiling bound", ceiling: repeatedHosts(MaxCeilingEntries + 1), wantErr: true},
+		{name: "baseline bound", ceiling: repeatedHosts(MaxBaselineEntries + 1), baseline: repeatedHosts(MaxBaselineEntries + 1), wantErr: true},
+		{name: "selection bound", ceiling: repeatedHosts(MaxProjectEntries + 1), selection: repeatedHosts(MaxProjectEntries + 1), wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := Evaluate(test.ceiling, test.baseline, test.selection)
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("Evaluate unexpectedly succeeded: %#v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Join(hostnameStrings(got.Effective), ",") != strings.Join(hostnameStrings(test.want), ",") {
+				t.Fatalf("effective = %#v, want %#v", got.Effective, test.want)
+			}
+		})
+	}
+}
+
+func TestRuntimeRevisionCanonicalAndStable(t *testing.T) {
+	configHash := sha256.Sum256([]byte("immutable config"))
+	first := RuntimeRevisionInputs{
+		InstallationUID: "installation-uid", ConfigMapUID: "config-uid", ConfigMapContentSHA256: configHash, ProjectUID: "project-uid",
+		Ceiling: []string{"z.example.com", "api.example.com", "git.example.com"}, Baseline: []string{"git.example.com"}, ProjectSelection: []string{"z.example.com", "api.example.com"},
+	}
+	second := first
+	second.Ceiling = []string{"git.example.com", "z.example.com", "api.example.com"}
+	second.ProjectSelection = []string{"api.example.com", "z.example.com"}
+	firstBytes, err := first.CanonicalBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondBytes, err := second.CanonicalBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(firstBytes) != string(secondBytes) {
+		t.Fatalf("ordering changed canonical bytes:\n%s\n%s", firstBytes, secondBytes)
+	}
+	wantBytes := `{"domain":"swe.dev/egress-policy/runtime-revision/v1","installationUID":"installation-uid","configMapUID":"config-uid","configMapContentSHA256":"1d7d78aa9b2d7295da53b1a23b6abdfcd1957523da38db1deb6a9eba909bd2d6","ceiling":["api.example.com","git.example.com","z.example.com"],"baseline":["git.example.com"],"projectUID":"project-uid","projectSelection":["api.example.com","z.example.com"]}`
+	if string(firstBytes) != wantBytes {
+		t.Fatalf("canonical bytes changed:\n got %s\nwant %s", firstBytes, wantBytes)
+	}
+	revision, err := first.Revision()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := revision.String(), "b2905abe69e3622311928373d2ece0fe6e6edcd578594f5eef983e742bfb131d"; got != want {
+		t.Fatalf("revision = %s, want %s", got, want)
+	}
+
+	mutations := []struct {
+		name string
+		edit func(*RuntimeRevisionInputs)
+	}{
+		{name: "installation UID", edit: func(in *RuntimeRevisionInputs) { in.InstallationUID = types.UID("other-installation") }},
+		{name: "ConfigMap UID", edit: func(in *RuntimeRevisionInputs) { in.ConfigMapUID = types.UID("other-config") }},
+		{name: "ConfigMap content", edit: func(in *RuntimeRevisionInputs) { in.ConfigMapContentSHA256 = sha256.Sum256([]byte("other config")) }},
+		{name: "ceiling", edit: func(in *RuntimeRevisionInputs) { in.Ceiling = append(in.Ceiling, "other.example.com") }},
+		{name: "baseline", edit: func(in *RuntimeRevisionInputs) { in.Baseline = append(in.Baseline, "api.example.com") }},
+		{name: "Project UID", edit: func(in *RuntimeRevisionInputs) { in.ProjectUID = types.UID("other-project") }},
+		{name: "Project selection", edit: func(in *RuntimeRevisionInputs) { in.ProjectSelection = []string{"z.example.com"} }},
+	}
+	for _, mutation := range mutations {
+		t.Run(mutation.name, func(t *testing.T) {
+			changed := first
+			changed.Ceiling = append([]string(nil), first.Ceiling...)
+			changed.Baseline = append([]string(nil), first.Baseline...)
+			changed.ProjectSelection = append([]string(nil), first.ProjectSelection...)
+			mutation.edit(&changed)
+			got, err := changed.Revision()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got == revision {
+				t.Fatal("revision did not change")
+			}
+		})
+	}
+}
+
+func TestRuntimeRevisionRequiresAuthoritativeInputs(t *testing.T) {
+	valid := RuntimeRevisionInputs{InstallationUID: "i", ConfigMapUID: "c", ConfigMapContentSHA256: sha256.Sum256([]byte("config")), ProjectUID: "p"}
+	for _, test := range []struct {
+		name string
+		edit func(*RuntimeRevisionInputs)
+	}{
+		{name: "installation", edit: func(in *RuntimeRevisionInputs) { in.InstallationUID = "" }},
+		{name: "ConfigMap", edit: func(in *RuntimeRevisionInputs) { in.ConfigMapUID = "" }},
+		{name: "ConfigMap content hash", edit: func(in *RuntimeRevisionInputs) { in.ConfigMapContentSHA256 = [sha256.Size]byte{} }},
+		{name: "Project", edit: func(in *RuntimeRevisionInputs) { in.ProjectUID = "" }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			input := valid
+			test.edit(&input)
+			if _, err := input.Revision(); err == nil {
+				t.Fatal("missing identity accepted")
+			}
+		})
+	}
+}
+
+func repeatedHosts(count int) []string {
+	result := make([]string, count)
+	for i := range result {
+		result[i] = "host-" + strconv.Itoa(i) + ".example.com"
+	}
+	return result
+}
+
+func hostnameStrings(values []Hostname) []string {
+	result := make([]string, len(values))
+	for i := range values {
+		result[i] = string(values[i])
+	}
+	return result
+}

--- a/internal/egressproxy/doc.go
+++ b/internal/egressproxy/doc.go
@@ -1,0 +1,8 @@
+// Package egressproxy contains the INERT, DISABLED and non-authoritative
+// transport slice of the future egress proxy. It does not consult Kubernetes,
+// authorize live Environments, or enforce network policy. The shipped command
+// deliberately installs an authorizer which denies every request. Tests and a
+// future authoritative integration may inject an Authorizer.
+// This inert slice intentionally emits no request-derived logs until bounded,
+// non-sensitive observability is integrated.
+package egressproxy

--- a/internal/egressproxy/policy.go
+++ b/internal/egressproxy/policy.go
@@ -1,0 +1,358 @@
+package egressproxy
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/netip"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/Chris-Cullins/swe-platform/internal/egresspolicy"
+	"golang.org/x/net/dns/dnsmessage"
+)
+
+func canonicalTarget(s string) (string, error) {
+	if !strings.HasSuffix(s, ":443") {
+		return "", errors.New("invalid CONNECT target")
+	}
+	hostname, err := egresspolicy.ParseHostname(strings.TrimSuffix(s, ":443"))
+	if err != nil {
+		return "", err
+	}
+	return string(hostname), nil
+}
+
+type ForbiddenPrefixEntry struct {
+	Prefix netip.Prefix
+	Name   string
+	Source string
+}
+
+func forbidden(prefix, name, source string) ForbiddenPrefixEntry {
+	return ForbiddenPrefixEntry{Prefix: netip.MustParsePrefix(prefix), Name: name, Source: source}
+}
+
+// ForbiddenPrefixSnapshot is the complete Address Block snapshot from the IANA IPv4 and IPv6
+// Special-Purpose Address Registries, both Last Updated 2025-10-09, retrieved 2026-08-09.
+// Sources: https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry-1.csv
+// and https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry-1.csv.
+var ForbiddenPrefixSnapshot = []ForbiddenPrefixEntry{
+	forbidden("0.0.0.0/8", "This network", "IANA IPv4"), forbidden("0.0.0.0/32", "This host on this network", "IANA IPv4"), forbidden("10.0.0.0/8", "Private-Use", "IANA IPv4"), forbidden("100.64.0.0/10", "Shared Address Space", "IANA IPv4"), forbidden("127.0.0.0/8", "Loopback", "IANA IPv4"), forbidden("169.254.0.0/16", "Link Local", "IANA IPv4"), forbidden("172.16.0.0/12", "Private-Use", "IANA IPv4"),
+	forbidden("192.0.0.0/24", "IETF Protocol Assignments", "IANA IPv4"), forbidden("192.0.0.0/29", "IPv4 Service Continuity Prefix", "IANA IPv4"), forbidden("192.0.0.8/32", "IPv4 dummy address", "IANA IPv4"), forbidden("192.0.0.9/32", "Port Control Protocol Anycast", "IANA IPv4"), forbidden("192.0.0.10/32", "TURN Anycast", "IANA IPv4"), forbidden("192.0.0.170/32", "NAT64/DNS64 Discovery", "IANA IPv4"), forbidden("192.0.0.171/32", "NAT64/DNS64 Discovery", "IANA IPv4"),
+	forbidden("192.0.2.0/24", "Documentation (TEST-NET-1)", "IANA IPv4"), forbidden("192.31.196.0/24", "AS112-v4", "IANA IPv4"), forbidden("192.52.193.0/24", "AMT", "IANA IPv4"), forbidden("192.88.99.0/24", "Deprecated (6to4 Relay Anycast)", "IANA IPv4"), forbidden("192.88.99.2/32", "6a44-relay anycast address", "IANA IPv4"), forbidden("192.168.0.0/16", "Private-Use", "IANA IPv4"), forbidden("192.175.48.0/24", "Direct Delegation AS112 Service", "IANA IPv4"), forbidden("198.18.0.0/15", "Benchmarking", "IANA IPv4"), forbidden("198.51.100.0/24", "Documentation (TEST-NET-2)", "IANA IPv4"), forbidden("203.0.113.0/24", "Documentation (TEST-NET-3)", "IANA IPv4"), forbidden("240.0.0.0/4", "Reserved", "IANA IPv4"), forbidden("255.255.255.255/32", "Limited Broadcast", "IANA IPv4"),
+	forbidden("::1/128", "Loopback Address", "IANA IPv6"), forbidden("::/128", "Unspecified Address", "IANA IPv6"), forbidden("::ffff:0:0/96", "IPv4-mapped Address", "IANA IPv6"), forbidden("64:ff9b::/96", "IPv4-IPv6 Translation", "IANA IPv6"), forbidden("64:ff9b:1::/48", "IPv4-IPv6 Translation", "IANA IPv6"), forbidden("100::/64", "Discard-Only Address Block", "IANA IPv6"), forbidden("100:0:0:1::/64", "Dummy IPv6 Prefix", "IANA IPv6"), forbidden("2001::/23", "IETF Protocol Assignments", "IANA IPv6"), forbidden("2001::/32", "TEREDO", "IANA IPv6"), forbidden("2001:1::1/128", "Port Control Protocol Anycast", "IANA IPv6"), forbidden("2001:1::2/128", "TURN Anycast", "IANA IPv6"), forbidden("2001:1::3/128", "DNS-SD Service Registration Anycast", "IANA IPv6"), forbidden("2001:2::/48", "Benchmarking", "IANA IPv6"), forbidden("2001:3::/32", "AMT", "IANA IPv6"), forbidden("2001:4:112::/48", "AS112-v6", "IANA IPv6"), forbidden("2001:10::/28", "Deprecated ORCHID", "IANA IPv6"), forbidden("2001:20::/28", "ORCHIDv2", "IANA IPv6"), forbidden("2001:30::/28", "Drone Remote ID DETs", "IANA IPv6"), forbidden("2001:db8::/32", "Documentation", "IANA IPv6"), forbidden("2002::/16", "6to4", "IANA IPv6"), forbidden("2620:4f:8000::/48", "Direct Delegation AS112 Service", "IANA IPv6"), forbidden("3fff::/20", "Documentation", "IANA IPv6"), forbidden("5f00::/16", "Segment Routing SIDs", "IANA IPv6"), forbidden("fc00::/7", "Unique-Local", "IANA IPv6"), forbidden("fe80::/10", "Link-Local Unicast", "IANA IPv6"),
+	// Protocol-reserved additions: multicast is outside the two special-purpose registries.
+	forbidden("224.0.0.0/4", "IPv4 Multicast", "protocol-reserved"), forbidden("ff00::/8", "IPv6 Multicast", "protocol-reserved"),
+}
+
+var ForbiddenPrefixes = func() []netip.Prefix {
+	result := make([]netip.Prefix, len(ForbiddenPrefixSnapshot))
+	for i, entry := range ForbiddenPrefixSnapshot {
+		result[i] = entry.Prefix
+	}
+	return result
+}()
+
+func ValidateAddress(a netip.Addr, extra []netip.Prefix) error {
+	if !a.IsValid() || a.Zone() != "" {
+		return errors.New("invalid address")
+	}
+	a = a.Unmap()
+	if !a.IsGlobalUnicast() {
+		return errors.New("non-global address")
+	}
+	for _, p := range append(ForbiddenPrefixes, extra...) {
+		if p.Contains(a) {
+			return errors.New("forbidden address")
+		}
+	}
+	return nil
+}
+
+// DNSResolver exposes raw answer records; implementations must not synthesize or recursively follow names.
+type DNSResolver interface {
+	Query(context.Context, dnsmessage.Name, dnsmessage.Type) ([]dnsmessage.Resource, error)
+}
+
+// DNSClient sends bounded DNS queries only to explicitly configured resolver endpoints.
+type DNSClient struct {
+	Resolvers   []string
+	next        atomic.Uint32
+	once        sync.Once
+	addresses   []string
+	validateErr error
+}
+
+func NewDNSClient(resolvers []string) (*DNSClient, error) {
+	d := &DNSClient{Resolvers: append([]string(nil), resolvers...)}
+	d.validate()
+	return d, d.validateErr
+}
+
+func (d *DNSClient) validate() {
+	d.once.Do(func() {
+		if len(d.Resolvers) == 0 {
+			d.validateErr = errors.New("DNS resolver address required")
+			return
+		}
+		for _, raw := range d.Resolvers {
+			a := raw
+			if _, _, err := net.SplitHostPort(a); err != nil {
+				a = net.JoinHostPort(a, "53")
+			}
+			host, port, err := net.SplitHostPort(a)
+			if err != nil || port == "" {
+				d.validateErr = errors.New("invalid DNS resolver address")
+				return
+			}
+			ip, err := netip.ParseAddr(host)
+			if err != nil || ip.Zone() != "" {
+				d.validateErr = errors.New("DNS resolver must be a literal IP address")
+				return
+			}
+			d.addresses = append(d.addresses, net.JoinHostPort(ip.String(), port))
+		}
+	})
+}
+
+func (d *DNSClient) Query(ctx context.Context, name dnsmessage.Name, typ dnsmessage.Type) ([]dnsmessage.Resource, error) {
+	d.validate()
+	if d.validateErr != nil {
+		return nil, d.validateErr
+	}
+	var last error
+	for i := 0; i < len(d.addresses); i++ {
+		a := d.addresses[(int(d.next.Add(1)-1)+i)%len(d.addresses)]
+		ans, e := dnsExchange(ctx, a, name, typ)
+		if e == nil {
+			return ans, nil
+		}
+		last = e
+	}
+	return nil, last
+}
+
+var dnsID atomic.Uint32
+
+func dnsExchange(ctx context.Context, address string, name dnsmessage.Name, typ dnsmessage.Type) ([]dnsmessage.Resource, error) {
+	id := uint16(dnsID.Add(1))
+	m := dnsmessage.Message{Header: dnsmessage.Header{ID: id, RecursionDesired: true}, Questions: []dnsmessage.Question{{Name: name, Type: typ, Class: dnsmessage.ClassINET}}}
+	wire, e := m.Pack()
+	if e != nil {
+		return nil, e
+	}
+	exchange := func(network string) (dnsmessage.Message, error) {
+		c, e := (&net.Dialer{}).DialContext(ctx, network, address)
+		if e != nil {
+			return dnsmessage.Message{}, e
+		}
+		defer c.Close()
+		deadline, _ := ctx.Deadline()
+		_ = c.SetDeadline(deadline)
+		if network == "tcp" {
+			p := make([]byte, 2+len(wire))
+			binary.BigEndian.PutUint16(p, uint16(len(wire)))
+			copy(p[2:], wire)
+			_, e = c.Write(p)
+			if e != nil {
+				return dnsmessage.Message{}, e
+			}
+			h := make([]byte, 2)
+			if _, e = io.ReadFull(c, h); e != nil {
+				return dnsmessage.Message{}, e
+			}
+			n := int(binary.BigEndian.Uint16(h))
+			if n > 65535 {
+				return dnsmessage.Message{}, errors.New("DNS response too large")
+			}
+			p = make([]byte, n)
+			_, e = io.ReadFull(c, p)
+			if e != nil {
+				return dnsmessage.Message{}, e
+			}
+			var x dnsmessage.Message
+			e = x.Unpack(p)
+			return x, e
+		}
+		if _, e = c.Write(wire); e != nil {
+			return dnsmessage.Message{}, e
+		}
+		p := make([]byte, 4096)
+		n, e := c.Read(p)
+		if e != nil {
+			return dnsmessage.Message{}, e
+		}
+		var x dnsmessage.Message
+		e = x.Unpack(p[:n])
+		return x, e
+	}
+	x, e := exchange("udp")
+	if e != nil {
+		return nil, e
+	}
+	validate := func(response dnsmessage.Message) error {
+		if response.Header.ID != id || !response.Header.Response || response.Header.OpCode != 0 || len(response.Questions) != 1 || response.Questions[0].Name != name || response.Questions[0].Type != typ || response.Questions[0].Class != dnsmessage.ClassINET {
+			return errors.New("invalid DNS response")
+		}
+		return nil
+	}
+	if e = validate(x); e != nil {
+		return nil, e
+	}
+	if x.Header.Truncated {
+		x, e = exchange("tcp")
+		if e != nil {
+			return nil, e
+		}
+		if e = validate(x); e != nil {
+			return nil, e
+		}
+	}
+	if x.Header.Truncated {
+		return nil, errors.New("truncated final DNS response")
+	}
+	if x.Header.RCode != dnsmessage.RCodeSuccess {
+		return nil, fmt.Errorf("DNS rcode %v", x.Header.RCode)
+	}
+	return x.Answers, nil
+}
+
+const (
+	maxDNSQueries      = 18 // Nine names (original plus an eight-hop chain), each queried for A and AAAA.
+	maxDNSQueriedNames = 9
+)
+
+func Resolve(ctx context.Context, r DNSResolver, name string, extra []netip.Prefix) ([]netip.Addr, error) {
+	if r == nil {
+		return nil, errors.New("resolver required")
+	}
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	original, cur := ensureRoot(name), ensureRoot(name)
+	edges := map[string]string{}
+	addresses := map[string][]netip.Addr{}
+	queried := map[string]bool{}
+	queries := 0
+	records := 0
+	for {
+		queriedName := cur
+		if queried[cur] {
+			return nil, errors.New("DNS resolution made no progress")
+		}
+		if len(queried) >= maxDNSQueriedNames {
+			return nil, errors.New("too many DNS names")
+		}
+		queried[cur] = true
+		dn, e := dnsmessage.NewName(cur)
+		if e != nil {
+			return nil, e
+		}
+		for _, typ := range []dnsmessage.Type{dnsmessage.TypeA, dnsmessage.TypeAAAA} {
+			if queries >= maxDNSQueries {
+				return nil, errors.New("too many DNS queries")
+			}
+			queries++
+			ans, e := r.Query(ctx, dn, typ)
+			if e != nil {
+				return nil, e
+			}
+			records += len(ans)
+			if records > 64 {
+				return nil, errors.New("too many DNS answers")
+			}
+			responseEdges := map[string]string{}
+			responseOwners := map[string]bool{}
+			for _, rr := range ans {
+				owner := rr.Header.Name.String()
+				responseOwners[owner] = true
+				switch b := rr.Body.(type) {
+				case *dnsmessage.CNAMEResource:
+					n := b.CNAME.String()
+					if _, exists := responseEdges[owner]; exists {
+						return nil, errors.New("duplicate CNAME")
+					}
+					responseEdges[owner] = n
+					if old, exists := edges[owner]; exists && old != n {
+						return nil, errors.New("conflicting CNAME")
+					}
+				case *dnsmessage.AResource:
+					ip := netip.AddrFrom4(b.A)
+					if e = ValidateAddress(ip, extra); e != nil {
+						return nil, e
+					}
+					addresses[owner] = append(addresses[owner], ip)
+				case *dnsmessage.AAAAResource:
+					ip := netip.AddrFrom16(b.AAAA).Unmap()
+					if e = ValidateAddress(ip, extra); e != nil {
+						return nil, e
+					}
+					addresses[owner] = append(addresses[owner], ip)
+				default:
+					return nil, errors.New("unexpected DNS answer")
+				}
+			}
+			for owner, to := range responseEdges {
+				edges[owner] = to
+			}
+			for owner := range responseOwners {
+				x := cur
+				reachable := false
+				for i := 0; i <= 8; i++ {
+					if x == owner {
+						reachable = true
+						break
+					}
+					next, ok := edges[x]
+					if !ok {
+						break
+					}
+					x = next
+				}
+				if !reachable {
+					return nil, errors.New("unrelated DNS answer")
+				}
+			}
+		}
+		x, seen := original, map[string]bool{}
+		for hops := 0; ; hops++ {
+			if seen[x] {
+				return nil, errors.New("CNAME loop")
+			}
+			seen[x] = true
+			if len(addresses[x]) != 0 {
+				if _, ok := edges[x]; ok {
+					return nil, errors.New("CNAME and address conflict")
+				}
+				return addresses[x], nil
+			}
+			next, ok := edges[x]
+			if !ok {
+				cur = x
+				break
+			}
+			if hops >= 8 {
+				return nil, errors.New("CNAME chain too long")
+			}
+			trim := strings.TrimSuffix(next, ".")
+			if _, e = canonicalTarget(trim + ":443"); e != nil {
+				return nil, e
+			}
+			x = next
+		}
+		if cur == queriedName && len(addresses[cur]) == 0 {
+			return nil, errors.New("no addresses")
+		}
+	}
+}
+func ensureRoot(s string) string {
+	if !strings.HasSuffix(s, ".") {
+		return s + "."
+	}
+	return s
+}

--- a/internal/egressproxy/policy_test.go
+++ b/internal/egressproxy/policy_test.go
@@ -1,0 +1,277 @@
+package egressproxy
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"net"
+	"net/netip"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Chris-Cullins/swe-platform/internal/egresspolicy"
+	"golang.org/x/net/dns/dnsmessage"
+)
+
+type fakeResolver struct {
+	answers map[string][]dnsmessage.Resource
+	calls   []string
+}
+
+func (f *fakeResolver) Query(_ context.Context, n dnsmessage.Name, t dnsmessage.Type) ([]dnsmessage.Resource, error) {
+	k := n.String() + "/" + t.String()
+	f.calls = append(f.calls, k)
+	return f.answers[k], nil
+}
+func header(n string, t dnsmessage.Type) dnsmessage.ResourceHeader {
+	x, _ := dnsmessage.NewName(n)
+	return dnsmessage.ResourceHeader{Name: x, Type: t, Class: dnsmessage.ClassINET}
+}
+func a(n string, ip [4]byte) dnsmessage.Resource {
+	return dnsmessage.Resource{Header: header(n, dnsmessage.TypeA), Body: &dnsmessage.AResource{A: ip}}
+}
+func aaaa(n string, ip [16]byte) dnsmessage.Resource {
+	return dnsmessage.Resource{Header: header(n, dnsmessage.TypeAAAA), Body: &dnsmessage.AAAAResource{AAAA: ip}}
+}
+func cname(n, to string) dnsmessage.Resource {
+	x, _ := dnsmessage.NewName(to)
+	return dnsmessage.Resource{Header: header(n, dnsmessage.TypeCNAME), Body: &dnsmessage.CNAMEResource{CNAME: x}}
+}
+func TestResolveRawAnswers(t *testing.T) {
+	f := &fakeResolver{answers: map[string][]dnsmessage.Resource{"a.example./TypeA": {cname("a.example.", "b.example.")}, "a.example./TypeAAAA": {cname("a.example.", "b.example.")}, "b.example./TypeA": {a("b.example.", [4]byte{8, 8, 8, 8})}}}
+	got, e := Resolve(context.Background(), f, "a.example", nil)
+	if e != nil || len(got) != 1 || got[0].String() != "8.8.8.8" {
+		t.Fatal(got, e)
+	}
+	for _, c := range f.calls {
+		if c[0] == '.' {
+			t.Fatal(c)
+		}
+	}
+	for _, ip := range []string{"192.88.99.1", "64:ff9b:1::1", "100:0:0:1::1", "2001::1", "2002::1", "3fff::1", "5f00::1", "fe80::1%eth0"} {
+		if ValidateAddress(netip.MustParseAddr(ip), nil) == nil {
+			t.Errorf("accepted %s", ip)
+		}
+	}
+	mixed := &fakeResolver{answers: map[string][]dnsmessage.Resource{"x.example./TypeA": {a("x.example.", [4]byte{8, 8, 8, 8}), a("x.example.", [4]byte{127, 0, 0, 1})}}}
+	if _, e = Resolve(context.Background(), mixed, "x.example", nil); e == nil {
+		t.Error("mixed answer accepted")
+	}
+}
+func TestResolveRecursiveResponseAndUnrelatedAnswers(t *testing.T) {
+	chain := []dnsmessage.Resource{
+		cname("a.example.", "b.example."),
+		cname("b.example.", "c.example."),
+		a("c.example.", [4]byte{8, 8, 4, 4}),
+	}
+	f := &fakeResolver{answers: map[string][]dnsmessage.Resource{"a.example./TypeA": chain}}
+	got, err := Resolve(context.Background(), f, "a.example", nil)
+	if err != nil || len(got) != 1 || got[0].String() != "8.8.4.4" {
+		t.Fatalf("recursive response: %v %v", got, err)
+	}
+	for _, answers := range [][]dnsmessage.Resource{
+		{cname("a.example.", "b.example."), a("unrelated.example.", [4]byte{8, 8, 8, 8})},
+		{cname("a.example.", "b.example."), a("unrelated.example.", [4]byte{127, 0, 0, 1})},
+		{cname("a.example.", "b.example."), a("b.example.", [4]byte{8, 8, 8, 8}), cname("b.example.", "c.example.")},
+	} {
+		bad := &fakeResolver{answers: map[string][]dnsmessage.Resource{"a.example./TypeA": answers}}
+		if _, err := Resolve(context.Background(), bad, "a.example", nil); err == nil {
+			t.Error("accepted unrelated, forbidden, or mixed CNAME/address response")
+		}
+	}
+}
+
+func TestDNSClientRejectsHostnameResolver(t *testing.T) {
+	if _, err := NewDNSClient([]string{"resolver.example:53"}); err == nil {
+		t.Error("constructor accepted hostname resolver")
+	}
+	d := &DNSClient{Resolvers: []string{"resolver.example"}}
+	n, _ := dnsmessage.NewName("a.example.")
+	if _, err := d.Query(context.Background(), n, dnsmessage.TypeA); err == nil {
+		t.Error("Query accepted hostname resolver")
+	}
+}
+func TestResolveBounds(t *testing.T) {
+	f := &fakeResolver{answers: map[string][]dnsmessage.Resource{}}
+	for i := 0; i < 9; i++ {
+		n := string(rune('a'+i)) + ".example."
+		to := string(rune('b'+i)) + ".example."
+		f.answers[n+"/TypeA"] = []dnsmessage.Resource{cname(n, to)}
+		f.answers[n+"/TypeAAAA"] = []dnsmessage.Resource{cname(n, to)}
+	}
+	if _, e := Resolve(context.Background(), f, "a.example", nil); e == nil {
+		t.Error("over 8 hops accepted")
+	}
+	many := &fakeResolver{answers: map[string][]dnsmessage.Resource{}}
+	for i := 0; i < 65; i++ {
+		many.answers["x.example./TypeA"] = append(many.answers["x.example./TypeA"], a("x.example.", [4]byte{8, 8, 8, 8}))
+	}
+	if _, e := Resolve(context.Background(), many, "x.example", nil); e == nil {
+		t.Error("over 64 records accepted")
+	}
+}
+
+func TestCanonicalTargetMatchesPolicyGrammar(t *testing.T) {
+	label63 := strings.Repeat("a", 63)
+	values := []string{"example.com", "api-2.example123.com", label63 + "." + label63 + "." + label63 + "." + strings.Repeat("a", 61), "", "localhost", "Example.com", "example.com.", "example..com", "-api.example.com", "api-.example.com", strings.Repeat("a", 64) + ".com", label63 + "." + label63 + "." + label63 + "." + label63, "xn--bcher-kva.example", "www.xn--bcher-kva.example", "bücher.example", "*.example.com", "https://example.com", "example.com:443", "example.com/path", "example.com?x=y", "example.com#x", "user@example.com", "example%2ecom", "example .com", "example.com\t", "example.com\n", "example.com\x00", "127.0.0.1", "127.1", "0177.0.0.1", "0x7f.0x0.0x0.0x1", "0x7f.01", "0x.0x", "0x.1", "0x.0x.0x.1", "2130706433", "09.0.0.1", "2001:db8::1", "::ffff:127.0.0.1"}
+	for _, value := range values {
+		_, policyErr := egresspolicy.ParseHostname(value)
+		got, targetErr := canonicalTarget(value + ":443")
+		if (policyErr == nil) != (targetErr == nil) {
+			t.Errorf("%q: ParseHostname err=%v, canonicalTarget err=%v", value, policyErr, targetErr)
+		} else if targetErr == nil && got != value {
+			t.Errorf("%q canonicalized to %q", value, got)
+		}
+	}
+	for _, target := range []string{"example.com", "example.com:80", "example.com:443:443", ":443"} {
+		if _, err := canonicalTarget(target); err == nil {
+			t.Errorf("accepted target %q", target)
+		}
+	}
+}
+
+func TestForbiddenPrefixSnapshot(t *testing.T) {
+	expected := []string{
+		"0.0.0.0/8", "0.0.0.0/32", "10.0.0.0/8", "100.64.0.0/10", "127.0.0.0/8", "169.254.0.0/16", "172.16.0.0/12",
+		"192.0.0.0/24", "192.0.0.0/29", "192.0.0.8/32", "192.0.0.9/32", "192.0.0.10/32", "192.0.0.170/32", "192.0.0.171/32",
+		"192.0.2.0/24", "192.31.196.0/24", "192.52.193.0/24", "192.88.99.0/24", "192.88.99.2/32", "192.168.0.0/16", "192.175.48.0/24", "198.18.0.0/15", "198.51.100.0/24", "203.0.113.0/24", "240.0.0.0/4", "255.255.255.255/32",
+		"::1/128", "::/128", "::ffff:0.0.0.0/96", "64:ff9b::/96", "64:ff9b:1::/48", "100::/64", "100:0:0:1::/64", "2001::/23", "2001::/32", "2001:1::1/128", "2001:1::2/128", "2001:1::3/128", "2001:2::/48", "2001:3::/32", "2001:4:112::/48", "2001:10::/28", "2001:20::/28", "2001:30::/28", "2001:db8::/32", "2002::/16", "2620:4f:8000::/48", "3fff::/20", "5f00::/16", "fc00::/7", "fe80::/10",
+		"224.0.0.0/4", "ff00::/8",
+	}
+	if len(expected) != 53 {
+		t.Fatalf("expected snapshot contains %d prefixes, want 53", len(expected))
+	}
+	actual := make(map[string]int, len(ForbiddenPrefixSnapshot))
+	for _, entry := range ForbiddenPrefixSnapshot {
+		actual[entry.Prefix.String()]++
+	}
+	want := make(map[string]int, len(expected))
+	for _, prefix := range expected {
+		want[prefix]++
+	}
+	for prefix, count := range want {
+		if count != 1 {
+			t.Errorf("expected snapshot duplicates %s %d times", prefix, count)
+		}
+		if actual[prefix] == 0 {
+			t.Errorf("production snapshot is missing %s", prefix)
+		} else if actual[prefix] != 1 {
+			t.Errorf("production snapshot duplicates %s %d times", prefix, actual[prefix])
+		}
+	}
+	for prefix, count := range actual {
+		if want[prefix] == 0 {
+			t.Errorf("production snapshot has extra prefix %s (%d entries)", prefix, count)
+		}
+	}
+	if len(ForbiddenPrefixSnapshot) != len(expected) {
+		t.Errorf("production snapshot contains %d prefixes, want %d", len(ForbiddenPrefixSnapshot), len(expected))
+	}
+	for _, value := range expected {
+		prefix, err := netip.ParsePrefix(value)
+		if err != nil {
+			t.Fatalf("invalid expected prefix %q: %v", value, err)
+		}
+		t.Run(value, func(t *testing.T) {
+			if err := ValidateAddress(prefix.Addr(), nil); err == nil {
+				t.Fatalf("accepted first address of %s", prefix)
+			}
+		})
+	}
+	for _, value := range []string{"8.8.8.8", "2606:4700:4700::1111"} {
+		if err := ValidateAddress(netip.MustParseAddr(value), nil); err != nil {
+			t.Errorf("public address %s rejected: %v", value, err)
+		}
+	}
+}
+
+func TestResolveTerminalNODATAExactCalls(t *testing.T) {
+	f := &fakeResolver{answers: map[string][]dnsmessage.Resource{
+		"a.example./TypeA": {cname("a.example.", "b.example.")},
+	}}
+	if _, err := Resolve(context.Background(), f, "a.example", nil); err == nil {
+		t.Fatal("terminal NODATA accepted")
+	}
+	if len(f.calls) != 4 {
+		t.Fatalf("calls = %d (%v), want 4", len(f.calls), f.calls)
+	}
+}
+
+func TestResolveMaximumQueryBound(t *testing.T) {
+	f := &fakeResolver{answers: map[string][]dnsmessage.Resource{}}
+	for i := 0; i < 8; i++ {
+		from := string(rune('a'+i)) + ".example."
+		to := string(rune('b'+i)) + ".example."
+		f.answers[from+"/TypeA"] = []dnsmessage.Resource{cname(from, to)}
+	}
+	f.answers["i.example./TypeA"] = []dnsmessage.Resource{a("i.example.", [4]byte{8, 8, 8, 8})}
+	if _, err := Resolve(context.Background(), f, "a.example", nil); err != nil {
+		t.Fatal(err)
+	}
+	if len(f.calls) != maxDNSQueries {
+		t.Fatalf("calls = %d, want %d", len(f.calls), maxDNSQueries)
+	}
+}
+
+func TestDNSExchangeRejectsTruncatedTCPResponse(t *testing.T) {
+	tcp, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tcp.Close()
+	udp, err := net.ListenPacket("udp", tcp.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer udp.Close()
+	respond := func(query []byte) []byte {
+		var request dnsmessage.Message
+		if err := request.Unpack(query); err != nil {
+			t.Error(err)
+			return nil
+		}
+		response := dnsmessage.Message{Header: dnsmessage.Header{ID: request.ID, Response: true, Truncated: true}, Questions: request.Questions, Answers: []dnsmessage.Resource{a("a.example.", [4]byte{8, 8, 8, 8})}}
+		wire, err := response.Pack()
+		if err != nil {
+			t.Error(err)
+		}
+		return wire
+	}
+	done := make(chan struct{}, 2)
+	go func() {
+		defer func() { done <- struct{}{} }()
+		b := make([]byte, 2048)
+		n, addr, e := udp.ReadFrom(b)
+		if e == nil {
+			_, _ = udp.WriteTo(respond(b[:n]), addr)
+		}
+	}()
+	go func() {
+		defer func() { done <- struct{}{} }()
+		c, e := tcp.Accept()
+		if e != nil {
+			return
+		}
+		defer c.Close()
+		h := make([]byte, 2)
+		if _, e = io.ReadFull(c, h); e != nil {
+			return
+		}
+		b := make([]byte, binary.BigEndian.Uint16(h))
+		if _, e = io.ReadFull(c, b); e != nil {
+			return
+		}
+		wire := respond(b)
+		binary.BigEndian.PutUint16(h, uint16(len(wire)))
+		_, _ = c.Write(append(h, wire...))
+	}()
+	name, _ := dnsmessage.NewName("a.example.")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if _, err := dnsExchange(ctx, tcp.Addr().String(), name, dnsmessage.TypeA); err == nil {
+		t.Fatal("accepted truncated TCP response")
+	}
+	<-done
+	<-done
+}

--- a/internal/egressproxy/protocol.go
+++ b/internal/egressproxy/protocol.go
@@ -1,0 +1,196 @@
+package egressproxy
+
+import (
+	"bufio"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const (
+	protocolVersion  = 1
+	maxName          = 253
+	requestHeaderLen = 10
+	approvedPort     = 443
+)
+
+var protocolMagic = [4]byte{'S', 'W', 'E', 'E'}
+
+type forwardRequest struct{ Name string }
+
+func writeRequest(w io.Writer, name string) error {
+	if canonical, err := canonicalTarget(name + ":443"); err != nil || canonical != name {
+		return errors.New("invalid request name")
+	}
+	b := []byte(name)
+	if len(b) == 0 || len(b) > maxName {
+		return errors.New("invalid name length")
+	}
+	h := []byte{protocolMagic[0], protocolMagic[1], protocolMagic[2], protocolMagic[3], protocolVersion, 0, 0, 0, 0, 0}
+	binary.BigEndian.PutUint16(h[6:8], approvedPort)
+	binary.BigEndian.PutUint16(h[8:10], uint16(len(b)))
+	if err := writeFull(w, h); err != nil {
+		return err
+	}
+	return writeFull(w, b)
+}
+
+func readRequest(r io.Reader) (forwardRequest, error) {
+	h := make([]byte, requestHeaderLen)
+	if _, err := io.ReadFull(r, h); err != nil {
+		return forwardRequest{}, err
+	}
+	if string(h[:4]) != string(protocolMagic[:]) || h[4] != protocolVersion || h[5] != 0 || binary.BigEndian.Uint16(h[6:8]) != approvedPort {
+		return forwardRequest{}, errors.New("invalid protocol header")
+	}
+	n := int(binary.BigEndian.Uint16(h[8:10]))
+	if n == 0 || n > maxName {
+		return forwardRequest{}, errors.New("invalid protocol length")
+	}
+	b := make([]byte, n)
+	if _, err := io.ReadFull(r, b); err != nil {
+		return forwardRequest{}, err
+	}
+	name := string(b)
+	if canonical, err := canonicalTarget(name + ":443"); err != nil || canonical != name {
+		return forwardRequest{}, errors.New("invalid request name")
+	}
+	return forwardRequest{Name: name}, nil
+}
+
+func writeStatus(w io.Writer, ok bool) error {
+	var s byte
+	if !ok {
+		s = 1
+	}
+	return writeFull(w, []byte{protocolMagic[0], protocolMagic[1], protocolMagic[2], protocolMagic[3], protocolVersion, s})
+}
+
+func writeFull(w io.Writer, b []byte) error {
+	for len(b) != 0 {
+		n, err := w.Write(b)
+		if n > 0 {
+			b = b[n:]
+		}
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return io.ErrShortWrite
+		}
+	}
+	return nil
+}
+func readStatus(r io.Reader) error {
+	b := make([]byte, 6)
+	if _, err := io.ReadFull(r, b); err != nil {
+		return err
+	}
+	if string(b[:4]) != string(protocolMagic[:]) || b[4] != protocolVersion || b[5] > 1 {
+		return errors.New("invalid status")
+	}
+	if b[5] != 0 {
+		return errors.New("forward denied")
+	}
+	return nil
+}
+
+func parseCONNECT(input io.Reader) (string, error) {
+	const max = 8192
+	r := bufio.NewReaderSize(io.LimitReader(input, max+1), max+1)
+	var total int
+	lines := make([]string, 0, 16)
+	terminated := false
+	for len(lines) < 66 {
+		line, err := r.ReadString('\n')
+		total += len(line)
+		if total > max {
+			return "", errors.New("headers too large")
+		}
+		if err != nil {
+			return "", err
+		}
+		if len(line) < 2 || line[len(line)-2:] != "\r\n" {
+			return "", errors.New("invalid line ending")
+		}
+		line = line[:len(line)-2]
+		if line == "" {
+			terminated = true
+			break
+		}
+		lines = append(lines, line)
+	}
+	if !terminated || len(lines) == 0 || len(lines)-1 > 64 {
+		return "", errors.New("invalid header count")
+	}
+	var method, target, version string
+	if n, _ := fmt.Sscanf(lines[0], "%s %s %s", &method, &target, &version); n != 3 || method != "CONNECT" || version != "HTTP/1.1" {
+		return "", errors.New("CONNECT HTTP/1.1 required")
+	}
+	if lines[0] != method+" "+target+" "+version {
+		return "", errors.New("invalid request line")
+	}
+	hosts, contentLengths := 0, 0
+	for _, l := range lines[1:] {
+		if len(l) == 0 || l[0] == ' ' || l[0] == '\t' {
+			return "", errors.New("folded header")
+		}
+		i := -1
+		for j := range l {
+			if l[j] == ':' {
+				i = j
+				break
+			}
+		}
+		if i < 1 {
+			return "", errors.New("invalid header")
+		}
+		for _, c := range []byte(l[:i]) {
+			if !(c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' || strings.ContainsRune("!#$%&'*+-.^_`|~", rune(c))) {
+				return "", errors.New("invalid header name")
+			}
+		}
+		k, v := asciiLower(l[:i]), l[i+1:]
+		for len(v) > 0 && (v[0] == ' ' || v[0] == '\t') {
+			v = v[1:]
+		}
+		switch k {
+		case "host":
+			hosts++
+			if v != target {
+				return "", errors.New("Host mismatch")
+			}
+		case "content-length":
+			contentLengths++
+			if contentLengths != 1 || v != "0" {
+				return "", errors.New("body forbidden")
+			}
+		case "transfer-encoding", "proxy-authorization":
+			return "", errors.New("forbidden header")
+		}
+		for _, c := range []byte(l) {
+			if c < 32 || c == 127 {
+				return "", errors.New("control byte")
+			}
+		}
+	}
+	if hosts != 1 {
+		return "", errors.New("exactly one Host required")
+	}
+	if r.Buffered() != 0 {
+		return "", errors.New("pipelining forbidden")
+	}
+	return canonicalTarget(target)
+}
+
+func asciiLower(s string) string {
+	b := []byte(s)
+	for i, c := range b {
+		if c >= 'A' && c <= 'Z' {
+			b[i] = c + 32
+		}
+	}
+	return string(b)
+}

--- a/internal/egressproxy/protocol_test.go
+++ b/internal/egressproxy/protocol_test.go
@@ -1,0 +1,147 @@
+package egressproxy
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"strings"
+	"testing"
+)
+
+func TestParseCONNECT(t *testing.T) {
+	valid := "CONNECT api.example.com:443 HTTP/1.1\r\nHost: api.example.com:443\r\n\r\n"
+	bad := []string{
+		"GET api.example.com:443 HTTP/1.1\r\nHost: api.example.com:443\r\n\r\n", "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n",
+		"CONNECT https://api.example.com:443/ HTTP/1.1\r\nHost: https://api.example.com:443/\r\n\r\n",
+		"CONNECT u@api.example.com:443 HTTP/1.1\r\nHost: u@api.example.com:443\r\n\r\n",
+		"CONNECT api%2eexample.com:443 HTTP/1.1\r\nHost: api%2eexample.com:443\r\n\r\n",
+		"CONNECT [2001:4860::1]:443 HTTP/1.1\r\nHost: [2001:4860::1]:443\r\n\r\n",
+		"CONNECT 127.0.0.1:443 HTTP/1.1\r\nHost: 127.0.0.1:443\r\n\r\n",
+		"CONNECT 0x7f.0.0.1:443 HTTP/1.1\r\nHost: 0x7f.0.0.1:443\r\n\r\n",
+		"CONNECT 0177.0.0.1:443 HTTP/1.1\r\nHost: 0177.0.0.1:443\r\n\r\n",
+		"CONNECT 2130706433:443 HTTP/1.1\r\nHost: 2130706433:443\r\n\r\n",
+		"CONNECT API.example.com:443 HTTP/1.1\r\nHost: API.example.com:443\r\n\r\n",
+		"CONNECT xn--x.example:443 HTTP/1.1\r\nHost: xn--x.example:443\r\n\r\n",
+		"CONNECT localhost:443 HTTP/1.1\r\nHost: localhost:443\r\n\r\n",
+		"CONNECT  api.example.com:443 HTTP/1.1\r\nHost: api.example.com:443\r\n\r\n",
+		"CONNECT api.example.com:443 HTTP/1.1\nHost: api.example.com:443\n\n",
+		"CONNECT api.example.com:443 HTTP/1.1\r\n Host: api.example.com:443\r\n\r\n",
+		"CONNECT api.example.com:443 HTTP/1.1\r\nHost: api.example.com:443\r\nTransfer-Encoding: chunked\r\n\r\n",
+		"CONNECT api.example.com:443 HTTP/1.1\r\nHost: api.example.com:443\r\nContent-Length: 1\r\n\r\n",
+		"CONNECT api.example.com:443 HTTP/1.1\r\nHost: api.example.com:443\r\nContent-Length: 0\r\nContent-Length: 0\r\n\r\n",
+		"CONNECT api.example.com:443 HTTP/1.1\r\nHost: api.example.com:443\r\nProxy-Authorization: x\r\n\r\n",
+		"CONNECT api.example.com:443 HTTP/1.1\r\n\r\n", valid[:len(valid)-2] + "Host: api.example.com:443\r\n\r\n",
+		"CONNECT api.example.com:443 HTTP/1.1\r\nHost: other.example.com:443\r\n\r\n", valid + "x",
+		"CONNECT api.example.com:443 HTTP/1.1\r\nBad Name: x\r\nHost: api.example.com:443\r\n\r\n",
+	}
+	if got, err := parseCONNECT(bufio.NewReader(strings.NewReader(valid))); err != nil || got != "api.example.com" {
+		t.Fatalf("valid: %q %v", got, err)
+	}
+	for i, in := range bad {
+		if _, err := parseCONNECT(bufio.NewReader(strings.NewReader(in))); err == nil {
+			t.Errorf("bad[%d] accepted", i)
+		}
+	}
+	headers := "CONNECT api.example.com:443 HTTP/1.1\r\nHost: api.example.com:443\r\n" + strings.Repeat("X: y\r\n", 64) + "\r\n"
+	if _, err := parseCONNECT(bufio.NewReader(strings.NewReader(headers))); err == nil {
+		t.Error(">64 headers accepted")
+	}
+	if _, err := parseCONNECT(bufio.NewReader(strings.NewReader(valid[:len(valid)-2] + "X: " + strings.Repeat("a", 8192) + "\r\n\r\n"))); err == nil {
+		t.Error(">8KiB accepted")
+	}
+}
+
+func TestFrames(t *testing.T) {
+	var b bytes.Buffer
+	if err := writeRequest(&b, "api.example.com"); err != nil {
+		t.Fatal(err)
+	}
+	frame := append([]byte(nil), b.Bytes()...)
+	r, err := readRequest(&b)
+	if err != nil || r.Name != "api.example.com" {
+		t.Fatal(r, err)
+	}
+	if binary.BigEndian.Uint16(frame[6:8]) != 443 {
+		t.Fatal("request does not explicitly encode port 443")
+	}
+	for _, mutate := range []func([]byte){func(p []byte) { p[0] = 'X' }, func(p []byte) { p[4] = 2 }, func(p []byte) { p[5] = 1 }, func(p []byte) { binary.BigEndian.PutUint16(p[6:8], 80) }, func(p []byte) { binary.BigEndian.PutUint16(p[8:10], 0) }} {
+		b.Reset()
+		_ = writeRequest(&b, "api.example.com")
+		p := append([]byte(nil), b.Bytes()...)
+		mutate(p)
+		if _, e := readRequest(bytes.NewReader(p)); e == nil {
+			t.Error("malformed accepted")
+		}
+	}
+	for _, n := range []string{"API.example.com", "xn--x.example", "localhost"} {
+		var x bytes.Buffer
+		p := []byte(n)
+		x.Write([]byte{'S', 'W', 'E', 'E', 1, 0, 1, 187, byte(len(p) >> 8), byte(len(p))})
+		x.Write(p)
+		if _, e := readRequest(&x); e == nil {
+			t.Errorf("name %q accepted", n)
+		}
+	}
+	for _, ok := range []bool{true, false} {
+		b.Reset()
+		_ = writeStatus(&b, ok)
+		e := readStatus(&b)
+		if (e == nil) != ok {
+			t.Errorf("status %v: %v", ok, e)
+		}
+	}
+	for i := 0; i < len(frame); i++ {
+		if _, err := readRequest(bytes.NewReader(frame[:i])); err == nil {
+			t.Fatalf("accepted truncation at %d", i)
+		}
+	}
+	for _, statusLen := range []int{0, 1, 2, 3, 4, 5} {
+		if err := readStatus(bytes.NewReader([]byte{'S', 'W', 'E', 'E', 1, 0}[:statusLen])); err == nil {
+			t.Fatalf("accepted status truncation at %d", statusLen)
+		}
+	}
+	short := &shortWriter{limit: 1}
+	if err := writeRequest(short, "api.example.com"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readRequest(bytes.NewReader(short.b.Bytes())); err != nil {
+		t.Fatal(err)
+	}
+	short = &shortWriter{limit: 1}
+	if err := writeStatus(short, true); err != nil || readStatus(bytes.NewReader(short.b.Bytes())) != nil {
+		t.Fatal("short status write", err)
+	}
+}
+
+type shortWriter struct {
+	b     bytes.Buffer
+	limit int
+}
+
+func (w *shortWriter) Write(p []byte) (int, error) {
+	if len(p) > w.limit {
+		p = p[:w.limit]
+	}
+	return w.b.Write(p)
+}
+
+func FuzzParseCONNECT(f *testing.F) {
+	f.Add([]byte("CONNECT api.example.com:443 HTTP/1.1\r\nHost: api.example.com:443\r\n\r\n"))
+	f.Fuzz(func(t *testing.T, b []byte) {
+		if len(b) > 16384 {
+			return
+		}
+		_, _ = parseCONNECT(bufio.NewReader(bytes.NewReader(b)))
+	})
+}
+func FuzzReadRequest(f *testing.F) {
+	var b bytes.Buffer
+	_ = writeRequest(&b, "api.example.com")
+	f.Add(b.Bytes())
+	f.Fuzz(func(t *testing.T, b []byte) {
+		if len(b) > 1024 {
+			return
+		}
+		_, _ = readRequest(bytes.NewReader(b))
+	})
+}

--- a/internal/egressproxy/proxy.go
+++ b/internal/egressproxy/proxy.go
@@ -68,15 +68,21 @@ func (s *Server) Serve(l net.Listener) error {
 		select {
 		case preAuth <- struct{}{}:
 			go func() {
-				defer func() { <-preAuth }()
-				s.handle(c)
+				release := sync.OnceFunc(func() { <-preAuth })
+				defer release()
+				s.handleWithPreAuth(c, release)
 			}()
 		default:
 			_ = c.Close()
 		}
 	}
 }
+
 func (s *Server) handle(c net.Conn) {
+	s.handleWithPreAuth(c, func() {})
+}
+
+func (s *Server) handleWithPreAuth(c net.Conn, releasePreAuth func()) {
 	defer c.Close()
 	_ = c.SetDeadline(time.Now().Add(5 * time.Second))
 	tc, ok := c.(*tls.Conn)
@@ -103,6 +109,7 @@ func (s *Server) handle(c net.Conn) {
 	authCtx, authCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	a, e := s.Authorizer.Authorize(authCtx, id, name)
 	authCancel()
+	releasePreAuth()
 	if e != nil {
 		s.deny(c)
 		return
@@ -385,8 +392,13 @@ func bytesContains(b []byte, want byte) bool {
 func relay(a, b net.Conn, idle, absolute time.Duration) {
 	end := time.Now().Add(absolute)
 	var wg sync.WaitGroup
+	closeBoth := sync.OnceFunc(func() {
+		_ = a.Close()
+		_ = b.Close()
+	})
 	cp := func(dst, src net.Conn) {
 		defer wg.Done()
+		defer closeBoth()
 		buf := make([]byte, 32<<10)
 		for {
 			d := time.Now().Add(idle)

--- a/internal/egressproxy/proxy.go
+++ b/internal/egressproxy/proxy.go
@@ -1,0 +1,413 @@
+package egressproxy
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/binary"
+	"errors"
+	"io"
+	"net"
+	"net/netip"
+	"sync"
+	"time"
+)
+
+type Identity struct {
+	Fingerprint [32]byte
+	Subject     string
+}
+type Authorization struct {
+	ExecutionKey, ProjectKey string
+	DeniedPrefixes           []netip.Prefix
+}
+type Authorizer interface {
+	Authorize(context.Context, Identity, string) (Authorization, error)
+}
+type DisabledAuthorizer struct{}
+
+func (DisabledAuthorizer) Authorize(context.Context, Identity, string) (Authorization, error) {
+	return Authorization{}, errors.New("egress proxy is disabled")
+}
+
+type Server struct {
+	TLSConfig  *tls.Config
+	Authorizer Authorizer
+	Resolver   DNSResolver
+	Quotas     *QuotaManager
+	Dialer     func(context.Context, string, string) (net.Conn, error)
+	// MaxPreAuth bounds accepted connections that have not completed authorization.
+	// Zero selects the default of 2048.
+	MaxPreAuth int
+}
+
+func (s *Server) Serve(l net.Listener) error {
+	if s.Authorizer == nil || s.Resolver == nil {
+		return errors.New("authorizer and resolver required")
+	}
+	if s.TLSConfig == nil || len(s.TLSConfig.Certificates) == 0 || s.TLSConfig.MinVersion != tls.VersionTLS13 || s.TLSConfig.MaxVersion != tls.VersionTLS13 || s.TLSConfig.ClientAuth != tls.RequireAnyClientCert || !s.TLSConfig.SessionTicketsDisabled {
+		return errors.New("TLS 1.3 client certificates required")
+	}
+	if s.Quotas == nil {
+		s.Quotas = NewQuotaManager()
+	}
+	tl := tls.NewListener(l, s.TLSConfig)
+	max := s.MaxPreAuth
+	if max == 0 {
+		max = 2048
+	}
+	if max < 0 {
+		return errors.New("invalid pre-auth connection limit")
+	}
+	preAuth := make(chan struct{}, max)
+	for {
+		c, e := tl.Accept()
+		if e != nil {
+			return e
+		}
+		select {
+		case preAuth <- struct{}{}:
+			go func() {
+				defer func() { <-preAuth }()
+				s.handle(c)
+			}()
+		default:
+			_ = c.Close()
+		}
+	}
+}
+func (s *Server) handle(c net.Conn) {
+	defer c.Close()
+	_ = c.SetDeadline(time.Now().Add(5 * time.Second))
+	tc, ok := c.(*tls.Conn)
+	if !ok || tc.Handshake() != nil {
+		return
+	}
+	st := tc.ConnectionState()
+	if len(st.PeerCertificates) < 1 {
+		return
+	}
+	_ = c.SetDeadline(time.Now().Add(5 * time.Second))
+	req, e := readRequest(c)
+	if e != nil {
+		return
+	}
+	name, e := canonicalTarget(req.Name + ":443")
+	if e != nil {
+		s.deny(c)
+		return
+	}
+	// The self-signed leaf is untrusted lookup material. The Authorizer is the
+	// authority and must pin this SHA-256 fingerprint to the execution.
+	id := Identity{Fingerprint: sha256.Sum256(st.PeerCertificates[0].Raw), Subject: st.PeerCertificates[0].Subject.String()}
+	authCtx, authCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	a, e := s.Authorizer.Authorize(authCtx, id, name)
+	authCancel()
+	if e != nil {
+		s.deny(c)
+		return
+	}
+	reservation, e := s.quota().Reserve(a.ExecutionKey, a.ProjectKey)
+	if e != nil {
+		s.deny(c)
+		return
+	}
+	defer reservation.Release()
+	ips, e := Resolve(context.Background(), s.Resolver, name, a.DeniedPrefixes)
+	if e != nil {
+		s.deny(c)
+		return
+	}
+	var out net.Conn
+	dialCtx, dialCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	for _, ip := range ips {
+		ctx := dialCtx
+		out, e = s.dialer()(ctx, "tcp", net.JoinHostPort(ip.String(), "443"))
+		if e == nil {
+			break
+		}
+	}
+	dialCancel()
+	if out == nil {
+		s.deny(c)
+		return
+	}
+	defer out.Close()
+	_ = c.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	if writeStatus(c, true) != nil {
+		return
+	}
+	hello, e := readClientHello(c, name)
+	if e != nil {
+		return
+	}
+	if e = reservation.Activate(); e != nil {
+		return
+	}
+	_ = out.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	if _, e = out.Write(hello); e != nil {
+		return
+	}
+	_ = c.SetDeadline(time.Time{})
+	_ = out.SetDeadline(time.Time{})
+	relay(c, out, 5*time.Minute, time.Hour)
+}
+func (s *Server) deny(c net.Conn) {
+	_ = c.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	_ = writeStatus(c, false)
+}
+func (s *Server) dialer() func(context.Context, string, string) (net.Conn, error) {
+	if s.Dialer != nil {
+		return s.Dialer
+	}
+	d := net.Dialer{}
+	return d.DialContext
+}
+func (s *Server) quota() *QuotaManager {
+	return s.Quotas
+}
+
+type Forwarder struct {
+	TLSConfig     *tls.Config
+	ServerAddress string
+	// MaxConnections bounds all accepted connections for their entire lifetime.
+	// Zero selects the default of 32.
+	MaxConnections int
+	DialTLS        func(context.Context, string, string, *tls.Config) (net.Conn, error)
+}
+
+func (f *Forwarder) Serve(l net.Listener) error {
+	if f.TLSConfig == nil || f.TLSConfig.MinVersion != tls.VersionTLS13 || f.TLSConfig.MaxVersion != tls.VersionTLS13 || f.TLSConfig.RootCAs == nil || f.TLSConfig.ServerName == "" || len(f.TLSConfig.Certificates) == 0 {
+		return errors.New("complete TLS 1.3 configuration required")
+	}
+	if ip := net.ParseIP(hostOnly(l.Addr().String())); ip == nil || !ip.IsLoopback() {
+		return errors.New("forward listener must be loopback")
+	}
+	max := f.MaxConnections
+	if max == 0 {
+		max = 32
+	}
+	if max < 0 {
+		return errors.New("invalid connection limit")
+	}
+	connections := make(chan struct{}, max)
+	for {
+		c, e := l.Accept()
+		if e != nil {
+			return e
+		}
+		select {
+		case connections <- struct{}{}:
+			go func() {
+				defer func() { <-connections }()
+				f.handle(c)
+			}()
+		default:
+			_ = c.Close()
+		}
+	}
+}
+func hostOnly(s string) string {
+	h, _, e := net.SplitHostPort(s)
+	if e != nil {
+		return ""
+	}
+	return h
+}
+func (f *Forwarder) handle(c net.Conn) {
+	defer c.Close()
+	_ = c.SetDeadline(time.Now().Add(5 * time.Second))
+	name, e := parseCONNECT(c)
+	if e != nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	up, e := f.dialTLS(ctx, "tcp", f.ServerAddress)
+	if e != nil {
+		return
+	}
+	defer up.Close()
+	_ = up.SetDeadline(time.Now().Add(5 * time.Second))
+	if writeRequest(up, name) != nil || readStatus(up) != nil {
+		return
+	}
+	if _, e = io.WriteString(c, "HTTP/1.1 200 Connection Established\r\n\r\n"); e != nil {
+		return
+	}
+	_ = c.SetDeadline(time.Time{})
+	_ = up.SetDeadline(time.Time{})
+	relay(c, up, 5*time.Minute, time.Hour)
+}
+
+func (f *Forwarder) dialTLS(ctx context.Context, network, address string) (net.Conn, error) {
+	if f.DialTLS != nil {
+		return f.DialTLS(ctx, network, address, f.TLSConfig)
+	}
+	d := tls.Dialer{Config: f.TLSConfig}
+	return d.DialContext(ctx, network, address)
+}
+
+func readClientHello(r io.Reader, want string) ([]byte, error) {
+	deadline, ok := r.(interface{ SetReadDeadline(time.Time) error })
+	if ok {
+		_ = deadline.SetReadDeadline(time.Now().Add(5 * time.Second))
+	}
+	var all, hs []byte
+	for records := 0; records < 64 && len(all) < 65536; records++ {
+		h := make([]byte, 5)
+		if _, e := io.ReadFull(r, h); e != nil {
+			return nil, e
+		}
+		if h[0] != 22 || h[1] != 3 || h[2] > 4 {
+			return nil, errors.New("non-TLS ClientHello")
+		}
+		n := int(binary.BigEndian.Uint16(h[3:]))
+		if n == 0 || len(all)+5+n > 65536 {
+			return nil, errors.New("ClientHello oversized")
+		}
+		b := make([]byte, n)
+		if _, e := io.ReadFull(r, b); e != nil {
+			return nil, e
+		}
+		all = append(all, h...)
+		all = append(all, b...)
+		hs = append(hs, b...)
+		if len(hs) >= 4 {
+			z := int(hs[1])<<16 | int(hs[2])<<8 | int(hs[3])
+			if z+4 > 65536 {
+				return nil, errors.New("handshake oversized")
+			}
+			if len(hs) >= z+4 {
+				if len(hs) != z+4 {
+					return nil, errors.New("bytes after ClientHello")
+				}
+				sni, e := clientHelloSNI(hs[:z+4])
+				if e != nil || sni != want {
+					return nil, errors.New("SNI mismatch")
+				}
+				return all, nil
+			}
+		}
+	}
+	return nil, errors.New("ClientHello incomplete")
+}
+func clientHelloSNI(b []byte) (string, error) {
+	if len(b) < 4 || b[0] != 1 {
+		return "", errors.New("not ClientHello")
+	}
+	if len(b) < 6 || b[4] != 3 || b[5] < 3 {
+		return "", errors.New("legacy TLS version too old")
+	}
+	p := 4 + 2 + 32
+	if p >= len(b) {
+		return "", io.ErrUnexpectedEOF
+	}
+	sid := int(b[p])
+	p += 1 + sid
+	if p+2 > len(b) {
+		return "", io.ErrUnexpectedEOF
+	}
+	cs := int(binary.BigEndian.Uint16(b[p:]))
+	if cs == 0 || cs%2 != 0 {
+		return "", errors.New("bad cipher suites")
+	}
+	p += 2 + cs
+	if p >= len(b) {
+		return "", io.ErrUnexpectedEOF
+	}
+	cm := int(b[p])
+	if cm == 0 || p+1+cm > len(b) || !bytesContains(b[p+1:p+1+cm], 0) {
+		return "", errors.New("null compression required")
+	}
+	p += 1 + cm
+	if p+2 > len(b) {
+		return "", io.ErrUnexpectedEOF
+	}
+	el := int(binary.BigEndian.Uint16(b[p:]))
+	p += 2
+	if p+el != len(b) {
+		return "", errors.New("bad extensions")
+	}
+	var sni string
+	seenExtensions := make(map[uint16]bool)
+	for p < len(b) {
+		if p+4 > len(b) {
+			return "", io.ErrUnexpectedEOF
+		}
+		typ, n := binary.BigEndian.Uint16(b[p:]), int(binary.BigEndian.Uint16(b[p+2:]))
+		p += 4
+		if p+n > len(b) {
+			return "", io.ErrUnexpectedEOF
+		}
+		v := b[p : p+n]
+		p += n
+		if seenExtensions[typ] {
+			return "", errors.New("duplicate extension")
+		}
+		seenExtensions[typ] = true
+		if typ == 0xfe0d || typ == 0xffce {
+			return "", errors.New("ECH forbidden")
+		}
+		if typ == 0 {
+			if sni != "" || len(v) < 5 {
+				return "", errors.New("bad SNI")
+			}
+			ln := int(binary.BigEndian.Uint16(v))
+			if ln+2 != len(v) || v[2] != 0 {
+				return "", errors.New("bad SNI")
+			}
+			nn := int(binary.BigEndian.Uint16(v[3:]))
+			if nn+5 != len(v) {
+				return "", errors.New("bad SNI")
+			}
+			sni = string(v[5:])
+		}
+	}
+	if sni == "" {
+		return "", errors.New("SNI required")
+	}
+	if _, e := canonicalTarget(sni + ":443"); e != nil {
+		return "", e
+	}
+	return sni, nil
+}
+
+func bytesContains(b []byte, want byte) bool {
+	for _, v := range b {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}
+
+func relay(a, b net.Conn, idle, absolute time.Duration) {
+	end := time.Now().Add(absolute)
+	var wg sync.WaitGroup
+	cp := func(dst, src net.Conn) {
+		defer wg.Done()
+		buf := make([]byte, 32<<10)
+		for {
+			d := time.Now().Add(idle)
+			if d.After(end) {
+				d = end
+			}
+			_ = src.SetReadDeadline(d)
+			n, e := src.Read(buf)
+			if n > 0 {
+				_ = dst.SetWriteDeadline(d)
+				if _, w := dst.Write(buf[:n]); w != nil {
+					return
+				}
+			}
+			if e != nil {
+				return
+			}
+		}
+	}
+	wg.Add(2)
+	go cp(a, b)
+	go cp(b, a)
+	wg.Wait()
+}

--- a/internal/egressproxy/proxy_test.go
+++ b/internal/egressproxy/proxy_test.go
@@ -1,0 +1,270 @@
+package egressproxy
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/binary"
+	"errors"
+	"io"
+	"math/big"
+	"net"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/net/dns/dnsmessage"
+)
+
+type authorizerFunc func(context.Context, Identity, string) (Authorization, error)
+
+func (f authorizerFunc) Authorize(ctx context.Context, id Identity, name string) (Authorization, error) {
+	return f(ctx, id, name)
+}
+
+type panicResolver struct{}
+
+func (panicResolver) Query(context.Context, dnsmessage.Name, dnsmessage.Type) ([]dnsmessage.Resource, error) {
+	panic("resolver invoked after denial")
+}
+
+func hello(name string, extra ...uint16) []byte {
+	ext := func(typ uint16, v []byte) []byte {
+		b := make([]byte, 4+len(v))
+		binary.BigEndian.PutUint16(b, typ)
+		binary.BigEndian.PutUint16(b[2:], uint16(len(v)))
+		copy(b[4:], v)
+		return b
+	}
+	s := make([]byte, 5+len(name))
+	binary.BigEndian.PutUint16(s, uint16(3+len(name)))
+	s[2] = 0
+	binary.BigEndian.PutUint16(s[3:], uint16(len(name)))
+	copy(s[5:], name)
+	exts := ext(0, s)
+	for _, x := range extra {
+		exts = append(exts, ext(x, nil)...)
+	}
+	body := append([]byte{3, 3}, make([]byte, 32)...)
+	body = append(body, 0, 0, 2, 0x13, 1, 1, 0)
+	z := make([]byte, 2)
+	binary.BigEndian.PutUint16(z, uint16(len(exts)))
+	body = append(body, z...)
+	body = append(body, exts...)
+	hs := append([]byte{1, byte(len(body) >> 16), byte(len(body) >> 8), byte(len(body))}, body...)
+	rec := []byte{22, 3, 3, byte(len(hs) >> 8), byte(len(hs))}
+	return append(rec, hs...)
+}
+func TestClientHello(t *testing.T) {
+	b := hello("api.example.com")
+	got, e := readClientHello(bytes.NewReader(b), "api.example.com")
+	if e != nil || !bytes.Equal(got, b) {
+		t.Fatal(e)
+	}
+	for _, tc := range []struct {
+		name  string
+		extra []uint16
+	}{{"other.example.com", nil}, {"API.example.com", nil}, {"api.example.com", []uint16{0xfe0d}}, {"api.example.com", []uint16{0xffce}}} {
+		if _, e := readClientHello(bytes.NewReader(hello(tc.name, tc.extra...)), "api.example.com"); e == nil {
+			t.Errorf("accepted %+v", tc)
+		}
+	}
+	if _, e := readClientHello(bytes.NewReader(hello("api.example.com", 0)), "api.example.com"); e == nil {
+		t.Error("duplicate SNI accepted")
+	}
+	for _, b := range [][]byte{{1, 2, 3}, hello("api.example.com")[:10]} {
+		if _, e := readClientHello(bytes.NewReader(b), "api.example.com"); e == nil {
+			t.Error("malformed accepted")
+		}
+	}
+	// Split one handshake over two records and ensure exact wire bytes survive.
+	hs := b[5:]
+	cut := len(hs) / 2
+	fragmented := append([]byte{22, 3, 3, byte(cut >> 8), byte(cut)}, hs[:cut]...)
+	n := len(hs) - cut
+	fragmented = append(fragmented, 22, 3, 3, byte(n>>8), byte(n))
+	fragmented = append(fragmented, hs[cut:]...)
+	got, e = readClientHello(bytes.NewReader(fragmented), "api.example.com")
+	if e != nil || !bytes.Equal(got, fragmented) {
+		t.Fatal("fragment", e)
+	}
+}
+func TestDisabledAndLoopback(t *testing.T) {
+	if _, err := (DisabledAuthorizer{}).Authorize(context.Background(), Identity{}, "api.example.com"); err == nil {
+		t.Error("disabled authorizer allowed")
+	}
+	if got := hostOnly(net.JoinHostPort("127.0.0.1", "443")); got != "127.0.0.1" {
+		t.Fatalf("hostOnly=%q", got)
+	}
+}
+
+func TestForwarderMaxConnections(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	cert := testCertificate(t, "forwarder")
+	forwarder := &Forwarder{
+		TLSConfig:      &tls.Config{Certificates: []tls.Certificate{cert}, RootCAs: x509.NewCertPool(), ServerName: "proxy.example.com", MinVersion: tls.VersionTLS13, MaxVersion: tls.VersionTLS13},
+		MaxConnections: 1,
+	}
+	var dialCount atomic.Int32
+	firstEntered := make(chan struct{})
+	secondEntered := make(chan struct{})
+	release := make(chan struct{})
+	defer func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	}()
+	forwarder.DialTLS = func(context.Context, string, string, *tls.Config) (net.Conn, error) {
+		switch count := dialCount.Add(1); count {
+		case 1:
+			close(firstEntered)
+			<-release
+		case 2:
+			close(secondEntered)
+		default:
+			t.Errorf("DialTLS called %d times", count)
+		}
+		return nil, errors.New("test dial")
+	}
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- forwarder.Serve(listener) }()
+
+	first, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer first.Close()
+	if _, err := io.WriteString(first, "CONNECT api.example.com:443 HTTP/1.1\r\nHost: api.example.com:443\r\n\r\n"); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-firstEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first DialTLS did not start")
+	}
+
+	second, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer second.Close()
+	_ = second.SetReadDeadline(time.Now().Add(2 * time.Second))
+	one := make([]byte, 1)
+	if _, err := second.Read(one); err == nil {
+		t.Fatal("excess connection was not closed")
+	} else if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+		t.Fatalf("excess connection remained open until timeout: %v", err)
+	} else if !errors.Is(err, io.EOF) && !errors.Is(err, syscall.ECONNRESET) {
+		t.Fatalf("excess connection read returned %v, want EOF or connection reset", err)
+	}
+	if got := dialCount.Load(); got != 1 {
+		t.Fatalf("DialTLS count while first connection blocked = %d, want 1", got)
+	}
+
+	close(release)
+	_ = first.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, err := first.Read(one); err == nil {
+		t.Fatal("first handler did not close its connection")
+	} else if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+		t.Fatalf("first handler did not end before timeout: %v", err)
+	}
+
+	third, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer third.Close()
+	if _, err := io.WriteString(third, "CONNECT api.example.com:443 HTTP/1.1\r\nHost: api.example.com:443\r\n\r\n"); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-secondEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("third connection did not acquire the released slot")
+	}
+	if got := dialCount.Load(); got != 2 {
+		t.Fatalf("DialTLS count = %d, want 2", got)
+	}
+
+	_ = listener.Close()
+	select {
+	case <-serveDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Serve did not stop")
+	}
+}
+
+func TestSelfSignedClientFingerprintAuthorizerDenial(t *testing.T) {
+	serverCert := testCertificate(t, "server")
+	clientCert := testCertificate(t, "execution")
+	want := sha256.Sum256(clientCert.Certificate[0])
+	called := false
+	s := &Server{
+		TLSConfig: &tls.Config{Certificates: []tls.Certificate{serverCert}, ClientAuth: tls.RequireAnyClientCert, MinVersion: tls.VersionTLS13, MaxVersion: tls.VersionTLS13, SessionTicketsDisabled: true},
+		Resolver:  panicResolver{},
+		Authorizer: authorizerFunc(func(_ context.Context, id Identity, name string) (Authorization, error) {
+			called = true
+			if id.Fingerprint != want || name != "api.example.com" {
+				t.Errorf("identity/name mismatch: %x %q", id.Fingerprint, name)
+			}
+			return Authorization{}, errors.New("deny")
+		}),
+		Dialer: func(context.Context, string, string) (net.Conn, error) {
+			t.Error("dial invoked after denial")
+			return nil, errors.New("unexpected")
+		},
+	}
+	serverSide, clientSide := net.Pipe()
+	done := make(chan struct{})
+	go func() { s.handle(tls.Server(serverSide, s.TLSConfig)); close(done) }()
+	c := tls.Client(clientSide, &tls.Config{Certificates: []tls.Certificate{clientCert}, InsecureSkipVerify: true, MinVersion: tls.VersionTLS13, MaxVersion: tls.VersionTLS13})
+	if err := c.Handshake(); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeRequest(c, "api.example.com"); err != nil {
+		t.Fatal(err)
+	}
+	if err := readStatus(c); err == nil {
+		t.Fatal("denial status accepted")
+	}
+	_ = c.Close()
+	<-done
+	if !called {
+		t.Fatal("authorizer not called")
+	}
+}
+
+func testCertificate(t *testing.T, cn string) tls.Certificate {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{SerialNumber: big.NewInt(1), Subject: pkix.Name{CommonName: cn}, NotBefore: time.Now().Add(-time.Minute), NotAfter: time.Now().Add(time.Hour), KeyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment, ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+}
+func FuzzClientHello(f *testing.F) {
+	f.Add(hello("api.example.com"))
+	f.Fuzz(func(t *testing.T, b []byte) {
+		if len(b) > 70000 {
+			return
+		}
+		_, _ = readClientHello(bytes.NewReader(b), "api.example.com")
+	})
+}

--- a/internal/egressproxy/proxy_test.go
+++ b/internal/egressproxy/proxy_test.go
@@ -34,6 +34,20 @@ func (panicResolver) Query(context.Context, dnsmessage.Name, dnsmessage.Type) ([
 	panic("resolver invoked after denial")
 }
 
+type releaseCheckingResolver struct {
+	released <-chan struct{}
+	t        *testing.T
+}
+
+func (r releaseCheckingResolver) Query(context.Context, dnsmessage.Name, dnsmessage.Type) ([]dnsmessage.Resource, error) {
+	select {
+	case <-r.released:
+	default:
+		r.t.Error("pre-authorization slot was retained after authorization")
+	}
+	return nil, errors.New("stop after authorization")
+}
+
 func hello(name string, extra ...uint16) []byte {
 	ext := func(typ uint16, v []byte) []byte {
 		b := make([]byte, 4+len(v))
@@ -206,6 +220,31 @@ func TestForwarderMaxConnections(t *testing.T) {
 	}
 }
 
+func TestRelayClosesBothDirectionsWhenOneSideEnds(t *testing.T) {
+	client, relayClient := net.Pipe()
+	relayUpstream, upstream := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		relay(relayClient, relayUpstream, time.Minute, time.Hour)
+		close(done)
+	}()
+
+	if err := client.Close(); err != nil {
+		t.Fatal(err)
+	}
+	_ = upstream.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, err := upstream.Read(make([]byte, 1)); err == nil {
+		t.Fatal("opposite relay direction remained open")
+	} else if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+		t.Fatalf("opposite relay direction blocked until deadline: %v", err)
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("relay did not release after one direction ended")
+	}
+}
+
 func TestSelfSignedClientFingerprintAuthorizerDenial(t *testing.T) {
 	serverCert := testCertificate(t, "server")
 	clientCert := testCertificate(t, "execution")
@@ -244,6 +283,38 @@ func TestSelfSignedClientFingerprintAuthorizerDenial(t *testing.T) {
 	if !called {
 		t.Fatal("authorizer not called")
 	}
+}
+
+func TestServerReleasesPreAuthSlotBeforeResolution(t *testing.T) {
+	serverCert := testCertificate(t, "server")
+	clientCert := testCertificate(t, "execution")
+	released := make(chan struct{})
+	s := &Server{
+		TLSConfig: &tls.Config{Certificates: []tls.Certificate{serverCert}, ClientAuth: tls.RequireAnyClientCert, MinVersion: tls.VersionTLS13, MaxVersion: tls.VersionTLS13, SessionTicketsDisabled: true},
+		Resolver:  releaseCheckingResolver{released: released, t: t},
+		Quotas:    NewQuotaManager(),
+		Authorizer: authorizerFunc(func(context.Context, Identity, string) (Authorization, error) {
+			return Authorization{ExecutionKey: "execution", ProjectKey: "project"}, nil
+		}),
+	}
+	serverSide, clientSide := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		s.handleWithPreAuth(tls.Server(serverSide, s.TLSConfig), func() { close(released) })
+		close(done)
+	}()
+	c := tls.Client(clientSide, &tls.Config{Certificates: []tls.Certificate{clientCert}, InsecureSkipVerify: true, MinVersion: tls.VersionTLS13, MaxVersion: tls.VersionTLS13})
+	if err := c.Handshake(); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeRequest(c, "api.example.com"); err != nil {
+		t.Fatal(err)
+	}
+	if err := readStatus(c); err == nil {
+		t.Fatal("resolution failure status accepted")
+	}
+	_ = c.Close()
+	<-done
 }
 
 func testCertificate(t *testing.T, cn string) tls.Certificate {

--- a/internal/egressproxy/quota.go
+++ b/internal/egressproxy/quota.go
@@ -1,0 +1,115 @@
+package egressproxy
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+type quotaEntry struct {
+	active, pending int
+	tokens          float64
+	last            time.Time
+}
+type QuotaManager struct {
+	mu       sync.Mutex
+	global   int
+	projects map[string]int
+	exec     map[string]*quotaEntry
+	now      func() time.Time
+}
+
+type Reservation struct {
+	q           *QuotaManager
+	ex, project string
+	state       reservationState
+}
+
+type reservationState uint8
+
+const (
+	reservationPending reservationState = iota
+	reservationActive
+	reservationReleased
+)
+
+func NewQuotaManager() *QuotaManager {
+	return &QuotaManager{projects: map[string]int{}, exec: map[string]*quotaEntry{}, now: time.Now}
+}
+func (q *QuotaManager) Acquire(ex, project string) (func(), error) {
+	r, err := q.Reserve(ex, project)
+	if err != nil {
+		return nil, err
+	}
+	if err := r.Activate(); err != nil {
+		r.Release()
+		return nil, err
+	}
+	return r.Release, nil
+}
+
+func (q *QuotaManager) Reserve(ex, project string) (*Reservation, error) {
+	if ex == "" || project == "" {
+		return nil, errors.New("identity keys required")
+	}
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	e := q.exec[ex]
+	if e == nil {
+		e = &quotaEntry{tokens: 20, last: q.now()}
+		q.exec[ex] = e
+	}
+	now := q.now()
+	e.tokens += now.Sub(e.last).Seconds() * 10
+	if e.tokens > 20 {
+		e.tokens = 20
+	}
+	e.last = now
+	if e.tokens < 1 || e.pending >= 16 {
+		return nil, errors.New("quota exceeded")
+	}
+	e.tokens--
+	e.pending++
+	return &Reservation{q: q, ex: ex, project: project}, nil
+}
+
+func (r *Reservation) Activate() error {
+	r.q.mu.Lock()
+	defer r.q.mu.Unlock()
+	e := r.q.exec[r.ex]
+	if r.state == reservationReleased {
+		return errors.New("reservation released")
+	}
+	if r.state == reservationActive {
+		return nil
+	}
+	if e.active >= 32 || r.q.projects[r.project] >= 256 || r.q.global >= 2048 {
+		return errors.New("quota exceeded")
+	}
+	e.pending--
+	e.active++
+	r.q.projects[r.project]++
+	r.q.global++
+	r.state = reservationActive
+	return nil
+}
+
+func (r *Reservation) Release() {
+	r.q.mu.Lock()
+	defer r.q.mu.Unlock()
+	if r.state == reservationReleased {
+		return
+	}
+	e := r.q.exec[r.ex]
+	if r.state == reservationActive {
+		e.active--
+		r.q.projects[r.project]--
+		if r.q.projects[r.project] == 0 {
+			delete(r.q.projects, r.project)
+		}
+		r.q.global--
+	} else {
+		e.pending--
+	}
+	r.state = reservationReleased
+}

--- a/internal/egressproxy/quota_test.go
+++ b/internal/egressproxy/quota_test.go
@@ -1,0 +1,137 @@
+package egressproxy
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestQuota(t *testing.T) {
+	q := NewQuotaManager()
+	now := time.Unix(1, 0)
+	q.now = func() time.Time { return now }
+	var rel []func()
+	for i := 0; i < 20; i++ {
+		r, e := q.Acquire("e", fmt.Sprint("p", i))
+		if e != nil {
+			t.Fatal(i, e)
+		}
+		rel = append(rel, r)
+	}
+	if _, e := q.Acquire("e", "p"); e == nil {
+		t.Error("burst exceeded")
+	}
+	for _, r := range rel {
+		r()
+		r()
+	}
+	now = now.Add(time.Second)
+	for i := 0; i < 10; i++ {
+		r, e := q.Acquire("e", fmt.Sprint("q", i))
+		if e != nil {
+			t.Fatal(e)
+		}
+		r()
+	}
+	if _, e := q.Acquire("e", "q"); e == nil {
+		t.Error("rate exceeded")
+	}
+	q = NewQuotaManager()
+	var reservations []*Reservation
+	for i := 0; i < 16; i++ {
+		r, e := q.Reserve("e", "p")
+		if e != nil {
+			t.Fatal(e)
+		}
+		reservations = append(reservations, r)
+	}
+	if _, e := q.Reserve("e", "p"); e == nil {
+		t.Error("pending exceeded")
+	}
+	for _, r := range reservations {
+		r.Release()
+	}
+}
+func TestQuotaCapsAndConcurrency(t *testing.T) {
+	q := NewQuotaManager()
+	q.now = func() time.Time { return time.Unix(1, 0) }
+	// Seed tokens to isolate active cap behavior from rate limiting.
+	q.exec["e"] = &quotaEntry{tokens: 100, last: q.now()}
+	var rs []func()
+	for i := 0; i < 32; i++ {
+		q.exec["e"].tokens = 20
+		r, e := q.Acquire("e", "p")
+		if e != nil {
+			t.Fatal(e)
+		}
+		rs = append(rs, r)
+	}
+	if _, e := q.Acquire("e", "p"); e == nil {
+		t.Error("execution cap exceeded")
+	}
+	for _, r := range rs {
+		r()
+	}
+	q = NewQuotaManager()
+	for i := 0; i < 3000; i++ {
+		q.exec[fmt.Sprint("e", i)] = &quotaEntry{tokens: 20, last: q.now()}
+	}
+	rs = nil
+	for i := 0; i < 256; i++ {
+		r, e := q.Acquire(fmt.Sprint("e", i), "p")
+		if e != nil {
+			t.Fatal(e)
+		}
+		rs = append(rs, r)
+	}
+	if _, e := q.Acquire("e2999", "p"); e == nil {
+		t.Error("project cap exceeded")
+	}
+	for _, r := range rs {
+		r()
+	}
+	q = NewQuotaManager()
+	rs = nil
+	for i := 0; i < 2048; i++ {
+		r, e := q.Acquire(fmt.Sprint("g", i), fmt.Sprint("gp", i))
+		if e != nil {
+			t.Fatal("global setup", i, e)
+		}
+		rs = append(rs, r)
+	}
+	if _, e := q.Acquire("global-over", "global-over"); e == nil {
+		t.Error("global cap exceeded")
+	}
+	for _, r := range rs {
+		r()
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			r, e := q.Acquire(fmt.Sprint("c", i), fmt.Sprint("cp", i))
+			if e == nil {
+				r()
+				r()
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestReservationCannotReactivateAfterRelease(t *testing.T) {
+	q := NewQuotaManager()
+	r, err := q.Reserve("e", "p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.Release()
+	if err := r.Activate(); err == nil {
+		t.Fatal("released reservation activated")
+	}
+	if len(q.projects) != 0 {
+		t.Fatalf("empty project retained: %#v", q.projects)
+	}
+}


### PR DESCRIPTION
## Summary

- define the approved strict Project egress hostname contract and generated CRD bounds
- add canonical admin ceiling/baseline/Project composition and deterministic runtime revision hashing
- add an inert, disabled egress forwarder/proxy protocol foundation with bounded CONNECT, mTLS framing, TLS ClientHello/SNI validation, pinned DNS resolution, special-range denial, quotas, and adversarial tests
- retain the existing non-empty `Project.spec.egressAllowlist` execution fence; no runtime, image, chart, controller, or production egress behavior is enabled

Maintainer decision: https://github.com/Chris-Cullins/swe-platform/issues/68#issuecomment-5231375346

Slice 3 Calico proof work remains separate pending proof-safety review.

## Validation

- `make test`
- `make vet`
- `make check-chart-crds`
- `go test -race -count=1 ./internal/egressproxy ./cmd/egress-proxy`
- `git diff --check`

All passed locally.
