### PR TITLE
Clean up egress conformance temporary files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,8 @@ runs both via `make` targets:
   The required `build-test` CI job runs the root and sandboxd Go suites plus
   the four shell checks above, mirroring `make test`. The egress-conformance live runner remains
   default-off on its separate `hack/kind-calico-conformance.yaml` topology and must not be invoked
-  by CI/e2e; only its guard test runs.
+  by CI/e2e; only its guard test runs. Keep its temporary kind admin kubeconfig and Python bytecode
+  inside cleanup-managed temporary paths so both early exits and `make test` leave no artifacts.
 - **Operations console:** from `ui/`, install with `npm ci`; use `npm run lint`,
   `npm run typecheck`, `npm test -- --run`, and `npm run build`. Start the standalone
   Vite development server with `npm run dev`. Production uses `make ui-build`

--- a/hack/egress-conformance.sh
+++ b/hack/egress-conformance.sh
@@ -14,7 +14,9 @@ CALICO_CNI_IMAGE='quay.io/calico/cni:v3.32.1'
 CALICO_CONTROLLERS_IMAGE='quay.io/calico/kube-controllers:v3.32.1'
 KUBERNETES_VERSION=v1.35.0
 MANIFEST=
+KIND_CONFIG=
 CONTEXT=
+FIXTURE_CREATED=false
 
 die() { echo "FAIL: $*" >&2; exit 1; }
 pass() { echo "PASS: $*"; }
@@ -23,7 +25,8 @@ pass() { echo "PASS: $*"; }
 kubectl() { command kubectl --context "$CONTEXT" "$@"; }
 cleanup() {
 	[[ -z "$MANIFEST" ]] || rm -f "$MANIFEST"
-	kubectl delete namespace "$NS" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+	[[ -z "$KIND_CONFIG" ]] || rm -f "$KIND_CONFIG"
+	[[ "$FIXTURE_CREATED" = false ]] || kubectl delete namespace "$NS" --ignore-not-found --wait=false >/dev/null 2>&1 || true
 }
 gate() {
 	[[ "${EGRESS_CONFORMANCE_EXPERIMENTAL:-}" == 1 ]] || die "experimental runner disabled; set EGRESS_CONFORMANCE_EXPERIMENTAL=1"
@@ -33,12 +36,13 @@ gate() {
 	[[ "$CONTEXT" == "kind-$KIND_CLUSTER" ]] || die "expected context is not the exact kind cluster context"
 	kind get clusters | grep -Fxq "$KIND_CLUSTER" || die "expected kind cluster does not exist"
 	[[ "$(kubectl config current-context)" == "$EGRESS_CONFORMANCE_EXPECTED_CONTEXT" ]] || die "kube context mismatch"
-	local kind_config active_config expected_config connection_filter
-	kind_config=$(mktemp)
-	kind get kubeconfig --name "$KIND_CLUSTER" >"$kind_config"
+	local active_config expected_config connection_filter
+	KIND_CONFIG=$(mktemp)
+	kind get kubeconfig --name "$KIND_CLUSTER" >"$KIND_CONFIG"
 	active_config=$(kubectl config view --raw --flatten -o json)
-	expected_config=$(KUBECONFIG="$kind_config" kubectl config view --raw --flatten -o json)
-	rm -f "$kind_config"
+	expected_config=$(KUBECONFIG="$KIND_CONFIG" kubectl config view --raw --flatten -o json)
+	rm -f "$KIND_CONFIG"
+	KIND_CONFIG=
 	connection_filter='. as $root|.contexts[]|select(.name==$ctx)|.context.cluster as $cluster|$root.clusters[]|select(.name==$cluster)|[.cluster.server,.cluster["certificate-authority-data"]]|@tsv'
 	[[ "$(jq -er --arg ctx "$CONTEXT" "$connection_filter" <<<"$active_config")" == "$(jq -er --arg ctx "$CONTEXT" "$connection_filter" <<<"$expected_config")" ]] || die "active context server or CA differs from exact kind kubeconfig"
 	[[ "$(kubectl get namespace kube-system -o jsonpath='{.metadata.uid}')" == "$EGRESS_CONFORMANCE_EXPECTED_CLUSTER_UID" ]] || die "kube-system UID mismatch"
@@ -127,6 +131,7 @@ spec:
 YAML
 }
 create_fixture() {
+	FIXTURE_CREATED=true
 	kubectl create namespace "$NS" >/dev/null
 	for node in "${NODES[@]}"; do
 		local n=${node//./-}
@@ -213,7 +218,8 @@ run_checks() {
 	done
 }
 run() {
-	gate; require_clean_cluster; trap cleanup EXIT
+	trap cleanup EXIT
+	gate; require_clean_cluster
 	install_calico; check_cluster_shape; create_fixture; run_checks
 	check_cluster_shape
 	echo "PASS: all experimental diagnostic checks completed; no reusable proof was produced"

--- a/hack/egress-conformance_test.sh
+++ b/hack/egress-conformance_test.sh
@@ -25,6 +25,8 @@ grep -q 'kind get kubeconfig --name "\$KIND_CLUSTER"' "$h"
 grep -q 'active context server or CA differs from exact kind kubeconfig' "$h"
 grep -q 'kubectl() { command kubectl --context "\$CONTEXT"' "$h"
 grep -q 'timeout 8 kubectl --context "\$CONTEXT"' "$h"
+grep -q '\[\[ -z "\$KIND_CONFIG" \]\] || rm -f "\$KIND_CONFIG"' "$h"
+[[ "$(grep -n 'trap cleanup EXIT' "$h" | cut -d: -f1)" -lt "$(grep -n 'gate; require_clean_cluster' "$h" | cut -d: -f1)" ]]
 grep -q 'kubectl delete namespace "\$NS"' "$h"
 [[ "$(grep -c 'command kubectl' "$h")" == 1 ]]
 grep -q 'kind fixture must have one control-plane and two exact eligible v1.35.0 workers' "$h"
@@ -68,7 +70,8 @@ grep -q 'target post-check' "$h"
 ! grep -Rqs 'egress-conformance.sh run' .github/workflows
 
 # Fixture protocol exercises TCP and UDP over both families without Kubernetes.
-python3 -m py_compile hack/egress-conformance-client.py hack/egress-conformance-server.py
+PYTHONPYCACHEPREFIX="$tmp/pycache" python3 -m py_compile hack/egress-conformance-client.py hack/egress-conformance-server.py
+! test -e hack/__pycache__
 python3 hack/egress-conformance-server.py tcp:18443 udp:18444 >"$tmp/server.log" 2>&1 &
 server_pid=$!
 sleep .2


### PR DESCRIPTION
Fixes both valid post-merge review findings on #173:

- install the runner cleanup trap before gate validation and track/remove the temporary kind admin kubeconfig on every early-exit path
- delete the fixture namespace only after this invocation starts creating it
- direct `py_compile` bytecode into the test's temporary directory so `make test` leaves no `hack/__pycache__`
- add focused guards for trap ordering, kubeconfig cleanup, and bytecode cleanliness

Validation:
- `./hack/egress-conformance_test.sh`
- `bash -n hack/egress-conformance.sh hack/egress-conformance_test.sh`
- `sh -n hack/egress-conformance-felix-check.sh`
- `git diff --check`
