### PR TITLE
Allow transcript cleanup during offboarding fencing

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -286,8 +286,9 @@ Tenancy mode is required and has no compatibility default:
   available. Reconcile entry and every client mutation re-read the exact Installation,
   Namespace UID/claim/lifecycle, and sole Project through an uncached reader. The control plane
   performs TokenReview/SAR first, then requires both allowlist membership and the same uncached
-  active-claim proof before any namespaced resource work. Namespaced RoleBindings supply
-  workload authority only after onboarding.
+  active-claim proof before namespaced resource work, subject only to the exact transcript
+  deletion exception below. Namespaced RoleBindings supply workload authority only after
+  onboarding.
 - **`trusted-admin`.** Explicit opt-in cluster-wide cache and workload RBAC, allowing newly
   claimed namespaces to be discovered without a restart-bound list. Exact Installation,
   Namespace, and sole-Project claims remain mandatory, so multiple releases do not reconcile
@@ -301,8 +302,10 @@ Environment hold intents, waits for terminal Runs and suspended podless Environm
 marks the namespace `fenced`. It deletes no Namespace, Project, Template, quota, RBAC, policy,
 credential profile or owned Secret, PVC, Run, Environment, or transcript data. Normal
 Environment suspension still revokes the pod incarnation's ephemeral sandboxd credential
-Secret. After fencing, operators may retain/archive the namespace, remove it from
-`tenancy.namespaces`, and restart the scoped components. Purge is not implemented; it remains
+Secret. Offboarding does not initiate transcript deletion, but exact cleanup for a separately
+deleting Run may finish while the claim remains `fencing` + `offboarding`; `fenced` is denied.
+After fencing, operators may retain/archive the namespace, remove it from `tenancy.namespaces`,
+and restart the scoped components. Purge is not implemented; it remains
 blocked on an exact Namespace-UID-preconditioned durable resumable operation.
 
 ### Environment boundary and backend portability
@@ -541,12 +544,15 @@ only when an authorized request resolves the exact current Run UID; conflicting 
 rejected, and otherwise-unprovable rows are retained indefinitely. The control plane now has an
 internal, explicit-bearer exact transcript DELETE foundation for a deleting Run. It requires
 `delete` authorization on the exact `runs/transcript`, an exact Namespace UID precondition,
-fresh active-tenancy and deleting-Run proof, and a bounded process-local cutoff/drain before the
-store performs idempotent exact `(namespace name, Namespace UID, Run UID)` deletion. PostgreSQL
-uses the existing Namespace-UID association and one transaction; the memory development store
-reclaims its accounting and subscribers. No operator, finalizer, client, CLI, or RBAC wiring
-invokes this capability yet, so transcript rows are not currently garbage-collected when a Run
-or Project is deleted and the existing operational limitation remains.
+fresh tenancy and deleting-Run proof both before and after a bounded process-local cutoff/drain,
+and then idempotent exact `(namespace name, Namespace UID, Run UID)` store deletion. Tenancy must
+be active except that this exact no-session DELETE alone may continue during
+`LifecycleFencing` + `OperationOffboarding`; onboarding fencing, fenced claims, GET/POST/SSE,
+and every other namespaced operation remain denied. PostgreSQL uses the existing Namespace-UID
+association and one transaction; the memory development store reclaims its accounting and
+subscribers. No operator, finalizer, client, CLI, or RBAC wiring invokes this capability yet, so
+transcript rows are not currently garbage-collected when a Run or Project is deleted and the
+existing operational limitation remains.
 
 ### Authentication and exact identity fences
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -269,17 +269,23 @@ The scoped operator cache is restart-bound to the explicit `tenancy.namespaces` 
 reconcile entry, and every mutation revalidate the Installation and exact Namespace/Project
 claim through uncached reads. The control plane first performs its existing TokenReview and
 SubjectAccessReview checks, then independently requires allowlist membership and an uncached
-active-claim proof. A second release has different Installation and cluster-role identities and
-an Installation-UID-derived leader lease; it cannot satisfy or receive another release's
-namespaced workload authority. `trusted-admin` is a separate explicit cluster-wide mode; absent
-or invalid mode configuration never enables it. Its cache and RBAC are cluster-wide, but exact
-Installation/Namespace/Project claims remain mandatory at mutation boundaries.
+active-claim proof, with one narrow retention exception: an explicit-bearer, exact-name `delete`
+on `runs/transcript` may also pass during `LifecycleFencing` + `OperationOffboarding` so its
+required post-drain authorization can finish. The exception admits no session, GET/POST/SSE,
+other resource tuple, onboarding fencing, or fenced claim. A second release has different
+Installation and cluster-role identities and an Installation-UID-derived leader lease; it
+cannot satisfy or receive another release's namespaced workload authority. `trusted-admin` is a
+separate explicit cluster-wide mode; absent or invalid mode configuration never enables it. Its
+cache and RBAC are cluster-wide, but exact Installation/Namespace/Project claims remain
+mandatory at mutation boundaries.
 
 Onboarding installs an ingress-only default-deny NetworkPolicy and a tokenless Environment
 ServiceAccount. The existing Environment-specific policy adds only the sandboxd ingress needed
 from the installation's system components. These policies do not restrict egress. Offboarding
 fences before drain and retains the Namespace, workspace PVCs, credential profiles and their
-owned Secrets, and transcript data. Suspending an Environment still revokes its ephemeral
+owned Secrets, and transcript data; it does not trigger transcript cleanup. An independently
+deleting Run may complete its already-exact transcript cleanup during offboarding fencing, but
+not after the claim becomes fenced. Suspending an Environment still revokes its ephemeral
 per-pod sandboxd credential Secret as described above. Destructive Project purge is not
 implemented.
 

--- a/charts/swe-platform/README.md
+++ b/charts/swe-platform/README.md
@@ -1096,11 +1096,13 @@ idempotency: after an event is evicted, its key may be reused and creates a new 
 
 The internal `DELETE` on the same exact transcript route is release-sequencing foundation, not a
 current user workflow. It accepts only an explicit bearer credential, requires both the exact
-`SWE-Run-UID` and `SWE-Namespace-UID`, repeats TokenReview, exact `delete` SAR, active tenancy,
-Namespace identity, and exact deleting-Run currentness after draining admitted appends, and
-returns `204` for both committed and already-absent cleanup. Cutoff cancels existing streams and
-causes future reads/appends to return the fixed `410 transcript-retention-cutoff` problem. Failed
-cleanup remains cut off for retry in the current process; after restart, the still-deleting Run
+`SWE-Run-UID` and `SWE-Namespace-UID`, and repeats TokenReview, exact `delete` SAR, Namespace
+identity, and exact deleting-Run currentness after draining admitted appends. Tenancy must be
+active except that this exact no-session DELETE may finish during offboarding fencing; onboarding
+fencing, fenced claims, and all other operations remain denied. Successful cleanup returns `204`
+for both committed and already-absent deletion. Cutoff cancels existing streams and causes future
+reads/appends to return the fixed `410 transcript-retention-cutoff` problem. Failed cleanup
+remains cut off for retry in the current process; after restart, the still-deleting Run
 reestablishes the cutoff before an idempotent store retry. The bounded cleanup metrics above have
 no namespace, name, or UID labels. No supported caller ships in this release.
 

--- a/charts/swe-platform/README.md
+++ b/charts/swe-platform/README.md
@@ -787,8 +787,10 @@ This permits producer credentials to be restricted to one Run using an RBAC Role
 authoritative only after RBAC authorizes that exact namespaced identity. In scoped mode,
 authorization happens first and is then supplemented by the restart-bound
 `tenancy.namespaces` allowlist and an uncached proof of the exact active Installation UID,
-Namespace UID, Namespace annotations, sole Project name/UID, and lifecycle. TokenReview/SAR is
-never replaced by labels or claims. Unknown Runs are
+Namespace UID, Namespace annotations, sole Project name/UID, and lifecycle. The sole lifecycle
+exception is the explicit-bearer, exact-name deleting-Run transcript cleanup above during exact
+offboarding fencing; it does not admit sessions or any other operation. TokenReview/SAR is never
+replaced by labels or claims. Unknown Runs are
 rejected before transcript state is allocated; every transcript read and append additionally
 requires the exact `SWE-Run-UID` header so a recreated Run never receives stale events or
 readers. An already-open stream is not continuously reauthorized or closed when its Run is

--- a/internal/controlplane/tenancy_access.go
+++ b/internal/controlplane/tenancy_access.go
@@ -15,6 +15,8 @@ type namespaceUIDContextKey struct{}
 
 // TenancyAccessController preserves the existing authentication/SAR ordering,
 // then rejects namespaced work outside the exact active Installation claim.
+// The sole transition exception admits an explicit-bearer exact transcript
+// deletion during offboarding fencing.
 type TenancyAccessController struct {
 	Access     AccessController
 	Verifier   *tenancy.Verifier
@@ -65,11 +67,20 @@ func (a TenancyAccessController) AuthorizePrincipal(r *http.Request, access Reso
 		}
 		return "", fmt.Errorf("authorize namespace scope: %w", err)
 	}
-	if claim.Lifecycle != tenancy.LifecycleActive {
+	if claim.Lifecycle != tenancy.LifecycleActive && !allowOffboardingTranscriptDelete(r, access, allowSession, claim) {
 		return "", errForbidden
 	}
 	*r = *r.WithContext(context.WithValue(r.Context(), namespaceUIDContextKey{}, claim.NamespaceUID))
 	return principalKey, nil
+}
+
+func allowOffboardingTranscriptDelete(r *http.Request, access ResourceAccess, allowSession bool, claim tenancy.Claim) bool {
+	if allowSession || claim.Lifecycle != tenancy.LifecycleFencing || claim.Operation != tenancy.OperationOffboarding ||
+		access.Verb != "delete" || access.Resource != "runs" || access.Subresource != "transcript" || access.Name == "" {
+		return false
+	}
+	_, _, err := requestBearerToken(r)
+	return err == nil
 }
 
 func namespaceUIDFromRequest(r *http.Request) types.UID {

--- a/internal/controlplane/tenancy_access_test.go
+++ b/internal/controlplane/tenancy_access_test.go
@@ -1,15 +1,18 @@
 package controlplane
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
@@ -35,6 +38,16 @@ func (a *orderedAccess) AuthenticatePrincipal(*http.Request, bool) (string, erro
 
 func tenancyAccessFixture(t *testing.T, lifecycle tenancy.Lifecycle, claimed bool) *tenancy.Verifier {
 	t.Helper()
+	operation := ""
+	if lifecycle == tenancy.LifecycleFencing {
+		operation = tenancy.OperationOffboarding
+	}
+	verifier, _ := tenancyAccessFixtureForOperation(t, lifecycle, operation, claimed)
+	return verifier
+}
+
+func tenancyAccessFixtureForOperation(t *testing.T, lifecycle tenancy.Lifecycle, operation string, claimed bool) (*tenancy.Verifier, client.Client) {
+	t.Helper()
 	scheme := runtime.NewScheme()
 	if err := corev1.AddToScheme(scheme); err != nil {
 		t.Fatal(err)
@@ -46,10 +59,6 @@ func tenancyAccessFixture(t *testing.T, lifecycle tenancy.Lifecycle, claimed boo
 	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "team", UID: "namespace-uid"}}
 	objects := []runtime.Object{installation, namespace}
 	if claimed {
-		operation := ""
-		if lifecycle == tenancy.LifecycleFencing {
-			operation = tenancy.OperationOffboarding
-		}
 		namespace.Annotations = map[string]string{
 			tenancy.InstallationNamespaceAnnotation: "system",
 			tenancy.InstallationNameAnnotation:      "main",
@@ -61,8 +70,8 @@ func tenancyAccessFixture(t *testing.T, lifecycle tenancy.Lifecycle, claimed boo
 		}
 		objects = append(objects, &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "project", Namespace: "team", UID: "project-uid"}})
 	}
-	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
-	return &tenancy.Verifier{Reader: client, Installation: tenancy.InstallationIdentity{Key: types.NamespacedName{Namespace: "system", Name: "main"}, UID: "installation-uid"}, Mode: tenancy.ModeScoped}
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
+	return &tenancy.Verifier{Reader: kubeClient, Installation: tenancy.InstallationIdentity{Key: types.NamespacedName{Namespace: "system", Name: "main"}, UID: "installation-uid"}, Mode: tenancy.ModeScoped}, kubeClient
 }
 
 func TestTenancyAccessPreservesAuthorizationBeforeScopeValidation(t *testing.T) {
@@ -112,6 +121,54 @@ func TestTenancyAccessRequiresConfiguredExactActiveClaim(t *testing.T) {
 	}
 }
 
+func TestTenancyAccessAllowsOnlyExactOffboardingTranscriptDelete(t *testing.T) {
+	exactDelete := ResourceAccess{Namespace: "team", Verb: "delete", Resource: "runs", Subresource: "transcript", Name: "run"}
+	tests := []struct {
+		name         string
+		lifecycle    tenancy.Lifecycle
+		operation    string
+		access       ResourceAccess
+		allowSession bool
+		bearer       bool
+		configured   bool
+		want         error
+	}{
+		{name: "offboarding exact bearer delete", lifecycle: tenancy.LifecycleFencing, operation: tenancy.OperationOffboarding, access: exactDelete, bearer: true, configured: true},
+		{name: "offboarding session-capable delete", lifecycle: tenancy.LifecycleFencing, operation: tenancy.OperationOffboarding, access: exactDelete, allowSession: true, bearer: true, configured: true, want: errForbidden},
+		{name: "offboarding delete without bearer", lifecycle: tenancy.LifecycleFencing, operation: tenancy.OperationOffboarding, access: exactDelete, configured: true, want: errForbidden},
+		{name: "offboarding transcript get and SSE", lifecycle: tenancy.LifecycleFencing, operation: tenancy.OperationOffboarding, access: ResourceAccess{Namespace: "team", Verb: "get", Resource: "runs", Subresource: "transcript", Name: "run"}, allowSession: true, bearer: true, configured: true, want: errForbidden},
+		{name: "offboarding transcript post", lifecycle: tenancy.LifecycleFencing, operation: tenancy.OperationOffboarding, access: ResourceAccess{Namespace: "team", Verb: "update", Resource: "runs", Subresource: "transcript", Name: "run"}, bearer: true, configured: true, want: errForbidden},
+		{name: "offboarding other resource", lifecycle: tenancy.LifecycleFencing, operation: tenancy.OperationOffboarding, access: ResourceAccess{Namespace: "team", Verb: "delete", Resource: "environments", Subresource: "transcript", Name: "run"}, bearer: true, configured: true, want: errForbidden},
+		{name: "offboarding other subresource", lifecycle: tenancy.LifecycleFencing, operation: tenancy.OperationOffboarding, access: ResourceAccess{Namespace: "team", Verb: "delete", Resource: "runs", Subresource: "terminal", Name: "run"}, bearer: true, configured: true, want: errForbidden},
+		{name: "offboarding unnamed delete", lifecycle: tenancy.LifecycleFencing, operation: tenancy.OperationOffboarding, access: ResourceAccess{Namespace: "team", Verb: "delete", Resource: "runs", Subresource: "transcript"}, bearer: true, configured: true, want: errForbidden},
+		{name: "offboarding unconfigured namespace", lifecycle: tenancy.LifecycleFencing, operation: tenancy.OperationOffboarding, access: exactDelete, bearer: true, want: errForbidden},
+		{name: "onboarding fencing", lifecycle: tenancy.LifecycleFencing, operation: tenancy.OperationOnboarding, access: exactDelete, bearer: true, configured: true, want: errForbidden},
+		{name: "fenced", lifecycle: tenancy.LifecycleFenced, access: exactDelete, bearer: true, configured: true, want: errForbidden},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			verifier, _ := tenancyAccessFixtureForOperation(t, test.lifecycle, test.operation, true)
+			namespaces := map[string]struct{}{}
+			if test.configured {
+				namespaces["team"] = struct{}{}
+			}
+			underlying := &orderedAccess{}
+			controller := TenancyAccessController{Access: underlying, Verifier: verifier, Namespaces: namespaces}
+			request := httptest.NewRequest(http.MethodDelete, "https://api.test/api/v1/namespaces/team/runs/run/transcript", nil)
+			if test.bearer {
+				request.Header.Set("Authorization", "Bearer cleanup")
+			}
+			err := controller.Authorize(request, test.access, test.allowSession)
+			if !underlying.called || !errors.Is(err, test.want) {
+				t.Fatalf("called=%v err=%v want=%v", underlying.called, err, test.want)
+			}
+			if test.want == nil && namespaceUIDFromRequest(request) != "namespace-uid" {
+				t.Fatalf("Namespace UID context = %q", namespaceUIDFromRequest(request))
+			}
+		})
+	}
+}
+
 func TestTenancyAccessTrustedAdminIsExplicit(t *testing.T) {
 	verifier := tenancyAccessFixture(t, tenancy.LifecycleActive, true)
 	verifier.Mode = tenancy.ModeTrustedAdmin
@@ -132,7 +189,7 @@ func TestTenancyAccessTrustedAdminIsExplicit(t *testing.T) {
 	}
 }
 
-func TestTranscriptDeleteRequiresFreshActiveTenancyProof(t *testing.T) {
+func TestTranscriptDeleteRequiresFreshTenancyProof(t *testing.T) {
 	underlying := &orderedAccess{}
 	access := TenancyAccessController{
 		Access: underlying, Verifier: tenancyAccessFixture(t, tenancy.LifecycleActive, true),
@@ -157,9 +214,10 @@ func TestTranscriptDeleteRequiresFreshActiveTenancyProof(t *testing.T) {
 		}
 	}
 
+	onboardingVerifier, _ := tenancyAccessFixtureForOperation(t, tenancy.LifecycleFencing, tenancy.OperationOnboarding, true)
 	deniedAPI := NewServer(nil, ServerOptions{
 		Access: TenancyAccessController{
-			Access: &orderedAccess{}, Verifier: tenancyAccessFixture(t, tenancy.LifecycleFencing, true),
+			Access: &orderedAccess{}, Verifier: onboardingVerifier,
 			Namespaces: map[string]struct{}{"team": {}},
 		},
 		Runs: &fakeRunResolver{uid: "run-uid", deleting: true}, TranscriptStore: NewMemoryTranscriptStore(MemoryTranscriptStoreOptions{}),
@@ -167,6 +225,108 @@ func TestTranscriptDeleteRequiresFreshActiveTenancyProof(t *testing.T) {
 	deniedResponse := httptest.NewRecorder()
 	deniedAPI.Handler().ServeHTTP(deniedResponse, request.Clone(request.Context()))
 	if deniedResponse.Code != http.StatusForbidden || len(deniedAPI.transcriptGate.entries) != 0 {
-		t.Fatalf("fencing tenancy cleanup response/gates = %d/%d", deniedResponse.Code, len(deniedAPI.transcriptGate.entries))
+		t.Fatalf("onboarding-fencing cleanup response/gates = %d/%d", deniedResponse.Code, len(deniedAPI.transcriptGate.entries))
+	}
+}
+
+func TestTranscriptDeleteReauthorizesAcrossOffboardingFencingDuringDrain(t *testing.T) {
+	verifier, kubeClient := tenancyAccessFixtureForOperation(t, tenancy.LifecycleActive, "", true)
+	underlying := &orderedAccess{}
+	access := TenancyAccessController{Access: underlying, Verifier: verifier, Namespaces: map[string]struct{}{"team": {}}}
+	run := RunIdentity{Namespace: "team", NamespaceUID: "namespace-uid", UID: "run-uid"}
+	memory := NewMemoryTranscriptStore(MemoryTranscriptStoreOptions{})
+	appendStoreEvent(t, memory, run, "retained")
+	store := &blockingUnsubscribeTranscriptStore{
+		TranscriptStore:    memory,
+		unsubscribeStarted: make(chan struct{}),
+		releaseUnsubscribe: make(chan struct{}),
+		deleteStarted:      make(chan struct{}),
+	}
+	released := false
+	releaseDrain := func() {
+		if !released {
+			close(store.releaseUnsubscribe)
+			released = true
+		}
+	}
+	resolver := &mutableRunResolver{uid: "run-uid"}
+	api := NewServer(nil, ServerOptions{Access: access, Runs: resolver, TranscriptStore: store})
+	server := httptest.NewServer(api.Handler())
+	defer server.Close()
+
+	streamContext, cancelStream := context.WithCancel(context.Background())
+	defer cancelStream()
+	streamRequest, err := http.NewRequestWithContext(streamContext, http.MethodGet, server.URL+"/api/v1/namespaces/team/runs/run/transcript", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	streamRequest.Header.Set("Authorization", "Bearer reader")
+	streamRequest.Header.Set(RunUIDHeader, "run-uid")
+	streamResponse, err := http.DefaultClient.Do(streamRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer streamResponse.Body.Close()
+	defer releaseDrain()
+
+	resolver.setDeleting(true)
+	deleteRequest, err := http.NewRequest(http.MethodDelete, server.URL+"/api/v1/namespaces/team/runs/run/transcript", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	deleteRequest.Header.Set("Authorization", "Bearer cleanup")
+	deleteRequest.Header.Set(RunUIDHeader, "run-uid")
+	deleteRequest.Header.Set(NamespaceUIDHeader, "namespace-uid")
+	type deleteResult struct {
+		response *http.Response
+		err      error
+	}
+	deleteDone := make(chan deleteResult, 1)
+	go func() {
+		response, err := http.DefaultClient.Do(deleteRequest)
+		deleteDone <- deleteResult{response: response, err: err}
+	}()
+	select {
+	case <-store.unsubscribeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("DELETE did not enter transcript drain")
+	}
+
+	var namespace corev1.Namespace
+	if err := kubeClient.Get(context.Background(), types.NamespacedName{Name: "team"}, &namespace); err != nil {
+		t.Fatal(err)
+	}
+	namespace.Annotations[tenancy.LifecycleAnnotation] = string(tenancy.LifecycleFencing)
+	namespace.Annotations[tenancy.LifecycleOperationAnnotation] = tenancy.OperationOffboarding
+	if err := kubeClient.Update(context.Background(), &namespace); err != nil {
+		t.Fatal(err)
+	}
+	releaseDrain()
+
+	var result deleteResult
+	select {
+	case result = <-deleteDone:
+	case <-time.After(time.Second):
+		t.Fatal("DELETE did not finish after offboarding-fencing reauthorization")
+	}
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	result.response.Body.Close()
+	if result.response.StatusCode != http.StatusNoContent {
+		t.Fatalf("DELETE status = %d, want %d", result.response.StatusCode, http.StatusNoContent)
+	}
+	deleteProof := ResourceAccess{Namespace: "team", Verb: "delete", Resource: "runs", Subresource: "transcript", Name: "run"}
+	proofs := 0
+	for _, proof := range underlying.access {
+		if proof == deleteProof {
+			proofs++
+		}
+	}
+	if proofs != 2 {
+		t.Fatalf("exact DELETE authorization proofs = %d, want initial and post-drain", proofs)
+	}
+	if _, exists := memory.(*memoryTranscriptStore).runs[run]; exists {
+		t.Fatal("exact transcript remained after offboarding-fencing cleanup")
 	}
 }


### PR DESCRIPTION
## Summary
- narrowly permit explicit-bearer exact transcript DELETE during verified offboarding fencing
- keep onboarding fencing, fenced tenancy, sessions, GET/POST/SSE, and every other resource tuple denied
- prove the post-drain authorization survives an active-to-offboarding transition and still deletes only the exact transcript

This remains a control-plane/store foundation only. It does not wire operator finalizers, the transcript client, RBAC, CLI deletion, or automatic garbage collection.

## Verification
- `go test -race ./internal/controlplane -run 'TestTenancyAccess|TestTranscriptDeleteRequiresFreshTenancyProof|TestTranscriptDeleteReauthorizesAcrossOffboardingFencingDuringDrain' -count=1`
- worker verification: full control-plane race suite, transition test `-count=10`, `make test`, `make vet`
- `git diff --check origin/main..HEAD`