### PR TITLE
Add experimental Calico egress conformance runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,6 +110,9 @@ jobs:
       - name: BYOC preset validation
         run: ./hack/validate-byoc_test.sh
 
+      - name: Disabled egress conformance guards
+        run: ./hack/egress-conformance_test.sh
+
       - name: Generated code is current
         run: |
           make generate manifests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,11 +118,14 @@ runs both via `make` targets:
 - **Local operator:** `make run` requires explicit `RUN_TENANCY_MODE`,
   `RUN_SYSTEM_NAMESPACE`, and `RUN_INSTALLATION_NAME`; scoped mode also takes a
   space-separated `RUN_TENANCY_NAMESPACES` list.
-- **Unit tests:** `make test` (including rendered Helm RBAC, Argo port-forward, and BYOC
-  production-preset checks) · **Vet:** `make vet`. PostgreSQL transcript/session integration tests
+- **Unit tests:** `make test` (including rendered Helm RBAC, Argo port-forward, BYOC
+  production-preset checks, and the disabled egress-conformance guard) · **Vet:** `make vet`.
+  PostgreSQL transcript/session integration tests
   run when `SWE_TEST_POSTGRES_URL` points to a disposable database; CI supplies PostgreSQL 17.
   The required `build-test` CI job runs the root and sandboxd Go suites plus
-  the three shell checks above, mirroring `make test`.
+  the four shell checks above, mirroring `make test`. The egress-conformance live runner remains
+  default-off on its separate `hack/kind-calico-conformance.yaml` topology and must not be invoked
+  by CI/e2e; only its guard test runs.
 - **Operations console:** from `ui/`, install with `npm ci`; use `npm run lint`,
   `npm run typecheck`, `npm test -- --run`, and `npm run build`. Start the standalone
   Vite development server with `npm run dev`. Production uses `make ui-build`

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -760,14 +760,16 @@ strips credentials, session cookies, and hop-by-hop headers and supports WebSock
 
 ### Approved fail-closed proxy-only egress contract
 
-The maintainer approved the [outbound-network contract in #68](https://github.com/Chris-Cullins/swe-platform/issues/68#issuecomment-5078805740):
+The maintainer approved the [outbound-network contract in #68](https://github.com/Chris-Cullins/swe-platform/issues/68#issuecomment-5231375346):
 
 - production requires a demonstrably enforcing CNI and fails before execution when enforcement
   is unavailable; any unrestricted local mode is explicitly non-production;
 - Environment traffic is technically forced through an authenticated shared proxy, with no
   direct fallback; proxy environment variables are compatibility, not enforcement;
-- installation administrators define a destination ceiling and Projects may select only a
-  subset;
+- installation administrators define a destination ceiling and baseline; the effective policy
+  is the baseline union the Project selection, with both constrained by the ceiling. The
+  platform baseline is empty, Templates have no egress-policy role, and no required destination
+  is inferred;
 - the first version allows canonical HTTPS FQDN destinations on port 443 and HTTPS Git, not
   direct IPs, Git SSH/`git://`, arbitrary TCP/UDP, QUIC, private Project networks, or alternate
   DNS paths;
@@ -812,6 +814,16 @@ path forcing, Calico v3.32.1-only enforcement proof, and acceptance land togethe
 currently no default-deny egress, proxy deployment, runtime policy ConfigMap, restricted profile,
 or production egress-enforcement claim; generic Kubernetes, k3s, GKE, and EKS restricted profiles
 remain deferred. Issue #68 is not runtime-complete.
+
+Slice 3 provides only a default-off experimental conformance runner. The separate pinned
+dual-stack, two-worker kind topology and `hack/egress-conformance.sh` can perform one disposable,
+human-observed Calico v3.32.1 diagnostic run after explicit context and cluster-UID confirmation.
+The runner aborts on unavailable prerequisites and exits nonzero on any failed positive or
+negative check. It emits human-readable diagnostics only: there is no persisted proof schema,
+freshness model, attestation, controller, chart component, production capability, or runtime
+input. Normal CI and `hack/e2e.sh` never execute the live runner; CI only checks that it remains
+disabled and isolated. This groundwork installs no proxy and changes no Environment policy or
+non-empty allowlist rejection behavior.
 
 ## Remaining decisions and open work
 

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ test: ## Run unit tests in both modules
 	./hack/argocd-port-forward_test.sh
 	./hack/helm-rbac_test.sh
 	./hack/validate-byoc_test.sh
+	./hack/egress-conformance_test.sh
 
 .PHONY: vet
 vet: ## Run go vet in both modules

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -141,6 +141,14 @@ Environment egress today, which remains subject to cluster network configuration
 ConfigMap, proxy, identity, path forcing, restricted NetworkPolicy, or enforcement proof is wired;
 the approved restricted runtime is Calico v3.32.1-only and remains later issue #68 work.
 
+An experimental Calico v3.32.1 conformance runner exists as default-off diagnostic groundwork.
+It runs only by explicit invocation against its separate disposable kind fixture, aborts when
+its clean-cluster prerequisites cannot be checked, and exits nonzero on any failed positive or
+negative network check. Its terminal output is not attestation or freshness evidence and is not
+persisted or accepted by any controller, chart, runtime component, or production preset. Normal
+CI and E2E never execute the live runner. This diagnostic does not establish production egress
+isolation and does not change the allowlist behavior above.
+
 When an EnvironmentTemplate explicitly names a RuntimeClass, the operator verifies that the
 cluster-scoped RuntimeClass object exists before execution and fences exact-owned execution if
 it is removed or replaced under the same name. Environment pods pin the RuntimeClass UID; the

--- a/charts/swe-platform/README.md
+++ b/charts/swe-platform/README.md
@@ -482,6 +482,11 @@ The chart does not install default-deny egress or an egress allowlist proxy. Pro
 `egressAllowlist` values are reserved and rejected when non-empty; empty or omitted values leave
 egress subject to the cluster's network configuration.
 
+The repository also contains a deliberately disabled experimental Calico v3.32.1 diagnostic
+runner on a separate dual-stack kind topology. It is not a chart component, production preset
+capability, attestation mechanism, or runtime input, and normal E2E does not run it. Its
+human-readable one-shot results do not change this table or claim production enforcement.
+
 For local development, use `values-kind.yaml`; it references locally loaded `:dev`
 images and disables leader election. `values-argocd.yaml` is the preset for the
 local Argo CD mirror (`hack/argocd-up.sh`): it tracks the mutable `:latest` images

--- a/hack/egress-conformance-client.py
+++ b/hack/egress-conformance-client.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Structured one-shot and continuous TCP/UDP conformance client."""
+
+import ipaddress
+import os
+import socket
+import sys
+import time
+
+
+mode, protocol, raw_address, raw_port = sys.argv[1:]
+address = ipaddress.ip_address(raw_address)
+family = socket.AF_INET6 if address.version == 6 else socket.AF_INET
+kind = socket.SOCK_DGRAM if protocol == "udp" else socket.SOCK_STREAM
+target = (raw_address, int(raw_port))
+
+
+def reachable() -> bool:
+    try:
+        with socket.socket(family, kind) as sock:
+            sock.settimeout(2)
+            if protocol == "tcp":
+                sock.connect(target)
+            else:
+                nonce = f"swe-{os.getpid()}-{time.monotonic_ns()}".encode()
+                sock.sendto(nonce, target)
+                payload, peer = sock.recvfrom(65535)
+                if payload != nonce or peer[0] != raw_address or peer[1] != int(raw_port):
+                    return False
+        return True
+    except (OSError, TimeoutError):
+        return False
+
+
+if mode == "once":
+    print("REACHED" if reachable() else "UNREACHED", flush=True)
+elif mode == "continuous":
+    while True:
+        if not reachable():
+            print("FAILED", flush=True)
+            raise SystemExit(1)
+        print("OK", flush=True)
+        time.sleep(0.05)
+else:
+    raise SystemExit("unknown mode")

--- a/hack/egress-conformance-felix-check.sh
+++ b/hack/egress-conformance-felix-check.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# Runs inside calico-node. Tests may point PROC_ROOT at a synthetic proc tree.
+set -eu
+proc_root=${PROC_ROOT:-/proc}
+pids=
+for process in "$proc_root"/[0-9]*; do
+	[ -f "$process/cmdline" ] || continue
+	args=$(tr '\0' '\n' <"$process/cmdline" 2>/dev/null || :)
+	first=$(printf '%s\n' "$args" | sed -n '1p')
+	case "${first##*/}" in felix) is_felix=true ;; *) is_felix=false ;; esac
+	if printf '%s\n' "$args" | grep -qx -- '-felix'; then is_felix=true; fi
+	if [ "${first##*/}" = calico ] && printf '%s\n' "$args" | awk 'previous=="component" && $0=="felix"{found=1} {previous=$0} END{exit !found}'; then is_felix=true; fi
+	[ "$is_felix" = false ] || pids="$pids ${process##*/}"
+done
+set -- $pids
+[ "$#" -eq 1 ] || { echo "expected exactly one felix process" >&2; exit 1; }
+pid=$1
+environment="$proc_root/$pid/environ"
+cmdline="$proc_root/$pid/cmdline"
+tr '\0' '\n' <"$environment" | grep -Eiq '^felix_defaultendpointtohostaction=' && { echo "Felix environment override" >&2; exit 1; }
+tr '\0' '\n' <"$environment" | grep -Eiq '^felix_interfaceprefix=' && { echo "Felix interface-prefix environment override" >&2; exit 1; }
+args=$(tr '\0' '\n' <"$cmdline")
+printf '%s\n' "$args" | grep -Eiq 'default[-_]?endpoint[-_]?to[-_]?host[-_]?action' && { echo "Felix argument override" >&2; exit 1; }
+printf '%s\n' "$args" | grep -Eiq 'interface[-_]?prefix' && { echo "Felix interface-prefix argument override" >&2; exit 1; }
+config_file=
+expect_config=false
+while IFS= read -r argument; do
+	if [ "$expect_config" = true ]; then
+		[ -z "$config_file" ] || { echo "multiple Felix config-file options" >&2; exit 1; }
+		config_file=$argument; expect_config=false; continue
+	fi
+	case "$argument" in
+		-c|--config-file) expect_config=true ;;
+		--config-file=*) [ -z "$config_file" ] || { echo "multiple Felix config-file options" >&2; exit 1; }; config_file=${argument#*=}; [ -n "$config_file" ] || { echo "empty Felix config-file argument" >&2; exit 1; } ;;
+		-c?*) [ -z "$config_file" ] || { echo "multiple Felix config-file options" >&2; exit 1; }; config_file=${argument#-c} ;;
+	esac
+done <<EOF
+$args
+EOF
+[ "$expect_config" = false ] || { echo "missing Felix config-file argument" >&2; exit 1; }
+config_file=${config_file:-/etc/calico/felix.cfg}
+case "$config_file" in /*) ;; *) echo "relative Felix config-file path" >&2; exit 1 ;; esac
+[ -r "$config_file" ] || { echo "unreadable selected Felix config-file" >&2; exit 1; }
+grep -Eiq '^[[:space:]]*default[-_]?endpoint[-_]?to[-_]?host[-_]?action[[:space:]]*[:=]' "$config_file" && { echo "Felix config-file override" >&2; exit 1; }
+grep -Eiq '^[[:space:]]*interface[-_]?prefix[[:space:]]*[:=]' "$config_file" && { echo "Felix interface-prefix config-file override" >&2; exit 1; }
+env_hostname=$(tr '\0' '\n' <"$environment" | awk -F= 'tolower($1)=="felix_felixhostname"{sub(/^[^=]*=/, ""); print}')
+env_hostname_count=$(tr '\0' '\n' <"$environment" | awk -F= 'tolower($1)=="felix_felixhostname"{count++} END{print count+0}')
+[ "$env_hostname_count" -le 1 ] || { echo "multiple Felix hostname environment values" >&2; exit 1; }
+[ "$env_hostname_count" -eq 0 ] || [ -n "$env_hostname" ] || { echo "empty Felix hostname environment value" >&2; exit 1; }
+file_hostnames=$(awk '/[:=]/{line=$0; key=line; sub(/^[[:space:]]*/, "", key); sub(/[[:space:]]*[:=].*$/, "", key); if (tolower(key)=="felixhostname") {sub(/^[^:=]*[:=][[:space:]]*/, "", line); print line}}' "$config_file")
+file_hostname_count=$(awk '/[:=]/{key=$0; sub(/^[[:space:]]*/, "", key); sub(/[[:space:]]*[:=].*$/, "", key); if (tolower(key)=="felixhostname") count++} END{print count+0}' "$config_file")
+[ "$file_hostname_count" -le 1 ] || { echo "ambiguous Felix hostname config-file values" >&2; exit 1; }
+[ "$file_hostname_count" -eq 0 ] || [ -n "$file_hostnames" ] || { echo "empty Felix hostname config-file value" >&2; exit 1; }
+file_hostname=$file_hostnames
+effective_hostname=${env_hostname:-${file_hostname:-$(hostname | tr '[:upper:]' '[:lower:]')}}
+[ -n "${EXPECTED_FELIX_HOSTNAME:-}" ] && [ "$effective_hostname" = "$EXPECTED_FELIX_HOSTNAME" ] || { echo "effective Felix hostname mismatch" >&2; exit 1; }
+printf 'FILE:%s\n' "$config_file"; sha256sum "$config_file"
+printf 'HOSTNAME:%s\n' "$effective_hostname"
+printf 'PID:%s\n' "$pid"
+sha256sum "$cmdline" "$environment"

--- a/hack/egress-conformance-server.py
+++ b/hack/egress-conformance-server.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Small fixture-only dual-stack TCP acceptor and UDP echo server."""
+
+import selectors
+import socket
+import sys
+
+
+selector = selectors.DefaultSelector()
+
+
+def register(family: socket.AddressFamily, kind: socket.SocketKind, port: int) -> None:
+    sock = socket.socket(family, kind)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    if family == socket.AF_INET6:
+        sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
+    sock.bind(("::" if family == socket.AF_INET6 else "0.0.0.0", port))
+    if kind == socket.SOCK_STREAM:
+        sock.listen(128)
+        sock.setblocking(False)
+        selector.register(sock, selectors.EVENT_READ, "tcp")
+    else:
+        sock.setblocking(False)
+        selector.register(sock, selectors.EVENT_READ, "udp")
+
+
+for argument in sys.argv[1:]:
+    protocol, raw_ports = argument.split(":", 1)
+    kind = {"tcp": socket.SOCK_STREAM, "udp": socket.SOCK_DGRAM}[protocol]
+    for raw_port in raw_ports.split(","):
+        for address_family in (socket.AF_INET, socket.AF_INET6):
+            register(address_family, kind, int(raw_port))
+
+open("/tmp/ready", "w").close()
+while True:
+    for key, _ in selector.select():
+        if key.data == "tcp":
+            connection, _ = key.fileobj.accept()
+            connection.close()
+        else:
+            payload, peer = key.fileobj.recvfrom(65535)
+            key.fileobj.sendto(payload, peer)

--- a/hack/egress-conformance.sh
+++ b/hack/egress-conformance.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# Default-off, one-shot diagnostic runner for a disposable kind cluster created
+# from hack/kind-calico-conformance.yaml. Output is human-readable diagnostics,
+# not reusable evidence, attestation, or a runtime input.
+set -euo pipefail
+
+NS=swe-egress-conformance
+SELECTOR='swe.dev/egress-conformance=eligible'
+PYTHON='docker.io/library/python:3.12.11-alpine3.22'
+CALICO_MANIFEST_URL='https://raw.githubusercontent.com/projectcalico/calico/v3.32.1/manifests/calico.yaml'
+CALICO_MANIFEST_SHA256='a1df919d9721cf667accdc3e72848911b0cb25cfab7d2478ad0c996302c95744'
+CALICO_NODE_IMAGE='quay.io/calico/node:v3.32.1'
+CALICO_CNI_IMAGE='quay.io/calico/cni:v3.32.1'
+CALICO_CONTROLLERS_IMAGE='quay.io/calico/kube-controllers:v3.32.1'
+KUBERNETES_VERSION=v1.35.0
+MANIFEST=
+CONTEXT=
+
+die() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "PASS: $*"; }
+# CONTEXT is assigned before the first kubectl call. Keeping the pin in one
+# wrapper also protects cleanup if another process changes current-context.
+kubectl() { command kubectl --context "$CONTEXT" "$@"; }
+cleanup() {
+	[[ -z "$MANIFEST" ]] || rm -f "$MANIFEST"
+	kubectl delete namespace "$NS" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+}
+gate() {
+	[[ "${EGRESS_CONFORMANCE_EXPERIMENTAL:-}" == 1 ]] || die "experimental runner disabled; set EGRESS_CONFORMANCE_EXPERIMENTAL=1"
+	[[ -n "${EGRESS_CONFORMANCE_EXPECTED_KIND_CLUSTER:-}" && -n "${EGRESS_CONFORMANCE_EXPECTED_CONTEXT:-}" && -n "${EGRESS_CONFORMANCE_EXPECTED_CLUSTER_UID:-}" ]] || die "exact kind cluster, context, and kube-system UID are required"
+	KIND_CLUSTER=$EGRESS_CONFORMANCE_EXPECTED_KIND_CLUSTER
+	CONTEXT=$EGRESS_CONFORMANCE_EXPECTED_CONTEXT
+	[[ "$CONTEXT" == "kind-$KIND_CLUSTER" ]] || die "expected context is not the exact kind cluster context"
+	kind get clusters | grep -Fxq "$KIND_CLUSTER" || die "expected kind cluster does not exist"
+	[[ "$(kubectl config current-context)" == "$EGRESS_CONFORMANCE_EXPECTED_CONTEXT" ]] || die "kube context mismatch"
+	local kind_config active_config expected_config connection_filter
+	kind_config=$(mktemp)
+	kind get kubeconfig --name "$KIND_CLUSTER" >"$kind_config"
+	active_config=$(kubectl config view --raw --flatten -o json)
+	expected_config=$(KUBECONFIG="$kind_config" kubectl config view --raw --flatten -o json)
+	rm -f "$kind_config"
+	connection_filter='. as $root|.contexts[]|select(.name==$ctx)|.context.cluster as $cluster|$root.clusters[]|select(.name==$cluster)|[.cluster.server,.cluster["certificate-authority-data"]]|@tsv'
+	[[ "$(jq -er --arg ctx "$CONTEXT" "$connection_filter" <<<"$active_config")" == "$(jq -er --arg ctx "$CONTEXT" "$connection_filter" <<<"$expected_config")" ]] || die "active context server or CA differs from exact kind kubeconfig"
+	[[ "$(kubectl get namespace kube-system -o jsonpath='{.metadata.uid}')" == "$EGRESS_CONFORMANCE_EXPECTED_CLUSTER_UID" ]] || die "kube-system UID mismatch"
+	[[ "$(kubectl version -o json | jq -er '.serverVersion.gitVersion')" == "$KUBERNETES_VERSION" ]] || die "server version is not $KUBERNETES_VERSION"
+	local nodes; nodes=$(kubectl get nodes -o json)
+	jq -e --arg cluster "$KIND_CLUSTER" --arg selector "swe.dev/egress-conformance" --arg v "$KUBERNETES_VERSION" '
+	 .items|length==3 and ([.[].metadata.name]|sort)==([$cluster+"-control-plane",$cluster+"-worker",$cluster+"-worker2"]|sort) and
+	 ([.[]|select(.metadata.labels["node-role.kubernetes.io/control-plane"]!=null)]|length)==1 and
+	 ([.[]|select(.metadata.labels[$selector]=="eligible" and .metadata.labels["node-role.kubernetes.io/control-plane"]==null)]|length)==2 and
+	 all(.[];.status.nodeInfo.kubeletVersion==$v)' <<<"$nodes" >/dev/null || die "kind fixture must have one control-plane and two exact eligible v1.35.0 workers"
+	mapfile -t NODES < <(jq -r --arg selector "swe.dev/egress-conformance" '.items[]|select(.metadata.labels[$selector]=="eligible")|.metadata.name' <<<"$nodes" | sort)
+}
+require_clean_cluster() {
+	! kubectl get namespace "$NS" >/dev/null 2>&1 || die "fixture namespace already exists"
+	[[ "$(kubectl get customresourcedefinitions.apiextensions.k8s.io -o json | jq '.items|length')" == 0 ]] || die "clean fixture must start without CRDs"
+	[[ "$(kubectl get validatingwebhookconfigurations.admissionregistration.k8s.io -o json | jq '.items|length')" == 0 ]] || die "validating admission webhooks are unsupported"
+	[[ "$(kubectl get mutatingwebhookconfigurations.admissionregistration.k8s.io -o json | jq '.items|length')" == 0 ]] || die "mutating admission webhooks are unsupported"
+	[[ "$(kubectl get apiservices.apiregistration.k8s.io -o json | jq '[.items[]|select(.spec.service!=null)]|length')" == 0 ]] || die "aggregated APIServices are unsupported"
+	jq -e '[.items[].metadata.name]|sort==["kube-proxy"]' < <(kubectl -n kube-system get daemonsets.apps -o json) >/dev/null || die "clean fixture has unexpected daemonsets"
+	pass "clean kind topology and extension surface"
+}
+install_calico() {
+	MANIFEST=$(mktemp)
+	curl -fsSL "$CALICO_MANIFEST_URL" -o "$MANIFEST"
+	[[ "$(sha256sum "$MANIFEST" | cut -d' ' -f1)" == "$CALICO_MANIFEST_SHA256" ]] || die "Calico manifest content hash mismatch"
+	kubectl create -f "$MANIFEST" >/dev/null
+	kubectl wait --for=condition=Established crd/felixconfigurations.crd.projectcalico.org --timeout=120s >/dev/null
+	cat <<'YAML' | kubectl apply -f - >/dev/null
+apiVersion: crd.projectcalico.org/v1
+kind: FelixConfiguration
+metadata: {name: default}
+spec: {defaultEndpointToHostAction: Drop, interfacePrefix: cali}
+YAML
+	kubectl -n kube-system set env daemonset/calico-node FELIX_DEFAULTENDPOINTTOHOSTACTION- FELIX_IPV6SUPPORT=true IP6=autodetect CALICO_IPV6POOL_CIDR=fd00:10:244::/64 >/dev/null
+	kubectl -n kube-system rollout status daemonset/calico-node --timeout=240s >/dev/null
+	kubectl -n kube-system rollout status deployment/calico-kube-controllers --timeout=240s >/dev/null
+	kubectl wait --for=condition=Ready nodes --all --timeout=180s >/dev/null
+	pass "pinned Calico manifest installed"
+}
+check_cluster_shape() {
+	local crds ds pods controllers
+	crds=$(kubectl get customresourcedefinitions.apiextensions.k8s.io -o json)
+	[[ "$(jq -r '.items[].metadata.name' <<<"$crds" | sort | sha256sum | cut -d' ' -f1)" == '30065969bde7934ba7d78c31a2da2fc2a9ee522fb1c864b6baaa39de55d5f237' ]] || die "CRD inventory is not the pinned Calico fixture"
+	[[ "$(kubectl get validatingwebhookconfigurations.admissionregistration.k8s.io -o json | jq '.items|length')" == 0 && "$(kubectl get mutatingwebhookconfigurations.admissionregistration.k8s.io -o json | jq '.items|length')" == 0 ]] || die "admission webhooks appeared"
+	[[ "$(kubectl get apiservices.apiregistration.k8s.io -o json | jq '[.items[]|select(.spec.service!=null)]|length')" == 0 ]] || die "aggregated APIService appeared"
+	ds=$(kubectl -n kube-system get daemonsets.apps -o json)
+	jq -e --arg node "$CALICO_NODE_IMAGE" --arg cni "$CALICO_CNI_IMAGE" '([.items[].metadata.name]|sort)==["calico-node","kube-proxy"] and ([.items[]|select(.metadata.name=="calico-node")]|length)==1 and (.items[]|select(.metadata.name=="calico-node")) as $d|([$d.spec.template.spec.containers[]|{name,image}]==[{name:"calico-node",image:$node}]) and ([$d.spec.template.spec.initContainers[]|{name,image}]==[{name:"upgrade-ipam",image:$cni},{name:"install-cni",image:$cni},{name:"ebpf-bootstrap",image:$node}]) and ($d.spec.template.spec.ephemeralContainers//[])==[] and ([$d.spec.template.spec.containers[],$d.spec.template.spec.initContainers[]]|all((.envFrom//[])==[])) and ([$d.spec.template.spec.containers[]|.env[]?|select(.name|ascii_downcase=="felix_defaultendpointtohostaction")]|length)==0' <<<"$ds" >/dev/null || die "unexpected Calico daemonset/container shape"
+	pods=$(kubectl -n kube-system get pods -l k8s-app=calico-node -o json)
+	jq -e --arg node "$CALICO_NODE_IMAGE" --arg cni "$CALICO_CNI_IMAGE" --argjson count "$(kubectl get nodes -o json | jq '.items|length')" '.items|length==$count and all(.items[]; ([.spec.containers[]|{name,image}]==[{name:"calico-node",image:$node}]) and ([.spec.initContainers[]|{name,image}]==[{name:"upgrade-ipam",image:$cni},{name:"install-cni",image:$cni},{name:"ebpf-bootstrap",image:$node}]) and (.spec.ephemeralContainers//[])==[] and (.status.conditions|any(.type=="Ready" and .status=="True")) and ([.status.containerStatuses[]|select(.name=="calico-node" and .ready==true and (.imageID|test("@sha256:[0-9a-f]{64}$")))]|length)==1)' <<<"$pods" >/dev/null || die "unexpected Calico pod/image shape"
+	controllers=$(kubectl -n kube-system get deployments.apps -o json)
+	jq -e --arg image "$CALICO_CONTROLLERS_IMAGE" '([.items[].metadata.name]|sort)==["calico-kube-controllers","coredns"] and ([.items[]|select(.metadata.name=="calico-kube-controllers")]|length)==1 and (.items[]|select(.metadata.name=="calico-kube-controllers")) as $d|([$d.spec.template.spec.containers[]|{name,image}]==[{name:"calico-kube-controllers",image:$image}]) and ($d.spec.template.spec.initContainers//[])==[] and ($d.spec.template.spec.ephemeralContainers//[])==[] and ([$d.spec.template.spec.containers[]|.envFrom[]?]|length)==0' <<<"$controllers" >/dev/null || die "unexpected Calico kube-controller shape"
+	jq -e '.items|length==1 and .[0].metadata.name=="default" and .[0].spec.defaultEndpointToHostAction=="Drop" and .[0].spec.interfacePrefix=="cali" and (.[0].metadata.annotations//{}|keys|all(startswith("config.projectcalico.org/")|not))' < <(kubectl get felixconfigurations.crd.projectcalico.org -o json) >/dev/null || die "Felix configuration override"
+	jq -e '.items|length==1 and .[0].metadata.name=="default" and ((.[0].spec.controllers.node.hostEndpoint.autoCreate//"Disabled")=="Disabled") and (.[0].metadata.annotations//{}|keys|all(startswith("config.projectcalico.org/")|not))' < <(kubectl get kubecontrollersconfigurations.crd.projectcalico.org -o json) >/dev/null || die "kube-controller override"
+	[[ "$(kubectl get hostendpoints.crd.projectcalico.org -o json | jq '.items|length')" == 0 ]] || die "HostEndpoints are unsupported"
+	jq -e '.items|length==1 and .[0].metadata.name=="default" and ((.[0].spec.order//1000000)==1000000) and ((.[0].spec.defaultAction//"Deny")=="Deny")' < <(kubectl get tiers.crd.projectcalico.org -o json) >/dev/null || die "Tier inventory is not canonical"
+	for node in "${NODES[@]}"; do
+		local pod; pod=$(jq -r --arg n "$node" '.items[]|select(.spec.nodeName==$n)|.metadata.name' <<<"$pods")
+		[[ -n "$pod" ]] || die "missing calico-node on $node"
+		kubectl -n kube-system exec "$pod" -c calico-node -- env EXPECTED_FELIX_HOSTNAME="$node" sh -s <hack/egress-conformance-felix-check.sh >/dev/null || die "effective Felix override on $node"
+	done
+	pass "Calico/Felix/controller shape and policy prerequisites"
+}
+server_pod() { # name node role hostNetwork protocol:ports...
+	local name=$1 node=$2 role=$3 host=$4 code command add='[]'; shift 4
+	code=$(cat hack/egress-conformance-server.py)
+	command=$(jq -cn --arg code "$code" --args '$ARGS.positional|["python3","-c",$code]+.' -- "$@")
+	[[ "$role" != udp ]] || add='[NET_BIND_SERVICE]'
+	cat <<YAML | kubectl apply -f - >/dev/null
+apiVersion: v1
+kind: Pod
+metadata: {name: "$name", namespace: "$NS", labels: {swe.dev/egress-role: "$role"}}
+spec:
+  nodeName: "$node"
+  hostNetwork: $host
+  dnsPolicy: ClusterFirstWithHostNet
+  automountServiceAccountToken: false
+  enableServiceLinks: false
+  tolerations: [{operator: Exists}]
+  securityContext: {seccompProfile: {type: RuntimeDefault}}
+  containers:
+  - name: fixture
+    image: $PYTHON
+    command: $command
+    securityContext: {allowPrivilegeEscalation: false, privileged: false, capabilities: {drop: [ALL], add: $add}, seccompProfile: {type: RuntimeDefault}}
+    readinessProbe: {exec: {command: [sh, -ec, "test -f /tmp/ready"]}, initialDelaySeconds: 1, periodSeconds: 1}
+YAML
+}
+create_fixture() {
+	kubectl create namespace "$NS" >/dev/null
+	for node in "${NODES[@]}"; do
+		local n=${node//./-}
+		server_pod "control-$n" "$node" control false
+		server_pod "allowed-$n" "$node" allowed false tcp:8443,8444 udp:8443
+		server_pod "nonproxy-$n" "$node" nonproxy false tcp:8443
+		server_pod "resident-$n" "$node" resident true tcp:18080
+		server_pod "udp-$n" "$node" udp false udp:53,443
+	done
+	cat <<'YAML' | kubectl apply -f - >/dev/null
+apiVersion: crd.projectcalico.org/v1
+kind: NetworkPolicy
+metadata: {name: restricted-probe, namespace: swe-egress-conformance}
+spec:
+  selector: "swe.dev/egress-role == 'probe'"
+  types: [Egress]
+  egress:
+  - {action: Allow, protocol: TCP, destination: {selector: "swe.dev/egress-role == 'allowed'", ports: [8443]}}
+  - {action: Allow, protocol: UDP, destination: {selector: "swe.dev/egress-role == 'allowed'", ports: [8443]}}
+YAML
+	for node in "${NODES[@]}"; do server_pod "probe-${node//./-}" "$node" probe false; done
+	kubectl wait -n "$NS" --for=condition=Ready pod --all --timeout=180s >/dev/null
+	jq -e --arg ns "$NS" '.items|length==1 and .[0].metadata.name=="restricted-probe" and .[0].metadata.namespace==$ns' < <(kubectl get networkpolicies.crd.projectcalico.org -A -o json) >/dev/null || die "fixture Calico policy inventory changed"
+	[[ "$(kubectl get networkpolicies.networking.k8s.io -A -o json | jq '.items|length')" == 0 && "$(kubectl get globalnetworkpolicies.crd.projectcalico.org -o json | jq '.items|length')" == 0 && "$(kubectl get clusternetworkpolicies.policy.networking.k8s.io -o json | jq '.items|length')" == 0 ]] || die "unexpected active policy"
+	[[ "$(kubectl get hostendpoints.crd.projectcalico.org -o json | jq '.items|length')" == 0 ]] || die "HostEndpoint appeared"
+	jq -e --arg ns "$NS" '.metadata.name==$ns and .metadata.labels=={"kubernetes.io/metadata.name":$ns} and (.metadata.annotations//{})=={}' < <(kubectl get namespace "$NS" -o json) >/dev/null || die "Namespace-derived Profile inputs changed"
+	jq -e '.metadata.name=="default" and (.metadata.labels//{})=={} and (.metadata.annotations//{})=={} and (.imagePullSecrets//[])==[]' < <(kubectl -n "$NS" get serviceaccount default -o json) >/dev/null || die "ServiceAccount-derived Profile inputs changed"
+	pass "canonical isolated fixture created"
+}
+ip_for() { kubectl -n "$NS" get pod "$1" -o json | jq -r --arg f "$2" '.status.podIPs[].ip|select(if $f=="ipv4" then contains(":")|not else contains(":") end)' | head -1; }
+attempt() { timeout 8 kubectl --context "$CONTEXT" -n "$NS" exec "$1" -- python3 - once "$2" "$3" "$4" <hack/egress-conformance-client.py; }
+expect_reached() { [[ "$(attempt "$1" "$2" "$3" "$4" 2>/dev/null)" == REACHED ]] || die "$5 positive control could not reach $3:$4"; }
+expect_denied() {
+	local check=$1 proto=$2 probe=$3 control=$4 ip=$5 port=$6
+	expect_reached "$probe" "$proto" "$ALLOWED" 8443 "$check selected-policy"
+	expect_reached "$control" "$proto" "$ip" "$port" "$check target"
+	[[ "$(attempt "$probe" "$proto" "$ip" "$port" 2>/dev/null)" == UNREACHED ]] || die "$check unexpectedly reached $ip:$port"
+	expect_reached "$probe" "$proto" "$ALLOWED" 8443 "$check selected-policy post-check"
+	expect_reached "$control" "$proto" "$ip" "$port" "$check target post-check"
+	pass "$check denied ($ip:$port)"
+}
+validate_external() {
+	python3 - "$1" "$2" <<'PY'
+import ipaddress, sys
+a=ipaddress.ip_address(sys.argv[1]); family=sys.argv[2]
+assert a.version == (4 if family == "ipv4" else 6) and not getattr(a, "ipv4_mapped", None)
+if sys.argv[1] not in ("169.254.169.254", "fd00:ec2::254"):
+    assert a.is_global
+PY
+}
+run_checks() {
+	for node in "${NODES[@]}"; do
+		local n=${node//./-} control="control-${node//./-}" probe="probe-${node//./-}" other other_control
+		for other in "${NODES[@]}"; do [[ "$other" == "$node" ]] || break; done
+		[[ "$other" != "$node" ]] || die "no independent worker available for resident-node control"
+		other_control="control-${other//./-}"
+		for family in ipv4 ipv6; do
+			local suffix=${family^^} nonproxy udpip hostip metadata public443 public8443
+			ALLOWED=$(ip_for "allowed-$n" "$family"); nonproxy=$(ip_for "nonproxy-$n" "$family"); udpip=$(ip_for "udp-$n" "$family")
+			hostip=$(kubectl get node "$node" -o json | jq -r --arg f "$family" '.status.addresses[]|select(.type=="InternalIP")|.address|select(if $f=="ipv4" then contains(":")|not else contains(":") end)' | head -1)
+			[[ -n "$ALLOWED" && -n "$nonproxy" && -n "$udpip" && -n "$hostip" ]] || die "$node lacks $family fixture addresses"
+			expect_reached "$probe" tcp "$ALLOWED" 8443 "allowed target"; pass "$node/$family allowed target reached"
+			expect_denied "$node/$family proxy-wrong-port" tcp "$probe" "$control" "$ALLOWED" 8444
+			expect_denied "$node/$family non-proxy-8443" tcp "$probe" "$control" "$nonproxy" 8443
+			expect_denied "$node/$family resident-node-live-port" tcp "$probe" "$other_control" "$hostip" 18080
+			expect_denied "$node/$family UDP-53" udp "$probe" "$control" "$udpip" 53
+			expect_denied "$node/$family UDP-443" udp "$probe" "$control" "$udpip" 443
+			if [[ "$family" == ipv6 ]]; then expect_denied "$node/$family IPv6-direct" tcp "$probe" "$control" "$nonproxy" 8443; fi
+			local metadata_var="EGRESS_CONFORMANCE_METADATA_${suffix}" public443_var="EGRESS_CONFORMANCE_PUBLIC_443_${suffix}" public8443_var="EGRESS_CONFORMANCE_PUBLIC_8443_${suffix}"
+			metadata=${!metadata_var:-}; public443=${!public443_var:-}; public8443=${!public8443_var:-}
+			[[ -n "$metadata" && -n "$public443" && -n "$public8443" ]] || die "$node/$family external positive-control literals are required"
+			[[ "$metadata" == "$( [[ "$family" == ipv4 ]] && echo 169.254.169.254 || echo fd00:ec2::254 )" ]] || die "$metadata_var must be the designated metadata literal"
+			validate_external "$metadata" "$family"; validate_external "$public443" "$family"; validate_external "$public8443" "$family"
+			expect_denied "$node/$family metadata" tcp "$probe" "$control" "$metadata" 80
+			expect_denied "$node/$family direct-public-443" tcp "$probe" "$control" "$public443" 443
+			expect_denied "$node/$family direct-public-8443" tcp "$probe" "$control" "$public8443" 8443
+			if [[ "$family" == ipv4 ]]; then
+				local api service_ip; service_ip=$(kubectl get service kubernetes -o jsonpath='{.spec.clusterIP}')
+				api=$(kubectl get endpoints kubernetes -o jsonpath='{.subsets[0].addresses[0].ip}')
+				expect_denied "$node/ipv4 Kubernetes-Service" tcp "$probe" "$control" "$service_ip" 443
+				expect_denied "$node/ipv4 direct-API" tcp "$probe" "$control" "$api" 6443
+			fi
+		done
+	done
+}
+run() {
+	gate; require_clean_cluster; trap cleanup EXIT
+	install_calico; check_cluster_shape; create_fixture; run_checks
+	check_cluster_shape
+	echo "PASS: all experimental diagnostic checks completed; no reusable proof was produced"
+}
+[[ "${1:-}" == run && $# == 1 ]] || die "usage: $0 run"
+run

--- a/hack/egress-conformance_test.sh
+++ b/hack/egress-conformance_test.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+h=hack/egress-conformance.sh
+felix=hack/egress-conformance-felix-check.sh
+tmp=$(mktemp -d)
+trap '[[ -z "${server_pid:-}" ]] || kill "$server_pid" >/dev/null 2>&1 || true; rm -rf "$tmp"' EXIT
+
+bash -n "$h" hack/egress-conformance_test.sh
+sh -n "$felix"
+if EGRESS_CONFORMANCE_EXPERIMENTAL=1 EGRESS_CONFORMANCE_EXPECTED_KIND_CLUSTER=must-not-be-used EGRESS_CONFORMANCE_EXPECTED_CONTEXT=must-not-be-used EGRESS_CONFORMANCE_EXPECTED_CLUSTER_UID=must-not-be-used \
+	env -u EGRESS_CONFORMANCE_EXPERIMENTAL -u EGRESS_CONFORMANCE_EXPECTED_KIND_CLUSTER -u EGRESS_CONFORMANCE_EXPECTED_CONTEXT -u EGRESS_CONFORMANCE_EXPECTED_CLUSTER_UID \
+	"$h" run >"$tmp/off" 2>&1; then echo "runner was not default-off" >&2; exit 1; fi
+grep -q 'experimental runner disabled' "$tmp/off"
+
+# The runner is isolated, one-shot, diagnostic-only, and materially smaller than
+# the rejected persisted-proof implementation.
+(( $(wc -l <"$h") < 300 ))
+grep -q "SELECTOR='swe.dev/egress-conformance=eligible'" "$h"
+grep -q "CALICO_MANIFEST_SHA256='[0-9a-f]\{64\}'" "$h"
+grep -q 'kind-calico-conformance.yaml' "$h"
+grep -q 'EGRESS_CONFORMANCE_EXPECTED_KIND_CLUSTER' "$h"
+grep -q 'kind get clusters' "$h"
+grep -q 'kind get kubeconfig --name "\$KIND_CLUSTER"' "$h"
+grep -q 'active context server or CA differs from exact kind kubeconfig' "$h"
+grep -q 'kubectl() { command kubectl --context "\$CONTEXT"' "$h"
+grep -q 'timeout 8 kubectl --context "\$CONTEXT"' "$h"
+grep -q 'kubectl delete namespace "\$NS"' "$h"
+[[ "$(grep -c 'command kubectl' "$h")" == 1 ]]
+grep -q 'kind fixture must have one control-plane and two exact eligible v1.35.0 workers' "$h"
+grep -q 'validating admission webhooks are unsupported' "$h"
+grep -q 'mutating admission webhooks are unsupported' "$h"
+grep -q 'aggregated APIServices are unsupported' "$h"
+grep -q 'unexpected Calico daemonset/container shape' "$h"
+grep -q 'unexpected Calico pod/image shape' "$h"
+grep -q 'unexpected Calico kube-controller shape' "$h"
+grep -q 'effective Felix override' "$h"
+grep -q 'Namespace-derived Profile inputs changed' "$h"
+grep -q 'ServiceAccount-derived Profile inputs changed' "$h"
+grep -q 'HostEndpoints are unsupported' "$h"
+grep -q 'Tier inventory is not canonical' "$h"
+grep -q 'fixture Calico policy inventory changed' "$h"
+grep -q 'swe.dev/egress-role ==.*probe' "$h"
+grep -q 'selector:.*allowed.*ports: \[8443\]' "$h"
+grep -q 'server_pod.*allowed.*tcp:8443,8444 udp:8443' "$h"
+grep -q 'server_pod.*udp.*udp:53,443' "$h"
+grep -q 'expect_denied.*proxy-wrong-port' "$h"
+grep -q 'expect_denied.*non-proxy-8443' "$h"
+grep -q 'expect_denied.*resident-node-live-port' "$h"
+grep -q 'resident-node-live-port.*"\$other_control"' "$h"
+grep -q 'expect_denied.*metadata' "$h"
+grep -q 'expect_denied.*direct-public-443' "$h"
+grep -q 'expect_denied.*direct-public-8443' "$h"
+grep -q 'expect_denied.*UDP-53' "$h"
+grep -q 'expect_denied.*UDP-443' "$h"
+grep -q 'expect_denied.*IPv6-direct' "$h"
+grep -q 'expect_denied.*Kubernetes-Service' "$h"
+grep -q 'expect_denied.*direct-API' "$h"
+grep -q 'direct-API.*"\$control".*"\$api"' "$h"
+! grep -q 'direct-API.*resident' "$h"
+grep -q 'selected-policy post-check' "$h"
+grep -q 'target post-check' "$h"
+! grep -Eq 'schemaVersion|expiresAt|OUTPUT_DIR|expected-policy-inventory|trusted.digest' "$h"
+! test -e cmd/egress-proof-validator
+! test -e internal/egressproof
+! grep -q 'egress-conformance.sh' hack/e2e.sh
+! grep -Rqs 'egress-conformance.sh' charts/swe-platform/templates charts/swe-platform/values*.yaml
+! grep -Rqs 'egress-conformance.sh run' .github/workflows
+
+# Fixture protocol exercises TCP and UDP over both families without Kubernetes.
+python3 -m py_compile hack/egress-conformance-client.py hack/egress-conformance-server.py
+python3 hack/egress-conformance-server.py tcp:18443 udp:18444 >"$tmp/server.log" 2>&1 &
+server_pid=$!
+sleep .2
+for endpoint in 127.0.0.1 ::1; do
+	[[ "$(python3 hack/egress-conformance-client.py once tcp "$endpoint" 18443)" == REACHED ]]
+	[[ "$(python3 hack/egress-conformance-client.py once udp "$endpoint" 18444)" == REACHED ]]
+done
+[[ "$(python3 hack/egress-conformance-client.py once tcp 127.0.0.1 18445)" == UNREACHED ]]
+kill "$server_pid"; wait "$server_pid" || true; server_pid=
+
+echo "experimental egress conformance runner guards passed"

--- a/hack/kind-calico-conformance.yaml
+++ b/hack/kind-calico-conformance.yaml
@@ -1,0 +1,19 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+# Default-off issue #68 diagnostic topology. Normal E2E continues to use kind-calico.yaml.
+networking:
+  disableDefaultCNI: true
+  ipFamily: dual
+  podSubnet: "192.168.0.0/16,fd00:10:244::/64"
+  serviceSubnet: "10.96.0.0/16,fd00:10:96::/112"
+nodes:
+  - role: control-plane
+    image: kindest/node:v1.35.0
+  - role: worker
+    image: kindest/node:v1.35.0
+    labels:
+      swe.dev/egress-conformance: eligible
+  - role: worker
+    image: kindest/node:v1.35.0
+    labels:
+      swe.dev/egress-conformance: eligible


### PR DESCRIPTION
## Summary

- add a default-off, one-shot Calico v3.32.1 conformance diagnostic on a separate pinned dual-stack/two-worker kind topology
- require explicit disposable-kind cluster identity, exact context/server/CA and kube-system UID confirmation, and context-pin every Kubernetes operation
- exercise allowed proxy-shaped traffic plus wrong-port, non-proxy, resident-node, API, metadata, direct-public, UDP, and IPv6 denial diagnostics with independent ordinary-workload liveness controls
- run only static/default-off guards and local fixture protocol tests in CI
- document that this is human-observed diagnostic groundwork, not proof, attestation, runtime enforcement, or a production capability

The existing non-empty `Project.spec.egressAllowlist` execution fence remains unchanged. This is issue #68 slice 3 and does **not** close #68.

## Validation

- `make test`
- `make vet`
- `make check-chart-crds`
- `git diff --check origin/main...HEAD`
- `git show --check HEAD`

A live kind/Calico run was not possible in the implementation orb because Docker/kind/kubectl were unavailable; the PR intentionally makes no dataplane-success claim from static tests.
