### PR TITLE
Add inert egress currentness authority foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,9 @@ Pi deliberately supports no credential profiles or credential injection.
   outside `make build` and image publishing until the fail-closed runtime is enabled.
   `internal/egresspolicy/` owns the strict immutable ConfigMap parser as well as destination and
   revision authority; `internal/egressproxy/` contains an uncached two-second currentness
-  authorizer foundation, but the command must remain wired to `DisabledAuthorizer`.
+  authorizer foundation, but the command must remain wired to `DisabledAuthorizer`. Future
+  transport wiring must release every successful currentness lease when replacing it or closing
+  its tunnel so per-fingerprint state remains bounded.
   `internal/egressidentity/` and `internal/egresspod/` are likewise inert contract foundations;
   do not wire them into reconciliation or relax the non-empty allowlist fence before the complete
   restricted runtime is atomically enabled. The exact adapter contract boundary is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,9 @@ Pi deliberately supports no credential profiles or credential injection.
   `internal/controllers/`, and `cmd/{operator,control-plane,swe,egress-proxy}` for root-module
   binaries. The egress proxy command is a disabled protocol foundation and intentionally remains
   outside `make build` and image publishing until the fail-closed runtime is enabled.
+  `internal/egresspolicy/` owns the strict immutable ConfigMap parser as well as destination and
+  revision authority; `internal/egressproxy/` contains an uncached two-second currentness
+  authorizer foundation, but the command must remain wired to `DisabledAuthorizer`.
   `internal/egressidentity/` and `internal/egresspod/` are likewise inert contract foundations;
   do not wire them into reconciliation or relax the non-empty allowlist fence before the complete
   restricted runtime is atomically enabled. The exact adapter contract boundary is

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -813,9 +813,26 @@ it. The versioned canonical identity binds exact Installation namespace/name/UID
 namespace/name/UID, Environment namespace/name/UID, Pod name/UID, execution generation, runtime
 policy revision, forwarder security revision, and SHA-256 client-certificate fingerprint.
 Certificate subject fields and the fingerprint presented by TLS are untrusted lookup hints: a
-future authorizer must resolve the fingerprint and repeat exact currentness checks against
-authoritative objects. A separate self-signed ECDSA ClientAuth keypair is generated for each
+disabled currentness-authorizer foundation resolves canonical claims by fingerprint and, within
+two seconds, repeats uncached reads for the exact live Installation, active Namespace claim and
+sole Project, frozen Project-bound ready Environment execution, controlled non-deleting Pod,
+and immutable policy ConfigMap. It independently recomputes policy and revision, checks the Pod's
+execution, policy, forwarder, and certificate-fingerprint annotations, and rejects API
+uncertainty. Each successful fingerprint receives a currentness signal that closes after any
+failed recheck so future tunnel wiring can revoke established connections without caching
+authority. No command constructs this authorizer; `egress-proxy serve` still uses the deny-all
+`DisabledAuthorizer`. A separate self-signed ECDSA ClientAuth keypair is generated for each
 execution and is not sandboxd ServerAuth material.
+
+`internal/egresspolicy` also strictly parses the future administrator policy ConfigMap contract.
+The exact live object must have a UID, be non-deleting and immutable, contain only canonical
+`policy.json`, and carry its canonical SHA-256 content address. Schema v1 fixes
+`unrestricted|restricted` mode, the existing 256-entry ceiling and 64-entry baseline bounds,
+an immutable digest-qualified proxy image, and an administrator TLS Secret name. Restricted mode
+requires the exact `calico-v3.32.1` profile with 1–4 canonical resolver IPs and bounded canonical
+API server, Pod, Service, node, control-plane, and additional-denial CIDR sets. Invalid,
+mutable, replaced, or non-canonical authority fails closed; Helm values are not authority. The
+chart does not create this ConfigMap, Secret, proxy, ServiceAccount, or RBAC.
 
 The Pod helper resolves the UID ordering problem with a staged Kubernetes scheduling gate. Before
 CREATE it accepts a complete Linux Pod-backend preparation input, prepends the native restartable
@@ -840,8 +857,9 @@ The current non-empty Project allowlist rejection remains unchanged and runs bef
 Pod-spec construction. It stays until identity publication and exact two-second currentness,
 proxy readiness, technical path forcing, Calico v3.32.1-only enforcement proof, and acceptance
 land together. There is currently no default-deny egress, proxy deployment, runtime policy
-ConfigMap, restricted profile, or production egress-enforcement claim; generic Kubernetes, k3s,
-GKE, and EKS restricted profiles remain deferred. Issue #68 is not runtime-complete.
+ConfigMap instance, active restricted profile, or production egress-enforcement claim; generic
+Kubernetes, k3s, GKE, and EKS restricted profiles remain deferred. Issue #68 is not
+runtime-complete.
 
 Slice 3 provides only a default-off experimental conformance runner. The separate pinned
 dual-stack, two-worker kind topology and `hack/egress-conformance.sh` can perform one disposable,

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -820,7 +820,10 @@ and immutable policy ConfigMap. It independently recomputes policy and revision,
 execution, policy, forwarder, and certificate-fingerprint annotations, and rejects API
 uncertainty. Each successful fingerprint receives a currentness signal that closes after any
 failed recheck so future tunnel wiring can revoke established connections without caching
-authority. No command constructs this authorizer; `egress-proxy serve` still uses the deny-all
+authority. Every successful authorization also returns a one-shot lifecycle release; future
+transport wiring must release the prior lease when a recheck replaces it and release the final
+lease when the tunnel closes. The final release closes the signal and reclaims its bounded state.
+No command constructs this authorizer; `egress-proxy serve` still uses the deny-all
 `DisabledAuthorizer`. A separate self-signed ECDSA ClientAuth keypair is generated for each
 execution and is not sandboxd ServerAuth material.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -138,7 +138,7 @@ selection.
 The operator still rejects every non-empty Project selection and fences any existing Environment
 execution rather than running with unenforced intent. Empty or omitted selections do not restrict
 Environment egress today, which remains subject to cluster network configuration. No policy
-ConfigMap, proxy deployment, identity publication, path forcing, restricted NetworkPolicy, or
+ConfigMap instance, proxy deployment, identity publication, path forcing, restricted NetworkPolicy, or
 enforcement proof is wired; the approved restricted runtime is Calico v3.32.1-only and remains
 later issue #68 work.
 
@@ -146,10 +146,20 @@ The implemented but unreachable identity foundation uses bounded canonical v1 cl
 Installation, Project, Environment, Pod, execution, policy, forwarder, and certificate-fingerprint
 identity. A separate per-execution self-signed ECDSA certificate has ClientAuth usage only; its
 key and trust material are distinct from sandboxd's ServerAuth credential. TLS certificate
-subjects and presented fingerprints are lookup hints, never authorization claims. A future proxy
-authorizer must map the fingerprint to canonical claims, independently repeat exact uncached
-currentness checks, and reject any stale object, execution, policy revision, forwarder revision,
-or fingerprint.
+subjects and presented fingerprints are lookup hints, never authorization claims. The unreachable
+proxy currentness foundation maps the fingerprint to canonical claims, then performs a fresh,
+two-second-bounded proof of the exact Installation, active Namespace claim and sole Project,
+frozen Project-bound ready Environment execution, controlled non-deleting Pod, and live effective
+policy revision. API errors, replacements, malformed or out-of-ceiling policy, and stale
+execution/policy/forwarder/fingerprint values deny and close a per-fingerprint currentness signal
+suitable for future tunnel revocation. The shipped serve command still installs only the deny-all
+authorizer.
+
+The policy library now also validates a future immutable, content-addressed ConfigMap document:
+canonical schema v1, `unrestricted|restricted` mode, bounded ceiling/baseline, digest-qualified
+proxy image, named administrator TLS Secret, and exact Calico v3.32.1 resolver/CIDR bounds for
+restricted mode. The chart creates none of those resources and Helm rendering is not authority;
+runtime authority would be the exact ConfigMap UID plus canonical content.
 
 Kubernetes assigns a Pod UID only after creation. The inert Pod helper therefore adds an
 egress-specific scheduling gate and a required, deliberately absent credential Secret reference

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -152,8 +152,10 @@ two-second-bounded proof of the exact Installation, active Namespace claim and s
 frozen Project-bound ready Environment execution, controlled non-deleting Pod, and live effective
 policy revision. API errors, replacements, malformed or out-of-ceiling policy, and stale
 execution/policy/forwarder/fingerprint values deny and close a per-fingerprint currentness signal
-suitable for future tunnel revocation. The shipped serve command still installs only the deny-all
-authorizer.
+suitable for future tunnel revocation. Successful authorizations carry a one-shot lifecycle
+release that future transport wiring must call when replacing a recheck lease and when closing the
+last tunnel; final release closes the signal and reclaims its bounded state. The shipped serve
+command still installs only the deny-all authorizer.
 
 The policy library now also validates a future immutable, content-addressed ConfigMap document:
 canonical schema v1, `unrestricted|restricted` mode, bounded ceiling/baseline, digest-qualified

--- a/charts/swe-platform/README.md
+++ b/charts/swe-platform/README.md
@@ -480,7 +480,10 @@ Environment status does not report it as effective isolation.
 
 The chart does not install default-deny egress or an egress allowlist proxy. Project
 `egressAllowlist` values are reserved and rejected when non-empty; empty or omitted values leave
-egress subject to the cluster's network configuration.
+egress subject to the cluster's network configuration. The Go foundation can validate a future
+immutable, content-addressed system policy ConfigMap and perform disabled uncached currentness
+proofs, but this chart deliberately has no values, ConfigMap, Deployment, Service, ServiceAccount,
+RBAC, TLS Secret, or NetworkPolicy for that foundation. No production preset enables it.
 
 The repository also contains a deliberately disabled experimental Calico v3.32.1 diagnostic
 runner on a separate dual-stack kind topology. It is not a chart component, production preset
@@ -730,7 +733,7 @@ plane pod from starting after installation, with no memory fallback.
 |---|---|---|
 | Control-plane exposure | ClusterIP Service on port 80. Optional portal Ingress owns only `*.controlPlane.portal.suffix` | Expose the ordinary API separately; provide wildcard DNS and an administrator-owned wildcard TLS Secret for portals |
 | Environment sandboxd isolation | Ingress NetworkPolicy per environment pod: port 50051 admitted only from release-namespace control-plane and operator pods | CNI must enforce Kubernetes NetworkPolicy for defense in depth; TLS and capability authorization remain mandatory regardless |
-| Environment egress | No default-deny egress or egress proxy | Environment egress is subject to cluster network configuration; `Project.spec.egressAllowlist` is reserved and rejected when non-empty |
+| Environment egress | No default-deny egress, policy ConfigMap instance, or egress proxy; parser/currentness code is inert and not chart-rendered | Environment egress is subject to cluster network configuration; `Project.spec.egressAllowlist` is reserved and rejected when non-empty |
 | Operator → control plane | In-cluster HTTP to the control-plane Service | No external networking required; both components run in the release namespace |
 
 The `controlPlane.auth.trustProxyHeaders` option is available for a trusted reverse proxy

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Chris-Cullins/swe-platform/sandboxd v0.0.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
+	github.com/distribution/reference v0.6.0
 	github.com/google/jsonschema-go v0.4.3
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/jackc/pgx/v5 v5.9.2
@@ -25,6 +26,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.36.0
 	k8s.io/apimachinery v0.36.2
 	k8s.io/client-go v0.36.2
+	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/controller-runtime v0.24.1
 	sigs.k8s.io/yaml v1.6.0
 )
@@ -80,6 +82,7 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
@@ -119,7 +122,6 @@ require (
 	k8s.io/component-base v0.36.0 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
-	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
+github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bFY/oTyCes=
 github.com/emicklei/go-restful/v3 v3.13.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
@@ -165,6 +167,8 @@ github.com/onsi/ginkgo/v2 v2.27.4 h1:fcEcQW/A++6aZAZQNUmNjvA9PSOzefMJBerHJ4t8v8Y
 github.com/onsi/ginkgo/v2 v2.27.4/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.39.0 h1:y2ROC3hKFmQZJNFeGAMeHZKkjBL65mIZcvrLQBF9k6Q=
 github.com/onsi/gomega v1.39.0/go.mod h1:ZCU1pkQcXDO5Sl9/VVEGlDyp+zm0m1cmeG5TOzLgdh4=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/internal/egresspod/pod.go
+++ b/internal/egresspod/pod.go
@@ -25,16 +25,19 @@ import (
 )
 
 const (
-	ForwarderName                 = "egress-forwarder"
-	CredentialVolume              = "egress-client-credentials"
-	ProxyCAVolume                 = "egress-proxy-ca"
-	CredentialMount               = "/var/run/swe-platform/egress/client"
-	ProxyCAMount                  = "/var/run/swe-platform/egress/proxy"
-	ProxyServerCAKey              = "ca.crt"
-	SchedulingGateName            = "egress.swe.dev/identity-ready"
-	ExecutionGenerationAnnotation = "swe.dev/execution-generation"
-	LoopbackPort                  = int32(15001)
-	ForwarderRevision             = "1"
+	ForwarderName                    = "egress-forwarder"
+	CredentialVolume                 = "egress-client-credentials"
+	ProxyCAVolume                    = "egress-proxy-ca"
+	CredentialMount                  = "/var/run/swe-platform/egress/client"
+	ProxyCAMount                     = "/var/run/swe-platform/egress/proxy"
+	ProxyServerCAKey                 = "ca.crt"
+	SchedulingGateName               = "egress.swe.dev/identity-ready"
+	ExecutionGenerationAnnotation    = "swe.dev/execution-generation"
+	PolicyRevisionAnnotation         = "swe.dev/egress-policy-revision"
+	ForwarderRevisionAnnotation      = "swe.dev/egress-forwarder-security-revision"
+	CertificateFingerprintAnnotation = "swe.dev/egress-client-certificate-sha256"
+	LoopbackPort                     = int32(15001)
+	ForwarderRevision                = "1"
 )
 
 type RestrictedEgress struct {
@@ -267,6 +270,9 @@ func validatePreparation(pod *corev1.Pod, in RestrictedEgress) error {
 	if pod.Spec.HostPID || pod.Spec.HostIPC || pod.Spec.HostNetwork || pod.Spec.ShareProcessNamespace != nil && *pod.Spec.ShareProcessNamespace {
 		return errors.New("restricted egress Pod must not use host or shared process namespaces")
 	}
+	if pod.Spec.RestartPolicy != corev1.RestartPolicyNever {
+		return errors.New("restricted egress Pod must use restartPolicy Never")
+	}
 	if pod.Spec.NodeName != "" {
 		return errors.New("restricted egress Pod must be held by the scheduler")
 	}
@@ -294,6 +300,9 @@ func validatePersistedPod(pod *corev1.Pod, in RestrictedEgress) error {
 	}
 	if pod.Spec.HostPID || pod.Spec.HostIPC || pod.Spec.HostNetwork || pod.Spec.ShareProcessNamespace != nil && *pod.Spec.ShareProcessNamespace {
 		return errors.New("persisted Pod uses a forbidden namespace")
+	}
+	if pod.Spec.RestartPolicy != corev1.RestartPolicyNever {
+		return errors.New("persisted Pod can restart within one execution identity")
 	}
 	if pod.Spec.NodeName != "" {
 		return errors.New("persisted Pod bypasses the scheduling gate")

--- a/internal/egresspod/pod_test.go
+++ b/internal/egresspod/pod_test.go
@@ -15,6 +15,7 @@ func fixture() (*corev1.Pod, RestrictedEgress) {
 	group := int64(10001)
 	controller := true
 	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "env-one", Namespace: "project", Annotations: map[string]string{ExecutionGenerationAnnotation: "1"}, OwnerReferences: []metav1.OwnerReference{{APIVersion: "swe.dev/v1alpha1", Kind: "Environment", Name: "one", UID: "e", Controller: &controller}}}, Spec: corev1.PodSpec{
+		RestartPolicy:   corev1.RestartPolicyNever,
 		SecurityContext: &corev1.PodSecurityContext{FSGroup: &group}, Containers: []corev1.Container{{Name: "environment", Env: []corev1.EnvVar{{Name: "NO_PROXY", Value: "metadata"}}}},
 		InitContainers: []corev1.Container{{Name: "repository-clone"}, {Name: "project-hooks"}}, Volumes: []corev1.Volume{{Name: "workspace"}},
 	}}
@@ -250,7 +251,10 @@ func TestPrepareRejectsUnsupportedAndAmbientCredentialExposureAtomically(t *test
 	for name, mutate := range map[string]func(*corev1.Pod, *RestrictedEgress){
 		"unsupported backend": func(_ *corev1.Pod, in *RestrictedEgress) { in.Backend = "kubevirt" }, "Windows": func(_ *corev1.Pod, in *RestrictedEgress) { in.OperatingSystem = "windows" },
 		"host PID": func(p *corev1.Pod, _ *RestrictedEgress) { p.Spec.HostPID = true }, "no fsGroup": func(p *corev1.Pod, _ *RestrictedEgress) { p.Spec.SecurityContext.FSGroup = nil },
-		"preset nodeName": func(p *corev1.Pod, _ *RestrictedEgress) { p.Spec.NodeName = "worker" },
+		"preset nodeName":           func(p *corev1.Pod, _ *RestrictedEgress) { p.Spec.NodeName = "worker" },
+		"empty restart policy":      func(p *corev1.Pod, _ *RestrictedEgress) { p.Spec.RestartPolicy = "" },
+		"always restart policy":     func(p *corev1.Pod, _ *RestrictedEgress) { p.Spec.RestartPolicy = corev1.RestartPolicyAlways },
+		"on-failure restart policy": func(p *corev1.Pod, _ *RestrictedEgress) { p.Spec.RestartPolicy = corev1.RestartPolicyOnFailure },
 		"aliased Secret volume": func(p *corev1.Pod, in *RestrictedEgress) {
 			p.Spec.Volumes = append(p.Spec.Volumes, corev1.Volume{Name: "alias", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: in.CredentialSecret}}})
 		},

--- a/internal/egresspolicy/config.go
+++ b/internal/egresspolicy/config.go
@@ -1,0 +1,226 @@
+package egresspolicy
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/netip"
+	"sort"
+
+	"github.com/distribution/reference"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+const (
+	ConfigAPIVersion              = "swe.dev/egress-policy/v1"
+	ConfigDataKey                 = "policy.json"
+	ConfigContentSHA256Annotation = "swe.dev/egress-policy-content-sha256"
+	RestrictedProfileCalicoV1     = "calico-v3.32.1"
+)
+
+const (
+	ModeUnrestricted = "unrestricted"
+	ModeRestricted   = "restricted"
+)
+
+// RestrictedProfile is the bounded Calico v3.32.1-only network authority
+// input. Generic Kubernetes NetworkPolicy profiles are deliberately absent.
+type RestrictedProfile struct {
+	Name                  string   `json:"name"`
+	ResolverIPs           []string `json:"resolverIPs"`
+	APIServerCIDRs        []string `json:"apiServerCIDRs"`
+	PodCIDRs              []string `json:"podCIDRs"`
+	ServiceCIDRs          []string `json:"serviceCIDRs"`
+	NodeCIDRs             []string `json:"nodeCIDRs"`
+	ControlPlaneCIDRs     []string `json:"controlPlaneCIDRs"`
+	AdditionalDeniedCIDRs []string `json:"additionalDeniedCIDRs"`
+}
+
+// Config is the canonical administrator-owned system egress policy document.
+// ProxyImage is an immutable repository@sha256 identity, not a mutable tag.
+type Config struct {
+	APIVersion        string             `json:"apiVersion"`
+	Mode              string             `json:"mode"`
+	Ceiling           []Hostname         `json:"ceiling"`
+	Baseline          []Hostname         `json:"baseline"`
+	RestrictedProfile *RestrictedProfile `json:"restrictedProfile,omitempty"`
+	TLSSecretName     string             `json:"tlsSecretName"`
+	ProxyImage        string             `json:"proxyImage"`
+}
+
+// ParsedConfig binds validated canonical policy content to the exact live
+// immutable ConfigMap incarnation that carried it.
+type ParsedConfig struct {
+	Config
+	ContentSHA256 [sha256.Size]byte
+}
+
+type configWire struct {
+	APIVersion        string             `json:"apiVersion"`
+	Mode              string             `json:"mode"`
+	Ceiling           []string           `json:"ceiling"`
+	Baseline          []string           `json:"baseline"`
+	RestrictedProfile *RestrictedProfile `json:"restrictedProfile,omitempty"`
+	TLSSecretName     string             `json:"tlsSecretName"`
+	ProxyImage        string             `json:"proxyImage"`
+}
+
+// ParseConfigMap strictly validates immutable, content-addressed authority.
+// The only accepted data is canonical policy.json; Helm-rendered values are
+// never treated as authority.
+func ParseConfigMap(configMap *corev1.ConfigMap) (ParsedConfig, error) {
+	if configMap == nil || configMap.UID == "" || !configMap.DeletionTimestamp.IsZero() {
+		return ParsedConfig{}, errors.New("stable live policy ConfigMap is required")
+	}
+	if configMap.Immutable == nil || !*configMap.Immutable {
+		return ParsedConfig{}, errors.New("policy ConfigMap must be immutable")
+	}
+	if len(configMap.Data) != 1 || len(configMap.BinaryData) != 0 {
+		return ParsedConfig{}, errors.New("policy ConfigMap must contain only policy.json")
+	}
+	raw, ok := configMap.Data[ConfigDataKey]
+	if !ok || raw == "" {
+		return ParsedConfig{}, errors.New("policy ConfigMap has no policy.json")
+	}
+	parsed, canonical, err := parseConfig([]byte(raw))
+	if err != nil {
+		return ParsedConfig{}, err
+	}
+	if !bytes.Equal([]byte(raw), canonical) {
+		return ParsedConfig{}, errors.New("policy.json is not canonical")
+	}
+	digest := sha256.Sum256(canonical)
+	wantDigest := hex.EncodeToString(digest[:])
+	if configMap.Annotations[ConfigContentSHA256Annotation] != wantDigest {
+		return ParsedConfig{}, errors.New("policy ConfigMap content address does not match canonical content")
+	}
+	return ParsedConfig{Config: parsed, ContentSHA256: digest}, nil
+}
+
+func parseConfig(raw []byte) (Config, []byte, error) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var wire configWire
+	if err := decoder.Decode(&wire); err != nil {
+		return Config{}, nil, fmt.Errorf("decode policy.json: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return Config{}, nil, errors.New("policy.json has trailing content")
+	}
+	if wire.APIVersion != ConfigAPIVersion {
+		return Config{}, nil, errors.New("unsupported egress policy apiVersion")
+	}
+	policy, err := Evaluate(wire.Ceiling, wire.Baseline, nil)
+	if err != nil {
+		return Config{}, nil, err
+	}
+	if len(validation.IsDNS1123Subdomain(wire.TLSSecretName)) != 0 {
+		return Config{}, nil, errors.New("TLS Secret name must be a DNS-1123 subdomain")
+	}
+	image, err := reference.ParseNormalizedNamed(wire.ProxyImage)
+	digested, isDigested := image.(reference.Digested)
+	_, isTagged := image.(reference.Tagged)
+	if err != nil || !isDigested || isTagged || digested.Digest().Algorithm().String() != "sha256" || reference.FamiliarString(image) != wire.ProxyImage {
+		return Config{}, nil, errors.New("proxy image must be an immutable repository@sha256 identity")
+	}
+	config := Config{APIVersion: wire.APIVersion, Mode: wire.Mode, Ceiling: policy.Ceiling,
+		Baseline: policy.Baseline, RestrictedProfile: wire.RestrictedProfile,
+		TLSSecretName: wire.TLSSecretName, ProxyImage: wire.ProxyImage}
+	switch wire.Mode {
+	case ModeUnrestricted:
+		if wire.RestrictedProfile != nil {
+			return Config{}, nil, errors.New("unrestricted mode must not define a restricted profile")
+		}
+	case ModeRestricted:
+		if wire.RestrictedProfile == nil {
+			return Config{}, nil, errors.New("restricted mode requires a profile")
+		}
+		profile, err := validateRestrictedProfile(*wire.RestrictedProfile)
+		if err != nil {
+			return Config{}, nil, err
+		}
+		config.RestrictedProfile = &profile
+	default:
+		return Config{}, nil, errors.New("mode must be unrestricted or restricted")
+	}
+	canonical, err := json.Marshal(config)
+	if err != nil {
+		return Config{}, nil, err
+	}
+	return config, canonical, nil
+}
+
+func validateRestrictedProfile(profile RestrictedProfile) (RestrictedProfile, error) {
+	if profile.Name != RestrictedProfileCalicoV1 {
+		return RestrictedProfile{}, errors.New("restricted profile must be calico-v3.32.1")
+	}
+	var err error
+	if profile.ResolverIPs, err = canonicalIPs("resolverIPs", profile.ResolverIPs, 1, 4); err != nil {
+		return RestrictedProfile{}, err
+	}
+	for _, set := range []struct {
+		name             string
+		values           *[]string
+		minimum, maximum int
+	}{
+		{"apiServerCIDRs", &profile.APIServerCIDRs, 1, 8},
+		{"podCIDRs", &profile.PodCIDRs, 1, 16},
+		{"serviceCIDRs", &profile.ServiceCIDRs, 1, 16},
+		{"nodeCIDRs", &profile.NodeCIDRs, 1, 32},
+		{"controlPlaneCIDRs", &profile.ControlPlaneCIDRs, 1, 16},
+		{"additionalDeniedCIDRs", &profile.AdditionalDeniedCIDRs, 0, 32},
+	} {
+		*set.values, err = canonicalCIDRs(set.name, *set.values, set.minimum, set.maximum)
+		if err != nil {
+			return RestrictedProfile{}, err
+		}
+	}
+	return profile, nil
+}
+
+func canonicalIPs(name string, values []string, minimum, maximum int) ([]string, error) {
+	if len(values) < minimum || len(values) > maximum {
+		return nil, fmt.Errorf("%s must contain %d-%d entries", name, minimum, maximum)
+	}
+	result := make([]string, len(values))
+	copy(result, values)
+	seen := make(map[netip.Addr]struct{}, len(values))
+	for _, value := range result {
+		address, err := netip.ParseAddr(value)
+		if err != nil || address.Zone() != "" || address.String() != value {
+			return nil, fmt.Errorf("%s contains a non-canonical IP literal", name)
+		}
+		if _, exists := seen[address]; exists {
+			return nil, fmt.Errorf("%s contains a duplicate", name)
+		}
+		seen[address] = struct{}{}
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+func canonicalCIDRs(name string, values []string, minimum, maximum int) ([]string, error) {
+	if len(values) < minimum || len(values) > maximum {
+		return nil, fmt.Errorf("%s must contain %d-%d entries", name, minimum, maximum)
+	}
+	result := make([]string, len(values))
+	copy(result, values)
+	seen := make(map[netip.Prefix]struct{}, len(values))
+	for _, value := range result {
+		prefix, err := netip.ParsePrefix(value)
+		if err != nil || prefix.Addr().Zone() != "" || prefix != prefix.Masked() || prefix.String() != value {
+			return nil, fmt.Errorf("%s contains a non-canonical CIDR", name)
+		}
+		if _, exists := seen[prefix]; exists {
+			return nil, fmt.Errorf("%s contains a duplicate", name)
+		}
+		seen[prefix] = struct{}{}
+	}
+	sort.Strings(result)
+	return result, nil
+}

--- a/internal/egresspolicy/config.go
+++ b/internal/egresspolicy/config.go
@@ -192,7 +192,7 @@ func canonicalIPs(name string, values []string, minimum, maximum int) ([]string,
 	seen := make(map[netip.Addr]struct{}, len(values))
 	for _, value := range result {
 		address, err := netip.ParseAddr(value)
-		if err != nil || address.Zone() != "" || address.String() != value {
+		if err != nil || address.Zone() != "" || address.Is4In6() || address.String() != value {
 			return nil, fmt.Errorf("%s contains a non-canonical IP literal", name)
 		}
 		if _, exists := seen[address]; exists {
@@ -213,7 +213,7 @@ func canonicalCIDRs(name string, values []string, minimum, maximum int) ([]strin
 	seen := make(map[netip.Prefix]struct{}, len(values))
 	for _, value := range result {
 		prefix, err := netip.ParsePrefix(value)
-		if err != nil || prefix.Addr().Zone() != "" || prefix != prefix.Masked() || prefix.String() != value {
+		if err != nil || prefix.Addr().Zone() != "" || prefix.Addr().Is4In6() || prefix != prefix.Masked() || prefix.String() != value {
 			return nil, fmt.Errorf("%s contains a non-canonical CIDR", name)
 		}
 		if _, exists := seen[prefix]; exists {

--- a/internal/egresspolicy/config_test.go
+++ b/internal/egresspolicy/config_test.go
@@ -1,0 +1,115 @@
+package egresspolicy
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func validConfig() Config {
+	return Config{
+		APIVersion: ConfigAPIVersion, Mode: ModeRestricted,
+		Ceiling: []Hostname{"api.example.com", "git.example.com"}, Baseline: []Hostname{"git.example.com"},
+		RestrictedProfile: &RestrictedProfile{
+			Name: RestrictedProfileCalicoV1, ResolverIPs: []string{"10.96.0.10"},
+			APIServerCIDRs: []string{"10.0.0.1/32"}, PodCIDRs: []string{"10.244.0.0/16"},
+			ServiceCIDRs: []string{"10.96.0.0/12"}, NodeCIDRs: []string{"192.168.0.0/16"},
+			ControlPlaneCIDRs: []string{"172.16.0.0/16"}, AdditionalDeniedCIDRs: []string{},
+		},
+		TLSSecretName: "egress-proxy-tls", ProxyImage: "registry.example.com/swe/egress-proxy@sha256:" + strings.Repeat("a", 64),
+	}
+}
+
+func configMapFor(t *testing.T, config Config) *corev1.ConfigMap {
+	t.Helper()
+	raw, err := json.Marshal(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256(raw)
+	return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "policy", Namespace: "system", UID: "config-uid", Annotations: map[string]string{
+		ConfigContentSHA256Annotation: hex.EncodeToString(digest[:]),
+	}}, Immutable: ptr.To(true), Data: map[string]string{ConfigDataKey: string(raw)}}
+}
+
+func TestParseConfigMapCanonicalAuthority(t *testing.T) {
+	configMap := configMapFor(t, validConfig())
+	got, err := ParseConfigMap(configMap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Mode != ModeRestricted || got.RestrictedProfile == nil || got.RestrictedProfile.Name != RestrictedProfileCalicoV1 || len(got.Ceiling) != 2 {
+		t.Fatalf("unexpected parsed config: %#v", got)
+	}
+
+	tests := map[string]func(*corev1.ConfigMap){
+		"mutable":              func(c *corev1.ConfigMap) { c.Immutable = ptr.To(false) },
+		"missing UID":          func(c *corev1.ConfigMap) { c.UID = "" },
+		"deleting":             func(c *corev1.ConfigMap) { now := metav1.Now(); c.DeletionTimestamp = &now },
+		"extra data":           func(c *corev1.ConfigMap) { c.Data["other"] = "value" },
+		"binary data":          func(c *corev1.ConfigMap) { c.BinaryData = map[string][]byte{"other": {1}} },
+		"content address":      func(c *corev1.ConfigMap) { c.Annotations[ConfigContentSHA256Annotation] = strings.Repeat("0", 64) },
+		"noncanonical content": func(c *corev1.ConfigMap) { c.Data[ConfigDataKey] += "\n" },
+		"unknown field": func(c *corev1.ConfigMap) {
+			c.Data[ConfigDataKey] = strings.TrimSuffix(c.Data[ConfigDataKey], "}") + `,"extra":true}`
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			configMap := configMapFor(t, validConfig())
+			mutate(configMap)
+			if _, err := ParseConfigMap(configMap); err == nil {
+				t.Fatal("expected rejection")
+			}
+		})
+	}
+}
+
+func TestParseConfigMapStrictSchemaAndBounds(t *testing.T) {
+	tests := map[string]func(*Config){
+		"version":          func(c *Config) { c.APIVersion = "v2" },
+		"mode":             func(c *Config) { c.Mode = "production" },
+		"profile":          func(c *Config) { c.RestrictedProfile.Name = "generic-knp" },
+		"resolver minimum": func(c *Config) { c.RestrictedProfile.ResolverIPs = nil },
+		"resolver maximum": func(c *Config) {
+			c.RestrictedProfile.ResolverIPs = []string{"1.1.1.1", "2.2.2.2", "3.3.3.3", "4.4.4.4", "5.5.5.5"}
+		},
+		"noncanonical resolver":    func(c *Config) { c.RestrictedProfile.ResolverIPs = []string{"2001:0db8::1"} },
+		"API CIDR minimum":         func(c *Config) { c.RestrictedProfile.APIServerCIDRs = nil },
+		"unmasked CIDR":            func(c *Config) { c.RestrictedProfile.PodCIDRs = []string{"10.244.1.1/16"} },
+		"baseline outside ceiling": func(c *Config) { c.Baseline = []Hostname{"other.example.com"} },
+		"ceiling maximum":          func(c *Config) { c.Ceiling = make([]Hostname, MaxCeilingEntries+1) },
+		"TLS Secret":               func(c *Config) { c.TLSSecretName = "Bad" },
+		"mutable image":            func(c *Config) { c.ProxyImage = "proxy:latest" },
+		"tagged digest image":      func(c *Config) { c.ProxyImage = "registry.example.com/proxy:latest@sha256:" + strings.Repeat("a", 64) },
+		"noncanonical image":       func(c *Config) { c.ProxyImage = "docker.io/library/proxy@sha256:" + strings.Repeat("a", 64) },
+		"invalid image path":       func(c *Config) { c.ProxyImage = "registry.example.com/Bad/proxy@sha256:" + strings.Repeat("a", 64) },
+		"image control byte":       func(c *Config) { c.ProxyImage = "registry.example.com/proxy\n@sha256:" + strings.Repeat("a", 64) },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			config := validConfig()
+			mutate(&config)
+			if _, err := ParseConfigMap(configMapFor(t, config)); err == nil {
+				t.Fatal("expected rejection")
+			}
+		})
+	}
+
+	unrestricted := validConfig()
+	unrestricted.Mode = ModeUnrestricted
+	unrestricted.RestrictedProfile = nil
+	if _, err := ParseConfigMap(configMapFor(t, unrestricted)); err != nil {
+		t.Fatalf("valid unrestricted config rejected: %v", err)
+	}
+	unrestricted.RestrictedProfile = validConfig().RestrictedProfile
+	if _, err := ParseConfigMap(configMapFor(t, unrestricted)); err == nil {
+		t.Fatal("unrestricted config accepted a restricted profile")
+	}
+}

--- a/internal/egresspolicy/config_test.go
+++ b/internal/egresspolicy/config_test.go
@@ -81,8 +81,10 @@ func TestParseConfigMapStrictSchemaAndBounds(t *testing.T) {
 			c.RestrictedProfile.ResolverIPs = []string{"1.1.1.1", "2.2.2.2", "3.3.3.3", "4.4.4.4", "5.5.5.5"}
 		},
 		"noncanonical resolver":    func(c *Config) { c.RestrictedProfile.ResolverIPs = []string{"2001:0db8::1"} },
+		"mapped IPv4 resolver":     func(c *Config) { c.RestrictedProfile.ResolverIPs = []string{"::ffff:8.8.8.8"} },
 		"API CIDR minimum":         func(c *Config) { c.RestrictedProfile.APIServerCIDRs = nil },
 		"unmasked CIDR":            func(c *Config) { c.RestrictedProfile.PodCIDRs = []string{"10.244.1.1/16"} },
+		"mapped IPv4 CIDR":         func(c *Config) { c.RestrictedProfile.AdditionalDeniedCIDRs = []string{"::ffff:8.8.8.8/128"} },
 		"baseline outside ceiling": func(c *Config) { c.Baseline = []Hostname{"other.example.com"} },
 		"ceiling maximum":          func(c *Config) { c.Ceiling = make([]Hostname, MaxCeilingEntries+1) },
 		"TLS Secret":               func(c *Config) { c.TLSSecretName = "Bad" },

--- a/internal/egressproxy/currentness.go
+++ b/internal/egressproxy/currentness.go
@@ -111,6 +111,9 @@ func (a *CurrentnessAuthorizer) authorize(ctx context.Context, hint Identity, ta
 	if claims.InstallationNamespace != a.Installation.Key.Namespace || claims.InstallationName != a.Installation.Key.Name || claims.InstallationUID != a.Installation.UID || a.PolicyConfigMap.Namespace != a.Installation.Key.Namespace {
 		return Authorization{}, errors.New("identity or policy ConfigMap does not match the configured Installation")
 	}
+	if claims.ProjectNamespace == a.Installation.Key.Namespace {
+		return Authorization{}, errors.New("Project namespace must be distinct from the Installation system namespace")
+	}
 	presentedFingerprint := hex.EncodeToString(hint.Fingerprint[:])
 	if claims.CertificateFingerprint != presentedFingerprint {
 		return Authorization{}, errors.New("presented certificate fingerprint does not match canonical identity")

--- a/internal/egressproxy/currentness.go
+++ b/internal/egressproxy/currentness.go
@@ -1,0 +1,317 @@
+package egressproxy
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/netip"
+	"slices"
+	"strconv"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
+	"github.com/Chris-Cullins/swe-platform/internal/egressidentity"
+	"github.com/Chris-Cullins/swe-platform/internal/egresspod"
+	"github.com/Chris-Cullins/swe-platform/internal/egresspolicy"
+	"github.com/Chris-Cullins/swe-platform/internal/tenancy"
+)
+
+const CurrentnessTimeout = 2 * time.Second
+const MaxCurrentnessStates = 2048
+
+// IdentityLookup resolves an untrusted presented certificate fingerprint to
+// canonical claims. Implementations must not treat the certificate subject as
+// authority. The future publisher may provide this lookup without granting the
+// proxy Kubernetes Secret-read permission.
+type IdentityLookup interface {
+	Lookup(context.Context, [sha256.Size]byte) ([]byte, error)
+}
+
+// CurrentnessAuthorizer is an inert Kubernetes currentness proof. Reader must
+// be an uncached API reader in future production wiring. The shipped command
+// deliberately does not construct this type.
+type CurrentnessAuthorizer struct {
+	Reader          client.Reader
+	Identities      IdentityLookup
+	Installation    tenancy.InstallationIdentity
+	PolicyConfigMap types.NamespacedName
+
+	mu      sync.Mutex
+	records map[[sha256.Size]byte]*executionRecord
+}
+
+type executionState struct {
+	done chan struct{}
+	once sync.Once
+}
+
+type executionRecord struct {
+	mu    sync.Mutex
+	state *executionState
+	users int
+}
+
+func newExecutionState() *executionState { return &executionState{done: make(chan struct{})} }
+func (s *executionState) revoke()        { s.once.Do(func() { close(s.done) }) }
+
+// Authorize performs a complete uncached proof on every call. Any failure
+// revokes the fingerprint's previously returned currentness signal; no cached
+// authorization survives uncertainty.
+func (a *CurrentnessAuthorizer) Authorize(ctx context.Context, hint Identity, target string) (Authorization, error) {
+	if a == nil || a.Reader == nil || a.Identities == nil || a.Installation.Key.Namespace == "" || a.Installation.Key.Name == "" || a.Installation.UID == "" || a.PolicyConfigMap.Namespace == "" || a.PolicyConfigMap.Name == "" {
+		return Authorization{}, errors.New("currentness authorizer is not configured")
+	}
+	if hint.Fingerprint == ([sha256.Size]byte{}) {
+		return Authorization{}, errors.New("certificate fingerprint is required")
+	}
+	evaluationCtx, cancel := context.WithTimeout(ctx, CurrentnessTimeout)
+	defer cancel()
+	record, err := a.record(hint.Fingerprint)
+	if err != nil {
+		return Authorization{}, err
+	}
+	record.mu.Lock()
+	defer func() {
+		record.mu.Unlock()
+		a.release(hint.Fingerprint, record)
+	}()
+	authorization, err := a.authorize(evaluationCtx, hint, target)
+	if err != nil {
+		record.state.revoke()
+		return Authorization{}, err
+	}
+	if isClosed(record.state.done) {
+		record.state = newExecutionState()
+	}
+	authorization.Currentness = record.state.done
+	return authorization, nil
+}
+
+func (a *CurrentnessAuthorizer) authorize(ctx context.Context, hint Identity, target string) (Authorization, error) {
+	hostname, err := egresspolicy.ParseHostname(target)
+	if err != nil || string(hostname) != target {
+		return Authorization{}, errors.New("target is not a canonical egress hostname")
+	}
+	canonicalClaims, err := a.Identities.Lookup(ctx, hint.Fingerprint)
+	if err != nil {
+		return Authorization{}, fmt.Errorf("resolve certificate identity: %w", err)
+	}
+	claims, err := egressidentity.Parse(canonicalClaims)
+	if err != nil {
+		return Authorization{}, err
+	}
+	if claims.InstallationNamespace != a.Installation.Key.Namespace || claims.InstallationName != a.Installation.Key.Name || claims.InstallationUID != a.Installation.UID || a.PolicyConfigMap.Namespace != a.Installation.Key.Namespace {
+		return Authorization{}, errors.New("identity or policy ConfigMap does not match the configured Installation")
+	}
+	presentedFingerprint := hex.EncodeToString(hint.Fingerprint[:])
+	if claims.CertificateFingerprint != presentedFingerprint {
+		return Authorization{}, errors.New("presented certificate fingerprint does not match canonical identity")
+	}
+
+	installationKey := a.Installation.Key
+	var installation platformv1alpha1.Installation
+	if err := a.Reader.Get(ctx, installationKey, &installation); err != nil {
+		return Authorization{}, fmt.Errorf("get Installation: %w", err)
+	}
+	if installation.UID != a.Installation.UID || !stable(&installation.ObjectMeta) {
+		return Authorization{}, errors.New("Installation identity is not current")
+	}
+	verifier := tenancy.Verifier{Reader: a.Reader, Installation: a.Installation, Mode: tenancy.ModeScoped}
+	claim, err := verifier.VerifyNamespace(ctx, claims.ProjectNamespace)
+	if err != nil {
+		return Authorization{}, err
+	}
+	if claim.Lifecycle != tenancy.LifecycleActive || claim.ProjectName != claims.ProjectName || claim.ProjectUID != claims.ProjectUID || claims.EnvironmentNamespace != claims.ProjectNamespace {
+		return Authorization{}, errors.New("active exact Namespace claim does not match identity")
+	}
+	var namespace corev1.Namespace
+	if err := a.Reader.Get(ctx, types.NamespacedName{Name: claims.ProjectNamespace}, &namespace); err != nil || namespace.UID != claim.NamespaceUID || !stable(&namespace.ObjectMeta) {
+		return Authorization{}, errors.New("Namespace identity is not current")
+	}
+
+	var project platformv1alpha1.Project
+	projectKey := types.NamespacedName{Namespace: claims.ProjectNamespace, Name: claims.ProjectName}
+	if err := a.Reader.Get(ctx, projectKey, &project); err != nil {
+		return Authorization{}, fmt.Errorf("get Project: %w", err)
+	}
+	if project.UID != claims.ProjectUID || !stable(&project.ObjectMeta) {
+		return Authorization{}, errors.New("Project identity is not current")
+	}
+
+	var configMap corev1.ConfigMap
+	if err := a.Reader.Get(ctx, a.PolicyConfigMap, &configMap); err != nil {
+		return Authorization{}, fmt.Errorf("get policy ConfigMap: %w", err)
+	}
+	config, err := egresspolicy.ParseConfigMap(&configMap)
+	if err != nil {
+		return Authorization{}, err
+	}
+	if config.Mode != egresspolicy.ModeRestricted || config.RestrictedProfile == nil {
+		return Authorization{}, errors.New("currentness authorization requires restricted mode")
+	}
+	policy, err := egresspolicy.Evaluate(hostnames(config.Ceiling), hostnames(config.Baseline), project.Spec.EgressAllowlist)
+	if err != nil {
+		return Authorization{}, err
+	}
+	if !slices.Contains(policy.Effective, hostname) {
+		return Authorization{}, errors.New("destination is outside the effective policy")
+	}
+	revision, err := (egresspolicy.RuntimeRevisionInputs{
+		InstallationUID: installation.UID, ConfigMapUID: configMap.UID,
+		ConfigMapContentSHA256: config.ContentSHA256, ProjectUID: project.UID,
+		Ceiling: hostnames(config.Ceiling), Baseline: hostnames(config.Baseline),
+		ProjectSelection: project.Spec.EgressAllowlist,
+	}).Revision()
+	if err != nil || claims.RuntimePolicyRevision != revision.String() {
+		return Authorization{}, errors.New("runtime policy revision is not current")
+	}
+
+	var environment platformv1alpha1.Environment
+	environmentKey := types.NamespacedName{Namespace: claims.EnvironmentNamespace, Name: claims.EnvironmentName}
+	if err := a.Reader.Get(ctx, environmentKey, &environment); err != nil {
+		return Authorization{}, fmt.Errorf("get Environment: %w", err)
+	}
+	if environment.UID != claims.EnvironmentUID || !stable(&environment.ObjectMeta) || environment.Spec.ProjectRef != project.Name ||
+		environment.Status.ExecutionGeneration != claims.ExecutionGeneration || environment.Status.PodName != claims.PodName ||
+		environment.Status.Provisioning == nil || environment.Status.Provisioning.Project == nil || !environment.Status.Provisioning.ProjectVerified ||
+		environment.Status.Provisioning.Project.Name != project.Name || environment.Status.Provisioning.Project.UID != project.UID ||
+		!platformv1alpha1.IsEnvironmentReady(&environment) || environment.Spec.Paused || environment.Status.Lifecycle.Suspended ||
+		environment.Spec.Lifecycle.Hold != nil && environment.Spec.Lifecycle.Hold.Enabled {
+		return Authorization{}, errors.New("Environment execution or frozen Project is not current")
+	}
+
+	var pod corev1.Pod
+	if err := a.Reader.Get(ctx, types.NamespacedName{Namespace: claims.EnvironmentNamespace, Name: claims.PodName}, &pod); err != nil {
+		return Authorization{}, fmt.Errorf("get Pod: %w", err)
+	}
+	owner := metav1.GetControllerOf(&pod)
+	annotations := pod.GetAnnotations()
+	if pod.UID != claims.PodUID || !stable(&pod.ObjectMeta) || pod.Spec.RestartPolicy != corev1.RestartPolicyNever || owner == nil || owner.APIVersion != platformv1alpha1.GroupVersion.String() || owner.Kind != "Environment" || owner.Name != environment.Name || owner.UID != environment.UID ||
+		annotations[egresspod.ExecutionGenerationAnnotation] != strconv.FormatInt(claims.ExecutionGeneration, 10) ||
+		annotations[egresspod.PolicyRevisionAnnotation] != claims.RuntimePolicyRevision ||
+		annotations[egresspod.ForwarderRevisionAnnotation] != claims.ForwarderRevision || claims.ForwarderRevision != egresspod.ForwarderRevision ||
+		annotations[egresspod.CertificateFingerprintAnnotation] != claims.CertificateFingerprint {
+		return Authorization{}, errors.New("Pod execution identity is not current")
+	}
+
+	// Start a complete second uncached pass. UID/resourceVersion drift or
+	// canonical authority changes invalidate the entire evaluation.
+	var finalConfigMap corev1.ConfigMap
+	if err := a.Reader.Get(ctx, a.PolicyConfigMap, &finalConfigMap); err != nil {
+		return Authorization{}, fmt.Errorf("recheck policy ConfigMap: %w", err)
+	}
+	finalConfig, err := egresspolicy.ParseConfigMap(&finalConfigMap)
+	if err != nil || finalConfigMap.UID != configMap.UID || finalConfigMap.ResourceVersion != configMap.ResourceVersion || finalConfig.ContentSHA256 != config.ContentSHA256 {
+		return Authorization{}, errors.New("policy ConfigMap changed during authorization")
+	}
+	finalClaims, err := a.Identities.Lookup(ctx, hint.Fingerprint)
+	if err != nil || !slices.Equal(finalClaims, canonicalClaims) {
+		return Authorization{}, errors.New("certificate identity changed during authorization")
+	}
+	finalClaim, err := verifier.VerifyNamespace(ctx, claims.ProjectNamespace)
+	if err != nil || finalClaim != claim || finalClaim.Lifecycle != tenancy.LifecycleActive {
+		return Authorization{}, errors.New("Namespace claim changed during authorization")
+	}
+	var finalNamespace corev1.Namespace
+	var finalProject platformv1alpha1.Project
+	var finalEnvironment platformv1alpha1.Environment
+	var finalPod corev1.Pod
+	if err := a.Reader.Get(ctx, types.NamespacedName{Name: claims.ProjectNamespace}, &finalNamespace); err != nil || finalNamespace.UID != namespace.UID || finalNamespace.ResourceVersion != namespace.ResourceVersion || !stable(&finalNamespace.ObjectMeta) {
+		return Authorization{}, errors.New("Namespace changed during authorization")
+	}
+	if err := a.Reader.Get(ctx, projectKey, &finalProject); err != nil || finalProject.UID != project.UID || finalProject.ResourceVersion != project.ResourceVersion || !stable(&finalProject.ObjectMeta) {
+		return Authorization{}, errors.New("Project changed during authorization")
+	}
+	if err := a.Reader.Get(ctx, environmentKey, &finalEnvironment); err != nil || finalEnvironment.UID != environment.UID || finalEnvironment.ResourceVersion != environment.ResourceVersion || !stable(&finalEnvironment.ObjectMeta) {
+		return Authorization{}, errors.New("Environment changed during authorization")
+	}
+	if err := a.Reader.Get(ctx, types.NamespacedName{Namespace: claims.EnvironmentNamespace, Name: claims.PodName}, &finalPod); err != nil || finalPod.UID != pod.UID || finalPod.ResourceVersion != pod.ResourceVersion || !stable(&finalPod.ObjectMeta) {
+		return Authorization{}, errors.New("Pod changed during authorization")
+	}
+	var finalInstallation platformv1alpha1.Installation
+	if err := a.Reader.Get(ctx, installationKey, &finalInstallation); err != nil || finalInstallation.UID != installation.UID || finalInstallation.ResourceVersion != installation.ResourceVersion || !stable(&finalInstallation.ObjectMeta) {
+		return Authorization{}, errors.New("Installation changed during authorization")
+	}
+	if err := ctx.Err(); err != nil {
+		return Authorization{}, fmt.Errorf("currentness evaluation expired: %w", err)
+	}
+	return Authorization{
+		ExecutionKey: string(environment.UID) + "/" + strconv.FormatInt(claims.ExecutionGeneration, 10) + "/" + string(pod.UID),
+		ProjectKey:   string(project.UID), DeniedPrefixes: deniedPrefixes(*config.RestrictedProfile),
+	}, nil
+}
+
+func stable(meta *metav1.ObjectMeta) bool {
+	return meta != nil && meta.UID != "" && meta.DeletionTimestamp.IsZero()
+}
+
+func hostnames(values []egresspolicy.Hostname) []string {
+	result := make([]string, len(values))
+	for i, value := range values {
+		result[i] = string(value)
+	}
+	return result
+}
+
+func deniedPrefixes(profile egresspolicy.RestrictedProfile) []netip.Prefix {
+	values := make([]string, 0, len(profile.APIServerCIDRs)+len(profile.PodCIDRs)+len(profile.ServiceCIDRs)+len(profile.NodeCIDRs)+len(profile.ControlPlaneCIDRs)+len(profile.AdditionalDeniedCIDRs)+len(profile.ResolverIPs))
+	values = append(values, profile.APIServerCIDRs...)
+	values = append(values, profile.PodCIDRs...)
+	values = append(values, profile.ServiceCIDRs...)
+	values = append(values, profile.NodeCIDRs...)
+	values = append(values, profile.ControlPlaneCIDRs...)
+	values = append(values, profile.AdditionalDeniedCIDRs...)
+	result := make([]netip.Prefix, 0, len(values)+len(profile.ResolverIPs))
+	for _, value := range values {
+		result = append(result, netip.MustParsePrefix(value))
+	}
+	for _, value := range profile.ResolverIPs {
+		address := netip.MustParseAddr(value)
+		result = append(result, netip.PrefixFrom(address, address.BitLen()))
+	}
+	return result
+}
+
+func (a *CurrentnessAuthorizer) record(fingerprint [sha256.Size]byte) (*executionRecord, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.records == nil {
+		a.records = make(map[[sha256.Size]byte]*executionRecord)
+	}
+	record := a.records[fingerprint]
+	if record == nil {
+		if len(a.records) >= MaxCurrentnessStates {
+			return nil, errors.New("currentness state capacity exceeded")
+		}
+		record = &executionRecord{state: newExecutionState()}
+		a.records[fingerprint] = record
+	}
+	record.users++
+	return record, nil
+}
+
+func (a *CurrentnessAuthorizer) release(fingerprint [sha256.Size]byte, record *executionRecord) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	record.users--
+	if record.users == 0 && isClosed(record.state.done) && a.records[fingerprint] == record {
+		delete(a.records, fingerprint)
+	}
+}
+
+func isClosed(done <-chan struct{}) bool {
+	select {
+	case <-done:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/egressproxy/currentness.go
+++ b/internal/egressproxy/currentness.go
@@ -54,9 +54,10 @@ type executionState struct {
 }
 
 type executionRecord struct {
-	mu    sync.Mutex
-	state *executionState
-	users int
+	mu     sync.Mutex
+	state  *executionState
+	users  int
+	leases int
 }
 
 func newExecutionState() *executionState { return &executionState{done: make(chan struct{})} }
@@ -92,6 +93,7 @@ func (a *CurrentnessAuthorizer) Authorize(ctx context.Context, hint Identity, ta
 		record.state = newExecutionState()
 	}
 	authorization.Currentness = record.state.done
+	authorization.ReleaseCurrentness = a.acquireLease(hint.Fingerprint, record)
 	return authorization, nil
 }
 
@@ -305,9 +307,31 @@ func (a *CurrentnessAuthorizer) release(fingerprint [sha256.Size]byte, record *e
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	record.users--
-	if record.users == 0 && isClosed(record.state.done) && a.records[fingerprint] == record {
+	if record.users == 0 && record.leases == 0 && a.records[fingerprint] == record {
 		delete(a.records, fingerprint)
 	}
+}
+
+func (a *CurrentnessAuthorizer) acquireLease(fingerprint [sha256.Size]byte, record *executionRecord) func() {
+	a.mu.Lock()
+	record.leases++
+	a.mu.Unlock()
+	return sync.OnceFunc(func() {
+		record.mu.Lock()
+		defer record.mu.Unlock()
+		a.mu.Lock()
+		defer a.mu.Unlock()
+		if record.leases == 0 {
+			return
+		}
+		record.leases--
+		if record.leases == 0 {
+			record.state.revoke()
+		}
+		if record.users == 0 && record.leases == 0 && a.records[fingerprint] == record {
+			delete(a.records, fingerprint)
+		}
+	})
 }
 
 func isClosed(done <-chan struct{}) bool {

--- a/internal/egressproxy/currentness_test.go
+++ b/internal/egressproxy/currentness_test.go
@@ -357,6 +357,23 @@ func TestCurrentnessAuthorizerForgedClaimsAndAPIUncertainty(t *testing.T) {
 	}
 }
 
+func TestCurrentnessAuthorizerRejectsSystemProjectNamespace(t *testing.T) {
+	f := newCurrentnessFixture(t)
+	reader := fake.NewClientBuilder().WithScheme(currentnessScheme(t)).WithObjects(f.objects()...).Build()
+	authorizer := f.authorizer(t, reader)
+	claims := f.claims
+	claims.ProjectNamespace = claims.InstallationNamespace
+	claims.EnvironmentNamespace = claims.InstallationNamespace
+	canonical, err := claims.CanonicalBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	authorizer.Identities = &staticIdentityLookup{claims: canonical}
+	if _, err := authorizer.Authorize(context.Background(), f.hint, "api.example.com"); err == nil || !strings.Contains(err.Error(), "must be distinct") {
+		t.Fatalf("system namespace was not rejected at the tenancy boundary: %v", err)
+	}
+}
+
 func TestCurrentnessAuthorizerRejectsForeignInstallationAndMidProofChange(t *testing.T) {
 	f := newCurrentnessFixture(t)
 	base := fake.NewClientBuilder().WithScheme(currentnessScheme(t)).WithObjects(f.objects()...).Build()

--- a/internal/egressproxy/currentness_test.go
+++ b/internal/egressproxy/currentness_test.go
@@ -189,13 +189,15 @@ func TestCurrentnessAuthorizerUnchangedIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if authorization.ExecutionKey != "environment-uid/7/pod-uid" || authorization.ProjectKey != "project-uid" || len(authorization.DeniedPrefixes) != 6 || authorization.Currentness == nil || isClosed(authorization.Currentness) {
+	if authorization.ExecutionKey != "environment-uid/7/pod-uid" || authorization.ProjectKey != "project-uid" || len(authorization.DeniedPrefixes) != 6 || authorization.Currentness == nil || authorization.ReleaseCurrentness == nil || isClosed(authorization.Currentness) {
 		t.Fatalf("unexpected authorization: %#v", authorization)
 	}
+	defer authorization.ReleaseCurrentness()
 	second, err := authorizer.Authorize(context.Background(), Identity{Fingerprint: f.hint.Fingerprint, Subject: "another forged subject"}, "api.example.com")
 	if err != nil || second.Currentness != authorization.Currentness || isClosed(second.Currentness) {
 		t.Fatalf("unchanged recheck = %#v, %v", second, err)
 	}
+	defer second.ReleaseCurrentness()
 	if _, err := authorizer.Authorize(context.Background(), f.hint, "denied.example.com"); err == nil {
 		t.Fatal("destination outside effective policy accepted")
 	}
@@ -425,6 +427,7 @@ func TestCurrentnessAuthorizerFailedRecheckRevokes(t *testing.T) {
 	if !isClosed(first.Currentness) {
 		t.Fatal("existing tunnel state remained current after failed recheck")
 	}
+	first.ReleaseCurrentness()
 
 	pod.Annotations[egresspod.CertificateFingerprintAnnotation] = f.claims.CertificateFingerprint
 	if err := reader.Update(context.Background(), &pod); err != nil {
@@ -434,8 +437,27 @@ func TestCurrentnessAuthorizerFailedRecheckRevokes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer second.ReleaseCurrentness()
 	authorizer.Reader = failingReader{Reader: reader}
 	if _, err := authorizer.Authorize(context.Background(), f.hint, "api.example.com"); err == nil || !isClosed(second.Currentness) {
 		t.Fatal("API uncertainty retained a previous authorization")
+	}
+}
+
+func TestCurrentnessAuthorizerReleaseReclaimsSuccessfulState(t *testing.T) {
+	f := newCurrentnessFixture(t)
+	reader := fake.NewClientBuilder().WithScheme(currentnessScheme(t)).WithObjects(f.objects()...).Build()
+	authorizer := f.authorizer(t, reader)
+	authorization, err := authorizer.Authorize(context.Background(), f.hint, "api.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(authorizer.records) != 1 {
+		t.Fatalf("currentness records = %d, want 1", len(authorizer.records))
+	}
+	authorization.ReleaseCurrentness()
+	authorization.ReleaseCurrentness()
+	if !isClosed(authorization.Currentness) || len(authorizer.records) != 0 {
+		t.Fatalf("released currentness remained live: closed=%t records=%d", isClosed(authorization.Currentness), len(authorizer.records))
 	}
 }

--- a/internal/egressproxy/currentness_test.go
+++ b/internal/egressproxy/currentness_test.go
@@ -1,0 +1,424 @@
+package egressproxy
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
+	"github.com/Chris-Cullins/swe-platform/internal/egressidentity"
+	"github.com/Chris-Cullins/swe-platform/internal/egresspod"
+	"github.com/Chris-Cullins/swe-platform/internal/egresspolicy"
+	"github.com/Chris-Cullins/swe-platform/internal/tenancy"
+)
+
+type staticIdentityLookup struct {
+	claims   []byte
+	err      error
+	wait     bool
+	deadline time.Duration
+}
+
+type failingReader struct{ client.Reader }
+
+type mutatingReader struct {
+	client.Client
+	projectGets int
+}
+
+func (failingReader) Get(context.Context, client.ObjectKey, client.Object, ...client.GetOption) error {
+	return errors.New("Kubernetes API unavailable")
+}
+
+func (failingReader) List(context.Context, client.ObjectList, ...client.ListOption) error {
+	return errors.New("Kubernetes API unavailable")
+}
+
+func (m *mutatingReader) Get(ctx context.Context, key client.ObjectKey, object client.Object, options ...client.GetOption) error {
+	if _, ok := object.(*platformv1alpha1.Project); ok {
+		m.projectGets++
+		if m.projectGets == 2 {
+			var project platformv1alpha1.Project
+			if err := m.Client.Get(ctx, key, &project); err != nil {
+				return err
+			}
+			project.Spec.EgressAllowlist = nil
+			if err := m.Client.Update(ctx, &project); err != nil {
+				return err
+			}
+		}
+	}
+	return m.Client.Get(ctx, key, object, options...)
+}
+
+func (s *staticIdentityLookup) Lookup(ctx context.Context, _ [sha256.Size]byte) ([]byte, error) {
+	if deadline, ok := ctx.Deadline(); ok {
+		s.deadline = time.Until(deadline)
+	}
+	if s.wait {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	return append([]byte(nil), s.claims...), s.err
+}
+
+type currentnessFixture struct {
+	installation *platformv1alpha1.Installation
+	namespace    *corev1.Namespace
+	project      *platformv1alpha1.Project
+	configMap    *corev1.ConfigMap
+	environment  *platformv1alpha1.Environment
+	pod          *corev1.Pod
+	claims       egressidentity.Claims
+	hint         Identity
+}
+
+func newCurrentnessFixture(t *testing.T) *currentnessFixture {
+	t.Helper()
+	fingerprint := sha256.Sum256([]byte("presented certificate"))
+	config := egresspolicy.Config{
+		APIVersion: egresspolicy.ConfigAPIVersion, Mode: egresspolicy.ModeRestricted,
+		Ceiling: []egresspolicy.Hostname{"api.example.com", "git.example.com"}, Baseline: []egresspolicy.Hostname{"git.example.com"},
+		RestrictedProfile: &egresspolicy.RestrictedProfile{
+			Name: egresspolicy.RestrictedProfileCalicoV1, ResolverIPs: []string{"10.96.0.10"},
+			APIServerCIDRs: []string{"10.0.0.1/32"}, PodCIDRs: []string{"10.244.0.0/16"},
+			ServiceCIDRs: []string{"10.96.0.0/12"}, NodeCIDRs: []string{"192.168.0.0/16"},
+			ControlPlaneCIDRs: []string{"172.16.0.0/16"}, AdditionalDeniedCIDRs: []string{},
+		}, TLSSecretName: "egress-proxy-tls", ProxyImage: "registry.example.com/egress-proxy@sha256:" + strings.Repeat("a", 64),
+	}
+	raw, err := json.Marshal(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	contentHash := sha256.Sum256(raw)
+	configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "egress-policy", Namespace: "system", UID: "config-uid", Annotations: map[string]string{
+		egresspolicy.ConfigContentSHA256Annotation: hex.EncodeToString(contentHash[:]),
+	}}, Immutable: ptr.To(true), Data: map[string]string{egresspolicy.ConfigDataKey: string(raw)}}
+	revision, err := (egresspolicy.RuntimeRevisionInputs{
+		InstallationUID: "installation-uid", ConfigMapUID: configMap.UID, ConfigMapContentSHA256: contentHash,
+		ProjectUID: "project-uid", Ceiling: []string{"api.example.com", "git.example.com"}, Baseline: []string{"git.example.com"},
+		ProjectSelection: []string{"api.example.com"},
+	}).Revision()
+	if err != nil {
+		t.Fatal(err)
+	}
+	claims := egressidentity.Claims{
+		InstallationNamespace: "system", InstallationName: "main", InstallationUID: "installation-uid",
+		ProjectNamespace: "project", ProjectName: "app", ProjectUID: "project-uid",
+		EnvironmentNamespace: "project", EnvironmentName: "env", EnvironmentUID: "environment-uid",
+		PodName: "env-env", PodUID: "pod-uid", ExecutionGeneration: 7,
+		RuntimePolicyRevision: revision.String(), ForwarderRevision: egresspod.ForwarderRevision,
+		CertificateFingerprint: hex.EncodeToString(fingerprint[:]),
+	}
+	controller := true
+	return &currentnessFixture{
+		installation: &platformv1alpha1.Installation{ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "system", UID: claims.InstallationUID}},
+		namespace: &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: claims.ProjectNamespace, UID: "namespace-uid", Annotations: map[string]string{
+			tenancy.InstallationNamespaceAnnotation: claims.InstallationNamespace, tenancy.InstallationNameAnnotation: claims.InstallationName,
+			tenancy.InstallationUIDAnnotation: string(claims.InstallationUID), tenancy.ProjectNameAnnotation: claims.ProjectName,
+			tenancy.ProjectUIDAnnotation: string(claims.ProjectUID), tenancy.LifecycleAnnotation: string(tenancy.LifecycleActive),
+		}}},
+		project:   &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: claims.ProjectName, Namespace: claims.ProjectNamespace, UID: claims.ProjectUID}, Spec: platformv1alpha1.ProjectSpec{EgressAllowlist: []string{"api.example.com"}}},
+		configMap: configMap,
+		environment: &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: claims.EnvironmentName, Namespace: claims.EnvironmentNamespace, UID: claims.EnvironmentUID, Generation: 1},
+			Spec: platformv1alpha1.EnvironmentSpec{ProjectRef: claims.ProjectName}, Status: platformv1alpha1.EnvironmentStatus{
+				ObservedGeneration: 1, Phase: platformv1alpha1.EnvironmentPhaseReady, ExecutionGeneration: claims.ExecutionGeneration, PodName: claims.PodName,
+				Conditions:   []metav1.Condition{{Type: platformv1alpha1.EnvironmentConditionReady, Status: metav1.ConditionTrue, ObservedGeneration: 1}},
+				Provisioning: &platformv1alpha1.EnvironmentProvisioningSnapshot{ProjectVerified: true, Project: &platformv1alpha1.EnvironmentProvisioningProject{Name: claims.ProjectName, UID: claims.ProjectUID}},
+			}},
+		pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: claims.PodName, Namespace: claims.EnvironmentNamespace, UID: claims.PodUID,
+			OwnerReferences: []metav1.OwnerReference{{APIVersion: platformv1alpha1.GroupVersion.String(), Kind: "Environment", Name: claims.EnvironmentName, UID: claims.EnvironmentUID, Controller: &controller}},
+			Annotations: map[string]string{
+				egresspod.ExecutionGenerationAnnotation: "7", egresspod.PolicyRevisionAnnotation: claims.RuntimePolicyRevision,
+				egresspod.ForwarderRevisionAnnotation: claims.ForwarderRevision, egresspod.CertificateFingerprintAnnotation: claims.CertificateFingerprint,
+			}}, Spec: corev1.PodSpec{RestartPolicy: corev1.RestartPolicyNever}},
+		claims: claims, hint: Identity{Fingerprint: fingerprint, Subject: "forged and ignored"},
+	}
+}
+
+func currentnessScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	return scheme
+}
+
+func (f *currentnessFixture) objects(extra ...client.Object) []client.Object {
+	objects := []client.Object{f.installation, f.namespace}
+	if f.project != nil {
+		objects = append(objects, f.project)
+	}
+	objects = append(objects, f.configMap, f.environment, f.pod)
+	return append(objects, extra...)
+}
+
+func (f *currentnessFixture) authorizer(t *testing.T, reader client.Reader) *CurrentnessAuthorizer {
+	t.Helper()
+	canonical, err := f.claims.CanonicalBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &CurrentnessAuthorizer{Reader: reader, Identities: &staticIdentityLookup{claims: canonical},
+		Installation:    tenancy.InstallationIdentity{Key: types.NamespacedName{Namespace: f.installation.Namespace, Name: f.installation.Name}, UID: f.claims.InstallationUID},
+		PolicyConfigMap: types.NamespacedName{Namespace: f.configMap.Namespace, Name: f.configMap.Name}}
+}
+
+func TestCurrentnessAuthorizerUnchangedIdentity(t *testing.T) {
+	f := newCurrentnessFixture(t)
+	reader := fake.NewClientBuilder().WithScheme(currentnessScheme(t)).WithObjects(f.objects()...).Build()
+	authorizer := f.authorizer(t, reader)
+	authorization, err := authorizer.Authorize(context.Background(), f.hint, "api.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if authorization.ExecutionKey != "environment-uid/7/pod-uid" || authorization.ProjectKey != "project-uid" || len(authorization.DeniedPrefixes) != 6 || authorization.Currentness == nil || isClosed(authorization.Currentness) {
+		t.Fatalf("unexpected authorization: %#v", authorization)
+	}
+	second, err := authorizer.Authorize(context.Background(), Identity{Fingerprint: f.hint.Fingerprint, Subject: "another forged subject"}, "api.example.com")
+	if err != nil || second.Currentness != authorization.Currentness || isClosed(second.Currentness) {
+		t.Fatalf("unchanged recheck = %#v, %v", second, err)
+	}
+	if _, err := authorizer.Authorize(context.Background(), f.hint, "denied.example.com"); err == nil {
+		t.Fatal("destination outside effective policy accepted")
+	}
+	if !isClosed(authorization.Currentness) {
+		t.Fatal("failed recheck did not revoke existing currentness")
+	}
+}
+
+func TestCurrentnessAuthorizerAdversarialCurrentness(t *testing.T) {
+	tests := map[string]func(*currentnessFixture) []client.Object{
+		"Installation replacement": func(f *currentnessFixture) []client.Object { f.installation.UID = "replacement"; return nil },
+		"inactive Namespace": func(f *currentnessFixture) []client.Object {
+			f.namespace.Annotations[tenancy.LifecycleAnnotation] = string(tenancy.LifecycleFenced)
+			return nil
+		},
+		"Namespace Installation claim": func(f *currentnessFixture) []client.Object {
+			f.namespace.Annotations[tenancy.InstallationUIDAnnotation] = "forged"
+			return nil
+		},
+		"Namespace Project claim": func(f *currentnessFixture) []client.Object {
+			f.namespace.Annotations[tenancy.ProjectUIDAnnotation] = "forged"
+			return nil
+		},
+		"Project replacement": func(f *currentnessFixture) []client.Object { f.project.UID = "replacement"; return nil },
+		"no Project":          func(f *currentnessFixture) []client.Object { f.project = nil; return nil },
+		"multiple Projects": func(f *currentnessFixture) []client.Object {
+			return []client.Object{&platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "project", UID: "other-uid"}}}
+		},
+		"invalid selection": func(f *currentnessFixture) []client.Object {
+			f.project.Spec.EgressAllowlist = []string{"UPPER.example.com"}
+			return nil
+		},
+		"outside ceiling": func(f *currentnessFixture) []client.Object {
+			f.project.Spec.EgressAllowlist = []string{"outside.example.com"}
+			return nil
+		},
+		"ConfigMap replacement": func(f *currentnessFixture) []client.Object { f.configMap.UID = "replacement"; return nil },
+		"mutable ConfigMap":     func(f *currentnessFixture) []client.Object { f.configMap.Immutable = ptr.To(false); return nil },
+		"ConfigMap content": func(f *currentnessFixture) []client.Object {
+			f.configMap.Data[egresspolicy.ConfigDataKey] = strings.Replace(f.configMap.Data[egresspolicy.ConfigDataKey], "api.example.com", "new.example.com", 1)
+			return nil
+		},
+		"Environment replacement": func(f *currentnessFixture) []client.Object { f.environment.UID = "replacement"; return nil },
+		"frozen Project": func(f *currentnessFixture) []client.Object {
+			f.environment.Status.Provisioning.Project.UID = "replacement"
+			return nil
+		},
+		"execution": func(f *currentnessFixture) []client.Object { f.environment.Status.ExecutionGeneration++; return nil },
+		"not ready": func(f *currentnessFixture) []client.Object { f.environment.Status.Conditions = nil; return nil },
+		"suspended": func(f *currentnessFixture) []client.Object {
+			f.environment.Status.Lifecycle.Suspended = true
+			return nil
+		},
+		"Pod replacement": func(f *currentnessFixture) []client.Object { f.pod.UID = "replacement"; return nil },
+		"deleting Pod": func(f *currentnessFixture) []client.Object {
+			now := metav1.Now()
+			f.pod.DeletionTimestamp = &now
+			f.pod.Finalizers = []string{"test"}
+			return nil
+		},
+		"Pod owner": func(f *currentnessFixture) []client.Object { f.pod.OwnerReferences[0].UID = "replacement"; return nil },
+		"Pod restart Always": func(f *currentnessFixture) []client.Object {
+			f.pod.Spec.RestartPolicy = corev1.RestartPolicyAlways
+			return nil
+		},
+		"Pod restart OnFailure": func(f *currentnessFixture) []client.Object {
+			f.pod.Spec.RestartPolicy = corev1.RestartPolicyOnFailure
+			return nil
+		},
+		"Pod restart default": func(f *currentnessFixture) []client.Object { f.pod.Spec.RestartPolicy = ""; return nil },
+		"Pod execution": func(f *currentnessFixture) []client.Object {
+			f.pod.Annotations[egresspod.ExecutionGenerationAnnotation] = "8"
+			return nil
+		},
+		"policy revision": func(f *currentnessFixture) []client.Object {
+			f.pod.Annotations[egresspod.PolicyRevisionAnnotation] = "stale"
+			return nil
+		},
+		"security revision": func(f *currentnessFixture) []client.Object {
+			f.pod.Annotations[egresspod.ForwarderRevisionAnnotation] = "stale"
+			return nil
+		},
+		"fingerprint": func(f *currentnessFixture) []client.Object {
+			f.pod.Annotations[egresspod.CertificateFingerprintAnnotation] = strings.Repeat("0", 64)
+			return nil
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			f := newCurrentnessFixture(t)
+			extra := mutate(f)
+			objects := f.objects(extra...)
+			filtered := objects[:0]
+			for _, object := range objects {
+				if object != nil {
+					filtered = append(filtered, object)
+				}
+			}
+			reader := fake.NewClientBuilder().WithScheme(currentnessScheme(t)).WithObjects(filtered...).Build()
+			if _, err := f.authorizer(t, reader).Authorize(context.Background(), f.hint, "api.example.com"); err == nil {
+				t.Fatal("expected rejection")
+			}
+		})
+	}
+}
+
+func TestCurrentnessAuthorizerForgedClaimsAndAPIUncertainty(t *testing.T) {
+	f := newCurrentnessFixture(t)
+	reader := fake.NewClientBuilder().WithScheme(currentnessScheme(t)).WithObjects(f.objects()...).Build()
+	authorizer := f.authorizer(t, reader)
+
+	for name, mutate := range map[string]func(*egressidentity.Claims){
+		"Installation": func(c *egressidentity.Claims) { c.InstallationUID = "forged" },
+		"Project":      func(c *egressidentity.Claims) { c.ProjectUID = "forged" },
+		"Environment":  func(c *egressidentity.Claims) { c.EnvironmentUID = "forged" },
+		"Pod":          func(c *egressidentity.Claims) { c.PodUID = "forged" },
+		"execution":    func(c *egressidentity.Claims) { c.ExecutionGeneration++ },
+		"policy":       func(c *egressidentity.Claims) { c.RuntimePolicyRevision = strings.Repeat("0", 64) },
+		"fingerprint":  func(c *egressidentity.Claims) { c.CertificateFingerprint = strings.Repeat("0", 64) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			claims := f.claims
+			mutate(&claims)
+			canonical, err := claims.CanonicalBytes()
+			if err != nil {
+				t.Fatal(err)
+			}
+			forged := &CurrentnessAuthorizer{Reader: reader, Identities: &staticIdentityLookup{claims: canonical}, Installation: authorizer.Installation, PolicyConfigMap: authorizer.PolicyConfigMap}
+			if _, err := forged.Authorize(context.Background(), f.hint, "api.example.com"); err == nil {
+				t.Fatal("forged claims accepted")
+			}
+		})
+	}
+	wrongHint := f.hint
+	wrongHint.Fingerprint = sha256.Sum256([]byte("other certificate"))
+	if _, err := authorizer.Authorize(context.Background(), wrongHint, "api.example.com"); err == nil {
+		t.Fatal("forged certificate hint accepted")
+	}
+
+	canonical, _ := f.claims.CanonicalBytes()
+	authorizer.Identities = &staticIdentityLookup{claims: canonical, err: errors.New("API unavailable")}
+	if _, err := authorizer.Authorize(context.Background(), f.hint, "api.example.com"); err == nil {
+		t.Fatal("lookup error accepted")
+	}
+	waiting := &staticIdentityLookup{claims: canonical, wait: true}
+	authorizer.Identities = waiting
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if _, err := authorizer.Authorize(ctx, f.hint, "api.example.com"); err == nil {
+		t.Fatal("timeout accepted")
+	}
+	if waiting.deadline <= 0 || waiting.deadline > CurrentnessTimeout {
+		t.Fatalf("evaluation deadline = %v", waiting.deadline)
+	}
+	bounded := &staticIdentityLookup{claims: canonical, err: errors.New("stop")}
+	authorizer.Identities = bounded
+	if _, err := authorizer.Authorize(context.Background(), f.hint, "api.example.com"); err == nil || bounded.deadline <= CurrentnessTimeout-time.Second || bounded.deadline > CurrentnessTimeout {
+		t.Fatalf("authorizer-owned deadline = %v, err = %v", bounded.deadline, err)
+	}
+}
+
+func TestCurrentnessAuthorizerRejectsForeignInstallationAndMidProofChange(t *testing.T) {
+	f := newCurrentnessFixture(t)
+	base := fake.NewClientBuilder().WithScheme(currentnessScheme(t)).WithObjects(f.objects()...).Build()
+	authorizer := f.authorizer(t, base)
+	authorizer.Installation = tenancy.InstallationIdentity{Key: types.NamespacedName{Namespace: "system", Name: "foreign"}, UID: "foreign-uid"}
+	if _, err := authorizer.Authorize(context.Background(), f.hint, "api.example.com"); err == nil {
+		t.Fatal("claims selected an Installation other than the configured authority")
+	}
+
+	authorizer = f.authorizer(t, &mutatingReader{Client: base})
+	if _, err := authorizer.Authorize(context.Background(), f.hint, "api.example.com"); err == nil {
+		t.Fatal("Project contraction during the proof was accepted")
+	}
+}
+
+func TestCurrentnessAuthorizerStateCapacity(t *testing.T) {
+	f := newCurrentnessFixture(t)
+	authorizer := &CurrentnessAuthorizer{Reader: failingReader{}, Identities: &staticIdentityLookup{},
+		Installation:    tenancy.InstallationIdentity{Key: types.NamespacedName{Namespace: "system", Name: "main"}, UID: "installation-uid"},
+		PolicyConfigMap: types.NamespacedName{Namespace: "system", Name: "policy"}, records: make(map[[sha256.Size]byte]*executionRecord, MaxCurrentnessStates)}
+	for i := 0; i < MaxCurrentnessStates; i++ {
+		fingerprint := sha256.Sum256([]byte(string(rune(i))))
+		authorizer.records[fingerprint] = &executionRecord{state: newExecutionState()}
+	}
+	if _, err := authorizer.Authorize(context.Background(), f.hint, "api.example.com"); err == nil {
+		t.Fatal("new fingerprint accepted above bounded state capacity")
+	}
+}
+
+func TestCurrentnessAuthorizerFailedRecheckRevokes(t *testing.T) {
+	f := newCurrentnessFixture(t)
+	reader := fake.NewClientBuilder().WithScheme(currentnessScheme(t)).WithObjects(f.objects()...).Build()
+	authorizer := f.authorizer(t, reader)
+	first, err := authorizer.Authorize(context.Background(), f.hint, "api.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var pod corev1.Pod
+	if err := reader.Get(context.Background(), types.NamespacedName{Namespace: f.pod.Namespace, Name: f.pod.Name}, &pod); err != nil {
+		t.Fatal(err)
+	}
+	pod.Annotations[egresspod.CertificateFingerprintAnnotation] = strings.Repeat("0", 64)
+	if err := reader.Update(context.Background(), &pod); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := authorizer.Authorize(context.Background(), f.hint, "api.example.com"); err == nil {
+		t.Fatal("failed recheck accepted")
+	}
+	if !isClosed(first.Currentness) {
+		t.Fatal("existing tunnel state remained current after failed recheck")
+	}
+
+	pod.Annotations[egresspod.CertificateFingerprintAnnotation] = f.claims.CertificateFingerprint
+	if err := reader.Update(context.Background(), &pod); err != nil {
+		t.Fatal(err)
+	}
+	second, err := authorizer.Authorize(context.Background(), f.hint, "api.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	authorizer.Reader = failingReader{Reader: reader}
+	if _, err := authorizer.Authorize(context.Background(), f.hint, "api.example.com"); err == nil || !isClosed(second.Currentness) {
+		t.Fatal("API uncertainty retained a previous authorization")
+	}
+}

--- a/internal/egressproxy/doc.go
+++ b/internal/egressproxy/doc.go
@@ -1,8 +1,8 @@
-// Package egressproxy contains the INERT, DISABLED and non-authoritative
-// transport slice of the future egress proxy. It does not consult Kubernetes,
-// authorize live Environments, or enforce network policy. The shipped command
-// deliberately installs an authorizer which denies every request. Tests and a
-// future authoritative integration may inject an Authorizer.
+// Package egressproxy contains the INERT and DISABLED transport plus an
+// unconstructed Kubernetes currentness-authorizer foundation for the future
+// egress proxy. It does not enforce network policy. The shipped command
+// deliberately installs an authorizer which denies every request; only tests
+// construct the uncached currentness proof.
 // This inert slice intentionally emits no request-derived logs until bounded,
 // non-sensitive observability is integrated.
 package egressproxy

--- a/internal/egressproxy/proxy.go
+++ b/internal/egressproxy/proxy.go
@@ -19,6 +19,9 @@ type Identity = egressidentity.CertificateHint
 type Authorization struct {
 	ExecutionKey, ProjectKey string
 	DeniedPrefixes           []netip.Prefix
+	// Currentness closes after any failed recheck for this certificate
+	// fingerprint. The disabled transport does not yet consume this signal.
+	Currentness <-chan struct{}
 }
 type Authorizer interface {
 	Authorize(context.Context, Identity, string) (Authorization, error)

--- a/internal/egressproxy/proxy.go
+++ b/internal/egressproxy/proxy.go
@@ -22,6 +22,9 @@ type Authorization struct {
 	// Currentness closes after any failed recheck for this certificate
 	// fingerprint. The disabled transport does not yet consume this signal.
 	Currentness <-chan struct{}
+	// ReleaseCurrentness releases this authorization's lifecycle lease. Future
+	// transport wiring must call it when replacing or closing a tunnel lease.
+	ReleaseCurrentness func()
 }
 type Authorizer interface {
 	Authorize(context.Context, Identity, string) (Authorization, error)

--- a/internal/egressproxy/proxy_test.go
+++ b/internal/egressproxy/proxy_test.go
@@ -195,18 +195,30 @@ func TestForwarderMaxConnections(t *testing.T) {
 		t.Fatalf("first handler did not end before timeout: %v", err)
 	}
 
-	third, err := net.Dial("tcp", listener.Addr().String())
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer third.Close()
-	if _, err := io.WriteString(third, "CONNECT api.example.com:443 HTTP/1.1\r\nHost: api.example.com:443\r\n\r\n"); err != nil {
-		t.Fatal(err)
-	}
-	select {
-	case <-secondEntered:
-	case <-time.After(2 * time.Second):
-		t.Fatal("third connection did not acquire the released slot")
+	// Observing the first connection's FIN does not guarantee the serving
+	// goroutine has run its immediately-following deferred slot release. Retry
+	// bounded connection attempts until one observes that released slot.
+	deadline := time.Now().Add(2 * time.Second)
+	acquired := false
+	for !acquired {
+		third, err := net.Dial("tcp", listener.Addr().String())
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, writeErr := io.WriteString(third, "CONNECT api.example.com:443 HTTP/1.1\r\nHost: api.example.com:443\r\n\r\n")
+		select {
+		case <-secondEntered:
+			acquired = true
+			_ = third.Close()
+		case <-time.After(50 * time.Millisecond):
+			_ = third.Close()
+		}
+		if !acquired && writeErr != nil && time.Now().After(deadline) {
+			t.Fatalf("connection attempts failed after slot release: %v", writeErr)
+		}
+		if !acquired && time.Now().After(deadline) {
+			t.Fatal("no connection acquired the released slot")
+		}
 	}
 	if got := dialCount.Load(); got != 2 {
 		t.Fatalf("DialTLS count = %d, want 2", got)


### PR DESCRIPTION
## Summary

- add a strict immutable/content-addressed `policy.json` ConfigMap parser with bounded ceiling/baseline, digest-only proxy image identity, admin TLS Secret name, and exact Calico v3.32.1 resolver/CIDR profile
- add an unconstructed two-second `CurrentnessAuthorizer` that performs two uncached passes over exact Installation, Namespace claim/sole Project, Project policy, Environment execution, Pod identity, and ConfigMap authority
- return a bounded per-fingerprint currentness signal that closes on failed recheck or API uncertainty
- reject IPv4-mapped resolver/CIDR forms so configured denial semantics cannot be lost after address unmapping
- require Project namespaces to remain distinct from the Installation system namespace
- require restartPolicy `Never` in the inert staged Pod contract

The shipped `egress-proxy serve` command still constructs `DisabledAuthorizer`; no controller constructs this authorizer or the inert Pod helper. No chart values/templates, image, Deployment, Service, RBAC, NetworkPolicy, credential publication, gate removal, path forcing, or allowlist-fence relaxation is included. This is issue #68 slice 5 and does **not** close #68.

## Validation

- `go test -race ./internal/egresspolicy ./internal/egressproxy ./internal/egresspod -count=1`
- `make test`
- `make vet`
- `make check-chart-crds`
- `git diff --check origin/main...HEAD`
- fresh blocker-only security review after hardening: **SHIP**
