### PR TITLE
Add inert per-execution egress identity foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,10 @@ Pi deliberately supports no credential profiles or credential injection.
 - **Layout:** kubebuilder conventions — `api/v1alpha1/` for types,
   `internal/controllers/`, and `cmd/{operator,control-plane,swe,egress-proxy}` for root-module
   binaries. The egress proxy command is a disabled protocol foundation and intentionally remains
-  outside `make build` and image publishing until the fail-closed runtime is enabled. The exact adapter contract boundary is
+  outside `make build` and image publishing until the fail-closed runtime is enabled.
+  `internal/egressidentity/` and `internal/egresspod/` are likewise inert contract foundations;
+  do not wire them into reconciliation or relax the non-empty allowlist fence before the complete
+  restricted runtime is atomically enabled. The exact adapter contract boundary is
   `internal/agent/`. Shared fenced Environment intent
   publication and validation belongs in `internal/lifecycle/`; controllers remain
   the sole owners of observed lifecycle transitions. Environment reconciliation is split

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -808,12 +808,40 @@ sorted ceiling and baseline, exact Project UID, and sorted Project selection. La
 proxy integration must independently recompute this from authoritative uncached reads. Helm
 rendering is not runtime authority.
 
-Only this API and canonical-policy foundation is implemented. The current non-empty Project
-allowlist rejection remains unchanged until per-execution identity, proxy readiness, technical
-path forcing, Calico v3.32.1-only enforcement proof, and acceptance land together. There is
-currently no default-deny egress, proxy deployment, runtime policy ConfigMap, restricted profile,
-or production egress-enforcement claim; generic Kubernetes, k3s, GKE, and EKS restricted profiles
-remain deferred. Issue #68 is not runtime-complete.
+The inert identity and Pod-construction foundation is also implemented, but no reconciler calls
+it. The versioned canonical identity binds exact Installation namespace/name/UID, Project
+namespace/name/UID, Environment namespace/name/UID, Pod name/UID, execution generation, runtime
+policy revision, forwarder security revision, and SHA-256 client-certificate fingerprint.
+Certificate subject fields and the fingerprint presented by TLS are untrusted lookup hints: a
+future authorizer must resolve the fingerprint and repeat exact currentness checks against
+authoritative objects. A separate self-signed ECDSA ClientAuth keypair is generated for each
+execution and is not sandboxd ServerAuth material.
+
+The Pod helper resolves the UID ordering problem with a staged Kubernetes scheduling gate. Before
+CREATE it accepts a complete Linux Pod-backend preparation input, prepends the native restartable
+init container and required non-optional but not-yet-created credential Secret, and leaves the
+Pod unscheduled. After the API assigns a UID, the separate binding validator requires the exact
+persisted/admission-mutated Pod, Environment owner, execution generation, scheduling gate,
+certificate fingerprint, and canonical claims. Future wiring may issue and create that exact
+UID-bound credential only after validation, then remove the gate; no unbound credential is ever
+placed in a runnable Pod. The foundation's issuer returns one immutable exact-Pod-owned Secret
+containing the mutually verified client certificate, matching private key, client trust copy,
+and canonical claims plus a private issuance binding. Future wiring must successfully create
+(never adopt, including on `AlreadyExists`) that Secret, seal the private binding exactly once
+with the UID/resourceVersion from that successful CREATE response, uncached-reread the Secret,
+revalidate the exact sealed identity and still-gated Pod, and only then UID/resourceVersion-fence
+gate removal. A GET, adoption, empty create identity, mismatched response, or reseal fails closed.
+The helper mounts per-execution client cert/key and the separate
+administrator-owned proxy server CA only in the forwarder, uses a fixed non-root, read-only,
+drop-all security context and bounded resources, and injects loopback proxy variables while
+clearing `NO_PROXY`. It rejects Windows and non-Pod backends.
+
+The current non-empty Project allowlist rejection remains unchanged and runs before child or
+Pod-spec construction. It stays until identity publication and exact two-second currentness,
+proxy readiness, technical path forcing, Calico v3.32.1-only enforcement proof, and acceptance
+land together. There is currently no default-deny egress, proxy deployment, runtime policy
+ConfigMap, restricted profile, or production egress-enforcement claim; generic Kubernetes, k3s,
+GKE, and EKS restricted profiles remain deferred. Issue #68 is not runtime-complete.
 
 Slice 3 provides only a default-off experimental conformance runner. The separate pinned
 dual-stack, two-worker kind topology and `hack/egress-conformance.sh` can perform one disposable,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -138,8 +138,38 @@ selection.
 The operator still rejects every non-empty Project selection and fences any existing Environment
 execution rather than running with unenforced intent. Empty or omitted selections do not restrict
 Environment egress today, which remains subject to cluster network configuration. No policy
-ConfigMap, proxy, identity, path forcing, restricted NetworkPolicy, or enforcement proof is wired;
-the approved restricted runtime is Calico v3.32.1-only and remains later issue #68 work.
+ConfigMap, proxy deployment, identity publication, path forcing, restricted NetworkPolicy, or
+enforcement proof is wired; the approved restricted runtime is Calico v3.32.1-only and remains
+later issue #68 work.
+
+The implemented but unreachable identity foundation uses bounded canonical v1 claims for exact
+Installation, Project, Environment, Pod, execution, policy, forwarder, and certificate-fingerprint
+identity. A separate per-execution self-signed ECDSA certificate has ClientAuth usage only; its
+key and trust material are distinct from sandboxd's ServerAuth credential. TLS certificate
+subjects and presented fingerprints are lookup hints, never authorization claims. A future proxy
+authorizer must map the fingerprint to canonical claims, independently repeat exact uncached
+currentness checks, and reject any stale object, execution, policy revision, forwarder revision,
+or fingerprint.
+
+Kubernetes assigns a Pod UID only after creation. The inert Pod helper therefore adds an
+egress-specific scheduling gate and a required, deliberately absent credential Secret reference
+before CREATE. After UID assignment, a separate validator checks the exact persisted Pod,
+Environment owner, execution generation, gate, canonical claims, and issued certificate
+fingerprint. The provided issuer constructs one immutable exact-Pod-owned Secret and a private
+issuance binding. Future wiring must treat create collision as failure, uncached-reread the
+assigned Secret UID/resourceVersion, and recheck its exact data, owner, canonical claims,
+fingerprint, matching key, self trust, and still-gated Pod against that binding before fenced gate
+removal. Only the exact successful CREATE response may seal the binding once; `AlreadyExists`,
+adoption/GET, empty or mismatched create identity, resealing, and a different UID or
+resourceVersion on uncached reread all fail closed. A Pod can never run with an unbound credential
+through this staged contract. The helper's native
+restartable init-sidecar precedes clone/hooks, receives the only egress client key/cert and
+administrator-owned proxy CA mounts, has no workspace or service-account-token mount and no
+host/shared PID namespace, and uses
+non-root, read-only-root, no-escalation, drop-all controls plus bounded requests and limits. Proxy
+environment variables are supplied to clone, hooks, and the environment only for compatibility;
+they are not enforcement. The helper supports only Linux Pod specs and is callable only by unit
+tests today.
 
 An experimental Calico v3.32.1 conformance runner exists as default-off diagnostic groundwork.
 It runs only by explicit invocation against its separate disposable kind fixture, aborts when

--- a/internal/controllers/environment_resources_test.go
+++ b/internal/controllers/environment_resources_test.go
@@ -3112,6 +3112,10 @@ func TestProjectRepositoryValidationIsTerminal(t *testing.T) {
 }
 
 func TestReconcileRejectsUnsupportedEgressAllowlistBeforeCreatingChildren(t *testing.T) {
+	// This reconcile-level test is also the activation fence for the inert
+	// egressidentity/egresspod foundation: the unsupported policy gate runs
+	// before any child or Pod-spec construction, so no future helper can be
+	// reached accidentally while non-empty selections remain unsupported.
 	scheme := runtime.NewScheme()
 	if err := corev1.AddToScheme(scheme); err != nil {
 		t.Fatal(err)

--- a/internal/egressidentity/identity.go
+++ b/internal/egressidentity/identity.go
@@ -1,0 +1,252 @@
+// Package egressidentity defines the inert v1 per-execution identity contract
+// shared by future restricted-egress publishers and proxy authorizers.
+package egressidentity
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+const (
+	Domain            = "swe.dev/egress-identity/v1"
+	MaxCanonicalBytes = 4096
+	MaxRevisionBytes  = 128
+
+	ClientCertificateKey = "client.crt"
+	ClientPrivateKeyKey  = "client.key"
+	ClientTrustKey       = "client-trust.crt"
+	CanonicalClaimsKey   = "identity.json"
+)
+
+// Claims is the canonical, exact authority lookup key. Certificate subject
+// fields are deliberately excluded: they are untrusted lookup hints only.
+type Claims struct {
+	InstallationNamespace  string    `json:"installationNamespace"`
+	InstallationName       string    `json:"installationName"`
+	InstallationUID        types.UID `json:"installationUID"`
+	ProjectNamespace       string    `json:"projectNamespace"`
+	ProjectName            string    `json:"projectName"`
+	ProjectUID             types.UID `json:"projectUID"`
+	EnvironmentNamespace   string    `json:"environmentNamespace"`
+	EnvironmentName        string    `json:"environmentName"`
+	EnvironmentUID         types.UID `json:"environmentUID"`
+	PodName                string    `json:"podName"`
+	PodUID                 types.UID `json:"podUID"`
+	ExecutionGeneration    int64     `json:"executionGeneration"`
+	RuntimePolicyRevision  string    `json:"runtimePolicyRevision"`
+	ForwarderRevision      string    `json:"forwarderSecurityRevision"`
+	CertificateFingerprint string    `json:"certificateSHA256"`
+}
+
+// CertificateHint is all the disabled proxy can learn from a presented leaf.
+// Neither field is authority; an authorizer must use the fingerprint to look
+// up and then revalidate canonical Claims against live authoritative objects.
+type CertificateHint struct {
+	Fingerprint [sha256.Size]byte
+	Subject     string
+}
+
+type canonicalClaims struct {
+	Domain                 string    `json:"domain"`
+	InstallationNamespace  string    `json:"installationNamespace"`
+	InstallationName       string    `json:"installationName"`
+	InstallationUID        types.UID `json:"installationUID"`
+	ProjectNamespace       string    `json:"projectNamespace"`
+	ProjectName            string    `json:"projectName"`
+	ProjectUID             types.UID `json:"projectUID"`
+	EnvironmentNamespace   string    `json:"environmentNamespace"`
+	EnvironmentName        string    `json:"environmentName"`
+	EnvironmentUID         types.UID `json:"environmentUID"`
+	PodName                string    `json:"podName"`
+	PodUID                 types.UID `json:"podUID"`
+	ExecutionGeneration    int64     `json:"executionGeneration"`
+	RuntimePolicyRevision  string    `json:"runtimePolicyRevision"`
+	ForwarderRevision      string    `json:"forwarderSecurityRevision"`
+	CertificateFingerprint string    `json:"certificateSHA256"`
+}
+
+func (c Claims) canonical() (canonicalClaims, error) {
+	for label, value := range map[string]string{
+		"Installation namespace": c.InstallationNamespace, "Project namespace": c.ProjectNamespace,
+		"Environment namespace": c.EnvironmentNamespace,
+	} {
+		if len(validation.IsDNS1123Label(value)) != 0 {
+			return canonicalClaims{}, fmt.Errorf("%s is invalid", label)
+		}
+	}
+	for label, value := range map[string]string{
+		"Installation name": c.InstallationName, "Project name": c.ProjectName,
+		"Environment name": c.EnvironmentName, "Pod name": c.PodName,
+	} {
+		if len(validation.IsDNS1123Subdomain(value)) != 0 {
+			return canonicalClaims{}, fmt.Errorf("%s is invalid", label)
+		}
+	}
+	if c.InstallationUID == "" || c.ProjectUID == "" || c.EnvironmentUID == "" || c.PodUID == "" {
+		return canonicalClaims{}, errors.New("Installation, Project, Environment, and Pod UIDs are required")
+	}
+	for label, value := range map[string]types.UID{"Installation": c.InstallationUID, "Project": c.ProjectUID, "Environment": c.EnvironmentUID, "Pod": c.PodUID} {
+		if len(value) > 128 || strings.IndexFunc(string(value), func(r rune) bool { return r < 0x21 || r > 0x7e }) >= 0 {
+			return canonicalClaims{}, fmt.Errorf("%s UID is invalid", label)
+		}
+	}
+	if c.ExecutionGeneration < 1 {
+		return canonicalClaims{}, errors.New("execution generation must be positive")
+	}
+	if !validRevision(c.RuntimePolicyRevision) || !validRevision(c.ForwarderRevision) {
+		return canonicalClaims{}, errors.New("runtime policy and forwarder security revisions must be bounded printable ASCII")
+	}
+	if len(c.CertificateFingerprint) != sha256.Size*2 {
+		return canonicalClaims{}, errors.New("certificate fingerprint must be a SHA-256 hex digest")
+	}
+	fingerprint, err := hex.DecodeString(c.CertificateFingerprint)
+	if err != nil || hex.EncodeToString(fingerprint) != c.CertificateFingerprint {
+		return canonicalClaims{}, errors.New("certificate fingerprint must be lowercase SHA-256 hex")
+	}
+	return canonicalClaims{Domain, c.InstallationNamespace, c.InstallationName, c.InstallationUID,
+		c.ProjectNamespace, c.ProjectName, c.ProjectUID, c.EnvironmentNamespace, c.EnvironmentName,
+		c.EnvironmentUID, c.PodName, c.PodUID, c.ExecutionGeneration, c.RuntimePolicyRevision,
+		c.ForwarderRevision, c.CertificateFingerprint}, nil
+}
+
+func validRevision(value string) bool {
+	return len(value) > 0 && len(value) <= MaxRevisionBytes && strings.IndexFunc(value, func(r rune) bool { return r < 0x21 || r > 0x7e }) < 0
+}
+
+func (c Claims) CanonicalBytes() ([]byte, error) {
+	canonical, err := c.canonical()
+	if err != nil {
+		return nil, err
+	}
+	b, err := json.Marshal(canonical)
+	if err != nil {
+		return nil, err
+	}
+	if len(b) > MaxCanonicalBytes {
+		return nil, errors.New("canonical egress identity is too large")
+	}
+	return b, nil
+}
+
+func Parse(value []byte) (Claims, error) {
+	if len(value) == 0 || len(value) > MaxCanonicalBytes {
+		return Claims{}, errors.New("invalid egress identity size")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(value))
+	decoder.DisallowUnknownFields()
+	var canonical canonicalClaims
+	if err := decoder.Decode(&canonical); err != nil {
+		return Claims{}, fmt.Errorf("decode egress identity: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return Claims{}, errors.New("egress identity has trailing content")
+	}
+	if canonical.Domain != Domain {
+		return Claims{}, errors.New("unsupported egress identity domain")
+	}
+	c := Claims{canonical.InstallationNamespace, canonical.InstallationName, canonical.InstallationUID,
+		canonical.ProjectNamespace, canonical.ProjectName, canonical.ProjectUID, canonical.EnvironmentNamespace,
+		canonical.EnvironmentName, canonical.EnvironmentUID, canonical.PodName, canonical.PodUID,
+		canonical.ExecutionGeneration, canonical.RuntimePolicyRevision, canonical.ForwarderRevision,
+		canonical.CertificateFingerprint}
+	reencoded, err := c.CanonicalBytes()
+	if err != nil {
+		return Claims{}, err
+	}
+	if !bytes.Equal(value, reencoded) {
+		return Claims{}, errors.New("egress identity is not canonical")
+	}
+	return c, nil
+}
+
+// Material is a separate ClientAuth credential; it must never be reused as
+// sandboxd's ServerAuth keypair. Clear destroys all returned byte slices.
+type Material struct {
+	Certificate []byte
+	PrivateKey  []byte
+	CA          []byte
+	Fingerprint [sha256.Size]byte
+}
+
+func (m *Material) Clear() {
+	if m == nil {
+		return
+	}
+	clear(m.Certificate)
+	clear(m.PrivateKey)
+	clear(m.CA)
+	clear(m.Fingerprint[:])
+}
+
+// IssueForClaims issues a client identity and returns claims bound to its exact
+// DER fingerprint. The input fingerprint must be empty so callers cannot
+// accidentally combine independently produced claims and material.
+func IssueForClaims(now time.Time, claims Claims) (Claims, *Material, error) {
+	if claims.CertificateFingerprint != "" {
+		return Claims{}, nil, errors.New("certificate fingerprint is output-only")
+	}
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return Claims{}, nil, err
+	}
+	defer key.D.SetInt64(0)
+	serialLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serial, err := rand.Int(rand.Reader, serialLimit)
+	if err != nil {
+		return Claims{}, nil, err
+	}
+	template := &x509.Certificate{
+		SerialNumber: serial, Subject: pkix.Name{CommonName: "egress-client.swe.dev"},
+		NotBefore: now.Add(-time.Minute), NotAfter: now.Add(24 * time.Hour),
+		KeyUsage: x509.KeyUsageDigitalSignature, ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		return Claims{}, nil, err
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return Claims{}, nil, err
+	}
+	defer clear(keyDER)
+	certificate := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	privateKey := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	fingerprint := sha256.Sum256(der)
+	claims.CertificateFingerprint = hex.EncodeToString(fingerprint[:])
+	if _, err := claims.CanonicalBytes(); err != nil {
+		clear(certificate)
+		clear(privateKey)
+		return Claims{}, nil, err
+	}
+	return claims, &Material{Certificate: certificate, PrivateKey: privateKey, CA: append([]byte(nil), certificate...), Fingerprint: fingerprint}, nil
+}
+
+// FingerprintCertificate returns the SHA-256 digest of one PEM certificate.
+func FingerprintCertificate(certificatePEM []byte) ([sha256.Size]byte, error) {
+	block, rest := pem.Decode(certificatePEM)
+	if block == nil || block.Type != "CERTIFICATE" || len(rest) != 0 {
+		return [sha256.Size]byte{}, errors.New("invalid canonical certificate PEM")
+	}
+	if _, err := x509.ParseCertificate(block.Bytes); err != nil {
+		return [sha256.Size]byte{}, err
+	}
+	return sha256.Sum256(block.Bytes), nil
+}

--- a/internal/egressidentity/identity_test.go
+++ b/internal/egressidentity/identity_test.go
@@ -1,0 +1,105 @@
+package egressidentity
+
+import (
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func validClaims() Claims {
+	return Claims{InstallationNamespace: "swe-system", InstallationName: "main", InstallationUID: "i-uid",
+		ProjectNamespace: "project-a", ProjectName: "project", ProjectUID: "p-uid",
+		EnvironmentNamespace: "project-a", EnvironmentName: "environment", EnvironmentUID: "e-uid",
+		PodName: "env-environment", PodUID: "pod-uid", ExecutionGeneration: 7,
+		RuntimePolicyRevision: strings.Repeat("a", 64), ForwarderRevision: "1",
+		CertificateFingerprint: strings.Repeat("b", 64)}
+}
+
+func TestClaimsExactCanonicalRoundTrip(t *testing.T) {
+	c := validClaims()
+	b, err := c.CanonicalBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{"domain":"swe.dev/egress-identity/v1","installationNamespace":"swe-system","installationName":"main","installationUID":"i-uid","projectNamespace":"project-a","projectName":"project","projectUID":"p-uid","environmentNamespace":"project-a","environmentName":"environment","environmentUID":"e-uid","podName":"env-environment","podUID":"pod-uid","executionGeneration":7,"runtimePolicyRevision":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","forwarderSecurityRevision":"1","certificateSHA256":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}`
+	if string(b) != want {
+		t.Fatalf("canonical bytes:\n got %s\nwant %s", b, want)
+	}
+	got, err := Parse(b)
+	if err != nil || !reflect.DeepEqual(got, c) {
+		t.Fatalf("Parse = %#v, %v", got, err)
+	}
+	for _, bad := range [][]byte{append([]byte(" "), b...), append(b, '\n'), []byte(strings.Replace(string(b), `"podUID":"pod-uid"`, `"podUID":"pod-uid","extra":1`, 1))} {
+		if _, err := Parse(bad); err == nil {
+			t.Fatalf("noncanonical identity accepted: %q", bad)
+		}
+	}
+}
+
+func TestClaimsRejectUnboundAndStaleInputs(t *testing.T) {
+	base := validClaims()
+	tests := map[string]func(*Claims){
+		"Pod UID": func(c *Claims) { c.PodUID = "" }, "generation": func(c *Claims) { c.ExecutionGeneration = 0 },
+		"fingerprint":        func(c *Claims) { c.CertificateFingerprint = strings.Repeat("A", 64) },
+		"runtime revision":   func(c *Claims) { c.RuntimePolicyRevision = "" },
+		"forwarder revision": func(c *Claims) { c.ForwarderRevision = strings.Repeat("x", MaxRevisionBytes+1) },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := base
+			mutate(&c)
+			if _, err := c.CanonicalBytes(); err == nil {
+				t.Fatal("invalid claims accepted")
+			}
+		})
+	}
+	first, _ := base.CanonicalBytes()
+	base.PodUID = "replacement"
+	second, _ := base.CanonicalBytes()
+	if string(first) == string(second) {
+		t.Fatal("stale Pod identity serialized identically")
+	}
+}
+
+func TestIssueClientAuthMaterialAndClear(t *testing.T) {
+	input := validClaims()
+	input.CertificateFingerprint = ""
+	claims, m, err := IssueForClaims(time.Unix(1000, 0), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, _ := pem.Decode(m.Certificate)
+	if block == nil {
+		t.Fatal("certificate is not PEM")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(cert.ExtKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}) || cert.KeyUsage != x509.KeyUsageDigitalSignature {
+		t.Fatalf("certificate usages = %v, %v", cert.ExtKeyUsage, cert.KeyUsage)
+	}
+	if got := sha256.Sum256(cert.Raw); got != m.Fingerprint {
+		t.Fatalf("fingerprint = %s, want %s", hex.EncodeToString(m.Fingerprint[:]), hex.EncodeToString(got[:]))
+	}
+	if claims.CertificateFingerprint != hex.EncodeToString(m.Fingerprint[:]) {
+		t.Fatalf("claims fingerprint = %q", claims.CertificateFingerprint)
+	}
+	if string(m.CA) != string(m.Certificate) {
+		t.Fatal("self-signed client trust material differs from certificate")
+	}
+	certBytes, keyBytes, caBytes := m.Certificate, m.PrivateKey, m.CA
+	m.Clear()
+	for name, value := range map[string][]byte{"certificate": certBytes, "key": keyBytes, "CA": caBytes, "fingerprint": m.Fingerprint[:]} {
+		for _, b := range value {
+			if b != 0 {
+				t.Fatalf("%s was not zeroized", name)
+			}
+		}
+	}
+}

--- a/internal/egresspod/pod.go
+++ b/internal/egresspod/pod.go
@@ -1,0 +1,430 @@
+// Package egresspod contains an inert staged Pod-spec foundation for future
+// restricted egress. No controller calls this package today.
+package egresspod
+
+import (
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"reflect"
+	"strconv"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+
+	"github.com/Chris-Cullins/swe-platform/internal/egressidentity"
+)
+
+const (
+	ForwarderName                 = "egress-forwarder"
+	CredentialVolume              = "egress-client-credentials"
+	ProxyCAVolume                 = "egress-proxy-ca"
+	CredentialMount               = "/var/run/swe-platform/egress/client"
+	ProxyCAMount                  = "/var/run/swe-platform/egress/proxy"
+	ProxyServerCAKey              = "ca.crt"
+	SchedulingGateName            = "egress.swe.dev/identity-ready"
+	ExecutionGenerationAnnotation = "swe.dev/execution-generation"
+	LoopbackPort                  = int32(15001)
+	ForwarderRevision             = "1"
+)
+
+type RestrictedEgress struct {
+	Backend           string
+	OperatingSystem   string
+	ForwarderImage    string
+	ProxyAddress      string
+	ProxyServerName   string
+	CredentialSecret  string
+	ProxyCASecret     string
+	CredentialFSGroup int64
+}
+
+// Binding is retained across Secret creation and uncached reread. Its private
+// expected identity and hashes prevent validation from adopting an unrelated,
+// internally consistent same-name Secret.
+type Binding struct {
+	data                   map[string][sha256.Size]byte
+	secretNamespace        string
+	secretName             string
+	podName                string
+	podUID                 types.UID
+	createdSecretUID       types.UID
+	createdResourceVersion string
+	sealed                 bool
+}
+
+// PrepareRestrictedEgress atomically adds an unscheduled native restartable
+// init-sidecar. The referenced credential Secret must not exist yet. A future
+// publisher may issue it only after CREATE returns a UID and the persisted Pod
+// passes ValidateBoundPod; only then may that publisher remove the gate.
+func PrepareRestrictedEgress(pod *corev1.Pod, in RestrictedEgress) error {
+	if err := validatePreparation(pod, in); err != nil {
+		return err
+	}
+	copy := pod.DeepCopy()
+	copy.Spec.AutomountServiceAccountToken = ptr.To(false)
+	copy.Spec.EnableServiceLinks = ptr.To(false)
+	copy.Spec.OS = &corev1.PodOS{Name: corev1.Linux}
+	copy.Spec.SchedulingGates = append(copy.Spec.SchedulingGates, corev1.PodSchedulingGate{Name: SchedulingGateName})
+	proxyURL := "http://127.0.0.1:" + strconv.Itoa(int(LoopbackPort))
+	for i := range copy.Spec.Containers {
+		copy.Spec.Containers[i].Env = proxyEnvironment(copy.Spec.Containers[i].Env, proxyURL)
+	}
+	for i := range copy.Spec.InitContainers {
+		copy.Spec.InitContainers[i].Env = proxyEnvironment(copy.Spec.InitContainers[i].Env, proxyURL)
+	}
+	forwarder := forwarderContainer(in)
+	copy.Spec.InitContainers = append([]corev1.Container{forwarder}, copy.Spec.InitContainers...)
+	clientVolume, caVolume := credentialVolumes(in)
+	copy.Spec.Volumes = append(copy.Spec.Volumes, clientVolume, caVolume)
+	*pod = *copy
+	return nil
+}
+
+func forwarderContainer(in RestrictedEgress) corev1.Container {
+	restart := corev1.ContainerRestartPolicyAlways
+	return corev1.Container{
+		Name: ForwarderName, Image: in.ForwarderImage, ImagePullPolicy: corev1.PullIfNotPresent,
+		TerminationMessagePath: "/dev/termination-log", TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+		Command: []string{"egress-proxy", "forward"},
+		Args: []string{"--address=127.0.0.1:" + strconv.Itoa(int(LoopbackPort)), "--server=" + in.ProxyAddress,
+			"--server-name=" + in.ProxyServerName, "--cert=" + CredentialMount + "/" + egressidentity.ClientCertificateKey,
+			"--key=" + CredentialMount + "/" + egressidentity.ClientPrivateKeyKey, "--ca=" + ProxyCAMount + "/" + ProxyServerCAKey},
+		RestartPolicy: &restart,
+		StartupProbe: &corev1.Probe{ProbeHandler: corev1.ProbeHandler{TCPSocket: &corev1.TCPSocketAction{
+			Port: intstr.FromInt32(LoopbackPort), Host: "127.0.0.1"}}, PeriodSeconds: 1, TimeoutSeconds: 1, FailureThreshold: 30, SuccessThreshold: 1},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("50m"), corev1.ResourceMemory: resource.MustParse("64Mi")},
+			Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m"), corev1.ResourceMemory: resource.MustParse("128Mi")},
+		},
+		SecurityContext: &corev1.SecurityContext{RunAsNonRoot: ptr.To(true), RunAsUser: ptr.To[int64](65532), RunAsGroup: ptr.To[int64](65532),
+			ReadOnlyRootFilesystem: ptr.To(true), AllowPrivilegeEscalation: ptr.To(false), Capabilities: &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}}},
+		VolumeMounts: []corev1.VolumeMount{{Name: CredentialVolume, MountPath: CredentialMount, ReadOnly: true}, {Name: ProxyCAVolume, MountPath: ProxyCAMount, ReadOnly: true}},
+	}
+}
+
+func credentialVolumes(in RestrictedEgress) (corev1.Volume, corev1.Volume) {
+	mode := int32(0o440)
+	return corev1.Volume{Name: CredentialVolume, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{
+			SecretName: in.CredentialSecret, DefaultMode: &mode, Optional: ptr.To(false), Items: []corev1.KeyToPath{
+				{Key: egressidentity.ClientCertificateKey, Path: egressidentity.ClientCertificateKey},
+				{Key: egressidentity.ClientPrivateKeyKey, Path: egressidentity.ClientPrivateKeyKey},
+			}}}}, corev1.Volume{Name: ProxyCAVolume, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{
+			SecretName: in.ProxyCASecret, DefaultMode: &mode, Optional: ptr.To(false), Items: []corev1.KeyToPath{{Key: ProxyServerCAKey, Path: ProxyServerCAKey}},
+		}}}
+}
+
+// IssueCredentialSecret validates the persisted gated Pod, binds claims to its
+// exact UID/execution, and returns one immutable exact-Pod-owned Secret.
+func IssueCredentialSecret(now time.Time, pod *corev1.Pod, in RestrictedEgress, claims egressidentity.Claims) (*corev1.Secret, *Binding, error) {
+	if err := validatePersistedPod(pod, in); err != nil {
+		return nil, nil, err
+	}
+	owner := metav1.GetControllerOf(pod)
+	generation, err := strconv.ParseInt(pod.Annotations[ExecutionGenerationAnnotation], 10, 64)
+	if pod.UID == "" || owner == nil || owner.APIVersion != "swe.dev/v1alpha1" || owner.Kind != "Environment" || owner.UID == "" || generation < 1 || err != nil {
+		return nil, nil, errors.New("persisted Pod has no exact Environment execution")
+	}
+	if claims.EnvironmentNamespace != pod.Namespace || claims.EnvironmentName != owner.Name || claims.EnvironmentUID != owner.UID ||
+		claims.ProjectNamespace != pod.Namespace || claims.PodName != pod.Name || claims.PodUID != pod.UID ||
+		claims.ExecutionGeneration != generation || claims.ForwarderRevision != ForwarderRevision {
+		return nil, nil, errors.New("authoritative identity does not match persisted Pod execution")
+	}
+	issued, material, err := egressidentity.IssueForClaims(now, claims)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer material.Clear()
+	canonical, err := issued.CanonicalBytes()
+	if err != nil {
+		return nil, nil, err
+	}
+	immutable := true
+	controller := true
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: in.CredentialSecret, Namespace: pod.Namespace, OwnerReferences: []metav1.OwnerReference{{APIVersion: "v1", Kind: "Pod", Name: pod.Name, UID: pod.UID, Controller: &controller}}}, Immutable: &immutable,
+		Data: map[string][]byte{egressidentity.ClientCertificateKey: append([]byte(nil), material.Certificate...), egressidentity.ClientPrivateKeyKey: append([]byte(nil), material.PrivateKey...), egressidentity.ClientTrustKey: append([]byte(nil), material.CA...), egressidentity.CanonicalClaimsKey: canonical}}
+	binding := &Binding{
+		data:            make(map[string][sha256.Size]byte, len(secret.Data)),
+		secretNamespace: secret.Namespace,
+		secretName:      secret.Name,
+		podName:         pod.Name,
+		podUID:          pod.UID,
+	}
+	for key, value := range secret.Data {
+		binding.data[key] = sha256.Sum256(value)
+	}
+	return secret, binding, nil
+}
+
+// SealCreatedSecret records the identity returned by the one successful Secret
+// CREATE. Future wiring must not call this after AlreadyExists, GET, or adoption.
+func (binding *Binding) SealCreatedSecret(secret *corev1.Secret) error {
+	if binding == nil || binding.sealed {
+		return errors.New("issuance binding is absent or already sealed")
+	}
+	if secret == nil || secret.UID == "" || secret.ResourceVersion == "" {
+		return errors.New("successful Secret CREATE response with identity is required")
+	}
+	if err := binding.validateIssuedSecret(secret); err != nil {
+		return fmt.Errorf("Secret CREATE response does not match issuance: %w", err)
+	}
+	binding.createdSecretUID = secret.UID
+	binding.createdResourceVersion = secret.ResourceVersion
+	binding.sealed = true
+	return nil
+}
+
+// ValidateBoundPod validates the exact persisted Pod and exact persisted Secret
+// immediately before a future caller may remove the scheduling gate.
+func ValidateBoundPod(pod *corev1.Pod, in RestrictedEgress, secret *corev1.Secret, binding *Binding) error {
+	if secret == nil || binding == nil || !binding.sealed || binding.createdSecretUID == "" || binding.createdResourceVersion == "" {
+		return errors.New("persisted credential Secret and issuance binding are required")
+	}
+	if secret.UID != binding.createdSecretUID || secret.ResourceVersion != binding.createdResourceVersion {
+		return errors.New("persisted credential Secret identity does not match successful creation")
+	}
+	if err := binding.validateIssuedSecret(secret); err != nil {
+		return err
+	}
+	claims, err := egressidentity.Parse(secret.Data[egressidentity.CanonicalClaimsKey])
+	if err != nil {
+		return err
+	}
+	if pod == nil || pod.UID == "" || pod.Name != claims.PodName || pod.UID != claims.PodUID || pod.Namespace != claims.EnvironmentNamespace {
+		return errors.New("identity does not bind the exact API-assigned Pod")
+	}
+	if claims.ForwarderRevision != ForwarderRevision {
+		return errors.New("forwarder security revision is stale")
+	}
+	fingerprint, err := egressidentity.FingerprintCertificate(secret.Data[egressidentity.ClientCertificateKey])
+	if err != nil || claims.CertificateFingerprint != hex.EncodeToString(fingerprint[:]) {
+		return errors.New("client certificate fingerprint does not match identity")
+	}
+	if _, err := tls.X509KeyPair(secret.Data[egressidentity.ClientCertificateKey], secret.Data[egressidentity.ClientPrivateKeyKey]); err != nil || !reflect.DeepEqual(secret.Data[egressidentity.ClientTrustKey], secret.Data[egressidentity.ClientCertificateKey]) {
+		return errors.New("client certificate, private key, and self trust do not match")
+	}
+	generation, err := strconv.ParseInt(pod.Annotations[ExecutionGenerationAnnotation], 10, 64)
+	owner := metav1.GetControllerOf(pod)
+	if err != nil || generation != claims.ExecutionGeneration || owner == nil || owner.APIVersion != "swe.dev/v1alpha1" || owner.Kind != "Environment" || owner.Name != claims.EnvironmentName || owner.UID != claims.EnvironmentUID {
+		return errors.New("persisted Pod execution or Environment owner does not match identity")
+	}
+	secretOwner := metav1.GetControllerOf(secret)
+	if secret.Name != in.CredentialSecret || secret.Namespace != pod.Namespace || secret.Immutable == nil || !*secret.Immutable || secretOwner == nil || secretOwner.APIVersion != "v1" || secretOwner.Kind != "Pod" || secretOwner.Name != pod.Name || secretOwner.UID != pod.UID || len(secret.Data[egressidentity.ClientPrivateKeyKey]) == 0 || len(secret.Data[egressidentity.ClientTrustKey]) == 0 {
+		return errors.New("credential Secret is not immutable and exact-Pod-owned")
+	}
+	if err := validatePersistedPod(pod, in); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (binding *Binding) validateIssuedSecret(secret *corev1.Secret) error {
+	if len(binding.data) != 4 || len(secret.Data) != len(binding.data) {
+		return errors.New("persisted credential Secret data changed")
+	}
+	for key, want := range binding.data {
+		if sha256.Sum256(secret.Data[key]) != want {
+			return errors.New("persisted credential Secret does not match issuance")
+		}
+	}
+	owner := metav1.GetControllerOf(secret)
+	if secret.Name != binding.secretName || secret.Namespace != binding.secretNamespace || secret.Immutable == nil || !*secret.Immutable ||
+		owner == nil || owner.APIVersion != "v1" || owner.Kind != "Pod" || owner.Name != binding.podName || owner.UID != binding.podUID {
+		return errors.New("credential Secret is not the exact immutable issued object")
+	}
+	return nil
+}
+
+func validatePreparation(pod *corev1.Pod, in RestrictedEgress) error {
+	if pod == nil || pod.Name == "" || pod.UID != "" {
+		return errors.New("pre-create Pod with a fixed name and no UID is required")
+	}
+	if in.Backend != "pod" || in.OperatingSystem != "linux" {
+		return fmt.Errorf("restricted egress backend/OS %q/%q is unsupported", in.Backend, in.OperatingSystem)
+	}
+	if in.ForwarderImage == "" || in.CredentialSecret == "" || in.ProxyCASecret == "" || in.ProxyServerName == "" || in.CredentialSecret == in.ProxyCASecret {
+		return errors.New("forwarder image, credential Secret, proxy CA Secret, and server name are required")
+	}
+	host, port, err := net.SplitHostPort(in.ProxyAddress)
+	if err != nil || host == "" || port == "" {
+		return errors.New("proxy address must be an explicit host and port")
+	}
+	if parsed, err := strconv.ParseUint(port, 10, 16); err != nil || parsed == 0 {
+		return errors.New("proxy address port is invalid")
+	}
+	if pod.Spec.OS != nil && pod.Spec.OS.Name != corev1.Linux {
+		return errors.New("Windows Pods are unsupported")
+	}
+	if pod.Spec.HostPID || pod.Spec.HostIPC || pod.Spec.HostNetwork || pod.Spec.ShareProcessNamespace != nil && *pod.Spec.ShareProcessNamespace {
+		return errors.New("restricted egress Pod must not use host or shared process namespaces")
+	}
+	if pod.Spec.SecurityContext == nil || pod.Spec.SecurityContext.FSGroup == nil || in.CredentialFSGroup <= 0 || *pod.Spec.SecurityContext.FSGroup != in.CredentialFSGroup {
+		return errors.New("restricted egress Pod requires an fsGroup for read-only credentials")
+	}
+	if len(pod.Spec.Containers) != 1 || pod.Spec.Containers[0].Name != "environment" {
+		return errors.New("restricted egress requires exactly the environment container")
+	}
+	if len(pod.Spec.InitContainers) != 0 && (len(pod.Spec.InitContainers) != 2 || pod.Spec.InitContainers[0].Name != "repository-clone" || pod.Spec.InitContainers[1].Name != "project-hooks") {
+		return errors.New("restricted egress requires clone then project-hooks init ordering")
+	}
+	if len(pod.Spec.SchedulingGates) != 0 {
+		return errors.New("restricted egress preparation requires no existing scheduling gates")
+	}
+	return rejectAmbientCredentialReferences(pod, in)
+}
+
+func validatePersistedPod(pod *corev1.Pod, in RestrictedEgress) error {
+	if pod == nil {
+		return errors.New("persisted Pod is required")
+	}
+	if pod.Spec.OS == nil || pod.Spec.OS.Name != corev1.Linux || len(pod.Spec.SchedulingGates) != 1 || pod.Spec.SchedulingGates[0].Name != SchedulingGateName {
+		return errors.New("persisted Pod is not Linux and identity-gated")
+	}
+	if pod.Spec.HostPID || pod.Spec.HostIPC || pod.Spec.HostNetwork || pod.Spec.ShareProcessNamespace != nil && *pod.Spec.ShareProcessNamespace {
+		return errors.New("persisted Pod uses a forbidden namespace")
+	}
+	if pod.Spec.AutomountServiceAccountToken == nil || *pod.Spec.AutomountServiceAccountToken || pod.Spec.EnableServiceLinks == nil || *pod.Spec.EnableServiceLinks || pod.Spec.SecurityContext == nil || pod.Spec.SecurityContext.FSGroup == nil || *pod.Spec.SecurityContext.FSGroup != in.CredentialFSGroup {
+		return errors.New("persisted Pod ambient identity settings changed")
+	}
+	if len(pod.Spec.Containers) != 1 || pod.Spec.Containers[0].Name != "environment" || len(pod.Spec.EphemeralContainers) != 0 ||
+		len(pod.Spec.InitContainers) != 1 && len(pod.Spec.InitContainers) != 3 || len(pod.Spec.InitContainers) == 3 && (pod.Spec.InitContainers[1].Name != "repository-clone" || pod.Spec.InitContainers[2].Name != "project-hooks") {
+		return errors.New("persisted Pod has no native restartable egress init-sidecar")
+	}
+	forwarder := pod.Spec.InitContainers[0]
+	if !apiequality.Semantic.DeepEqual(forwarder, forwarderContainer(in)) {
+		return errors.New("persisted forwarder isolation changed")
+	}
+	wantClient, wantCA := credentialVolumes(in)
+	clientVolume, caVolume := false, false
+	for _, volume := range pod.Spec.Volumes {
+		clientVolume = clientVolume || apiequality.Semantic.DeepEqual(volume, wantClient)
+		caVolume = caVolume || apiequality.Semantic.DeepEqual(volume, wantCA)
+		if volume.Name != CredentialVolume && volume.Name != ProxyCAVolume && volumeSourceReferencesEgressSecret(volume.VolumeSource, in) {
+			return errors.New("persisted Pod gained an aliased egress Secret volume")
+		}
+		if volume.Name != CredentialVolume && volume.Name != ProxyCAVolume && volume.Projected != nil {
+			for _, source := range volume.Projected.Sources {
+				if source.ServiceAccountToken != nil {
+					return errors.New("persisted Pod gained an ambient credential projection")
+				}
+			}
+		}
+	}
+	if !clientVolume || !caVolume {
+		return errors.New("persisted egress Secret sources changed")
+	}
+	all := append(append([]corev1.Container(nil), pod.Spec.InitContainers[1:]...), pod.Spec.Containers...)
+	for _, container := range all {
+		for _, mount := range container.VolumeMounts {
+			if mount.Name == CredentialVolume || mount.Name == ProxyCAVolume {
+				return errors.New("persisted workload gained an egress credential mount")
+			}
+		}
+		for _, from := range container.EnvFrom {
+			if from.SecretRef != nil && (from.SecretRef.Name == in.CredentialSecret || from.SecretRef.Name == in.ProxyCASecret) {
+				return errors.New("persisted workload gained egress Secret envFrom")
+			}
+		}
+		for _, variable := range container.Env {
+			if variable.ValueFrom != nil && variable.ValueFrom.SecretKeyRef != nil && (variable.ValueFrom.SecretKeyRef.Name == in.CredentialSecret || variable.ValueFrom.SecretKeyRef.Name == in.ProxyCASecret) {
+				return errors.New("persisted workload gained egress Secret env")
+			}
+		}
+	}
+	for _, container := range pod.Spec.EphemeralContainers {
+		for _, mount := range container.VolumeMounts {
+			if mount.Name == CredentialVolume || mount.Name == ProxyCAVolume {
+				return errors.New("persisted ephemeral container gained an egress credential mount")
+			}
+		}
+		for _, from := range container.EnvFrom {
+			if from.SecretRef != nil && (from.SecretRef.Name == in.CredentialSecret || from.SecretRef.Name == in.ProxyCASecret) {
+				return errors.New("persisted ephemeral container gained egress Secret envFrom")
+			}
+		}
+		for _, variable := range container.Env {
+			if variable.ValueFrom != nil && variable.ValueFrom.SecretKeyRef != nil && (variable.ValueFrom.SecretKeyRef.Name == in.CredentialSecret || variable.ValueFrom.SecretKeyRef.Name == in.ProxyCASecret) {
+				return errors.New("persisted ephemeral container gained egress Secret env")
+			}
+		}
+	}
+	return nil
+}
+
+func rejectAmbientCredentialReferences(pod *corev1.Pod, in RestrictedEgress) error {
+	for _, volume := range pod.Spec.Volumes {
+		if volume.Name == CredentialVolume || volume.Name == ProxyCAVolume || volumeSourceReferencesEgressSecret(volume.VolumeSource, in) {
+			return errors.New("egress credential or proxy CA volume already exists")
+		}
+		if volume.Projected != nil {
+			for _, source := range volume.Projected.Sources {
+				if source.ServiceAccountToken != nil {
+					return errors.New("ambient projected credential or service-account token is forbidden")
+				}
+			}
+		}
+	}
+	for _, container := range append(append([]corev1.Container(nil), pod.Spec.InitContainers...), pod.Spec.Containers...) {
+		for _, from := range container.EnvFrom {
+			if from.SecretRef != nil && (from.SecretRef.Name == in.CredentialSecret || from.SecretRef.Name == in.ProxyCASecret) {
+				return errors.New("ambient egress Secret envFrom is forbidden")
+			}
+		}
+		for _, variable := range container.Env {
+			if variable.ValueFrom != nil && variable.ValueFrom.SecretKeyRef != nil && (variable.ValueFrom.SecretKeyRef.Name == in.CredentialSecret || variable.ValueFrom.SecretKeyRef.Name == in.ProxyCASecret) {
+				return errors.New("ambient egress Secret env is forbidden")
+			}
+		}
+	}
+	return nil
+}
+
+// volumeSourceReferencesEgressSecret exhaustively covers Secret-name fields in
+// the pinned corev1.VolumeSource API, including deprecated inline providers.
+func volumeSourceReferencesEgressSecret(source corev1.VolumeSource, in RestrictedEgress) bool {
+	reserved := func(name string) bool {
+		return name == in.CredentialSecret || name == in.ProxyCASecret
+	}
+	if source.Secret != nil && reserved(source.Secret.SecretName) ||
+		source.ISCSI != nil && source.ISCSI.SecretRef != nil && reserved(source.ISCSI.SecretRef.Name) ||
+		source.RBD != nil && source.RBD.SecretRef != nil && reserved(source.RBD.SecretRef.Name) ||
+		source.FlexVolume != nil && source.FlexVolume.SecretRef != nil && reserved(source.FlexVolume.SecretRef.Name) ||
+		source.Cinder != nil && source.Cinder.SecretRef != nil && reserved(source.Cinder.SecretRef.Name) ||
+		source.CephFS != nil && source.CephFS.SecretRef != nil && reserved(source.CephFS.SecretRef.Name) ||
+		source.AzureFile != nil && reserved(source.AzureFile.SecretName) ||
+		source.ScaleIO != nil && source.ScaleIO.SecretRef != nil && reserved(source.ScaleIO.SecretRef.Name) ||
+		source.StorageOS != nil && source.StorageOS.SecretRef != nil && reserved(source.StorageOS.SecretRef.Name) ||
+		source.CSI != nil && source.CSI.NodePublishSecretRef != nil && reserved(source.CSI.NodePublishSecretRef.Name) {
+		return true
+	}
+	if source.Projected != nil {
+		for _, projection := range source.Projected.Sources {
+			if projection.Secret != nil && reserved(projection.Secret.Name) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func proxyEnvironment(existing []corev1.EnvVar, proxyURL string) []corev1.EnvVar {
+	names := map[string]struct{}{"HTTP_PROXY": {}, "HTTPS_PROXY": {}, "http_proxy": {}, "https_proxy": {}, "NO_PROXY": {}, "no_proxy": {}}
+	result := make([]corev1.EnvVar, 0, len(existing)+6)
+	for _, variable := range existing {
+		if _, replace := names[variable.Name]; !replace {
+			result = append(result, variable)
+		}
+	}
+	return append(result, corev1.EnvVar{Name: "HTTP_PROXY", Value: proxyURL}, corev1.EnvVar{Name: "HTTPS_PROXY", Value: proxyURL},
+		corev1.EnvVar{Name: "http_proxy", Value: proxyURL}, corev1.EnvVar{Name: "https_proxy", Value: proxyURL},
+		corev1.EnvVar{Name: "NO_PROXY", Value: ""}, corev1.EnvVar{Name: "no_proxy", Value: ""})
+}

--- a/internal/egresspod/pod.go
+++ b/internal/egresspod/pod.go
@@ -267,6 +267,9 @@ func validatePreparation(pod *corev1.Pod, in RestrictedEgress) error {
 	if pod.Spec.HostPID || pod.Spec.HostIPC || pod.Spec.HostNetwork || pod.Spec.ShareProcessNamespace != nil && *pod.Spec.ShareProcessNamespace {
 		return errors.New("restricted egress Pod must not use host or shared process namespaces")
 	}
+	if pod.Spec.NodeName != "" {
+		return errors.New("restricted egress Pod must be held by the scheduler")
+	}
 	if pod.Spec.SecurityContext == nil || pod.Spec.SecurityContext.FSGroup == nil || in.CredentialFSGroup <= 0 || *pod.Spec.SecurityContext.FSGroup != in.CredentialFSGroup {
 		return errors.New("restricted egress Pod requires an fsGroup for read-only credentials")
 	}
@@ -291,6 +294,9 @@ func validatePersistedPod(pod *corev1.Pod, in RestrictedEgress) error {
 	}
 	if pod.Spec.HostPID || pod.Spec.HostIPC || pod.Spec.HostNetwork || pod.Spec.ShareProcessNamespace != nil && *pod.Spec.ShareProcessNamespace {
 		return errors.New("persisted Pod uses a forbidden namespace")
+	}
+	if pod.Spec.NodeName != "" {
+		return errors.New("persisted Pod bypasses the scheduling gate")
 	}
 	if pod.Spec.AutomountServiceAccountToken == nil || *pod.Spec.AutomountServiceAccountToken || pod.Spec.EnableServiceLinks == nil || *pod.Spec.EnableServiceLinks || pod.Spec.SecurityContext == nil || pod.Spec.SecurityContext.FSGroup == nil || *pod.Spec.SecurityContext.FSGroup != in.CredentialFSGroup {
 		return errors.New("persisted Pod ambient identity settings changed")

--- a/internal/egresspod/pod_test.go
+++ b/internal/egresspod/pod_test.go
@@ -90,6 +90,7 @@ func TestValidateBoundPodRequiresExactUIDAndFingerprint(t *testing.T) {
 		"fingerprint":                       func(_ *corev1.Pod, s *corev1.Secret) { s.Data[egressidentity.ClientCertificateKey] = []byte("bad") },
 		"private key":                       func(_ *corev1.Pod, s *corev1.Secret) { s.Data[egressidentity.ClientPrivateKeyKey] = []byte("bad") },
 		"gate":                              func(p *corev1.Pod, _ *corev1.Secret) { p.Spec.SchedulingGates = nil },
+		"admission nodeName":                func(p *corev1.Pod, _ *corev1.Secret) { p.Spec.NodeName = "worker" },
 		"admission mount": func(p *corev1.Pod, _ *corev1.Secret) {
 			p.Spec.Containers[0].VolumeMounts = append(p.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{Name: CredentialVolume})
 		},
@@ -249,6 +250,7 @@ func TestPrepareRejectsUnsupportedAndAmbientCredentialExposureAtomically(t *test
 	for name, mutate := range map[string]func(*corev1.Pod, *RestrictedEgress){
 		"unsupported backend": func(_ *corev1.Pod, in *RestrictedEgress) { in.Backend = "kubevirt" }, "Windows": func(_ *corev1.Pod, in *RestrictedEgress) { in.OperatingSystem = "windows" },
 		"host PID": func(p *corev1.Pod, _ *RestrictedEgress) { p.Spec.HostPID = true }, "no fsGroup": func(p *corev1.Pod, _ *RestrictedEgress) { p.Spec.SecurityContext.FSGroup = nil },
+		"preset nodeName": func(p *corev1.Pod, _ *RestrictedEgress) { p.Spec.NodeName = "worker" },
 		"aliased Secret volume": func(p *corev1.Pod, in *RestrictedEgress) {
 			p.Spec.Volumes = append(p.Spec.Volumes, corev1.Volume{Name: "alias", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: in.CredentialSecret}}})
 		},

--- a/internal/egresspod/pod_test.go
+++ b/internal/egresspod/pod_test.go
@@ -1,0 +1,277 @@
+package egresspod
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/Chris-Cullins/swe-platform/internal/egressidentity"
+)
+
+func fixture() (*corev1.Pod, RestrictedEgress) {
+	group := int64(10001)
+	controller := true
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "env-one", Namespace: "project", Annotations: map[string]string{ExecutionGenerationAnnotation: "1"}, OwnerReferences: []metav1.OwnerReference{{APIVersion: "swe.dev/v1alpha1", Kind: "Environment", Name: "one", UID: "e", Controller: &controller}}}, Spec: corev1.PodSpec{
+		SecurityContext: &corev1.PodSecurityContext{FSGroup: &group}, Containers: []corev1.Container{{Name: "environment", Env: []corev1.EnvVar{{Name: "NO_PROXY", Value: "metadata"}}}},
+		InitContainers: []corev1.Container{{Name: "repository-clone"}, {Name: "project-hooks"}}, Volumes: []corev1.Volume{{Name: "workspace"}},
+	}}
+	return pod, RestrictedEgress{Backend: "pod", OperatingSystem: "linux", ForwarderImage: "proxy@sha256:abc", ProxyAddress: "proxy.system.svc:8443", ProxyServerName: "proxy.system.svc", CredentialSecret: "egress-one", ProxyCASecret: "proxy-ca", CredentialFSGroup: group}
+}
+
+func TestPrepareRestrictedEgressOrderingIsolationAndEnvironment(t *testing.T) {
+	pod, input := fixture()
+	if err := PrepareRestrictedEgress(pod, input); err != nil {
+		t.Fatal(err)
+	}
+	if got := []string{pod.Spec.InitContainers[0].Name, pod.Spec.InitContainers[1].Name, pod.Spec.InitContainers[2].Name}; !reflect.DeepEqual(got, []string{ForwarderName, "repository-clone", "project-hooks"}) {
+		t.Fatalf("init order = %v", got)
+	}
+	forwarder := pod.Spec.InitContainers[0]
+	if forwarder.RestartPolicy == nil || *forwarder.RestartPolicy != corev1.ContainerRestartPolicyAlways || forwarder.StartupProbe == nil || len(forwarder.Resources.Requests) != 2 || len(forwarder.Resources.Limits) != 2 {
+		t.Fatalf("forwarder lifecycle/resources = %#v", forwarder)
+	}
+	if forwarder.SecurityContext == nil || forwarder.SecurityContext.RunAsNonRoot == nil || !*forwarder.SecurityContext.RunAsNonRoot || forwarder.SecurityContext.ReadOnlyRootFilesystem == nil || !*forwarder.SecurityContext.ReadOnlyRootFilesystem || len(forwarder.SecurityContext.Capabilities.Drop) != 1 {
+		t.Fatalf("forwarder security = %#v", forwarder.SecurityContext)
+	}
+	if len(forwarder.VolumeMounts) != 2 || forwarder.VolumeMounts[0].Name != CredentialVolume || forwarder.VolumeMounts[1].Name != ProxyCAVolume {
+		t.Fatalf("forwarder mounts = %#v", forwarder.VolumeMounts)
+	}
+	for _, container := range append(pod.Spec.InitContainers[1:], pod.Spec.Containers...) {
+		for _, mount := range container.VolumeMounts {
+			if mount.Name == CredentialVolume || mount.Name == ProxyCAVolume {
+				t.Fatalf("%s received egress credential mount", container.Name)
+			}
+		}
+		values := map[string]string{}
+		for _, variable := range container.Env {
+			values[variable.Name] = variable.Value
+		}
+		if values["HTTP_PROXY"] != "http://127.0.0.1:15001" || values["https_proxy"] != "http://127.0.0.1:15001" || values["NO_PROXY"] != "" || values["no_proxy"] != "" {
+			t.Fatalf("%s proxy env = %#v", container.Name, values)
+		}
+	}
+	if pod.Spec.OS == nil || pod.Spec.OS.Name != corev1.Linux || len(pod.Spec.SchedulingGates) != 1 || pod.Spec.SchedulingGates[0].Name != SchedulingGateName {
+		t.Fatalf("Pod was not staged: %#v", pod.Spec)
+	}
+	if pod.Spec.EnableServiceLinks == nil || *pod.Spec.EnableServiceLinks || pod.Spec.AutomountServiceAccountToken == nil || *pod.Spec.AutomountServiceAccountToken || pod.Spec.ShareProcessNamespace != nil {
+		t.Fatalf("Pod ambient settings = %#v", pod.Spec)
+	}
+	if pod.Spec.Volumes[len(pod.Spec.Volumes)-1].Secret.SecretName != input.ProxyCASecret {
+		t.Fatal("administrator proxy CA is not separate")
+	}
+}
+
+func TestValidateBoundPodRequiresExactUIDAndFingerprint(t *testing.T) {
+	pod, input := fixture()
+	if err := PrepareRestrictedEgress(pod, input); err != nil {
+		t.Fatal(err)
+	}
+	pod.UID = "pod-uid"
+	claims := egressidentity.Claims{InstallationNamespace: "system", InstallationName: "main", InstallationUID: "i", ProjectNamespace: "project", ProjectName: "project", ProjectUID: "p", EnvironmentNamespace: pod.Namespace, EnvironmentName: "one", EnvironmentUID: "e", PodName: pod.Name, PodUID: pod.UID, ExecutionGeneration: 1, RuntimePolicyRevision: "policy-revision", ForwarderRevision: ForwarderRevision}
+	secret, binding, err := IssueCredentialSecret(time.Unix(1000, 0), pod, input, claims)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secret.UID, secret.ResourceVersion = "secret-uid", "1"
+	if err := binding.SealCreatedSecret(secret); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateBoundPod(pod, input, secret, binding); err != nil {
+		t.Fatal(err)
+	}
+	for name, mutate := range map[string]func(*corev1.Pod, *corev1.Secret){
+		"same-name replacement Pod":         func(p *corev1.Pod, _ *corev1.Secret) { p.UID = "replacement" },
+		"same-name replacement Environment": func(p *corev1.Pod, _ *corev1.Secret) { p.OwnerReferences[0].UID = "replacement" },
+		"replacement Secret UID":            func(_ *corev1.Pod, s *corev1.Secret) { s.UID = "replacement" },
+		"changed Secret resourceVersion":    func(_ *corev1.Pod, s *corev1.Secret) { s.ResourceVersion = "2" },
+		"fingerprint":                       func(_ *corev1.Pod, s *corev1.Secret) { s.Data[egressidentity.ClientCertificateKey] = []byte("bad") },
+		"private key":                       func(_ *corev1.Pod, s *corev1.Secret) { s.Data[egressidentity.ClientPrivateKeyKey] = []byte("bad") },
+		"gate":                              func(p *corev1.Pod, _ *corev1.Secret) { p.Spec.SchedulingGates = nil },
+		"admission mount": func(p *corev1.Pod, _ *corev1.Secret) {
+			p.Spec.Containers[0].VolumeMounts = append(p.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{Name: CredentialVolume})
+		},
+		"admission Secret alias": func(p *corev1.Pod, _ *corev1.Secret) {
+			p.Spec.Volumes = append(p.Spec.Volumes, corev1.Volume{Name: "alias", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: input.CredentialSecret}}})
+		},
+		"admission sidecar": func(p *corev1.Pod, _ *corev1.Secret) {
+			p.Spec.Containers = append(p.Spec.Containers, corev1.Container{Name: "injected"})
+		},
+		"ephemeral target": func(p *corev1.Pod, _ *corev1.Secret) {
+			p.Spec.EphemeralContainers = append(p.Spec.EphemeralContainers, corev1.EphemeralContainer{TargetContainerName: ForwarderName})
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			changedPod := pod.DeepCopy()
+			changedSecret := secret.DeepCopy()
+			mutate(changedPod, changedSecret)
+			if err := ValidateBoundPod(changedPod, input, changedSecret, binding); err == nil {
+				t.Fatal("stale binding accepted")
+			}
+		})
+	}
+	stalePod, staleInput := fixture()
+	if err := PrepareRestrictedEgress(stalePod, staleInput); err != nil {
+		t.Fatal(err)
+	}
+	stalePod.UID = "old-pod"
+	if _, _, err := IssueCredentialSecret(time.Unix(1000, 0), stalePod, staleInput, claims); err == nil {
+		t.Fatal("stale same-name Pod/Environment was adopted during issuance")
+	}
+}
+
+func TestBindingSealsOnlyExactSuccessfulCreateOnce(t *testing.T) {
+	pod, input := fixture()
+	if err := PrepareRestrictedEgress(pod, input); err != nil {
+		t.Fatal(err)
+	}
+	pod.UID = "pod-uid"
+	claims := egressidentity.Claims{InstallationNamespace: "system", InstallationName: "main", InstallationUID: "i", ProjectNamespace: "project", ProjectName: "project", ProjectUID: "p", EnvironmentNamespace: pod.Namespace, EnvironmentName: "one", EnvironmentUID: "e", PodName: pod.Name, PodUID: pod.UID, ExecutionGeneration: 1, RuntimePolicyRevision: "policy-revision", ForwarderRevision: ForwarderRevision}
+	secret, binding, err := IssueCredentialSecret(time.Unix(1000, 0), pod, input, claims)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateBoundPod(pod, input, secret, binding); err == nil {
+		t.Fatal("unsealed binding accepted")
+	}
+	for name, mutate := range map[string]func(*corev1.Secret){
+		"empty UID":             func(s *corev1.Secret) { s.ResourceVersion = "1" },
+		"empty resourceVersion": func(s *corev1.Secret) { s.UID = "secret-uid" },
+		"tampered data": func(s *corev1.Secret) {
+			s.UID, s.ResourceVersion = "secret-uid", "1"
+			s.Data[egressidentity.ClientCertificateKey] = []byte("tampered")
+		},
+		"tampered owner": func(s *corev1.Secret) {
+			s.UID, s.ResourceVersion = "secret-uid", "1"
+			s.OwnerReferences[0].UID = "other-pod"
+		},
+		"tampered name": func(s *corev1.Secret) {
+			s.UID, s.ResourceVersion = "secret-uid", "1"
+			s.Name = "other-secret"
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			changed := secret.DeepCopy()
+			mutate(changed)
+			if err := binding.SealCreatedSecret(changed); err == nil {
+				t.Fatal("tampered create response sealed")
+			}
+		})
+	}
+	secret.UID, secret.ResourceVersion = "secret-uid", "1"
+	if err := binding.SealCreatedSecret(secret); err != nil {
+		t.Fatal(err)
+	}
+	if err := binding.SealCreatedSecret(secret); err == nil {
+		t.Fatal("binding resealed")
+	}
+}
+
+func TestPrepareRejectsEveryVolumeSourceSecretAlias(t *testing.T) {
+	ref := func(name string) *corev1.LocalObjectReference {
+		return &corev1.LocalObjectReference{Name: name}
+	}
+	sources := map[string]func(string) corev1.VolumeSource{
+		"Secret": func(name string) corev1.VolumeSource {
+			return corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: name}}
+		},
+		"Projected": func(name string) corev1.VolumeSource {
+			return corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{Sources: []corev1.VolumeProjection{{Secret: &corev1.SecretProjection{LocalObjectReference: corev1.LocalObjectReference{Name: name}}}}}}
+		},
+		"CSI": func(name string) corev1.VolumeSource {
+			return corev1.VolumeSource{CSI: &corev1.CSIVolumeSource{NodePublishSecretRef: ref(name)}}
+		},
+		"ISCSI": func(name string) corev1.VolumeSource {
+			return corev1.VolumeSource{ISCSI: &corev1.ISCSIVolumeSource{SecretRef: ref(name)}}
+		},
+		"RBD": func(name string) corev1.VolumeSource {
+			return corev1.VolumeSource{RBD: &corev1.RBDVolumeSource{SecretRef: ref(name)}}
+		},
+		"FlexVolume": func(name string) corev1.VolumeSource {
+			return corev1.VolumeSource{FlexVolume: &corev1.FlexVolumeSource{SecretRef: ref(name)}}
+		},
+		"Cinder": func(name string) corev1.VolumeSource {
+			return corev1.VolumeSource{Cinder: &corev1.CinderVolumeSource{SecretRef: ref(name)}}
+		},
+		"CephFS": func(name string) corev1.VolumeSource {
+			return corev1.VolumeSource{CephFS: &corev1.CephFSVolumeSource{SecretRef: ref(name)}}
+		},
+		"AzureFile": func(name string) corev1.VolumeSource {
+			return corev1.VolumeSource{AzureFile: &corev1.AzureFileVolumeSource{SecretName: name}}
+		},
+		"ScaleIO": func(name string) corev1.VolumeSource {
+			return corev1.VolumeSource{ScaleIO: &corev1.ScaleIOVolumeSource{SecretRef: ref(name)}}
+		},
+		"StorageOS": func(name string) corev1.VolumeSource {
+			return corev1.VolumeSource{StorageOS: &corev1.StorageOSVolumeSource{SecretRef: ref(name)}}
+		},
+	}
+	for sourceName, source := range sources {
+		for secretName, selectName := range map[string]func(RestrictedEgress) string{
+			"credential": func(in RestrictedEgress) string { return in.CredentialSecret },
+			"proxy CA":   func(in RestrictedEgress) string { return in.ProxyCASecret },
+		} {
+			t.Run(sourceName+"/"+secretName, func(t *testing.T) {
+				pod, input := fixture()
+				pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{Name: "alias", VolumeSource: source(selectName(input))})
+				if err := PrepareRestrictedEgress(pod, input); err == nil {
+					t.Fatal("reserved Secret alias accepted")
+				}
+			})
+		}
+	}
+}
+
+func TestValidateBoundPodRejectsAdmissionInjectedCSIAlias(t *testing.T) {
+	pod, input := fixture()
+	if err := PrepareRestrictedEgress(pod, input); err != nil {
+		t.Fatal(err)
+	}
+	pod.UID = "pod-uid"
+	claims := egressidentity.Claims{InstallationNamespace: "system", InstallationName: "main", InstallationUID: "i", ProjectNamespace: "project", ProjectName: "project", ProjectUID: "p", EnvironmentNamespace: pod.Namespace, EnvironmentName: "one", EnvironmentUID: "e", PodName: pod.Name, PodUID: pod.UID, ExecutionGeneration: 1, RuntimePolicyRevision: "policy-revision", ForwarderRevision: ForwarderRevision}
+	secret, binding, err := IssueCredentialSecret(time.Unix(1000, 0), pod, input, claims)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secret.UID, secret.ResourceVersion = "secret-uid", "1"
+	if err := binding.SealCreatedSecret(secret); err != nil {
+		t.Fatal(err)
+	}
+	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{Name: "alias", VolumeSource: corev1.VolumeSource{CSI: &corev1.CSIVolumeSource{NodePublishSecretRef: &corev1.LocalObjectReference{Name: input.ProxyCASecret}}}})
+	if err := ValidateBoundPod(pod, input, secret, binding); err == nil {
+		t.Fatal("admission-injected CSI Secret alias accepted")
+	}
+}
+
+func TestPrepareRejectsUnsupportedAndAmbientCredentialExposureAtomically(t *testing.T) {
+	for name, mutate := range map[string]func(*corev1.Pod, *RestrictedEgress){
+		"unsupported backend": func(_ *corev1.Pod, in *RestrictedEgress) { in.Backend = "kubevirt" }, "Windows": func(_ *corev1.Pod, in *RestrictedEgress) { in.OperatingSystem = "windows" },
+		"host PID": func(p *corev1.Pod, _ *RestrictedEgress) { p.Spec.HostPID = true }, "no fsGroup": func(p *corev1.Pod, _ *RestrictedEgress) { p.Spec.SecurityContext.FSGroup = nil },
+		"aliased Secret volume": func(p *corev1.Pod, in *RestrictedEgress) {
+			p.Spec.Volumes = append(p.Spec.Volumes, corev1.Volume{Name: "alias", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: in.CredentialSecret}}})
+		},
+		"projected Secret": func(p *corev1.Pod, in *RestrictedEgress) {
+			p.Spec.Volumes = append(p.Spec.Volumes, corev1.Volume{Name: "alias", VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{Sources: []corev1.VolumeProjection{{Secret: &corev1.SecretProjection{LocalObjectReference: corev1.LocalObjectReference{Name: in.CredentialSecret}}}}}}})
+		},
+		"service account projection": func(p *corev1.Pod, _ *RestrictedEgress) {
+			p.Spec.Volumes = append(p.Spec.Volumes, corev1.Volume{Name: "token", VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{Sources: []corev1.VolumeProjection{{ServiceAccountToken: &corev1.ServiceAccountTokenProjection{Path: "token"}}}}}})
+		},
+		"Secret env": func(p *corev1.Pod, in *RestrictedEgress) {
+			p.Spec.Containers[0].Env = append(p.Spec.Containers[0].Env, corev1.EnvVar{Name: "KEY", ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: in.CredentialSecret}, Key: "key"}}})
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			pod, input := fixture()
+			mutate(pod, &input)
+			before := pod.DeepCopy()
+			if err := PrepareRestrictedEgress(pod, input); err == nil {
+				t.Fatal("invalid input accepted")
+			}
+			if !reflect.DeepEqual(pod, before) {
+				t.Fatal("failed preparation mutated Pod")
+			}
+		})
+	}
+}

--- a/internal/egressproxy/proxy.go
+++ b/internal/egressproxy/proxy.go
@@ -11,12 +11,11 @@ import (
 	"net/netip"
 	"sync"
 	"time"
+
+	"github.com/Chris-Cullins/swe-platform/internal/egressidentity"
 )
 
-type Identity struct {
-	Fingerprint [32]byte
-	Subject     string
-}
+type Identity = egressidentity.CertificateHint
 type Authorization struct {
 	ExecutionKey, ProjectKey string
 	DeniedPrefixes           []netip.Prefix


### PR DESCRIPTION
## Summary

- define bounded canonical per-execution identity claims binding exact Installation, Project, Environment, Pod UID/name, execution generation, policy/forwarder revisions, and client-certificate fingerprint
- issue separate ECDSA ClientAuth material and expose only an untrusted certificate hint to the disabled proxy
- add an unreachable Linux Pod helper that prepares a native restartable init-sidecar behind a scheduling gate and a required not-yet-created credential Secret
- bind successful Secret creation through a one-way UID/resourceVersion seal and validate the exact uncached Pod/Secret before future gate removal
- reject admission/workload aliases to either egress Secret across every Secret-bearing inline `corev1.VolumeSource` field
- preserve the existing pre-child non-empty allowlist rejection; no controller imports or invokes these helpers

This is inert issue #68 slice 4 foundation. It adds no proxy deployment, chart/preset behavior, runtime activation, NetworkPolicy, or production enforcement claim, and does **not** close #68.

## Validation

- `go test ./internal/egresspod ./internal/egressidentity ./internal/egressproxy ./internal/controllers -count=1`
- focused identity/Pod/controller race tests
- `go test -race ./internal/egressproxy -count=1`
- `make test`
- `make vet`
- `make check-chart-crds`
- `git diff --check origin/main...HEAD`

Independent blocker-only security review: approve/no blockers after exact Secret identity sealing and exhaustive inline Secret-reference fixes.
