### PR TITLE
Document opaque adapter usage boundaries

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -346,6 +346,12 @@ other agent-controlled bytes remain only in adapter-owned opaque transcript even
 adapter rejection and cancellation conditions likewise use fixed platform messages. Reconcile
 also normalizes legacy adapter observation/rejection messages before terminal or deletion cleanup.
 
+`Run.status.usage` is currently an unwritten compatibility placeholder. Lifecycle wall duration
+is derivable as `FinishedAt - StartedAt`; it includes `Paused` and `NeedsInput` intervals and is
+unavailable for Runs that were never accepted because `StartedAt` remains absent. Usage-, token-,
+or cost-looking provider data in transcript events remains adapter-owned opaque bytes. The
+platform does not normalize or project it into Run status, and it is not accounting truth.
+
 One Environment controller owns suspension transitions. Explicit user/admin policy is a
 revisioned `spec.lifecycle.hold`; ordinary callers publish UID- and hold-revision-fenced wake,
 suspend, or source-keyed activity intents. The controller owns observed suspension state.

--- a/internal/adapters/amp/adapter_test.go
+++ b/internal/adapters/amp/adapter_test.go
@@ -328,6 +328,24 @@ func TestObservationMessagesExcludeAgentControlledDetails(t *testing.T) {
 	}
 }
 
+func TestUsageLookingOutputRemainsOpaque(t *testing.T) {
+	exit0 := int32(0)
+	raw := []byte(`{"type":"result","subtype":"success","is_error":false,"usage":{"inputTokens":23,"outputTokens":8},"cost":{"amount":0.01}}` + "\n")
+	client := &fakeClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "execution"}, stdout: raw}
+	var event agent.AdapterEvent
+	sandbox := testSandbox(client)
+	sandbox.EmitEvent = func(_ context.Context, got agent.AdapterEvent) error { event = got; return nil }
+
+	observation, message, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox)
+	if err != nil || observation != agent.AdapterObservationSucceeded || message != observation.StatusMessage() {
+		t.Fatalf("Observe = (%q, %q, %v)", observation, message, err)
+	}
+	var output outputEvent
+	if err := json.Unmarshal(event.Data, &output); err != nil || event.Source != "amp" || event.Type != "amp.process-output" || !bytes.Equal(output.Data, raw) {
+		t.Fatalf("opaque output event = %#v, output = %#v, error = %v", event, output, err)
+	}
+}
+
 func TestCancellationAndBoundedIdempotentOutput(t *testing.T) {
 	client := &fakeClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_RUNNING, ExecutionId: "execution"}, stdout: []byte("stdout"), stderr: []byte("stderr")}
 	var events []agent.AdapterEvent

--- a/internal/adapters/claudecode/adapter_test.go
+++ b/internal/adapters/claudecode/adapter_test.go
@@ -2,6 +2,7 @@ package claudecode
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"reflect"
 	"strings"
@@ -279,6 +280,24 @@ func TestObservationMessagesExcludeAgentControlledDetails(t *testing.T) {
 				t.Fatalf("Observe() = (%q, %q, %v), want fixed %q message", observation, message, err, test.want)
 			}
 		})
+	}
+}
+
+func TestUsageLookingOutputRemainsOpaque(t *testing.T) {
+	exit0 := int32(0)
+	raw := []byte(`{"type":"result","subtype":"success","is_error":false,"usage":{"input_tokens":17,"output_tokens":5},"total_cost_usd":0.0042}` + "\n")
+	client := &fakeProcessClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "execution"}, stdout: raw}
+	var event agent.AdapterEvent
+	sandbox := sandboxFor(client)
+	sandbox.EmitEvent = func(_ context.Context, got agent.AdapterEvent) error { event = got; return nil }
+
+	observation, message, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox)
+	if err != nil || observation != agent.AdapterObservationSucceeded || message != observation.StatusMessage() {
+		t.Fatalf("Observe() = (%q, %q, %v)", observation, message, err)
+	}
+	var output outputEvent
+	if err := json.Unmarshal(event.Data, &output); err != nil || event.Source != "claude-code" || event.Type != "claude-code.process-output" || !reflect.DeepEqual(output.Data, raw) {
+		t.Fatalf("opaque output event = %#v, output = %#v, error = %v", event, output, err)
 	}
 }
 

--- a/internal/adapters/codex/adapter_test.go
+++ b/internal/adapters/codex/adapter_test.go
@@ -292,6 +292,24 @@ func TestObservationMessagesExcludeAgentControlledDetails(t *testing.T) {
 	}
 }
 
+func TestUsageObjectCountsRemainOpaque(t *testing.T) {
+	exit0 := int32(0)
+	raw := []byte(`{"type":"thread.started","thread_id":"thread-1"}` + "\n" + `{"type":"turn.completed","usage":{"input_tokens":31,"cached_input_tokens":7,"output_tokens":11,"cost_usd":0.02}}` + "\n")
+	client := &fakeProcessClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "execution"}, stdout: raw}
+	var event agent.AdapterEvent
+	sandbox := processSandbox(client, "epoch")
+	sandbox.EmitEvent = func(_ context.Context, got agent.AdapterEvent) error { event = got; return nil }
+
+	observation, message, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox)
+	if err != nil || observation != agent.AdapterObservationSucceeded || message != observation.StatusMessage() {
+		t.Fatalf("Observe = (%q, %q, %v)", observation, message, err)
+	}
+	var output outputEvent
+	if err := json.Unmarshal(event.Data, &output); err != nil || event.Source != "codex" || event.Type != "codex.process-output" || !bytes.Equal(output.Data, raw) {
+		t.Fatalf("opaque output event = %#v, output = %#v, error = %v", event, output, err)
+	}
+}
+
 func TestTerminalObservationFailsOnRetainedOutputGap(t *testing.T) {
 	exit0 := int32(0)
 	client := &fakeProcessClient{

--- a/internal/adapters/pi/adapter_test.go
+++ b/internal/adapters/pi/adapter_test.go
@@ -242,6 +242,24 @@ func TestObservationMessagesExcludeAgentControlledDetails(t *testing.T) {
 	}
 }
 
+func TestUsageLookingOutputRemainsOpaque(t *testing.T) {
+	exit0 := int32(0)
+	raw := []byte(`{"type":"agent_end","messages":[{"role":"assistant","stopReason":"stop","usage":{"input":41,"output":13},"cost":0.03}]}` + "\n")
+	client := &processClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExitCode: &exit0, ExecutionId: "execution"}, stdout: raw}
+	var event agent.AdapterEvent
+	sandbox := processSandbox(client, "epoch")
+	sandbox.EmitEvent = func(_ context.Context, got agent.AdapterEvent) error { event = got; return nil }
+
+	observation, message, err := (&Adapter{}).Observe(context.Background(), agent.AdapterTask{ID: "run"}, sandbox)
+	if err != nil || observation != agent.AdapterObservationSucceeded || message != observation.StatusMessage() {
+		t.Fatalf("Observe = (%q, %q, %v)", observation, message, err)
+	}
+	var output outputEvent
+	if err := json.Unmarshal(event.Data, &output); err != nil || event.Source != "pi" || event.Type != "pi.process-output" || !bytes.Equal(output.Data, raw) {
+		t.Fatalf("opaque output event = %#v, output = %#v, error = %v", event, output, err)
+	}
+}
+
 func TestTerminalValidationFailsOnRetainedOutputGap(t *testing.T) {
 	exit0 := int32(0)
 	client := &processClient{process: &sandboxdv1.Process{State: sandboxdv1.ProcessState_PROCESS_STATE_EXITED, ExecutionId: "e", ExitCode: &exit0}, stdout: []byte(`{"type":"agent_end","messages":[]}`), retainedFrom: 41}

--- a/internal/controlplane/server_test.go
+++ b/internal/controlplane/server_test.go
@@ -433,6 +433,48 @@ func TestTranscriptAppendIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestUsageLookingTranscriptRemainsOpaqueAndDoesNotUpdateRunUsage(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := platformv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	run := &platformv1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Namespace: "project-1", Name: "run-1", UID: "run-1-uid"}}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(run).Build()
+	store := NewMemoryTranscriptStore(MemoryTranscriptStoreOptions{})
+	api := NewServer(nil, ServerOptions{Access: &fakeAccess{}, Runs: KubernetesRunResolver{Client: client}, TranscriptStore: store})
+	raw := []byte(`{ "usage" : {"input_tokens":101,"output_tokens":37}, "cost_usd" : 0.42 }`)
+	body := append([]byte(`{"source":"adapter","idempotencyKey":"usage-like","type":"adapter.process-output","data":`), raw...)
+	body = append(body, '}')
+	request := httptest.NewRequest(http.MethodPost, transcriptURL, bytes.NewReader(body))
+	request.Header.Set("Authorization", "Bearer producer")
+	request.Header.Set(RunUIDHeader, "run-1-uid")
+	response := httptest.NewRecorder()
+	api.Handler().ServeHTTP(response, request)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("append status = %d, want %d: %s", response.Code, http.StatusCreated, response.Body.String())
+	}
+
+	identity := RunIdentity{Namespace: "project-1", NamespaceUID: testNamespaceUID("project-1"), UID: "run-1-uid"}
+	subscription, err := store.Subscribe(context.Background(), identity, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer subscription.Unsubscribe()
+	if len(subscription.History) != 1 {
+		t.Fatalf("stored events = %d, want 1", len(subscription.History))
+	}
+	if !bytes.Equal(subscription.History[0].Data, raw) {
+		t.Fatalf("stored opaque data = %q, want exact %q", subscription.History[0].Data, raw)
+	}
+	var persisted platformv1alpha1.Run
+	if err := client.Get(context.Background(), types.NamespacedName{Namespace: run.Namespace, Name: run.Name}, &persisted); err != nil {
+		t.Fatal(err)
+	}
+	if persisted.Status.Usage != (platformv1alpha1.RunUsage{}) {
+		t.Fatalf("Run status usage was projected from transcript: %#v", persisted.Status.Usage)
+	}
+}
+
 func TestTranscriptLegacyAppendRemainsNonIdempotent(t *testing.T) {
 	api := newTestServer(&fakeAccess{})
 	body := `{"type":"output","data":{"text":"legacy"}}`


### PR DESCRIPTION
## Summary
- prove usage/token/cost-looking provider output remains exact opaque adapter-owned transcript bytes for Claude Code, Amp, Codex, and Pi
- prove transcript ingestion preserves usage-looking JSON byte-for-byte without projecting it into `Run.status.usage`
- document that usage is currently an unwritten compatibility placeholder and that lifecycle wall time is derived from the existing timestamps

This is coverage and contract documentation only. It adds no metering writer, normalization, cost model, telemetry, CRD/schema change, migration, or CLI behavior.

Refs #72.

## Verification
- `go test ./internal/adapters/claudecode ./internal/adapters/amp ./internal/adapters/codex ./internal/adapters/pi ./internal/controlplane -run 'TestUsageLookingOutputRemainsOpaque|TestUsageObjectCountsRemainOpaque|TestUsageLookingTranscriptRemainsOpaqueAndDoesNotUpdateRunUsage' -count=1`
- worker verification: `make test`, `make vet`
- `git diff --check origin/main...HEAD`