### PR TITLE
Add installation isolation fencing lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,13 @@ registered and use sandboxd managed processes. API-key profiles use process-scop
 material as `ANTHROPIC_API_KEY`,
 `AMP_API_KEY`, or `CODEX_API_KEY`; tests use fake process services and no provider credentials.
 Pi deliberately supports no credential profiles or credential injection.
+The Installation isolation lifecycle reports legacy or explicit development selection and
+uncached-resolves the future restricted dependency identities. Restricted selection fences every
+Environment through the existing ordered teardown and blocks warm replenishment, then remains
+`Blocked`; publish `Fencing` before dependency reads and again on observed authority drift. A
+non-legacy lifecycle may reopen development execution only from current exact `Active` status after
+fence proof. Trusted-admin fence proof ignores only exact foreign Installation namespace claims.
+This does not activate or claim restricted runtime or egress enforcement.
 
 ## Architecture invariants — do not violate these
 
@@ -82,7 +89,8 @@ Pi deliberately supports no credential profiles or credential injection.
   the sole owners of observed lifecycle transitions. Environment reconciliation is split
   within `internal/controllers/` into ordered gate orchestration, lifecycle intent,
   provisioning/resources, pod recovery, status, and manager setup files; keep gate names
-  bounded and preserve the ordering contract in its direct test. `sandboxd/` is a
+  bounded, keep the Installation isolation gate before Project/Template/provisioning dependencies,
+  and preserve the ordering contract in its direct test. `sandboxd/` is a
   **separate Go module** with its own `go.mod`: keep its dependencies minimal so it stays
   portable and the environment base image stays small.
   Generated protobuf code lives in `sandboxd/gen/` and is committed.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -76,7 +76,7 @@ All current CRDs are namespaced:
 
 | Resource | Current contract |
 |---|---|
-| `Installation` | System-namespace identity whose immutable Kubernetes UID remains the stable identity used by namespace claims, catalog sources, managed Template copies, and baseline resources. An optional, non-defaulted installation-wide `isolation` selection admits only explicit unrestricted development or the future Calico v3.32.1 restricted contract; omission exists only for staged legacy migration. Reserved status has bounded `LegacyUnclassified`, `Fencing`, `Blocked`, or `Active` vocabulary plus exact non-secret observed selection/object identities, a derived isolation revision, and conditions. No controller reads the selection or writes this status yet. |
+| `Installation` | System-namespace identity whose immutable Kubernetes UID remains the stable identity used by namespace claims, catalog sources, managed Template copies, and baseline resources. An optional, non-defaulted installation-wide `isolation` selection admits only explicit unrestricted development or the future Calico v3.32.1 restricted contract; omission exists only for staged legacy migration. The isolation controller publishes bounded `LegacyUnclassified`, `Fencing`, `Blocked`, or `Active` status, fixed conditions, exact non-secret observed object identities, and a canonical revision. Unrestricted development can be active but is explicitly non-production. Restricted selection fences every Environment and warm pool, then remains blocked because runtime activation is not implemented. |
 | `Project` | One repository URL (represented as a one-item list), a same-namespace default Template reference, changes-workflow metadata, and up to 64 exact lowercase-ASCII FQDN egress selections. The selection contract is admitted, but a non-empty selection remains rejected when an Environment uses the Project because runtime egress enforcement is not enabled. |
 | `EnvironmentTemplate` | Pod image, size/resources, disk, runtime class, idle timeout, warm-pool minimum, and backend. Admission currently permits only the `pod` backend. Chart-owned system-namespace objects are inert catalog sources; execution accepts only installation-managed same-namespace copies bound to exact Installation, source, and Project identities. |
 | `Environment` | Immutable Template selection, an immutable optional backend override, one-way empty-to-nonempty Project binding, explicit hold policy, bounded wake/suspend/activity intents, and up to 32 API- or Repository-owned service declarations. New declarations have an immutable-per-incarnation random `instanceID`; upgrade-retained legacy declarations may omit it, receive no portal route, and can add it only with a higher revision. Omitted legacy service ownership defaults only to `API` and is immutable thereafter. Controller-owned status includes the immutable resolved `provisioning` snapshot, readiness, lifecycle/execution, claim, observations, activity, and nested backend-neutral recovery state; recovery records attempts, exhaustion, the exact failed execution generation being accounted, and the next allowed attempt time, while generation zero means no recovery identity. The gateway owns bounded `portalRoutes` and monotonic `nextPortalRouteGeneration`; inactive routes are denial tombstones preserved by other status writers. |
@@ -87,9 +87,10 @@ The current ownership/reference shape is:
 
 `Installation.spec.isolation` is installation-administrator authority; tenant resources cannot
 select or weaken it. The chart renders it only from explicit bounded values and otherwise keeps
-the legacy field omitted. `Installation.status` remains controller-owned but has no writer in the
-current inert slice. Neither configuration nor reserved status changes the Installation UID or
-the Namespace-claim authority derived from it.
+the legacy field omitted. One system-scoped controller owns `Installation.status`; it resolves
+restricted dependencies through uncached reads and publishes only bounded non-secret observations.
+Neither configuration nor status changes the Installation UID or the Namespace-claim authority
+derived from it.
 
 Environment status is controller-owned: the operator and its Run controller retain status
 subresource authority. The control plane has update-only `environments/status` authority for
@@ -732,11 +733,11 @@ durable across replacement, but open streams disconnect and clients must reconne
 multi-replica or control-plane HA claim is made.
 
 - `values-kind.yaml` deliberately opts into trusted-admin for isolated local development,
-  explicitly selects the inert `UnrestrictedDevelopment` isolation contract, and uses local
+  explicitly selects active but non-production `UnrestrictedDevelopment`, and uses local
   `:dev` images and explicit memory-backed insecure HTTP sessions. Primary
   acceptance overrides it to scoped mode with distinct system and Project namespaces.
 - `values-argocd.yaml` deliberately opts into trusted-admin in the isolated Argo mirror,
-  explicitly selects the inert `UnrestrictedDevelopment` isolation contract, and uses mutable
+  explicitly selects active but non-production `UnrestrictedDevelopment`, and uses mutable
   `:latest` images and explicit memory-backed sessions. Base/default values also
   select memory for development.
 - `values-k3s.yaml`, `values-gke.yaml`, and `values-eks.yaml` use coordinated immutable chart
@@ -787,9 +788,9 @@ Hold, Requested suspension, stale association/declaration/route/execution, and u
 the same 404 as an unknown locator. Idle requests wake and await a fresh execution. The proxy
 strips credentials, session cookies, and hop-by-hop headers and supports WebSocket upgrade.
 
-### Approved installation isolation selection
+### Implemented installation isolation selection lifecycle
 
-The first inert issue #10 contract adds one Installation-owned selection rather than an
+The issue #10 contract adds one Installation-owned selection rather than an
 `IsolationProfile` CRD. `spec.isolation` has no default and is optional only for staged legacy
 migration. Its exact modes are `UnrestrictedDevelopment` and
 `RestrictedProductionCalicoV3_32_1`. Development mode has no restricted inputs. Restricted mode
@@ -797,21 +798,42 @@ references the existing immutable #68 policy ConfigMap and states exact RuntimeC
 name/handler and StorageClass name/CSI-driver expectations. The ConfigMap remains sole owner of
 network mode, Calico profile/CIDRs/resolvers, ceiling/baseline, proxy image, and TLS reference.
 
-The inert `internal/isolation` helper validates that cross-field contract and derives a
+The `internal/isolation` helper validates that cross-field contract and derives a
 domain-separated SHA-256 revision from the Installation UID, canonical selection, fixed API and
 revision domains, and exact policy ConfigMap, RuntimeClass, StorageClass, and CSIDriver UIDs plus
 canonical policy content hash and observed handler/driver. There is no administrator-entered
-security revision. No reconciler calls the helper, looks up those objects, changes Environment/Run/warm
-pool behavior, or writes Installation status. In particular,
+security revision. The Installation isolation controller uses uncached reads to resolve the exact
+immutable canonical policy ConfigMap, RuntimeClass handler/UID, StorageClass provisioner/UID, and
+CSIDriver UID. It publishes the exact selection and validated identities plus the derived revision;
+missing, replaced, deleting, malformed, mismatched, or uncertain authority never permits execution.
+For a new or changed restricted selection it durably publishes unresolved `Fencing` before the
+first dependency read. From established `Blocked`, any resolved identity/revision change or loss
+also publishes `Fencing` before the replacement or empty authority can return to `Blocked`.
+In particular,
 `RestrictedProductionCalicoV3_32_1` is admitted configuration, not an active or production-ready
 profile. Activation still requires the complete #68 currentness, identity, proxy, path-forcing,
 and Calico v3.32.1 enforcement path; generic restricted profiles remain unsupported.
 
-The reserved Installation status state vocabulary is `LegacyUnclassified`, `Fencing`,
-`Blocked`, and `Active`, with exact non-secret observed selection/object identities, derived
-revision, and conditions. It is schema only. A later compatibility release must explicitly
-activate selection and fence installation-wide execution; restricted mode must never adopt a
-live legacy execution. Installation UID remains tenancy identity throughout migration.
+The Installation status state vocabulary is `LegacyUnclassified`, `Fencing`, `Blocked`, and
+`Active`. Omitted selection remains legacy-unclassified. Explicit unrestricted development can
+become active, while `ProductionReady=False` makes its non-production contract explicit.
+Restricted selection first publishes `Fencing`; an Environment outer gate ahead of Project,
+Template, and provisioning dependencies withdraws readiness and reuses exact-owned Pod-then-
+credential invalid-configuration teardown while retaining PVCs, transcripts, and ingress policy.
+The warm-pool controller reports no ready capacity and neither replenishes nor cleans up warm
+Environment objects during this installation fence; each retained Environment's outer gate fences
+its execution. This applies before Project lookup, including empty
+allowlists and Project-less Environments. Only after every configured-scope Environment has no
+published connection or exact-owned Pod/credential does Installation status settle at `Blocked`
+with `IsolationReady=False/RuntimeActivationUnavailable`; restricted mode never becomes `Active`.
+Trusted-admin proof lists cluster-wide but uncached-classifies each Environment Namespace by exact
+Installation namespace/name/UID: exact foreign claims are ignored, while this Installation's or
+uncertain ownership fails closed. Switching a non-legacy lifecycle to unrestricted development (or
+back to omission) likewise publishes `Fencing` and proves its exact-owned execution absent before
+`Active` (or `LegacyUnclassified`) can reopen execution. Initial and `LegacyUnclassified` adoption
+of unrestricted development remains behavior-identical and does not tear down legacy execution.
+Dependency identity and revision publication are observations, not runtime authority. Installation
+UID remains tenancy identity throughout migration.
 
 ### Approved fail-closed proxy-only egress contract
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ to ~$0. Reviewable diff, branch, and PR publication remain planned work.
 - **Real isolation** — agents execute untrusted, model-generated code. Environments support
   hardened containers, sandboxd authentication, restricted sandboxd ingress, and optional
   RuntimeClasses such as gVisor. Installation API schema now admits an explicit unrestricted
-  development selection and a future Calico v3.32.1 restricted selection, but this contract is
-  inert: no controller activates it and default-deny egress is not implemented yet.
+  development selection and a future Calico v3.32.1 restricted selection. Unrestricted development
+  is explicitly non-production. Selecting restricted fences existing Environment execution and
+  stays blocked because default-deny egress and restricted runtime activation are not implemented.
 - **Pause economics** — idle environments are paused (pod deleted, disk retained) and
   woken on demand. A suspended Environment costs ~$0 in compute.
 - **Agent-agnostic** — existing agents plug in via adapters; the platform never depends

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -122,11 +122,28 @@ no default: `UnrestrictedDevelopment` or the future
 `RestrictedProductionCalicoV3_32_1`. Omission is retained only for staged legacy migration.
 Development mode carries no restricted inputs. Restricted mode references the immutable #68
 policy ConfigMap and exact RuntimeClass name/handler and StorageClass name/CSI-driver
-expectations; it does not duplicate the ConfigMap's network policy fields. The schema and inert
-canonical revision helper do not activate, verify, or enforce either mode, and no controller
-writes the reserved Installation isolation status. Installation UID remains namespace-claim
-authority. The local kind and Argo presets explicitly choose unrestricted development; current
-production presets remain legacy-unclassified and make no restricted-isolation claim.
+expectations; it does not duplicate the ConfigMap's network policy fields. A system-scoped
+controller uncached-resolves those exact objects, strictly parses the canonical ConfigMap, derives
+the revision, and publishes bounded non-secret identities and fixed conditions. Omission remains
+`LegacyUnclassified`; explicit unrestricted development may be `Active` but always reports
+`ProductionReady=False`. Restricted selection never becomes active: it enters `Fencing`, blocks
+warm replenishment and every Environment before Project/Template/provisioning dependencies, uses
+the existing readiness-withdrawal and exact Pod-then-credential teardown, and settles at `Blocked`
+with `RuntimeActivationUnavailable` only after execution is absent. API uncertainty and identity,
+handler, or provisioner mismatch fail closed. A new restricted selection publishes unresolved
+`Fencing` before dependency reads; replacement, loss, or uncertainty in established observed
+authority re-enters `Fencing` before returning to `Blocked`. Trusted-admin fence proof ignores only
+Namespaces with a complete exact foreign Installation namespace/name/UID claim; own or uncertain
+ownership fails closed. A non-legacy lifecycle cannot reopen from an unrestricted spec alone:
+current exact `Active` observed selection/revision and generation are required, and transition from
+restricted or invalid status remains in `Fencing` until exact-owned execution absence is proven.
+Only initial or `LegacyUnclassified` adoption bypasses that behavior-identical teardown. PVCs,
+transcripts, and ingress policy are retained.
+This compatibility lifecycle does not activate currentness authorization, proxy identity, a
+forced egress path, Calico enforcement, or any restricted-runtime claim. Installation UID remains
+namespace-claim authority. The local kind and Argo presets explicitly choose unrestricted
+development; current production presets remain legacy-unclassified and make no restricted-
+isolation claim.
 
 Default-deny egress and the per-project egress proxy are not implemented. The admitted v1
 `Project.spec.egressAllowlist` contract is a set of at most 64 exact lowercase ASCII FQDN tenant

--- a/api/v1alpha1/installation_types.go
+++ b/api/v1alpha1/installation_types.go
@@ -77,8 +77,8 @@ type InstallationSpec struct {
 	Isolation *InstallationIsolationSpec `json:"isolation,omitempty"`
 }
 
-// InstallationIsolationState is bounded controller-owned vocabulary reserved
-// for the staged activation flow. No controller writes it yet.
+// InstallationIsolationState is bounded controller-owned vocabulary for the
+// staged selection lifecycle.
 // +kubebuilder:validation:Enum=LegacyUnclassified;Fencing;Blocked;Active
 type InstallationIsolationState string
 
@@ -87,6 +87,10 @@ const (
 	InstallationIsolationStateFencing            InstallationIsolationState = "Fencing"
 	InstallationIsolationStateBlocked            InstallationIsolationState = "Blocked"
 	InstallationIsolationStateActive             InstallationIsolationState = "Active"
+
+	InstallationConditionIsolationDependenciesResolved = "IsolationDependenciesResolved"
+	InstallationConditionIsolationReady                = "IsolationReady"
+	InstallationConditionProductionReady               = "ProductionReady"
 )
 
 // InstallationRuntimeClassIdentity records an exact non-secret RuntimeClass
@@ -150,8 +154,8 @@ type InstallationPolicyConfigMapIdentity struct {
 	ContentSHA256 string `json:"contentSHA256"`
 }
 
-// InstallationStatus contains bounded non-secret observations reserved for the
-// future installation isolation controller. This slice does not write status.
+// InstallationStatus contains bounded non-secret observations from the
+// installation isolation selection controller.
 type InstallationStatus struct {
 	// +optional
 	IsolationState InstallationIsolationState `json:"isolationState,omitempty"`

--- a/charts/swe-platform/README.md
+++ b/charts/swe-platform/README.md
@@ -234,9 +234,13 @@ claims.
 `installation.isolation.mode` is a separately explicit, non-defaulted API selection. The kind
 and Argo development presets set `UnrestrictedDevelopment`. Production presets deliberately
 leave it empty for staged legacy migration because the only restricted mode,
-`RestrictedProductionCalicoV3_32_1`, is schema-only and cannot become active in this release.
+`RestrictedProductionCalicoV3_32_1`, cannot become active in this release.
 The restricted values path requires exact policy ConfigMap name, RuntimeClass name/handler, and
-StorageClass name/CSI driver; it does not create or verify those objects. Keep an
+StorageClass name/CSI driver; the chart does not create those objects. The operator uncached-
+validates them and publishes their exact non-secret identities and canonical revision, then fences
+all Environment execution and settles the Installation at `Blocked` with
+`RuntimeActivationUnavailable`. This is a compatibility fence, not restricted runtime or egress
+enforcement. Keep an
 administrator-selected value in the Helm release values on every upgrade so Helm remains the
 owner of the Installation selection rather than relying on an out-of-band edit. The selection
 does not change the Installation UID or Namespace-claim authority.
@@ -450,8 +454,8 @@ unmeasured.
 
 | Preset | Assumptions |
 |---|---|
-| `values-kind.yaml` | Isolated local kind development with explicit inert `UnrestrictedDevelopment` isolation selection, process-local `memory` sessions, deliberate `trusted-admin`, `:dev` images, insecure HTTP browser sessions, and `Recreate` operator upgrades. `make kind-up` installs gVisor and snapshot-capable CSI; pass the printed `environmentTemplates[0].spec.runtimeClass=gvisor` catalog override. Primary acceptance instead overrides this preset to scoped mode and distinct system/Project namespaces. |
-| `values-argocd.yaml` | Isolated local Argo CD mirror with explicit inert `UnrestrictedDevelopment` isolation selection, process-local `memory` sessions, deliberate `trusted-admin`, mutable `:latest` images, an out-of-band bootstrap Secret, insecure HTTP browser sessions, and `Recreate` operator upgrades. `hack/argocd-up.sh` requires one kind node with at least 5 CPUs and 6 GiB allocatable. |
+| `values-kind.yaml` | Isolated local kind development with explicit active but non-production `UnrestrictedDevelopment` isolation selection, process-local `memory` sessions, deliberate `trusted-admin`, `:dev` images, insecure HTTP browser sessions, and `Recreate` operator upgrades. `make kind-up` installs gVisor and snapshot-capable CSI; pass the printed `environmentTemplates[0].spec.runtimeClass=gvisor` catalog override. Primary acceptance instead overrides this preset to scoped mode and distinct system/Project namespaces. |
+| `values-argocd.yaml` | Isolated local Argo CD mirror with explicit active but non-production `UnrestrictedDevelopment` isolation selection, process-local `memory` sessions, deliberate `trusted-admin`, mutable `:latest` images, an out-of-band bootstrap Secret, insecure HTTP browser sessions, and `Recreate` operator upgrades. `hack/argocd-up.sh` requires one kind node with at least 5 CPUs and 6 GiB allocatable. |
 | `values-k3s.yaml` | Production `scoped` mode with legacy-unclassified isolation, PostgreSQL transcripts and sessions, and out-of-band `swe-platform-postgres` and `swe-platform-session-keyring` Secrets. Uses one operator replica, `Recreate` operator upgrades, and the default OCI runtime because k3s does not ship gVisor. It does not claim restricted production isolation. |
 | `values-gke.yaml` | Production `scoped` mode with legacy-unclassified isolation, PostgreSQL transcripts and sessions, and both out-of-band Secrets. GKE Sandbox is enabled on environment nodes. Sets `runtimeClass: gvisor`, runs two operator replicas with leader election, and uses `Recreate` upgrades for this compatibility transition. It does not claim restricted production isolation. |
 | `values-eks.yaml` | Production `scoped` mode with legacy-unclassified isolation, PostgreSQL transcripts and sessions, and both out-of-band Secrets. Uses a default EBS CSI StorageClass, two operator replicas, and `Recreate` upgrades for this compatibility transition. EKS does not provide a standard gVisor RuntimeClass, so managed Templates use the cluster default unless overridden. It does not claim restricted production isolation. |

--- a/charts/swe-platform/crds/swe.dev_installations.yaml
+++ b/charts/swe-platform/crds/swe.dev_installations.yaml
@@ -119,8 +119,8 @@ spec:
             type: object
           status:
             description: |-
-              InstallationStatus contains bounded non-secret observations reserved for the
-              future installation isolation controller. This slice does not write status.
+              InstallationStatus contains bounded non-secret observations from the
+              installation isolation selection controller.
             properties:
               conditions:
                 items:
@@ -213,8 +213,8 @@ spec:
                 type: string
               isolationState:
                 description: |-
-                  InstallationIsolationState is bounded controller-owned vocabulary reserved
-                  for the staged activation flow. No controller writes it yet.
+                  InstallationIsolationState is bounded controller-owned vocabulary for the
+                  staged selection lifecycle.
                 enum:
                 - LegacyUnclassified
                 - Fencing

--- a/charts/swe-platform/templates/rbac.yaml
+++ b/charts/swe-platform/templates/rbac.yaml
@@ -54,6 +54,9 @@ rules:
   - apiGroups: ["node.k8s.io"]
     resources: ["runtimeclasses"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "csidrivers"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -83,7 +86,13 @@ rules:
     verbs: ["create", "get", "list", "patch", "update", "watch"]
   - apiGroups: ["swe.dev"]
     resources: ["installations"]
-    verbs: ["get"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["swe.dev"]
+    resources: ["installations/status"]
+    verbs: ["get", "patch", "update"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["swe.dev"]
     resources: ["environmenttemplates"]
     verbs: ["get", "list", "patch", "update"]

--- a/charts/swe-platform/values-argocd.yaml
+++ b/charts/swe-platform/values-argocd.yaml
@@ -27,7 +27,7 @@ controlPlane:
 
 leaderElection: false
 
-# Explicit non-production selection; this contract is inert in this release.
+# Explicit active but non-production development selection.
 installation:
   isolation:
     mode: UnrestrictedDevelopment

--- a/charts/swe-platform/values-kind.yaml
+++ b/charts/swe-platform/values-kind.yaml
@@ -23,7 +23,7 @@ controlPlane:
 
 leaderElection: false
 
-# Explicit non-production selection; this contract is inert in this release.
+# Explicit active but non-production development selection.
 installation:
   isolation:
     mode: UnrestrictedDevelopment

--- a/charts/swe-platform/values.yaml
+++ b/charts/swe-platform/values.yaml
@@ -102,8 +102,8 @@ serviceAccount:
 leaderElection: true
 
 # Optional only for staged legacy migration and deliberately non-defaulted.
-# RestrictedProductionCalicoV3_32_1 is an inert API contract in this release;
-# selecting it does not activate an isolation runtime.
+# RestrictedProductionCalicoV3_32_1 fences execution and remains Blocked in
+# this release; selecting it does not activate an isolation runtime.
 installation:
   isolation:
     mode: ""

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -120,19 +120,7 @@ func main() {
 		setupLog.Error(err, "validate configured Project namespaces")
 		os.Exit(1)
 	}
-	cacheOptions := cache.Options{}
-	if mode == tenancy.ModeScoped {
-		cacheOptions.DefaultNamespaces = make(map[string]cache.Config, len(tenancyNamespaces))
-		for _, namespace := range tenancyNamespaces {
-			cacheOptions.DefaultNamespaces[namespace] = cache.Config{}
-		}
-		// An initial scoped install has no Project namespaces until onboarding.
-		// Keep its otherwise-unused cache restricted to the system namespace;
-		// no workload controllers are registered below until a claim is listed.
-		if len(cacheOptions.DefaultNamespaces) == 0 {
-			cacheOptions.DefaultNamespaces[installationNamespace] = cache.Config{}
-		}
-	}
+	cacheOptions := operatorCacheOptions(mode, tenancyNamespaces, installationNamespace)
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme: scheme,
 		Cache:  cacheOptions,
@@ -153,6 +141,16 @@ func main() {
 	verifier.Reader = mgr.GetAPIReader()
 	scope := &tenancy.ReconcileScope{Verifier: verifier}
 	guardedClient := tenancy.GuardedClient{Client: mgr.GetClient(), Verifier: verifier}
+	if err := (&controllers.InstallationIsolationReconciler{
+		Client:       mgr.GetClient(),
+		APIReader:    mgr.GetAPIReader(),
+		Installation: identity,
+		Mode:         mode,
+		Namespaces:   []string(tenancyNamespaces),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "InstallationIsolation")
+		os.Exit(1)
+	}
 	processConnections := sandboxclient.NewProcessConnectionPool(mgr.GetAPIReader())
 	if err := mgr.Add(processConnections); err != nil {
 		setupLog.Error(err, "unable to register sandboxd process connection pool")
@@ -262,6 +260,30 @@ func main() {
 }
 
 type stringListFlag []string
+
+func operatorCacheOptions(mode tenancy.Mode, projectNamespaces []string, installationNamespace string) cache.Options {
+	systemNamespaces := map[string]cache.Config{installationNamespace: {}}
+	options := cache.Options{ByObject: map[client.Object]cache.ByObject{
+		// These watches and their RBAC are intentionally system-namespace-only.
+		&corev1.ConfigMap{}:              {Namespaces: systemNamespaces},
+		&platformv1alpha1.Installation{}: {Namespaces: systemNamespaces},
+	}}
+	if mode != tenancy.ModeScoped {
+		return options
+	}
+	options.DefaultNamespaces = make(map[string]cache.Config, len(projectNamespaces))
+	for _, namespace := range projectNamespaces {
+		options.DefaultNamespaces[namespace] = cache.Config{}
+	}
+	// An initial scoped install has no Project namespaces until onboarding.
+	// Keep its otherwise-unused default cache restricted to the system
+	// namespace; Installation and ConfigMap watches are restricted above even
+	// after explicitly configured Project namespaces replace this default.
+	if len(options.DefaultNamespaces) == 0 {
+		options.DefaultNamespaces[installationNamespace] = cache.Config{}
+	}
+	return options
+}
 
 func (f *stringListFlag) String() string { return strings.Join(*f, ",") }
 

--- a/cmd/operator/main_test.go
+++ b/cmd/operator/main_test.go
@@ -3,7 +3,11 @@ package main
 import (
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
+	"github.com/Chris-Cullins/swe-platform/internal/tenancy"
 )
 
 func TestDefaultClaudeCodeAdapterIsRegistered(t *testing.T) {
@@ -28,5 +32,47 @@ func TestInstallationLeaderElectionIDIsReleaseIsolated(t *testing.T) {
 	}
 	if first != installationLeaderElectionID(types.UID("installation-1")) || len(first) > 63 {
 		t.Fatalf("leader-election ID is unstable or invalid: %q", first)
+	}
+}
+
+func TestManagerCacheScopesProjectAndSystemObjects(t *testing.T) {
+	options := operatorCacheOptions(tenancy.ModeScoped, []string{"project-b", "project-a"}, "system")
+	for _, namespace := range []string{"project-a", "project-b"} {
+		if _, ok := options.DefaultNamespaces[namespace]; !ok {
+			t.Errorf("scoped manager cache omitted %q", namespace)
+		}
+	}
+	if len(options.DefaultNamespaces) != 2 {
+		t.Fatalf("scoped manager cache namespaces = %#v", options.DefaultNamespaces)
+	}
+	if got := operatorCacheOptions(tenancy.ModeScoped, nil, "system"); len(got.DefaultNamespaces) != 1 {
+		t.Fatalf("empty scoped manager cache namespaces = %#v", got.DefaultNamespaces)
+	}
+	if got := operatorCacheOptions(tenancy.ModeTrustedAdmin, nil, "system"); got.DefaultNamespaces != nil {
+		t.Fatalf("trusted-admin unexpectedly restricted cache namespaces = %#v", got.DefaultNamespaces)
+	}
+	for _, mode := range []tenancy.Mode{tenancy.ModeScoped, tenancy.ModeTrustedAdmin} {
+		options := operatorCacheOptions(mode, []string{"project"}, "system")
+		seen := make(map[string]bool, 2)
+		for object, config := range options.ByObject {
+			kind := ""
+			switch object.(type) {
+			case *corev1.ConfigMap:
+				kind = "ConfigMap"
+			case *platformv1alpha1.Installation:
+				kind = "Installation"
+			default:
+				t.Fatalf("unexpected cache object restriction %T", object)
+			}
+			if len(config.Namespaces) != 1 {
+				t.Errorf("%s %s cache namespaces = %#v", mode, kind, config.Namespaces)
+			} else if _, ok := config.Namespaces["system"]; !ok {
+				t.Errorf("%s %s cache omitted system namespace: %#v", mode, kind, config.Namespaces)
+			}
+			seen[kind] = true
+		}
+		if !seen["ConfigMap"] || !seen["Installation"] {
+			t.Errorf("%s system cache restrictions = %#v", mode, seen)
+		}
 	}
 }

--- a/config/crd/bases/swe.dev_installations.yaml
+++ b/config/crd/bases/swe.dev_installations.yaml
@@ -119,8 +119,8 @@ spec:
             type: object
           status:
             description: |-
-              InstallationStatus contains bounded non-secret observations reserved for the
-              future installation isolation controller. This slice does not write status.
+              InstallationStatus contains bounded non-secret observations from the
+              installation isolation selection controller.
             properties:
               conditions:
                 items:
@@ -213,8 +213,8 @@ spec:
                 type: string
               isolationState:
                 description: |-
-                  InstallationIsolationState is bounded controller-owned vocabulary reserved
-                  for the staged activation flow. No controller writes it yet.
+                  InstallationIsolationState is bounded controller-owned vocabulary for the
+                  staged selection lifecycle.
                 enum:
                 - LegacyUnclassified
                 - Fencing

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - namespaces
   verbs:
   - get
@@ -55,6 +63,15 @@ rules:
   - list
   - watch
 - apiGroups:
+  - storage.k8s.io
+  resources:
+  - csidrivers
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - swe.dev
   resources:
   - agentcredentialprofiles
@@ -88,6 +105,7 @@ rules:
   resources:
   - environments/status
   - environmenttemplates/status
+  - installations/status
   - runs/status
   verbs:
   - get

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -44,6 +44,8 @@ E2E_SESSION_FIXTURE=""
 SELECTOR_ENV_NAME=""
 LEGACY_CRD_ACTIVE="false"
 LEGACY_ENV_NAMES=""
+ISOLATION_POLICY_CONFIGMAP=""
+ISOLATION_CREATED_RUNTIME_CLASS=""
 
 cleanup() {
 	if [[ "$LEGACY_CRD_ACTIVE" == "true" ]]; then
@@ -107,6 +109,12 @@ cleanup() {
 	kubectl -n "$SYSTEM_NAMESPACE" delete pod swe-ingress-allowed --ignore-not-found --wait=false >/dev/null 2>&1 || true
 	kubectl -n "$SYSTEM_NAMESPACE" delete pod swe-sandboxd-relay --ignore-not-found --wait=false >/dev/null 2>&1 || true
 	kubectl -n "$PROJECT_NAMESPACE" delete pod swe-ingress-denied --ignore-not-found --wait=false >/dev/null 2>&1 || true
+	if [[ -n "$ISOLATION_POLICY_CONFIGMAP" ]]; then
+		kubectl -n "$SYSTEM_NAMESPACE" delete configmap "$ISOLATION_POLICY_CONFIGMAP" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+	fi
+	if [[ -n "$ISOLATION_CREATED_RUNTIME_CLASS" ]]; then
+		kubectl delete runtimeclass "$ISOLATION_CREATED_RUNTIME_CLASS" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+	fi
 	rm -f /tmp/swe-platform-sandboxd-cert-"$$" /tmp/swe-platform-sandboxd-token-"$$" \
 		/tmp/swe-platform-observation-cert-"$$" /tmp/swe-platform-observation-process-token-"$$"
 	if [[ "${KEEP_CLUSTER:-false}" != "true" && "${E2E_USE_EXISTING_CLUSTER:-false}" != "true" ]]; then
@@ -3428,6 +3436,113 @@ if kubectl get secret "run-repository-credential-${GIT_CREDENTIAL_DISABLED_UID}"
 	exit 1
 fi
 kubectl delete run "$GIT_CREDENTIAL_DISABLED_RUN" --wait=true >/dev/null
+
+echo "==> verifying restricted Installation selection fences live execution without activation"
+ISOLATION_POLICY_CONFIGMAP=swe-e2e-restricted-policy
+ISOLATION_RUNTIME_CLASS="${E2E_RUNTIME_CLASS:-swe-e2e-isolation-runtime}"
+if [[ -z "${E2E_RUNTIME_CLASS:-}" ]]; then
+	ISOLATION_CREATED_RUNTIME_CLASS="$ISOLATION_RUNTIME_CLASS"
+	cat <<EOF | kubectl apply -f - >/dev/null
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: ${ISOLATION_RUNTIME_CLASS}
+handler: runc
+EOF
+fi
+ISOLATION_RUNTIME_HANDLER=$(kubectl get runtimeclass "$ISOLATION_RUNTIME_CLASS" -o jsonpath='{.handler}')
+ISOLATION_STORAGE_CLASS=csi-hostpath-sc
+ISOLATION_CSI_DRIVER=$(kubectl get storageclass "$ISOLATION_STORAGE_CLASS" -o jsonpath='{.provisioner}')
+kubectl get csidriver "$ISOLATION_CSI_DRIVER" >/dev/null
+ISOLATION_POLICY_JSON=$(jq -cn '
+  {
+    apiVersion:"swe.dev/egress-policy/v1",
+    mode:"restricted",
+    ceiling:[],
+    baseline:[],
+    restrictedProfile:{
+      name:"calico-v3.32.1",
+      resolverIPs:["10.96.0.10"],
+      apiServerCIDRs:["10.0.0.1/32"],
+      podCIDRs:["10.244.0.0/16"],
+      serviceCIDRs:["10.96.0.0/12"],
+      nodeCIDRs:["192.168.0.0/16"],
+      controlPlaneCIDRs:["172.16.0.0/16"],
+      additionalDeniedCIDRs:[]
+    },
+    tlsSecretName:"swe-e2e-egress-proxy-tls",
+    proxyImage:"ghcr.io/chris-cullins/swe-platform/egress-proxy@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }')
+ISOLATION_POLICY_SHA=$(printf '%s' "$ISOLATION_POLICY_JSON" | sha256sum | awk '{print $1}')
+jq -n --arg policy "$ISOLATION_POLICY_JSON" --arg digest "$ISOLATION_POLICY_SHA" --arg name "$ISOLATION_POLICY_CONFIGMAP" --arg namespace "$SYSTEM_NAMESPACE" '
+  {
+    apiVersion:"v1",
+    kind:"ConfigMap",
+    metadata:{name:$name,namespace:$namespace,annotations:{"swe.dev/egress-policy-content-sha256":$digest}},
+    immutable:true,
+    data:{"policy.json":$policy}
+  }' | kubectl apply -f - >/dev/null
+
+ISOLATION_POD_NAME=$(kubectl get environment "$ENV_NAME" -o jsonpath='{.status.podName}')
+ISOLATION_SECRET_NAME=$(kubectl get pod "$ISOLATION_POD_NAME" -o jsonpath='{.metadata.annotations.swe\.dev/sandboxd-secret-name}')
+ISOLATION_PVC_NAME=$(kubectl get pod "$ISOLATION_POD_NAME" -o jsonpath='{.spec.volumes[?(@.name=="workspace")].persistentVolumeClaim.claimName}')
+ISOLATION_PVC_UID=$(kubectl get pvc "$ISOLATION_PVC_NAME" -o jsonpath='{.metadata.uid}')
+ISOLATION_NETWORK_POLICY="$ISOLATION_SECRET_NAME"
+ISOLATION_NETWORK_POLICY_UID=$(kubectl get networkpolicy "$ISOLATION_NETWORK_POLICY" -o jsonpath='{.metadata.uid}')
+ISOLATION_PATCH=$(jq -cn \
+	--arg policy "$ISOLATION_POLICY_CONFIGMAP" \
+	--arg runtime "$ISOLATION_RUNTIME_CLASS" \
+	--arg handler "$ISOLATION_RUNTIME_HANDLER" \
+	--arg storage "$ISOLATION_STORAGE_CLASS" \
+	--arg driver "$ISOLATION_CSI_DRIVER" '
+  {spec:{isolation:{
+    mode:"RestrictedProductionCalicoV3_32_1",
+    policyConfigMapName:$policy,
+    runtimeClass:{name:$runtime,handler:$handler},
+    storageClass:{name:$storage,csiDriver:$driver}
+  }}}')
+kubectl -n "$SYSTEM_NAMESPACE" patch installation "$INSTALLATION_NAME" --type=merge -p "$ISOLATION_PATCH" >/dev/null
+if ! kubectl -n "$SYSTEM_NAMESPACE" wait --for=jsonpath='{.status.isolationState}'=Blocked installation/"$INSTALLATION_NAME" --timeout=2m; then
+	echo "FAIL: restricted Installation selection did not settle Blocked" >&2
+	kubectl -n "$SYSTEM_NAMESPACE" get installation "$INSTALLATION_NAME" -o yaml >&2 || true
+	kubectl get environments,pods -o wide >&2 || true
+	kubectl -n "$SYSTEM_NAMESPACE" logs deployment/"$INSTALLATION_NAME" --tail=200 >&2 || true
+	exit 1
+fi
+for _ in $(seq 1 120); do
+	if ! kubectl get pod "$ISOLATION_POD_NAME" >/dev/null 2>&1 && ! kubectl get secret "$ISOLATION_SECRET_NAME" >/dev/null 2>&1; then
+		break
+	fi
+	sleep 1
+done
+sleep 5
+ISOLATION_STATUS=$(kubectl -n "$SYSTEM_NAMESPACE" get installation "$INSTALLATION_NAME" -o json)
+if kubectl get pod "$ISOLATION_POD_NAME" >/dev/null 2>&1 || kubectl get secret "$ISOLATION_SECRET_NAME" >/dev/null 2>&1 ||
+	[[ -n "$(kubectl get environment "$ENV_NAME" -o jsonpath='{.status.podName}')" ]] ||
+	[[ "$(kubectl get environment "$ENV_NAME" -o jsonpath='{.status.conditions[?(@.type=="Ready")].reason}')" != "InvalidConfiguration" ]] ||
+	[[ "$(kubectl get pvc "$ISOLATION_PVC_NAME" -o jsonpath='{.metadata.uid}')" != "$ISOLATION_PVC_UID" ]] ||
+	[[ "$(kubectl get networkpolicy "$ISOLATION_NETWORK_POLICY" -o jsonpath='{.metadata.uid}')" != "$ISOLATION_NETWORK_POLICY_UID" ]] ||
+	! jq -e '
+    .status.isolationState == "Blocked" and
+    (.status.isolationRevision | test("^[a-f0-9]{64}$")) and
+    .status.policyConfigMap.uid != "" and .status.runtimeClass.uid != "" and
+    .status.storageClass.uid != "" and .status.csiDriver.uid != "" and
+    any(.status.conditions[]; .type == "IsolationReady" and .status == "False" and .reason == "RuntimeActivationUnavailable")
+  ' <<<"$ISOLATION_STATUS" >/dev/null; then
+	echo "FAIL: restricted Installation did not fence exactly without replacement or retain durable children" >&2
+	kubectl -n "$SYSTEM_NAMESPACE" get installation "$INSTALLATION_NAME" -o yaml >&2 || true
+	kubectl get environment "$ENV_NAME" -o yaml >&2 || true
+	kubectl get pods,pvc,networkpolicy >&2 || true
+	exit 1
+fi
+
+# Restore the explicit development selection for KEEP_CLUSTER and the final
+# sandboxd log check. A replacement is permitted only after this intent change.
+kubectl -n "$SYSTEM_NAMESPACE" patch installation "$INSTALLATION_NAME" --type=merge \
+	-p '{"spec":{"isolation":{"mode":"UnrestrictedDevelopment","policyConfigMapName":null,"runtimeClass":null,"storageClass":null}}}' >/dev/null
+kubectl -n "$SYSTEM_NAMESPACE" wait --for=jsonpath='{.status.isolationState}'=Active installation/"$INSTALLATION_NAME" --timeout=2m
+kubectl wait --for=jsonpath='{.status.phase}'=Ready environment/"$ENV_NAME" --timeout=3m
+POD_NAME=$(kubectl get environment "$ENV_NAME" -o jsonpath='{.status.podName}')
 
 echo "==> sandboxd logs from the environment pod"
 kubectl logs "$POD_NAME" -c environment | head -3

--- a/hack/helm-rbac_test.sh
+++ b/hack/helm-rbac_test.sh
@@ -109,6 +109,31 @@ for mode in scoped trusted-admin; do
 		echo "$mode render must let the operator watch owned credential Secret teardown" >&2
 		exit 1
 	fi
+	operator_scope_role=$(awk -v RS='---' '
+		/kind: ClusterRole\n/ && /resources: \["runtimeclasses"\]/ &&
+		/resources: \["storageclasses", "csidrivers"\]/ { print; exit }
+	' <<<"$render")
+	operator_system_role=$(awk -v RS='---' '
+		/kind: Role\n/ && /resources: \["installations"\]/ &&
+		/resources: \["installations\/status"\]/ && /resources: \["configmaps"\]/ { print; exit }
+	' <<<"$render")
+	if [[ -z "$operator_scope_role" || -z "$operator_system_role" ]]; then
+		echo "$mode render lacks Installation isolation dependency watches or system status authority" >&2
+		exit 1
+	fi
+	installation_status_rule=$(awk -v RS='  - apiGroups:' '
+		/\["swe.dev"\]/ && /resources: \["installations\/status"\]/ { print; exit }
+	' <<<"$operator_system_role")
+	configmap_rule=$(awk -v RS='  - apiGroups:' '
+		/\[""\]/ && /resources: \["configmaps"\]/ { print; exit }
+	' <<<"$operator_system_role")
+	if grep -Eq 'resources: \["(installations|installations/status|configmaps)"\]' <<<"$operator_role$operator_scope_role" ||
+		grep -Eq '"(create|delete|patch|update)"' <<<"$operator_scope_role" ||
+		grep -Eq '"(create|delete|list|watch)"' <<<"$installation_status_rule" ||
+		grep -Eq '"(create|delete|patch|update)"' <<<"$configmap_rule"; then
+		echo "$mode render grants Installation isolation authority beyond exact system status and dependency observation" >&2
+		exit 1
+	fi
 	disabled_status_rule=$(awk -v RS='  - apiGroups:' '
 		/\["swe.dev"\]/ && /resources: \["environments\/status"\]/ { print; exit }
 	' <<<"$control_plane_role")

--- a/internal/controllers/declared_service_controller.go
+++ b/internal/controllers/declared_service_controller.go
@@ -71,6 +71,13 @@ func (r *DeclaredServiceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	if !env.DeletionTimestamp.IsZero() || !serviceEnvironmentActive(&env) {
 		return ctrl.Result{RequeueAfter: declaredServiceInterval}, nil
 	}
+	allowed, err := installationExecutionCurrent(ctx, r.reader(), r.Scope)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if !allowed {
+		return ctrl.Result{RequeueAfter: declaredServiceInterval}, nil
+	}
 	fence := lifecycle.CaptureExecutionFence(&env)
 	file, err := r.Connector.ReadWorkspaceServices(ctx, fence)
 	if err != nil {
@@ -107,7 +114,7 @@ func (r *DeclaredServiceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		// patch advances metadata.generation to this future intent revision; a
 		// later launch at a positive route revision is therefore strictly newer,
 		// while retries of an uncertain empty-set call remain idempotent.
-		if err := r.Connector.ReconcileRepositoryServices(ctx, fence, append([]platformv1alpha1.EnvironmentServiceDeclaration(nil), current.Spec.Services...), nil, uint64(current.Generation+1), 0, nil); err != nil {
+		if err := r.reconcileRepositoryServices(ctx, fence, append([]platformv1alpha1.EnvironmentServiceDeclaration(nil), current.Spec.Services...), nil, uint64(current.Generation+1), 0, nil); err != nil {
 			ctrl.LoggerFrom(ctx).Error(err, "fence previous repository service processes")
 			return ctrl.Result{RequeueAfter: declaredServiceInterval}, nil
 		}
@@ -150,7 +157,7 @@ func (r *DeclaredServiceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			if hasActiveRepositoryRoute(&current) || env.Generation < 1 {
 				return ctrl.Result{RequeueAfter: declaredServiceInterval}, nil
 			}
-			if err := r.Connector.ReconcileRepositoryServices(ctx, fence, append([]platformv1alpha1.EnvironmentServiceDeclaration(nil), env.Spec.Services...), routeProofs, uint64(env.Generation), routeRevision, nil); err != nil {
+			if err := r.reconcileRepositoryServices(ctx, fence, append([]platformv1alpha1.EnvironmentServiceDeclaration(nil), env.Spec.Services...), routeProofs, uint64(env.Generation), routeRevision, nil); err != nil {
 				ctrl.LoggerFrom(ctx).Error(err, "stop repository services for disabled portal authority")
 				return ctrl.Result{RequeueAfter: declaredServiceInterval}, nil
 			}
@@ -168,11 +175,22 @@ func (r *DeclaredServiceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	if env.Generation < 1 {
 		return ctrl.Result{RequeueAfter: declaredServiceInterval}, nil
 	}
-	if err := r.Connector.ReconcileRepositoryServices(ctx, fence, append([]platformv1alpha1.EnvironmentServiceDeclaration(nil), env.Spec.Services...), routeProofs, uint64(env.Generation), routeRevision, specs); err != nil {
+	if err := r.reconcileRepositoryServices(ctx, fence, append([]platformv1alpha1.EnvironmentServiceDeclaration(nil), env.Spec.Services...), routeProofs, uint64(env.Generation), routeRevision, specs); err != nil {
 		ctrl.LoggerFrom(ctx).Error(err, "reconcile repository service processes")
 		return ctrl.Result{RequeueAfter: declaredServiceInterval}, nil
 	}
 	return ctrl.Result{RequeueAfter: declaredServiceInterval}, nil
+}
+
+func (r *DeclaredServiceReconciler) reconcileRepositoryServices(ctx context.Context, fence lifecycle.ExecutionFence, declarations []platformv1alpha1.EnvironmentServiceDeclaration, routes []platformv1alpha1.EnvironmentPortalRoute, intentRevision, routeRevision uint64, specs []*sandboxdv1.ManagedServiceSpec) error {
+	allowed, err := installationExecutionCurrent(ctx, r.reader(), r.Scope)
+	if err != nil {
+		return err
+	}
+	if !allowed {
+		return errInstallationIsolationBlocked
+	}
+	return r.Connector.ReconcileRepositoryServices(ctx, fence, declarations, routes, intentRevision, routeRevision, specs)
 }
 
 func (r *DeclaredServiceReconciler) reader() client.Reader {

--- a/internal/controllers/declared_service_controller_test.go
+++ b/internal/controllers/declared_service_controller_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -22,6 +23,7 @@ import (
 	"github.com/Chris-Cullins/swe-platform/internal/lifecycle"
 	"github.com/Chris-Cullins/swe-platform/internal/sandboxclient"
 	"github.com/Chris-Cullins/swe-platform/internal/serviceconfig"
+	"github.com/Chris-Cullins/swe-platform/internal/tenancy"
 	sandboxdv1 "github.com/Chris-Cullins/swe-platform/sandboxd/gen/proto/sandboxd/v1"
 )
 
@@ -369,6 +371,63 @@ func TestDeclaredServiceReconcilerDiscardsPostRouteRaces(t *testing.T) {
 				t.Fatalf("stale route launched: %#v", connector.reconciles)
 			}
 		})
+	}
+}
+
+func TestDeclaredServiceReconcilerRevalidatesInstallationIsolationBeforeProcessReconcile(t *testing.T) {
+	scheme := isolationTestScheme(t)
+	installation := &platformv1alpha1.Installation{ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "system", UID: "installation-uid"}}
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns", UID: "namespace-uid", Annotations: map[string]string{
+		tenancy.InstallationNamespaceAnnotation: "system",
+		tenancy.InstallationNameAnnotation:      "main",
+		tenancy.InstallationUIDAnnotation:       "installation-uid",
+		tenancy.ProjectNameAnnotation:           "project",
+		tenancy.ProjectUIDAnnotation:            "project-uid",
+		tenancy.LifecycleAnnotation:             string(tenancy.LifecycleActive),
+	}}}
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "project", Namespace: "ns", UID: "project-uid"}}
+	env := declaredEnvironment()
+	declaration := platformv1alpha1.EnvironmentServiceDeclaration{
+		Name: "web", Source: platformv1alpha1.EnvironmentServiceSourceRepository, InstanceID: "instance-abcdefghijklmnop", Revision: 2, TargetPort: 8080,
+		Protocol: platformv1alpha1.EnvironmentServiceProtocolHTTP, Visibility: platformv1alpha1.EnvironmentServiceVisibilityProject, Readiness: platformv1alpha1.EnvironmentServiceReadinessTCPConnect,
+		Launch: &platformv1alpha1.EnvironmentServiceLaunch{Argv: []platformv1alpha1.EnvironmentServiceLaunchArgument{"serve"}},
+	}
+	env.Spec.Services = []platformv1alpha1.EnvironmentServiceDeclaration{declaration}
+	env.Status.PortalRoutes = []platformv1alpha1.EnvironmentPortalRoute{{Name: declaration.Name, Active: true, DeclarationInstanceID: declaration.InstanceID, DeclarationRevision: declaration.Revision, Generation: 7}}
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(env).WithObjects(installation, namespace, project, env).Build()
+	identity := tenancy.InstallationIdentity{Key: client.ObjectKeyFromObject(installation), UID: installation.UID}
+	verifier := &tenancy.Verifier{Reader: kubeClient, Installation: identity, Mode: tenancy.ModeScoped}
+	connector := &declaredConnectorFake{file: sandboxclient.WorkspaceServicesFile{Data: []byte("version: 1\nservices:\n  web:\n    command: [serve]\n    port: 8080\n")}}
+	routes := &declaredRoutesFake{route: controlplaneclient.PortalRoute{URL: "https://web", EnvironmentUID: string(env.UID), Service: declaration.Name, DeclarationInstanceID: declaration.InstanceID, Revision: declaration.Revision, RouteGeneration: 7}}
+	routes.hook = func() {
+		var current platformv1alpha1.Installation
+		if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(installation), &current); err != nil {
+			t.Fatal(err)
+		}
+		current.Spec.Isolation = restrictedIsolationSelection()
+		if err := kubeClient.Update(context.Background(), &current); err != nil {
+			t.Fatal(err)
+		}
+	}
+	reconciler := &DeclaredServiceReconciler{
+		Client: tenancy.GuardedClient{Client: kubeClient, Verifier: verifier}, APIReader: kubeClient,
+		Scope: &tenancy.ReconcileScope{Verifier: verifier}, Connector: connector, Routes: routes,
+	}
+
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(env)})
+	if err != nil || result.RequeueAfter != declaredServiceInterval {
+		t.Fatalf("racing isolation Reconcile() = (%#v, %v)", result, err)
+	}
+	if len(connector.reads) != 1 || routes.calls != 1 || len(connector.reconciles) != 0 {
+		t.Fatalf("racing isolation crossed process boundary: reads=%d routes=%d reconciles=%#v", len(connector.reads), routes.calls, connector.reconciles)
+	}
+
+	result, err = reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(env)})
+	if err != nil || result.RequeueAfter != declaredServiceInterval {
+		t.Fatalf("blocked isolation Reconcile() = (%#v, %v)", result, err)
+	}
+	if len(connector.reads) != 1 || routes.calls != 1 || len(connector.reconciles) != 0 {
+		t.Fatalf("blocked isolation performed service work: reads=%d routes=%d reconciles=%#v", len(connector.reads), routes.calls, connector.reconciles)
 	}
 }
 

--- a/internal/controllers/environment_controller.go
+++ b/internal/controllers/environment_controller.go
@@ -879,6 +879,9 @@ func (r *EnvironmentReconciler) backendCreationSourcesCurrent(ctx context.Contex
 		!platformv1alpha1.ProvisioningSnapshotsEqual(currentEnv.Status.Provisioning, env.Status.Provisioning) {
 		return false, nil
 	}
+	if allowed, err := installationExecutionCurrent(ctx, r.apiReader(), r.Scope); err != nil || !allowed {
+		return false, err
+	}
 	// Direct unit-level callers may exercise the lower-level Pod constructor
 	// without the reconcile pipeline's required provisioning snapshot.
 	if env.Status.Provisioning == nil {

--- a/internal/controllers/environment_reconcile.go
+++ b/internal/controllers/environment_reconcile.go
@@ -82,6 +82,7 @@ var environmentReconcilePhases = []environmentReconcilePhase{
 	{name: "lifecycle", run: reconcileEnvironmentLifecycleGate},
 	{name: "legacy-provisioning-migration", run: reconcileEnvironmentLegacyProvisioningMigrationGate},
 	{name: "provisioning-fence", run: reconcileEnvironmentProvisioningFenceGate},
+	{name: "installation-isolation", run: reconcileEnvironmentInstallationIsolationGate},
 	{name: "project-resolution", run: reconcileEnvironmentProjectResolutionGate},
 	{name: "suspension", run: reconcileEnvironmentSuspensionGate},
 	{name: "project-validation", run: reconcileEnvironmentProjectValidationGate},
@@ -232,6 +233,27 @@ func reconcileEnvironmentLegacyProvisioningMigrationGate(r *EnvironmentReconcile
 		return phaseHandled(result, err)
 	}
 	return phaseContinue()
+}
+
+func reconcileEnvironmentInstallationIsolationGate(r *EnvironmentReconciler, ctx context.Context, state *environmentReconcileState) environmentPhaseOutcome {
+	identity, configured := installationIdentity(r.Scope)
+	if !configured {
+		return phaseContinue()
+	}
+	allowed, isolationErr := installationExecutionAllowed(ctx, r.apiReader(), identity)
+	if allowed {
+		return phaseContinue()
+	}
+	result, fenceErr := r.reconcileInvalidProvisioningConfiguration(ctx, &state.env, installationIsolationBlockedMessage)
+	if fenceErr != nil {
+		return phaseHandled(result, fenceErr)
+	}
+	// Progress readiness withdrawal and ordered Pod/credential teardown before
+	// surfacing API uncertainty through controller-runtime's retry path.
+	if isolationErr != nil && result == (ctrl.Result{}) {
+		return phaseHandled(ctrl.Result{}, isolationErr)
+	}
+	return phaseHandled(result, nil)
 }
 
 func reconcileEnvironmentProjectResolutionGate(r *EnvironmentReconciler, ctx context.Context, state *environmentReconcileState) environmentPhaseOutcome {

--- a/internal/controllers/environment_reconcile_test.go
+++ b/internal/controllers/environment_reconcile_test.go
@@ -13,6 +13,7 @@ func TestEnvironmentReconcilePhaseOrderingContract(t *testing.T) {
 		"lifecycle",
 		"legacy-provisioning-migration",
 		"provisioning-fence",
+		"installation-isolation",
 		"project-resolution",
 		"suspension",
 		"project-validation",
@@ -31,7 +32,7 @@ func TestEnvironmentReconcilePhaseOrderingContract(t *testing.T) {
 	}
 
 	// Teardown and execution fencing must never wait for dependency resolution.
-	for _, gate := range []string{"tenancy-fencing", "deletion", "recovery-migration", "lifecycle", "legacy-provisioning-migration", "provisioning-fence"} {
+	for _, gate := range []string{"tenancy-fencing", "deletion", "recovery-migration", "lifecycle", "legacy-provisioning-migration", "provisioning-fence", "installation-isolation"} {
 		for _, dependency := range []string{"project-resolution", "project-validation", "template", "recovery", "backend-runtime", "provisioning"} {
 			if slices.Index(got, gate) >= slices.Index(got, dependency) {
 				t.Errorf("gate %q must run before dependency phase %q", gate, dependency)

--- a/internal/controllers/environment_setup.go
+++ b/internal/controllers/environment_setup.go
@@ -69,6 +69,19 @@ func (r *EnvironmentReconciler) runtimeClassReferenceRequests(ctx context.Contex
 	return requests
 }
 
+func (r *EnvironmentReconciler) installationIsolationRequests(ctx context.Context, _ client.Object) []reconcile.Request {
+	var environments platformv1alpha1.EnvironmentList
+	if err := r.List(ctx, &environments); err != nil {
+		log.FromContext(ctx).Error(err, "list environments for Installation isolation")
+		return nil
+	}
+	requests := make([]reconcile.Request, 0, len(environments.Items))
+	for i := range environments.Items {
+		requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&environments.Items[i])})
+	}
+	return requests
+}
+
 // SetupWithManager registers the controller with the manager.
 func (r *EnvironmentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.APIReader = mgr.GetAPIReader()
@@ -107,5 +120,6 @@ func (r *EnvironmentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&nodev1.RuntimeClass{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
 			return r.runtimeClassReferenceRequests(ctx, object.GetName())
 		})).
+		Watches(&platformv1alpha1.Installation{}, handler.EnqueueRequestsFromMapFunc(r.installationIsolationRequests)).
 		Complete(r)
 }

--- a/internal/controllers/installation_isolation_controller.go
+++ b/internal/controllers/installation_isolation_controller.go
@@ -1,0 +1,545 @@
+package controllers
+
+import (
+	"context"
+	"encoding/hex"
+	stderrors "errors"
+	"fmt"
+	"slices"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	nodev1 "k8s.io/api/node/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
+	"github.com/Chris-Cullins/swe-platform/internal/egresspolicy"
+	"github.com/Chris-Cullins/swe-platform/internal/isolation"
+	"github.com/Chris-Cullins/swe-platform/internal/tenancy"
+)
+
+const (
+	installationIsolationBlockedMessage = "installation isolation does not permit environment execution"
+	isolationResolutionRetryDelay       = 5 * time.Second
+)
+
+var errIsolationDependenciesPending = stderrors.New("restricted isolation dependencies have not been resolved")
+
+// InstallationIsolationReconciler owns the observed selection lifecycle for
+// the one exact Installation loaded at operator startup. Restricted runtime
+// activation is deliberately unavailable in this slice.
+type InstallationIsolationReconciler struct {
+	client.Client
+	APIReader    client.Reader
+	Installation tenancy.InstallationIdentity
+	Mode         tenancy.Mode
+	Namespaces   []string
+}
+
+// +kubebuilder:rbac:groups=swe.dev,resources=installations,verbs=get;list;watch
+// +kubebuilder:rbac:groups=swe.dev,resources=installations/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
+// +kubebuilder:rbac:groups=node.k8s.io,resources=runtimeclasses,verbs=get;list;watch
+// +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses;csidrivers,verbs=get;list;watch
+
+func (r *InstallationIsolationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	if req.NamespacedName != r.Installation.Key {
+		return ctrl.Result{}, nil
+	}
+	var installation platformv1alpha1.Installation
+	if err := r.reader().Get(ctx, r.Installation.Key, &installation); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	if installation.UID != r.Installation.UID || !installation.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, nil
+	}
+
+	if installation.Spec.Isolation == nil {
+		return r.reconcileLegacySelection(ctx, &installation)
+	}
+
+	selection := installation.Spec.Isolation.DeepCopy()
+	if err := isolation.ValidateSelection(selection); err != nil {
+		return r.reconcileBlockedSelection(ctx, &installation, nil, nil, err)
+	}
+	if selection.Mode == platformv1alpha1.InstallationIsolationModeUnrestrictedDevelopment {
+		revision, err := (isolation.RevisionInputs{InstallationUID: installation.UID, Selection: *selection}).DeriveRevision()
+		if err != nil {
+			return r.reconcileBlockedSelection(ctx, &installation, nil, nil, err)
+		}
+		return r.reconcileUnrestrictedSelection(ctx, &installation, selection, revision)
+	}
+
+	// Publish the restricted intent and withdraw Active authority before any
+	// dependency read can stall or fail. Resolution starts only after this
+	// exact selection is durably observed in Fencing or Blocked.
+	if !apiequality.Semantic.DeepEqual(installation.Status.ObservedIsolation, selection) ||
+		installation.Status.IsolationState != platformv1alpha1.InstallationIsolationStateFencing && installation.Status.IsolationState != platformv1alpha1.InstallationIsolationStateBlocked {
+		return r.reconcileBlockedSelection(ctx, &installation, nil, nil, errIsolationDependenciesPending)
+	}
+	resolved, identities, resolveErr := r.resolveRestrictedSelection(ctx, &installation, selection)
+	return r.reconcileBlockedSelection(ctx, &installation, identities, resolved, resolveErr)
+}
+
+func (r *InstallationIsolationReconciler) reconcileLegacySelection(ctx context.Context, installation *platformv1alpha1.Installation) (ctrl.Result, error) {
+	desiredLegacy := r.legacyStatus(installation, platformv1alpha1.InstallationIsolationStateLegacyUnclassified)
+	if legacyCompatibleIsolationStatus(installation.Status) {
+		_, err := r.updateStatus(ctx, installation, desiredLegacy)
+		return ctrl.Result{}, err
+	}
+	desiredFencing := r.legacyStatus(installation, platformv1alpha1.InstallationIsolationStateFencing)
+	changed, err := r.updateStatus(ctx, installation, desiredFencing)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if changed {
+		return ctrl.Result{Requeue: true}, nil
+	}
+	fenced, err := r.allEnvironmentExecutionsFenced(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if !fenced {
+		return ctrl.Result{Requeue: true}, nil
+	}
+	changed, err = r.updateStatus(ctx, installation, desiredLegacy)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{Requeue: changed}, nil
+}
+
+func (r *InstallationIsolationReconciler) legacyStatus(installation *platformv1alpha1.Installation, state platformv1alpha1.InstallationIsolationState) platformv1alpha1.InstallationStatus {
+	desired := r.baseStatus(installation, state, nil)
+	readyReason := "LegacyUnclassified"
+	readyMessage := "installation isolation selection is omitted"
+	if state == platformv1alpha1.InstallationIsolationStateFencing {
+		readyReason = "Fencing"
+		readyMessage = "installation environment execution is being fenced"
+	}
+	r.setConditions(installation, &desired, true, "NotRequired", metav1.ConditionFalse, readyReason, readyMessage, "LegacyUnclassified", "legacy isolation is not classified for production")
+	return desired
+}
+
+func (r *InstallationIsolationReconciler) reconcileUnrestrictedSelection(ctx context.Context, installation *platformv1alpha1.Installation, selection *platformv1alpha1.InstallationIsolationSpec, revision isolation.Revision) (ctrl.Result, error) {
+	desiredActive := r.unrestrictedStatus(installation, platformv1alpha1.InstallationIsolationStateActive, selection, revision)
+	if legacyCompatibleIsolationStatus(installation.Status) || unrestrictedAuthorityMatches(installation.Status, selection, revision) {
+		_, err := r.updateStatus(ctx, installation, desiredActive)
+		return ctrl.Result{}, err
+	}
+
+	desiredFencing := r.unrestrictedStatus(installation, platformv1alpha1.InstallationIsolationStateFencing, selection, revision)
+	changed, err := r.updateStatus(ctx, installation, desiredFencing)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if changed {
+		return ctrl.Result{Requeue: true}, nil
+	}
+	fenced, err := r.allEnvironmentExecutionsFenced(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if !fenced {
+		return ctrl.Result{Requeue: true}, nil
+	}
+	changed, err = r.updateStatus(ctx, installation, desiredActive)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{Requeue: changed}, nil
+}
+
+func (r *InstallationIsolationReconciler) unrestrictedStatus(installation *platformv1alpha1.Installation, state platformv1alpha1.InstallationIsolationState, selection *platformv1alpha1.InstallationIsolationSpec, revision isolation.Revision) platformv1alpha1.InstallationStatus {
+	desired := r.baseStatus(installation, state, selection)
+	desired.IsolationRevision = revision.String()
+	readyStatus := metav1.ConditionFalse
+	readyReason := "Fencing"
+	readyMessage := "installation environment execution is being fenced"
+	if state == platformv1alpha1.InstallationIsolationStateActive {
+		readyStatus = metav1.ConditionTrue
+		readyReason = "UnrestrictedDevelopment"
+		readyMessage = "unrestricted development isolation is active"
+	}
+	r.setConditions(installation, &desired, true, "NotRequired", readyStatus, readyReason, readyMessage, "UnrestrictedDevelopment", "unrestricted development isolation is explicitly non-production")
+	return desired
+}
+
+type restrictedIsolationIdentities struct {
+	policy       *platformv1alpha1.InstallationPolicyConfigMapIdentity
+	runtimeClass *platformv1alpha1.InstallationRuntimeClassIdentity
+	storageClass *platformv1alpha1.InstallationStorageClassIdentity
+	csiDriver    *platformv1alpha1.InstallationCSIDriverIdentity
+}
+
+func (r *InstallationIsolationReconciler) resolveRestrictedSelection(ctx context.Context, installation *platformv1alpha1.Installation, selection *platformv1alpha1.InstallationIsolationSpec) (*isolation.Revision, *restrictedIsolationIdentities, error) {
+	var policyConfigMap corev1.ConfigMap
+	policyKey := types.NamespacedName{Namespace: installation.Namespace, Name: selection.PolicyConfigMapName}
+	if err := r.reader().Get(ctx, policyKey, &policyConfigMap); err != nil {
+		return nil, nil, fmt.Errorf("resolve isolation policy ConfigMap: %w", err)
+	}
+	policy, err := egresspolicy.ParseConfigMap(&policyConfigMap)
+	if err != nil {
+		return nil, nil, fmt.Errorf("validate isolation policy ConfigMap: %w", err)
+	}
+	if policy.Mode != egresspolicy.ModeRestricted || policy.RestrictedProfile == nil || policy.RestrictedProfile.Name != egresspolicy.RestrictedProfileCalicoV1 {
+		return nil, nil, stderrors.New("restricted installation isolation requires the canonical restricted Calico v3.32.1 policy")
+	}
+
+	var runtimeClass nodev1.RuntimeClass
+	if err := r.reader().Get(ctx, types.NamespacedName{Name: selection.RuntimeClass.Name}, &runtimeClass); err != nil {
+		return nil, nil, fmt.Errorf("resolve isolation RuntimeClass: %w", err)
+	}
+	if runtimeClass.UID == "" || !runtimeClass.DeletionTimestamp.IsZero() || runtimeClass.Handler != selection.RuntimeClass.Handler {
+		return nil, nil, stderrors.New("RuntimeClass identity or handler does not match the restricted isolation selection")
+	}
+
+	var storageClass storagev1.StorageClass
+	if err := r.reader().Get(ctx, types.NamespacedName{Name: selection.StorageClass.Name}, &storageClass); err != nil {
+		return nil, nil, fmt.Errorf("resolve isolation StorageClass: %w", err)
+	}
+	if storageClass.UID == "" || !storageClass.DeletionTimestamp.IsZero() || storageClass.Provisioner != selection.StorageClass.CSIDriver {
+		return nil, nil, stderrors.New("StorageClass identity or provisioner does not match the restricted isolation selection")
+	}
+
+	var csiDriver storagev1.CSIDriver
+	if err := r.reader().Get(ctx, types.NamespacedName{Name: selection.StorageClass.CSIDriver}, &csiDriver); err != nil {
+		return nil, nil, fmt.Errorf("resolve isolation CSIDriver: %w", err)
+	}
+	if csiDriver.UID == "" || !csiDriver.DeletionTimestamp.IsZero() {
+		return nil, nil, stderrors.New("stable live CSIDriver identity does not match the restricted isolation selection")
+	}
+
+	inputs := isolation.RevisionInputs{
+		InstallationUID: installation.UID,
+		Selection:       *selection,
+		PolicyConfigMap: &isolation.PolicyConfigMapIdentity{UID: policyConfigMap.UID, ContentSHA256: policy.ContentSHA256},
+		RuntimeClass:    &isolation.RuntimeClassIdentity{UID: runtimeClass.UID, Handler: runtimeClass.Handler},
+		StorageClass:    &isolation.StorageClassIdentity{UID: storageClass.UID, CSIDriver: storageClass.Provisioner},
+		CSIDriver:       &isolation.CSIDriverIdentity{UID: csiDriver.UID},
+	}
+	revision, err := inputs.DeriveRevision()
+	if err != nil {
+		return nil, nil, fmt.Errorf("derive restricted isolation revision: %w", err)
+	}
+	identities := &restrictedIsolationIdentities{
+		policy: &platformv1alpha1.InstallationPolicyConfigMapIdentity{
+			Name: selection.PolicyConfigMapName, UID: policyConfigMap.UID,
+			ContentSHA256: hex.EncodeToString(policy.ContentSHA256[:]),
+		},
+		runtimeClass: &platformv1alpha1.InstallationRuntimeClassIdentity{Name: runtimeClass.Name, UID: runtimeClass.UID, Handler: runtimeClass.Handler},
+		storageClass: &platformv1alpha1.InstallationStorageClassIdentity{Name: storageClass.Name, UID: storageClass.UID, CSIDriver: storageClass.Provisioner},
+		csiDriver:    &platformv1alpha1.InstallationCSIDriverIdentity{Name: csiDriver.Name, UID: csiDriver.UID},
+	}
+	return &revision, identities, nil
+}
+
+func (r *InstallationIsolationReconciler) reconcileBlockedSelection(ctx context.Context, installation *platformv1alpha1.Installation, identities *restrictedIsolationIdentities, revision *isolation.Revision, resolveErr error) (ctrl.Result, error) {
+	selectionValid := isolation.ValidateSelection(installation.Spec.Isolation) == nil
+	observed := installation.Spec.Isolation
+	if !selectionValid {
+		observed = nil
+	}
+	sameSelection := apiequality.Semantic.DeepEqual(installation.Status.ObservedIsolation, observed)
+	desiredFencing := r.blockedStatus(installation, platformv1alpha1.InstallationIsolationStateFencing, observed, identities, revision, resolveErr)
+	if !sameSelection || installation.Status.IsolationState != platformv1alpha1.InstallationIsolationStateFencing && installation.Status.IsolationState != platformv1alpha1.InstallationIsolationStateBlocked ||
+		installation.Status.IsolationState == platformv1alpha1.InstallationIsolationStateBlocked && !sameIsolationDependencyAuthority(installation.Status, desiredFencing) {
+		if _, err := r.updateStatus(ctx, installation, desiredFencing); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	fenced, fenceErr := r.allEnvironmentExecutionsFenced(ctx)
+	state := platformv1alpha1.InstallationIsolationStateBlocked
+	if fenceErr != nil || !fenced {
+		state = platformv1alpha1.InstallationIsolationStateFencing
+	}
+	desired := r.blockedStatus(installation, state, observed, identities, revision, resolveErr)
+	changed, err := r.updateStatus(ctx, installation, desired)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if fenceErr != nil {
+		return ctrl.Result{}, fenceErr
+	}
+	if changed || !fenced {
+		return ctrl.Result{Requeue: true}, nil
+	}
+	if resolveErr != nil {
+		log.FromContext(ctx).Error(resolveErr, "restricted installation isolation dependencies are unresolved")
+		return ctrl.Result{RequeueAfter: isolationResolutionRetryDelay}, nil
+	}
+	return ctrl.Result{}, nil
+}
+
+func sameIsolationDependencyAuthority(current, desired platformv1alpha1.InstallationStatus) bool {
+	return current.IsolationRevision == desired.IsolationRevision &&
+		apiequality.Semantic.DeepEqual(current.PolicyConfigMap, desired.PolicyConfigMap) &&
+		apiequality.Semantic.DeepEqual(current.RuntimeClass, desired.RuntimeClass) &&
+		apiequality.Semantic.DeepEqual(current.StorageClass, desired.StorageClass) &&
+		apiequality.Semantic.DeepEqual(current.CSIDriver, desired.CSIDriver)
+}
+
+func legacyCompatibleIsolationStatus(status platformv1alpha1.InstallationStatus) bool {
+	if status.ObservedIsolation != nil || status.IsolationRevision != "" || status.PolicyConfigMap != nil || status.RuntimeClass != nil || status.StorageClass != nil || status.CSIDriver != nil {
+		return false
+	}
+	switch status.IsolationState {
+	case "":
+		return len(status.Conditions) == 0
+	case platformv1alpha1.InstallationIsolationStateLegacyUnclassified:
+		return true
+	default:
+		return false
+	}
+}
+
+func unrestrictedAuthorityMatches(status platformv1alpha1.InstallationStatus, selection *platformv1alpha1.InstallationIsolationSpec, revision isolation.Revision) bool {
+	return status.IsolationState == platformv1alpha1.InstallationIsolationStateActive &&
+		apiequality.Semantic.DeepEqual(status.ObservedIsolation, selection) &&
+		status.IsolationRevision == revision.String() &&
+		status.PolicyConfigMap == nil && status.RuntimeClass == nil && status.StorageClass == nil && status.CSIDriver == nil
+}
+
+func (r *InstallationIsolationReconciler) blockedStatus(installation *platformv1alpha1.Installation, state platformv1alpha1.InstallationIsolationState, observed *platformv1alpha1.InstallationIsolationSpec, identities *restrictedIsolationIdentities, revision *isolation.Revision, resolveErr error) platformv1alpha1.InstallationStatus {
+	desired := r.baseStatus(installation, state, observed)
+	if identities != nil && revision != nil {
+		desired.IsolationRevision = revision.String()
+		desired.PolicyConfigMap = identities.policy
+		desired.RuntimeClass = identities.runtimeClass
+		desired.StorageClass = identities.storageClass
+		desired.CSIDriver = identities.csiDriver
+	}
+	dependenciesResolved := resolveErr == nil && identities != nil && revision != nil
+	dependencyReason := "DependenciesResolved"
+	if !dependenciesResolved {
+		dependencyReason = "DependencyResolutionFailed"
+	}
+	readyReason := "Fencing"
+	readyMessage := "installation environment execution is being fenced"
+	if state == platformv1alpha1.InstallationIsolationStateBlocked {
+		readyReason = "RuntimeActivationUnavailable"
+		readyMessage = "restricted runtime activation is unavailable"
+	}
+	r.setConditions(installation, &desired, dependenciesResolved, dependencyReason, metav1.ConditionFalse, readyReason, readyMessage, "RuntimeActivationUnavailable", "restricted production isolation is not active")
+	return desired
+}
+
+func (r *InstallationIsolationReconciler) baseStatus(_ *platformv1alpha1.Installation, state platformv1alpha1.InstallationIsolationState, observed *platformv1alpha1.InstallationIsolationSpec) platformv1alpha1.InstallationStatus {
+	status := platformv1alpha1.InstallationStatus{IsolationState: state}
+	if observed != nil {
+		status.ObservedIsolation = observed.DeepCopy()
+	}
+	return status
+}
+
+func (r *InstallationIsolationReconciler) setConditions(installation *platformv1alpha1.Installation, status *platformv1alpha1.InstallationStatus, dependenciesResolved bool, dependencyReason string, readyStatus metav1.ConditionStatus, readyReason, readyMessage, productionReason, productionMessage string) {
+	dependencyStatus := metav1.ConditionFalse
+	dependencyMessage := "restricted isolation dependencies are unresolved"
+	if dependenciesResolved {
+		dependencyStatus = metav1.ConditionTrue
+		dependencyMessage = "isolation dependencies are resolved"
+	}
+	conditions := []metav1.Condition{
+		{Type: platformv1alpha1.InstallationConditionIsolationDependenciesResolved, Status: dependencyStatus, Reason: dependencyReason, Message: dependencyMessage, ObservedGeneration: installation.Generation},
+		{Type: platformv1alpha1.InstallationConditionIsolationReady, Status: readyStatus, Reason: readyReason, Message: readyMessage, ObservedGeneration: installation.Generation},
+		{Type: platformv1alpha1.InstallationConditionProductionReady, Status: metav1.ConditionFalse, Reason: productionReason, Message: productionMessage, ObservedGeneration: installation.Generation},
+	}
+	status.Conditions = make([]metav1.Condition, 0, len(conditions))
+	for _, condition := range conditions {
+		current := apimeta.FindStatusCondition(installation.Status.Conditions, condition.Type)
+		one := make([]metav1.Condition, 0, 1)
+		if current != nil {
+			one = append(one, *current)
+		}
+		apimeta.SetStatusCondition(&one, condition)
+		status.Conditions = append(status.Conditions, one[0])
+	}
+}
+
+func (r *InstallationIsolationReconciler) updateStatus(ctx context.Context, installation *platformv1alpha1.Installation, desired platformv1alpha1.InstallationStatus) (bool, error) {
+	if apiequality.Semantic.DeepEqual(installation.Status, desired) {
+		return false, nil
+	}
+	installation.Status = desired
+	if err := r.Status().Update(ctx, installation); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("update Installation isolation status: %w", err)
+	}
+	return true, nil
+}
+
+func (r *InstallationIsolationReconciler) allEnvironmentExecutionsFenced(ctx context.Context) (bool, error) {
+	var environments []platformv1alpha1.Environment
+	switch r.Mode {
+	case tenancy.ModeScoped:
+		namespaces := slices.Clone(r.Namespaces)
+		slices.Sort(namespaces)
+		namespaces = slices.Compact(namespaces)
+		for _, namespace := range namespaces {
+			var list platformv1alpha1.EnvironmentList
+			if err := r.reader().List(ctx, &list, client.InNamespace(namespace)); err != nil {
+				return false, fmt.Errorf("list Environments while fencing installation: %w", err)
+			}
+			environments = append(environments, list.Items...)
+		}
+	case tenancy.ModeTrustedAdmin:
+		var list platformv1alpha1.EnvironmentList
+		if err := r.reader().List(ctx, &list); err != nil {
+			return false, fmt.Errorf("list Environments while fencing installation: %w", err)
+		}
+		ownership := make(map[string]bool)
+		for i := range list.Items {
+			environment := &list.Items[i]
+			owned, checked := ownership[environment.Namespace]
+			if !checked {
+				var err error
+				owned, err = r.trustedAdminNamespaceOwned(ctx, environment.Namespace)
+				if err != nil {
+					return false, err
+				}
+				ownership[environment.Namespace] = owned
+			}
+			if owned {
+				environments = append(environments, *environment)
+			}
+		}
+	default:
+		return false, stderrors.New("installation isolation controller has no valid tenancy mode")
+	}
+
+	for i := range environments {
+		environment := &environments[i]
+		if environment.Status.PodName != "" || environment.Status.Endpoints.Sandboxd != "" || platformv1alpha1.IsEnvironmentReady(environment) {
+			return false, nil
+		}
+		for _, child := range []client.Object{
+			&corev1.Pod{},
+			&corev1.Secret{},
+		} {
+			name := envPodName(environment)
+			if _, ok := child.(*corev1.Secret); ok {
+				name = envCredentialName(environment)
+			}
+			if err := r.reader().Get(ctx, types.NamespacedName{Namespace: environment.Namespace, Name: name}, child); err == nil {
+				if exactControllerOwner(child, platformv1alpha1.GroupVersion.String(), "Environment", environment.Name, environment.UID) {
+					return false, nil
+				}
+			} else if !apierrors.IsNotFound(err) {
+				return false, fmt.Errorf("prove Environment execution fencing: %w", err)
+			}
+		}
+	}
+	return true, nil
+}
+
+func (r *InstallationIsolationReconciler) trustedAdminNamespaceOwned(ctx context.Context, namespace string) (bool, error) {
+	var current corev1.Namespace
+	if err := r.reader().Get(ctx, types.NamespacedName{Name: namespace}, &current); err != nil {
+		return false, fmt.Errorf("resolve Environment Namespace ownership while fencing installation: %w", err)
+	}
+	if current.UID == "" || !current.DeletionTimestamp.IsZero() {
+		return false, fmt.Errorf("Environment Namespace %q has no stable live identity", namespace)
+	}
+	annotations := current.GetAnnotations()
+	installationNamespace := annotations[tenancy.InstallationNamespaceAnnotation]
+	installationName := annotations[tenancy.InstallationNameAnnotation]
+	installationUID := types.UID(annotations[tenancy.InstallationUIDAnnotation])
+	if installationNamespace == "" || installationName == "" || installationUID == "" {
+		return false, fmt.Errorf("Environment Namespace %q has uncertain Installation ownership", namespace)
+	}
+	if installationNamespace != r.Installation.Key.Namespace || installationName != r.Installation.Key.Name {
+		return false, nil
+	}
+	if installationUID != r.Installation.UID {
+		return false, fmt.Errorf("Environment Namespace %q has uncertain ownership by this Installation", namespace)
+	}
+	return true, nil
+}
+
+func installationExecutionAllowed(ctx context.Context, reader client.Reader, identity tenancy.InstallationIdentity) (bool, error) {
+	if reader == nil || identity.Key.Namespace == "" || identity.Key.Name == "" || identity.UID == "" {
+		return false, stderrors.New("complete installation isolation authority is required")
+	}
+	var installation platformv1alpha1.Installation
+	if err := reader.Get(ctx, identity.Key, &installation); err != nil {
+		return false, fmt.Errorf("revalidate Installation isolation: %w", err)
+	}
+	if installation.UID != identity.UID || !installation.DeletionTimestamp.IsZero() {
+		return false, stderrors.New("Installation isolation identity changed")
+	}
+	if installation.Spec.Isolation == nil {
+		return legacyCompatibleIsolationStatus(installation.Status), nil
+	}
+	if err := isolation.ValidateSelection(installation.Spec.Isolation); err != nil {
+		return false, fmt.Errorf("validate Installation isolation selection: %w", err)
+	}
+	switch installation.Spec.Isolation.Mode {
+	case platformv1alpha1.InstallationIsolationModeUnrestrictedDevelopment:
+		revision, err := (isolation.RevisionInputs{InstallationUID: installation.UID, Selection: *installation.Spec.Isolation}).DeriveRevision()
+		if err != nil {
+			return false, fmt.Errorf("derive Installation isolation revision: %w", err)
+		}
+		if legacyCompatibleIsolationStatus(installation.Status) {
+			return true, nil
+		}
+		ready := apimeta.FindStatusCondition(installation.Status.Conditions, platformv1alpha1.InstallationConditionIsolationReady)
+		return unrestrictedAuthorityMatches(installation.Status, installation.Spec.Isolation, revision) &&
+			ready != nil && ready.Status == metav1.ConditionTrue && ready.Reason == "UnrestrictedDevelopment" && ready.ObservedGeneration == installation.Generation, nil
+	case platformv1alpha1.InstallationIsolationModeRestrictedProductionCalicoV3_32_1:
+		return false, nil
+	default:
+		return false, stderrors.New("unsupported Installation isolation selection")
+	}
+}
+
+func installationIdentity(scope *tenancy.ReconcileScope) (tenancy.InstallationIdentity, bool) {
+	if scope == nil || scope.Verifier == nil {
+		return tenancy.InstallationIdentity{}, false
+	}
+	return scope.Verifier.Installation, true
+}
+
+func (r *InstallationIsolationReconciler) reader() client.Reader {
+	if r.APIReader != nil {
+		return r.APIReader
+	}
+	return r.Client
+}
+
+func (r *InstallationIsolationReconciler) dependencyRequests(_ context.Context, _ client.Object) []reconcile.Request {
+	return []reconcile.Request{{NamespacedName: r.Installation.Key}}
+}
+
+// SetupWithManager registers the exact Installation and all object families
+// whose replacement or mutation can change its observed restricted identity.
+func (r *InstallationIsolationReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.APIReader = mgr.GetAPIReader()
+	mapper := handler.EnqueueRequestsFromMapFunc(r.dependencyRequests)
+	builder := ctrl.NewControllerManagedBy(mgr).
+		For(&platformv1alpha1.Installation{}).
+		Watches(&corev1.ConfigMap{}, mapper).
+		Watches(&nodev1.RuntimeClass{}, mapper).
+		Watches(&storagev1.StorageClass{}, mapper).
+		Watches(&storagev1.CSIDriver{}, mapper)
+	// A scoped install without onboarded Project namespaces has no permitted
+	// Environment informer or execution to fence. Keep its lifecycle controller
+	// active without broadening the system namespace's workload RBAC.
+	if r.Mode != tenancy.ModeScoped || len(r.Namespaces) != 0 {
+		builder = builder.Watches(&platformv1alpha1.Environment{}, mapper)
+	}
+	return builder.Complete(r)
+}

--- a/internal/controllers/installation_isolation_controller.go
+++ b/internal/controllers/installation_isolation_controller.go
@@ -33,7 +33,10 @@ const (
 	isolationResolutionRetryDelay       = 5 * time.Second
 )
 
-var errIsolationDependenciesPending = stderrors.New("restricted isolation dependencies have not been resolved")
+var (
+	errInstallationIsolationBlocked = stderrors.New(installationIsolationBlockedMessage)
+	errIsolationDependenciesPending = stderrors.New("restricted isolation dependencies have not been resolved")
+)
 
 // InstallationIsolationReconciler owns the observed selection lifecycle for
 // the one exact Installation loaded at operator startup. Restricted runtime
@@ -511,6 +514,14 @@ func installationIdentity(scope *tenancy.ReconcileScope) (tenancy.InstallationId
 		return tenancy.InstallationIdentity{}, false
 	}
 	return scope.Verifier.Installation, true
+}
+
+func installationExecutionCurrent(ctx context.Context, reader client.Reader, scope *tenancy.ReconcileScope) (bool, error) {
+	identity, configured := installationIdentity(scope)
+	if !configured {
+		return true, nil
+	}
+	return installationExecutionAllowed(ctx, reader, identity)
 }
 
 func (r *InstallationIsolationReconciler) reader() client.Reader {

--- a/internal/controllers/installation_isolation_controller_test.go
+++ b/internal/controllers/installation_isolation_controller_test.go
@@ -452,6 +452,33 @@ func TestInstallationAPIUncertaintyStillWithdrawsEnvironmentReadiness(t *testing
 	}
 }
 
+func TestBackendCreationSourcesRevalidateInstallationIsolation(t *testing.T) {
+	scheme := isolationTestScheme(t)
+	installation := &platformv1alpha1.Installation{ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "system", UID: "installation-uid"}}
+	environment := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "environment", Namespace: "project", UID: "environment-uid", Generation: 1}}
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(installation, environment).Build()
+	identity := tenancy.InstallationIdentity{Key: client.ObjectKeyFromObject(installation), UID: installation.UID}
+	reconciler := &EnvironmentReconciler{
+		Client: kubeClient, APIReader: kubeClient,
+		Scope: &tenancy.ReconcileScope{Verifier: &tenancy.Verifier{Reader: kubeClient, Installation: identity, Mode: tenancy.ModeScoped}},
+	}
+
+	if current, err := reconciler.backendCreationSourcesCurrent(context.Background(), environment, tenancy.Claim{}); err != nil || !current {
+		t.Fatalf("legacy backend authority = (%t, %v), want current", current, err)
+	}
+	var restricted platformv1alpha1.Installation
+	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(installation), &restricted); err != nil {
+		t.Fatal(err)
+	}
+	restricted.Spec.Isolation = restrictedIsolationSelection()
+	if err := kubeClient.Update(context.Background(), &restricted); err != nil {
+		t.Fatal(err)
+	}
+	if current, err := reconciler.backendCreationSourcesCurrent(context.Background(), environment, tenancy.Claim{}); err != nil || current {
+		t.Fatalf("restricted backend authority = (%t, %v), want fenced", current, err)
+	}
+}
+
 func TestTrustedAdminFenceProofIgnoresForeignInstallationEnvironment(t *testing.T) {
 	installation := &platformv1alpha1.Installation{ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "system", UID: "installation-uid"}}
 	foreignInstallation := &platformv1alpha1.Installation{ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "foreign-system", UID: "foreign-installation-uid"}}

--- a/internal/controllers/installation_isolation_controller_test.go
+++ b/internal/controllers/installation_isolation_controller_test.go
@@ -1,0 +1,590 @@
+package controllers
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	nodev1 "k8s.io/api/node/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	kptr "k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
+	"github.com/Chris-Cullins/swe-platform/internal/egresspolicy"
+	"github.com/Chris-Cullins/swe-platform/internal/isolation"
+	"github.com/Chris-Cullins/swe-platform/internal/tenancy"
+)
+
+func isolationTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{corev1.AddToScheme, networkingv1.AddToScheme, nodev1.AddToScheme, storagev1.AddToScheme, platformv1alpha1.AddToScheme} {
+		if err := add(scheme); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return scheme
+}
+
+func restrictedIsolationSelection() *platformv1alpha1.InstallationIsolationSpec {
+	return &platformv1alpha1.InstallationIsolationSpec{
+		Mode:                platformv1alpha1.InstallationIsolationModeRestrictedProductionCalicoV3_32_1,
+		PolicyConfigMapName: "egress-policy",
+		RuntimeClass:        &platformv1alpha1.InstallationRuntimeClassExpectation{Name: "gvisor", Handler: "runsc"},
+		StorageClass:        &platformv1alpha1.InstallationStorageClassExpectation{Name: "workspace", CSIDriver: "csi.example.com"},
+	}
+}
+
+func restrictedPolicyConfigMap(t *testing.T) *corev1.ConfigMap {
+	t.Helper()
+	config := egresspolicy.Config{
+		APIVersion: egresspolicy.ConfigAPIVersion,
+		Mode:       egresspolicy.ModeRestricted,
+		Ceiling:    []egresspolicy.Hostname{},
+		Baseline:   []egresspolicy.Hostname{},
+		RestrictedProfile: &egresspolicy.RestrictedProfile{
+			Name: egresspolicy.RestrictedProfileCalicoV1, ResolverIPs: []string{"10.96.0.10"},
+			APIServerCIDRs: []string{"10.0.0.1/32"}, PodCIDRs: []string{"10.244.0.0/16"},
+			ServiceCIDRs: []string{"10.96.0.0/12"}, NodeCIDRs: []string{"192.168.0.0/16"},
+			ControlPlaneCIDRs: []string{"172.16.0.0/16"}, AdditionalDeniedCIDRs: []string{},
+		},
+		TLSSecretName: "egress-proxy-tls",
+		ProxyImage:    "registry.example.com/swe/egress-proxy@sha256:" + strings.Repeat("a", 64),
+	}
+	raw, err := json.Marshal(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := sha256.Sum256(raw)
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "egress-policy", Namespace: "system", UID: "policy-uid", Annotations: map[string]string{
+			egresspolicy.ConfigContentSHA256Annotation: hex.EncodeToString(digest[:]),
+		}},
+		Immutable: kptr.To(true),
+		Data:      map[string]string{egresspolicy.ConfigDataKey: string(raw)},
+	}
+}
+
+func restrictedIsolationDependencies(t *testing.T) []client.Object {
+	return []client.Object{
+		restrictedPolicyConfigMap(t),
+		&nodev1.RuntimeClass{ObjectMeta: metav1.ObjectMeta{Name: "gvisor", UID: "runtime-uid"}, Handler: "runsc"},
+		&storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "workspace", UID: "storage-uid"}, Provisioner: "csi.example.com"},
+		&storagev1.CSIDriver{ObjectMeta: metav1.ObjectMeta{Name: "csi.example.com", UID: "csi-uid"}},
+	}
+}
+
+func installationIsolationReconciler(t *testing.T, installation *platformv1alpha1.Installation, objects ...client.Object) (*InstallationIsolationReconciler, client.WithWatch) {
+	t.Helper()
+	all := append([]client.Object{installation}, objects...)
+	kubeClient := fake.NewClientBuilder().WithScheme(isolationTestScheme(t)).WithStatusSubresource(installation, &platformv1alpha1.Environment{}).WithObjects(all...).Build()
+	identity := tenancy.InstallationIdentity{Key: client.ObjectKeyFromObject(installation), UID: installation.UID}
+	return &InstallationIsolationReconciler{Client: kubeClient, APIReader: kubeClient, Installation: identity, Mode: tenancy.ModeScoped, Namespaces: []string{"project"}}, kubeClient
+}
+
+func TestInstallationIsolationLegacyAndUnrestrictedStatus(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		selection  *platformv1alpha1.InstallationIsolationSpec
+		wantState  platformv1alpha1.InstallationIsolationState
+		wantReady  metav1.ConditionStatus
+		wantReason string
+	}{
+		{name: "legacy omission", wantState: platformv1alpha1.InstallationIsolationStateLegacyUnclassified, wantReady: metav1.ConditionFalse, wantReason: "LegacyUnclassified"},
+		{name: "explicit unrestricted development", selection: &platformv1alpha1.InstallationIsolationSpec{Mode: platformv1alpha1.InstallationIsolationModeUnrestrictedDevelopment}, wantState: platformv1alpha1.InstallationIsolationStateActive, wantReady: metav1.ConditionTrue, wantReason: "UnrestrictedDevelopment"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			installation := &platformv1alpha1.Installation{ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "system", UID: "installation-uid", Generation: 2}, Spec: platformv1alpha1.InstallationSpec{Isolation: test.selection}}
+			reconciler, kubeClient := installationIsolationReconciler(t, installation)
+			if result, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(installation)}); err != nil || result != (ctrl.Result{}) {
+				t.Fatalf("Reconcile() = (%#v, %v)", result, err)
+			}
+			var updated platformv1alpha1.Installation
+			if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(installation), &updated); err != nil {
+				t.Fatal(err)
+			}
+			ready := apimeta.FindStatusCondition(updated.Status.Conditions, platformv1alpha1.InstallationConditionIsolationReady)
+			production := apimeta.FindStatusCondition(updated.Status.Conditions, platformv1alpha1.InstallationConditionProductionReady)
+			if updated.Status.IsolationState != test.wantState || ready == nil || ready.Status != test.wantReady || ready.Reason != test.wantReason {
+				t.Fatalf("status = %#v", updated.Status)
+			}
+			if production == nil || production.Status != metav1.ConditionFalse {
+				t.Fatalf("production condition = %#v", production)
+			}
+			if test.selection == nil {
+				if updated.Status.ObservedIsolation != nil || updated.Status.IsolationRevision != "" {
+					t.Fatalf("legacy status published selection identity: %#v", updated.Status)
+				}
+			} else if updated.Status.ObservedIsolation == nil || len(updated.Status.IsolationRevision) != 64 || production.Reason != "UnrestrictedDevelopment" {
+				t.Fatalf("unrestricted status = %#v", updated.Status)
+			}
+		})
+	}
+}
+
+func TestRestrictedInstallationFencesEnvironmentThenSettlesBlocked(t *testing.T) {
+	installation := &platformv1alpha1.Installation{
+		ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "system", UID: "installation-uid", Generation: 2},
+		Spec:       platformv1alpha1.InstallationSpec{Isolation: restrictedIsolationSelection()},
+	}
+	environment := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "warm", Namespace: "project", UID: "environment-uid", Generation: 1, Finalizers: []string{environmentFinalizer}},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: "missing"},
+		Status: platformv1alpha1.EnvironmentStatus{
+			ObservedGeneration: 1, Phase: platformv1alpha1.EnvironmentPhaseReady, PodName: "env-warm",
+			Endpoints:  platformv1alpha1.EnvironmentEndpoints{Sandboxd: "10.0.0.2:50051"},
+			Conditions: []metav1.Condition{{Type: platformv1alpha1.EnvironmentConditionReady, Status: metav1.ConditionTrue, Reason: "SandboxdReady", ObservedGeneration: 1}},
+		},
+	}
+	controller := true
+	owner := metav1.OwnerReference{APIVersion: platformv1alpha1.GroupVersion.String(), Kind: "Environment", Name: environment.Name, UID: environment.UID, Controller: &controller}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: envPodName(environment), Namespace: environment.Namespace, UID: "pod-uid", OwnerReferences: []metav1.OwnerReference{owner}}}
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: envCredentialName(environment), Namespace: environment.Namespace, UID: "secret-uid", OwnerReferences: []metav1.OwnerReference{owner}}}
+	pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: envPVCName(environment), Namespace: environment.Namespace, UID: "pvc-uid", OwnerReferences: []metav1.OwnerReference{owner}}}
+	policy := &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: envNetworkPolicyName(environment), Namespace: environment.Namespace, UID: "network-policy-uid", OwnerReferences: []metav1.OwnerReference{owner}}}
+	objects := append(restrictedIsolationDependencies(t), environment, pod, secret, pvc, policy)
+	reconciler, kubeClient := installationIsolationReconciler(t, installation, objects...)
+	request := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(installation)}
+
+	if result, err := reconciler.Reconcile(context.Background(), request); err != nil || !result.Requeue {
+		t.Fatalf("enter Fencing = (%#v, %v)", result, err)
+	}
+	var fencing platformv1alpha1.Installation
+	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(installation), &fencing); err != nil {
+		t.Fatal(err)
+	}
+	if fencing.Status.IsolationState != platformv1alpha1.InstallationIsolationStateFencing || fencing.Status.IsolationRevision != "" || fencing.Status.PolicyConfigMap != nil || fencing.Status.RuntimeClass != nil || fencing.Status.StorageClass != nil || fencing.Status.CSIDriver != nil {
+		t.Fatalf("initial Fencing status resolved dependencies: %#v", fencing.Status)
+	}
+	if result, err := reconciler.Reconcile(context.Background(), request); err != nil || !result.Requeue {
+		t.Fatalf("resolve dependencies while Fencing = (%#v, %v)", result, err)
+	}
+	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(installation), &fencing); err != nil {
+		t.Fatal(err)
+	}
+	if fencing.Status.IsolationState != platformv1alpha1.InstallationIsolationStateFencing || len(fencing.Status.IsolationRevision) != 64 || fencing.Status.PolicyConfigMap == nil || fencing.Status.RuntimeClass == nil || fencing.Status.StorageClass == nil || fencing.Status.CSIDriver == nil {
+		t.Fatalf("Fencing status lacks resolved identity: %#v", fencing.Status)
+	}
+
+	environmentReconciler := &EnvironmentReconciler{
+		Client: kubeClient, APIReader: kubeClient,
+		Scope: &tenancy.ReconcileScope{Verifier: &tenancy.Verifier{Installation: reconciler.Installation}},
+	}
+	for step := 0; step < 4; step++ {
+		var current platformv1alpha1.Environment
+		if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(environment), &current); err != nil {
+			t.Fatal(err)
+		}
+		outcome := reconcileEnvironmentInstallationIsolationGate(environmentReconciler, context.Background(), &environmentReconcileState{env: current})
+		if !outcome.handled || outcome.err != nil {
+			t.Fatalf("environment fence step %d = %#v", step, outcome)
+		}
+		if step == 0 {
+			if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(pod), &corev1.Pod{}); err != nil {
+				t.Fatal("Pod was deleted before readiness withdrawal")
+			}
+		}
+	}
+
+	if result, err := reconciler.Reconcile(context.Background(), request); err != nil || !result.Requeue {
+		t.Fatalf("publish Blocked = (%#v, %v)", result, err)
+	}
+	if result, err := reconciler.Reconcile(context.Background(), request); err != nil || result != (ctrl.Result{}) {
+		t.Fatalf("stable Blocked = (%#v, %v)", result, err)
+	}
+	var blocked platformv1alpha1.Installation
+	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(installation), &blocked); err != nil {
+		t.Fatal(err)
+	}
+	ready := apimeta.FindStatusCondition(blocked.Status.Conditions, platformv1alpha1.InstallationConditionIsolationReady)
+	if blocked.Status.IsolationState != platformv1alpha1.InstallationIsolationStateBlocked || ready == nil || ready.Status != metav1.ConditionFalse || ready.Reason != "RuntimeActivationUnavailable" {
+		t.Fatalf("blocked status = %#v", blocked.Status)
+	}
+	var fencedEnvironment platformv1alpha1.Environment
+	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(environment), &fencedEnvironment); err != nil {
+		t.Fatal(err)
+	}
+	environmentReady := apimeta.FindStatusCondition(fencedEnvironment.Status.Conditions, platformv1alpha1.EnvironmentConditionReady)
+	if fencedEnvironment.Status.Phase != platformv1alpha1.EnvironmentPhaseFailed || environmentReady == nil || environmentReady.Reason != "InvalidConfiguration" || environmentReady.Message != installationIsolationBlockedMessage {
+		t.Fatalf("fenced Environment status = %#v", fencedEnvironment.Status)
+	}
+	for _, removed := range []client.Object{pod, secret} {
+		if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(removed), removed); !apierrors.IsNotFound(err) {
+			t.Fatalf("execution child %T remains: %v", removed, err)
+		}
+	}
+	for _, retained := range []client.Object{pvc, policy} {
+		if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(retained), retained); err != nil {
+			t.Fatalf("retained child %T was removed: %v", retained, err)
+		}
+	}
+}
+
+func TestRestrictedSelectionPublishesFencingBeforeDependencyReads(t *testing.T) {
+	unrestricted := &platformv1alpha1.InstallationIsolationSpec{Mode: platformv1alpha1.InstallationIsolationModeUnrestrictedDevelopment}
+	revision, err := (isolation.RevisionInputs{InstallationUID: "installation-uid", Selection: *unrestricted}).DeriveRevision()
+	if err != nil {
+		t.Fatal(err)
+	}
+	installation := &platformv1alpha1.Installation{
+		ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "system", UID: "installation-uid", Generation: 2},
+		Spec:       platformv1alpha1.InstallationSpec{Isolation: restrictedIsolationSelection()},
+		Status: platformv1alpha1.InstallationStatus{
+			IsolationState:    platformv1alpha1.InstallationIsolationStateActive,
+			ObservedIsolation: unrestricted,
+			IsolationRevision: revision.String(),
+			Conditions: []metav1.Condition{{
+				Type: platformv1alpha1.InstallationConditionIsolationReady, Status: metav1.ConditionTrue,
+				Reason: "UnrestrictedDevelopment", ObservedGeneration: 1,
+			}},
+		},
+	}
+	scheme := isolationTestScheme(t)
+	base := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(installation).WithObjects(installation).Build()
+	dependencyReads := 0
+	reader := interceptor.NewClient(base, interceptor.Funcs{Get: func(ctx context.Context, delegate client.WithWatch, key client.ObjectKey, object client.Object, options ...client.GetOption) error {
+		switch object.(type) {
+		case *corev1.ConfigMap, *nodev1.RuntimeClass, *storagev1.StorageClass, *storagev1.CSIDriver:
+			dependencyReads++
+			return errors.New("dependency reader must not run before Fencing")
+		default:
+			return delegate.Get(ctx, key, object, options...)
+		}
+	}})
+	reconciler := &InstallationIsolationReconciler{
+		Client: base, APIReader: reader,
+		Installation: tenancy.InstallationIdentity{Key: client.ObjectKeyFromObject(installation), UID: installation.UID},
+		Mode:         tenancy.ModeScoped, Namespaces: []string{"project"},
+	}
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(installation)})
+	if err != nil || !result.Requeue || dependencyReads != 0 {
+		t.Fatalf("first restricted reconcile = (%#v, %v), dependency reads = %d", result, err, dependencyReads)
+	}
+	var updated platformv1alpha1.Installation
+	if err := base.Get(context.Background(), client.ObjectKeyFromObject(installation), &updated); err != nil {
+		t.Fatal(err)
+	}
+	if updated.Status.IsolationState != platformv1alpha1.InstallationIsolationStateFencing || !apiequality.Semantic.DeepEqual(updated.Status.ObservedIsolation, installation.Spec.Isolation) || updated.Status.IsolationRevision != "" || updated.Status.PolicyConfigMap != nil || updated.Status.RuntimeClass != nil || updated.Status.StorageClass != nil || updated.Status.CSIDriver != nil {
+		t.Fatalf("initial restricted status = %#v", updated.Status)
+	}
+}
+
+func convergeRestrictedInstallationBlocked(t *testing.T, reconciler *InstallationIsolationReconciler, installation *platformv1alpha1.Installation, kubeClient client.Client) platformv1alpha1.Installation {
+	t.Helper()
+	request := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(installation)}
+	for step := 0; step < 3; step++ {
+		result, err := reconciler.Reconcile(context.Background(), request)
+		if err != nil {
+			t.Fatalf("restricted convergence step %d: %v", step, err)
+		}
+		if step < 2 && !result.Requeue {
+			t.Fatalf("restricted convergence step %d = %#v", step, result)
+		}
+	}
+	var blocked platformv1alpha1.Installation
+	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(installation), &blocked); err != nil {
+		t.Fatal(err)
+	}
+	if blocked.Status.IsolationState != platformv1alpha1.InstallationIsolationStateBlocked || blocked.Status.RuntimeClass == nil || blocked.Status.IsolationRevision == "" {
+		t.Fatalf("restricted Installation did not converge Blocked: %#v", blocked.Status)
+	}
+	return blocked
+}
+
+func TestBlockedRestrictedDependencyAuthorityChangesReenterFencing(t *testing.T) {
+	t.Run("RuntimeClass UID replacement", func(t *testing.T) {
+		installation := &platformv1alpha1.Installation{ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "system", UID: "installation-uid", Generation: 1}, Spec: platformv1alpha1.InstallationSpec{Isolation: restrictedIsolationSelection()}}
+		dependencies := restrictedIsolationDependencies(t)
+		reconciler, kubeClient := installationIsolationReconciler(t, installation, dependencies...)
+		blocked := convergeRestrictedInstallationBlocked(t, reconciler, installation, kubeClient)
+		oldRevision := blocked.Status.IsolationRevision
+
+		var old nodev1.RuntimeClass
+		if err := kubeClient.Get(context.Background(), types.NamespacedName{Name: "gvisor"}, &old); err != nil {
+			t.Fatal(err)
+		}
+		if err := kubeClient.Delete(context.Background(), &old); err != nil {
+			t.Fatal(err)
+		}
+		replacement := old.DeepCopy()
+		replacement.ResourceVersion = ""
+		replacement.UID = "runtime-uid-2"
+		if err := kubeClient.Create(context.Background(), replacement); err != nil {
+			t.Fatal(err)
+		}
+
+		request := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(installation)}
+		if result, err := reconciler.Reconcile(context.Background(), request); err != nil || !result.Requeue {
+			t.Fatalf("replacement reconcile = (%#v, %v)", result, err)
+		}
+		var fencing platformv1alpha1.Installation
+		if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(installation), &fencing); err != nil {
+			t.Fatal(err)
+		}
+		if fencing.Status.IsolationState != platformv1alpha1.InstallationIsolationStateFencing || fencing.Status.RuntimeClass == nil || fencing.Status.RuntimeClass.UID != replacement.UID || fencing.Status.IsolationRevision == oldRevision {
+			t.Fatalf("replacement did not reenter Fencing with new authority: %#v", fencing.Status)
+		}
+		if _, err := reconciler.Reconcile(context.Background(), request); err != nil {
+			t.Fatal(err)
+		}
+		if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(installation), &blocked); err != nil {
+			t.Fatal(err)
+		}
+		if blocked.Status.IsolationState != platformv1alpha1.InstallationIsolationStateBlocked || blocked.Status.RuntimeClass == nil || blocked.Status.RuntimeClass.UID != replacement.UID {
+			t.Fatalf("replacement did not settle Blocked after Fencing: %#v", blocked.Status)
+		}
+	})
+
+	t.Run("dependency read uncertainty", func(t *testing.T) {
+		installation := &platformv1alpha1.Installation{ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "system", UID: "installation-uid", Generation: 1}, Spec: platformv1alpha1.InstallationSpec{Isolation: restrictedIsolationSelection()}}
+		reconciler, kubeClient := installationIsolationReconciler(t, installation, restrictedIsolationDependencies(t)...)
+		convergeRestrictedInstallationBlocked(t, reconciler, installation, kubeClient)
+		reconciler.APIReader = interceptor.NewClient(kubeClient, interceptor.Funcs{Get: func(ctx context.Context, delegate client.WithWatch, key client.ObjectKey, object client.Object, options ...client.GetOption) error {
+			if _, ok := object.(*nodev1.RuntimeClass); ok {
+				return errors.New("temporary RuntimeClass read failure")
+			}
+			return delegate.Get(ctx, key, object, options...)
+		}})
+
+		request := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(installation)}
+		if result, err := reconciler.Reconcile(context.Background(), request); err != nil || !result.Requeue {
+			t.Fatalf("uncertain dependency reconcile = (%#v, %v)", result, err)
+		}
+		var fencing platformv1alpha1.Installation
+		if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(installation), &fencing); err != nil {
+			t.Fatal(err)
+		}
+		if fencing.Status.IsolationState != platformv1alpha1.InstallationIsolationStateFencing || fencing.Status.IsolationRevision != "" || fencing.Status.RuntimeClass != nil {
+			t.Fatalf("uncertain dependency did not clear authority through Fencing: %#v", fencing.Status)
+		}
+		if _, err := reconciler.Reconcile(context.Background(), request); err != nil {
+			t.Fatal(err)
+		}
+		var blocked platformv1alpha1.Installation
+		if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(installation), &blocked); err != nil {
+			t.Fatal(err)
+		}
+		if blocked.Status.IsolationState != platformv1alpha1.InstallationIsolationStateBlocked || blocked.Status.IsolationRevision != "" || blocked.Status.RuntimeClass != nil {
+			t.Fatalf("uncertain dependency did not settle Blocked after Fencing: %#v", blocked.Status)
+		}
+	})
+}
+
+func TestRestrictedDependencyMismatchFailsClosedWithoutObservedIdentity(t *testing.T) {
+	installation := &platformv1alpha1.Installation{
+		ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "system", UID: "installation-uid", Generation: 1},
+		Spec:       platformv1alpha1.InstallationSpec{Isolation: restrictedIsolationSelection()},
+	}
+	dependencies := restrictedIsolationDependencies(t)
+	dependencies[1].(*nodev1.RuntimeClass).Handler = "other"
+	reconciler, kubeClient := installationIsolationReconciler(t, installation, dependencies...)
+	request := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(installation)}
+	if result, err := reconciler.Reconcile(context.Background(), request); err != nil || !result.Requeue {
+		t.Fatalf("enter Fencing = (%#v, %v)", result, err)
+	}
+	if result, err := reconciler.Reconcile(context.Background(), request); err != nil || !result.Requeue {
+		t.Fatalf("publish dependency failure = (%#v, %v)", result, err)
+	}
+	if result, err := reconciler.Reconcile(context.Background(), request); err != nil || result.RequeueAfter != isolationResolutionRetryDelay {
+		t.Fatalf("settle dependency failure = (%#v, %v)", result, err)
+	}
+	var blocked platformv1alpha1.Installation
+	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(installation), &blocked); err != nil {
+		t.Fatal(err)
+	}
+	dependenciesResolved := apimeta.FindStatusCondition(blocked.Status.Conditions, platformv1alpha1.InstallationConditionIsolationDependenciesResolved)
+	ready := apimeta.FindStatusCondition(blocked.Status.Conditions, platformv1alpha1.InstallationConditionIsolationReady)
+	if blocked.Status.IsolationState != platformv1alpha1.InstallationIsolationStateBlocked || blocked.Status.IsolationRevision != "" || blocked.Status.PolicyConfigMap != nil || blocked.Status.RuntimeClass != nil || blocked.Status.StorageClass != nil || blocked.Status.CSIDriver != nil || dependenciesResolved == nil || dependenciesResolved.Reason != "DependencyResolutionFailed" || ready == nil || ready.Reason != "RuntimeActivationUnavailable" {
+		t.Fatalf("dependency mismatch status = %#v", blocked.Status)
+	}
+	allowed, err := installationExecutionAllowed(context.Background(), kubeClient, reconciler.Installation)
+	if err != nil || allowed {
+		t.Fatalf("restricted selection allowed execution = %t, %v", allowed, err)
+	}
+}
+
+func TestInstallationAPIUncertaintyStillWithdrawsEnvironmentReadiness(t *testing.T) {
+	installation := &platformv1alpha1.Installation{ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "system", UID: "installation-uid"}}
+	environment := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "env", Namespace: "project", UID: "environment-uid", Generation: 1, Finalizers: []string{environmentFinalizer}},
+		Status: platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhaseReady, PodName: "env-env", Endpoints: platformv1alpha1.EnvironmentEndpoints{Sandboxd: "10.0.0.1:50051"},
+			Conditions: []metav1.Condition{{Type: platformv1alpha1.EnvironmentConditionReady, Status: metav1.ConditionTrue, Reason: "SandboxdReady"}}},
+	}
+	scheme := isolationTestScheme(t)
+	base := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(environment).WithObjects(installation, environment).Build()
+	uncertain := interceptor.NewClient(base, interceptor.Funcs{Get: func(ctx context.Context, delegate client.WithWatch, key client.ObjectKey, object client.Object, options ...client.GetOption) error {
+		if _, ok := object.(*platformv1alpha1.Installation); ok {
+			return errors.New("temporary API failure")
+		}
+		return delegate.Get(ctx, key, object, options...)
+	}})
+	reconciler := &EnvironmentReconciler{
+		Client: base, APIReader: uncertain,
+		Scope: &tenancy.ReconcileScope{Verifier: &tenancy.Verifier{Installation: tenancy.InstallationIdentity{Key: client.ObjectKeyFromObject(installation), UID: installation.UID}}},
+	}
+	outcome := reconcileEnvironmentInstallationIsolationGate(reconciler, context.Background(), &environmentReconcileState{env: *environment.DeepCopy()})
+	if !outcome.handled || outcome.err != nil || !outcome.result.Requeue {
+		t.Fatalf("uncertain isolation gate = %#v", outcome)
+	}
+	var updated platformv1alpha1.Environment
+	if err := base.Get(context.Background(), client.ObjectKeyFromObject(environment), &updated); err != nil {
+		t.Fatal(err)
+	}
+	ready := apimeta.FindStatusCondition(updated.Status.Conditions, platformv1alpha1.EnvironmentConditionReady)
+	if ready == nil || ready.Status != metav1.ConditionFalse || ready.Reason != "InvalidConfiguration" || updated.Status.PodName != "" || updated.Status.Endpoints.Sandboxd != "" {
+		t.Fatalf("API uncertainty did not withdraw readiness: %#v", updated.Status)
+	}
+}
+
+func TestTrustedAdminFenceProofIgnoresForeignInstallationEnvironment(t *testing.T) {
+	installation := &platformv1alpha1.Installation{ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "system", UID: "installation-uid"}}
+	foreignInstallation := &platformv1alpha1.Installation{ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "foreign-system", UID: "foreign-installation-uid"}}
+	ownNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "own-project", UID: "own-namespace-uid", Annotations: map[string]string{
+		tenancy.InstallationNamespaceAnnotation: installation.Namespace,
+		tenancy.InstallationNameAnnotation:      installation.Name,
+		tenancy.InstallationUIDAnnotation:       string(installation.UID),
+	}}}
+	foreignNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "foreign-project", UID: "foreign-namespace-uid", Annotations: map[string]string{
+		tenancy.InstallationNamespaceAnnotation: foreignInstallation.Namespace,
+		tenancy.InstallationNameAnnotation:      foreignInstallation.Name,
+		tenancy.InstallationUIDAnnotation:       string(foreignInstallation.UID),
+	}}}
+	readyStatus := platformv1alpha1.EnvironmentStatus{
+		Phase: platformv1alpha1.EnvironmentPhaseReady, PodName: "env-ready", Endpoints: platformv1alpha1.EnvironmentEndpoints{Sandboxd: "10.0.0.1:50051"},
+		Conditions: []metav1.Condition{{Type: platformv1alpha1.EnvironmentConditionReady, Status: metav1.ConditionTrue, Reason: "SandboxdReady"}},
+	}
+	ownEnvironment := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "own", Namespace: ownNamespace.Name, UID: "own-environment-uid"}, Status: readyStatus}
+	foreignEnvironment := &platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "foreign", Namespace: foreignNamespace.Name, UID: "foreign-environment-uid"}, Status: readyStatus}
+	scheme := isolationTestScheme(t)
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(installation, foreignInstallation, ownEnvironment, foreignEnvironment).WithObjects(installation, foreignInstallation, ownNamespace, foreignNamespace, ownEnvironment, foreignEnvironment).Build()
+	reconciler := &InstallationIsolationReconciler{
+		Client: kubeClient, APIReader: kubeClient,
+		Installation: tenancy.InstallationIdentity{Key: client.ObjectKeyFromObject(installation), UID: installation.UID},
+		Mode:         tenancy.ModeTrustedAdmin,
+	}
+
+	if fenced, err := reconciler.allEnvironmentExecutionsFenced(context.Background()); err != nil || fenced {
+		t.Fatalf("own Ready Environment fence proof = %t, %v", fenced, err)
+	}
+	if err := kubeClient.Delete(context.Background(), ownEnvironment); err != nil {
+		t.Fatal(err)
+	}
+	if fenced, err := reconciler.allEnvironmentExecutionsFenced(context.Background()); err != nil || !fenced {
+		t.Fatalf("foreign Ready Environment affected this Installation fence proof = %t, %v", fenced, err)
+	}
+}
+
+func TestRestrictedBlockedToUnrestrictedFencesBeforeActive(t *testing.T) {
+	installation := &platformv1alpha1.Installation{ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "system", UID: "installation-uid", Generation: 1}, Spec: platformv1alpha1.InstallationSpec{Isolation: restrictedIsolationSelection()}}
+	reconciler, kubeClient := installationIsolationReconciler(t, installation, restrictedIsolationDependencies(t)...)
+	convergeRestrictedInstallationBlocked(t, reconciler, installation, kubeClient)
+
+	var current platformv1alpha1.Installation
+	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(installation), &current); err != nil {
+		t.Fatal(err)
+	}
+	current.Spec.Isolation = &platformv1alpha1.InstallationIsolationSpec{Mode: platformv1alpha1.InstallationIsolationModeUnrestrictedDevelopment}
+	current.Generation++
+	if err := kubeClient.Update(context.Background(), &current); err != nil {
+		t.Fatal(err)
+	}
+	if allowed, err := installationExecutionAllowed(context.Background(), kubeClient, reconciler.Installation); err != nil || allowed {
+		t.Fatalf("restricted status reopened from unrestricted spec = %t, %v", allowed, err)
+	}
+
+	request := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(installation)}
+	if result, err := reconciler.Reconcile(context.Background(), request); err != nil || !result.Requeue {
+		t.Fatalf("unrestricted Fencing transition = (%#v, %v)", result, err)
+	}
+	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(installation), &current); err != nil {
+		t.Fatal(err)
+	}
+	if current.Status.IsolationState != platformv1alpha1.InstallationIsolationStateFencing || current.Status.ObservedIsolation == nil || current.Status.ObservedIsolation.Mode != platformv1alpha1.InstallationIsolationModeUnrestrictedDevelopment {
+		t.Fatalf("unrestricted transition skipped Fencing: %#v", current.Status)
+	}
+	if allowed, err := installationExecutionAllowed(context.Background(), kubeClient, reconciler.Installation); err != nil || allowed {
+		t.Fatalf("unrestricted Fencing permitted execution = %t, %v", allowed, err)
+	}
+
+	if result, err := reconciler.Reconcile(context.Background(), request); err != nil || !result.Requeue {
+		t.Fatalf("unrestricted Active transition = (%#v, %v)", result, err)
+	}
+	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(installation), &current); err != nil {
+		t.Fatal(err)
+	}
+	if current.Status.IsolationState != platformv1alpha1.InstallationIsolationStateActive {
+		t.Fatalf("unrestricted transition did not become Active: %#v", current.Status)
+	}
+	if allowed, err := installationExecutionAllowed(context.Background(), kubeClient, reconciler.Installation); err != nil || !allowed {
+		t.Fatalf("current unrestricted Active authority denied execution = %t, %v", allowed, err)
+	}
+}
+
+func TestLegacyUnclassifiedDevelopmentAdoptionDoesNotFence(t *testing.T) {
+	installation := &platformv1alpha1.Installation{
+		ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "system", UID: "installation-uid", Generation: 2},
+		Spec:       platformv1alpha1.InstallationSpec{Isolation: &platformv1alpha1.InstallationIsolationSpec{Mode: platformv1alpha1.InstallationIsolationModeUnrestrictedDevelopment}},
+		Status:     platformv1alpha1.InstallationStatus{IsolationState: platformv1alpha1.InstallationIsolationStateLegacyUnclassified},
+	}
+	reconciler, kubeClient := installationIsolationReconciler(t, installation)
+	if allowed, err := installationExecutionAllowed(context.Background(), kubeClient, reconciler.Installation); err != nil || !allowed {
+		t.Fatalf("LegacyUnclassified development adoption changed behavior = %t, %v", allowed, err)
+	}
+	if result, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(installation)}); err != nil || result != (ctrl.Result{}) {
+		t.Fatalf("LegacyUnclassified development adoption = (%#v, %v)", result, err)
+	}
+	var active platformv1alpha1.Installation
+	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(installation), &active); err != nil {
+		t.Fatal(err)
+	}
+	if active.Status.IsolationState != platformv1alpha1.InstallationIsolationStateActive {
+		t.Fatalf("LegacyUnclassified development adoption did not become Active: %#v", active.Status)
+	}
+}
+
+func TestIsolationDependencyMapperTargetsOnlyConfiguredInstallation(t *testing.T) {
+	reconciler := &InstallationIsolationReconciler{Installation: tenancy.InstallationIdentity{Key: types.NamespacedName{Namespace: "system", Name: "main"}, UID: "uid"}}
+	requests := reconciler.dependencyRequests(context.Background(), &storagev1.CSIDriver{})
+	if len(requests) != 1 || requests[0].NamespacedName != reconciler.Installation.Key {
+		t.Fatalf("dependency requests = %#v", requests)
+	}
+}
+
+func TestInstallationWatchMappersWakeEveryEnvironmentAndWarmPool(t *testing.T) {
+	scheme := isolationTestScheme(t)
+	installation := &platformv1alpha1.Installation{ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "system"}}
+	environments := []client.Object{
+		&platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "one", Namespace: "project-a"}},
+		&platformv1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "two", Namespace: "project-b"}},
+	}
+	templates := []client.Object{
+		&platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: "project-a"}},
+		&platformv1alpha1.EnvironmentTemplate{ObjectMeta: metav1.ObjectMeta{Name: "large", Namespace: "project-b"}},
+	}
+	objects := append(environments, templates...)
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	environmentReconciler := &EnvironmentReconciler{Client: kubeClient}
+	warmPoolReconciler := &WarmPoolReconciler{Client: kubeClient}
+	if requests := environmentReconciler.installationIsolationRequests(context.Background(), installation); len(requests) != 2 {
+		t.Fatalf("Installation Environment requests = %#v", requests)
+	}
+	if requests := warmPoolReconciler.installationTemplateRequests(context.Background(), installation); len(requests) != 2 {
+		t.Fatalf("Installation Template requests = %#v", requests)
+	}
+}

--- a/internal/controllers/run_controller.go
+++ b/internal/controllers/run_controller.go
@@ -2049,10 +2049,18 @@ func (r *RunReconciler) adapterAcceptanceSandbox(run *platformv1alpha1.Run, env 
 	dialProcess := sandbox.DialProcess
 	sandbox.DialProcess = func(ctx context.Context) (sandboxdv1.ProcessServiceClient, func() error, error) {
 		// Acceptance can start a new process and deliver launch-only credentials.
-		// Revalidate at the process boundary so an active reconcile cannot start
-		// work after Project offboarding has revoked the active Namespace claim.
+		// Revalidate both authorities at the process boundary so an active
+		// reconcile cannot start work after Project offboarding or installation
+		// isolation has revoked execution authority.
 		if _, err := r.Scope.Revalidate(ctx, run.Namespace, tenancy.LifecycleActive); err != nil {
 			return nil, nil, err
+		}
+		allowed, err := installationExecutionCurrent(ctx, r.apiReader(), r.Scope)
+		if err != nil {
+			return nil, nil, err
+		}
+		if !allowed {
+			return nil, nil, errInstallationIsolationBlocked
 		}
 		return dialProcess(ctx)
 	}
@@ -2080,6 +2088,10 @@ func (r *RunReconciler) resolveAllocatedExecution(ctx context.Context, run *plat
 	}
 	if !environmentReachable(current) {
 		return sandboxclient.Execution{}, false, nil
+	}
+	allowed, err := installationExecutionCurrent(ctx, r.apiReader(), r.Scope)
+	if err != nil || !allowed {
+		return sandboxclient.Execution{}, false, err
 	}
 	execution, err := r.connector().ResolveExecution(ctx, fence)
 	if err != nil {
@@ -2110,6 +2122,10 @@ func (r *RunReconciler) allocatedExecutionCurrent(ctx context.Context, run *plat
 	}
 	if !environmentReachable(current) {
 		return false, nil
+	}
+	allowed, err := installationExecutionCurrent(ctx, r.apiReader(), r.Scope)
+	if err != nil || !allowed {
+		return false, err
 	}
 	currentExecution, err := r.connector().ExecutionCurrent(ctx, fence, execution)
 	if errors.Is(err, lifecycle.ErrExecutionFenceChanged) {

--- a/internal/controllers/run_controller_test.go
+++ b/internal/controllers/run_controller_test.go
@@ -1143,12 +1143,14 @@ type blockingObserveAdapter struct {
 }
 
 type fencingDialAdapter struct {
-	mutate func()
+	mutate  func()
+	dialErr error
 }
 
 func (a *fencingDialAdapter) EnsureAccepted(ctx context.Context, _ agent.AdapterTask, sandbox agent.AdapterSandbox, _ *agent.AdapterLaunchMaterial) error {
 	a.mutate()
 	_, _, err := sandbox.DialProcess(ctx)
+	a.dialErr = err
 	return err
 }
 
@@ -4183,6 +4185,74 @@ func TestAdapterAcceptanceDialRevalidatesActiveTenancyClaim(t *testing.T) {
 	}
 	if !retained.Spec.Cancel {
 		t.Fatal("offboarding cancellation was blocked by the acceptance fence")
+	}
+}
+
+func TestAdapterAcceptanceDialRevalidatesInstallationIsolation(t *testing.T) {
+	installation := &platformv1alpha1.Installation{ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "system", UID: "installation-uid"}}
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns", UID: "namespace-uid", Annotations: map[string]string{
+		tenancy.InstallationNamespaceAnnotation: "system",
+		tenancy.InstallationNameAnnotation:      "main",
+		tenancy.InstallationUIDAnnotation:       "installation-uid",
+		tenancy.ProjectNameAnnotation:           "project",
+		tenancy.ProjectUIDAnnotation:            "project-uid",
+		tenancy.LifecycleAnnotation:             string(tenancy.LifecycleActive),
+	}}}
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "project", Namespace: "ns", UID: "project-uid"}}
+	run := &platformv1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns", UID: "run-uid", Finalizers: []string{runFinalizer}},
+		Spec:       platformv1alpha1.RunSpec{Agent: "test"},
+		Status: platformv1alpha1.RunStatus{
+			State:          platformv1alpha1.RunStateEnvironmentReady,
+			EnvironmentRef: &platformv1alpha1.RunEnvironmentReference{Name: "env", UID: "env-uid", Ownership: platformv1alpha1.EnvironmentOwnershipOwned},
+			Conditions:     []metav1.Condition{{Type: runConditionAdapterAcceptanceAttempted, Status: metav1.ConditionTrue, Reason: "AcceptancePending"}},
+		},
+	}
+	env := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "env", Namespace: "ns", UID: "env-uid"},
+		Status:     platformv1alpha1.EnvironmentStatus{Phase: platformv1alpha1.EnvironmentPhaseReady},
+	}
+	adapter := &fencingDialAdapter{}
+	r := reconciler(t, adapter, installation, namespace, project, run, env)
+	baseClient := r.Client
+	identity := tenancy.InstallationIdentity{Key: client.ObjectKeyFromObject(installation), UID: installation.UID}
+	verifier := &tenancy.Verifier{Reader: baseClient, Installation: identity, Mode: tenancy.ModeScoped}
+	r.Scope = &tenancy.ReconcileScope{Verifier: verifier}
+	r.Client = tenancy.GuardedClient{Client: baseClient, Verifier: verifier}
+	adapter.mutate = func() {
+		var current platformv1alpha1.Installation
+		if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(installation), &current); err != nil {
+			t.Fatal(err)
+		}
+		current.Spec.Isolation = restrictedIsolationSelection()
+		if err := baseClient.Update(context.Background(), &current); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)})
+	if err != nil || !result.Requeue {
+		t.Fatalf("acceptance reconcile after restricted selection = (%#v, %v), want clean requeue", result, err)
+	}
+	if !errors.Is(adapter.dialErr, errInstallationIsolationBlocked) {
+		t.Fatalf("acceptance process dial error = %v, want installation isolation fence", adapter.dialErr)
+	}
+	var retained platformv1alpha1.Run
+	if err := baseClient.Get(context.Background(), client.ObjectKeyFromObject(run), &retained); err != nil {
+		t.Fatal(err)
+	}
+	if !acceptanceAttempted(&retained) || runAccepted(&retained) {
+		t.Fatalf("installation fence lost conservative marker or published acceptance: %#v", retained.Status.Conditions)
+	}
+
+	adapter.mutate = func() { t.Fatal("adapter acceptance ran while installation isolation was already blocked") }
+	adapter.dialErr = nil
+	result, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)})
+	if err != nil || !result.Requeue {
+		t.Fatalf("acceptance reconcile with restricted selection = (%#v, %v), want clean requeue", result, err)
+	}
+	if adapter.dialErr != nil {
+		t.Fatalf("blocked acceptance reached process dial: %v", adapter.dialErr)
 	}
 }
 

--- a/internal/controllers/warmpool_controller.go
+++ b/internal/controllers/warmpool_controller.go
@@ -50,7 +50,7 @@ func (r *WarmPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if tenancy.IsCatalogSource(&tmpl) {
 		return ctrl.Result{}, nil
 	}
-	ctx, claim, err := r.Scope.Begin(ctx, tmpl.Namespace, tenancy.LifecycleActive)
+	ctx, claim, err := r.Scope.Begin(ctx, tmpl.Namespace, tenancy.LifecycleActive, tenancy.LifecycleFencing)
 	if err != nil {
 		if stderrors.Is(err, tenancy.ErrOutOfScope) {
 			return ctrl.Result{}, nil
@@ -82,6 +82,9 @@ func (r *WarmPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			}
 			return ctrl.Result{}, isolationErr
 		}
+	}
+	if claim.Lifecycle != tenancy.LifecycleActive {
+		return ctrl.Result{}, nil
 	}
 
 	minimum := int32(0)

--- a/internal/controllers/warmpool_controller.go
+++ b/internal/controllers/warmpool_controller.go
@@ -62,6 +62,27 @@ func (r *WarmPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			return ctrl.Result{}, err
 		}
 	}
+	if identity, configured := installationIdentity(r.Scope); configured {
+		allowed, isolationErr := installationExecutionAllowed(ctx, r.reader(), identity)
+		if !allowed {
+			if tmpl.Status.WarmPoolReady != 0 {
+				if current, err := r.templateCurrent(ctx, &tmpl); err != nil {
+					return ctrl.Result{}, err
+				} else if !current {
+					return ctrl.Result{Requeue: true}, nil
+				}
+				before := tmpl.DeepCopy()
+				tmpl.Status.WarmPoolReady = 0
+				if err := r.Status().Patch(ctx, &tmpl, client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{})); apierrors.IsConflict(err) || apierrors.IsNotFound(err) {
+					return ctrl.Result{Requeue: true}, nil
+				} else if err != nil {
+					return ctrl.Result{}, fmt.Errorf("clear isolation-blocked warm pool status: %w", err)
+				}
+				return ctrl.Result{Requeue: true}, nil
+			}
+			return ctrl.Result{}, isolationErr
+		}
+	}
 
 	minimum := int32(0)
 	if tmpl.Spec.WarmPool != nil {
@@ -282,19 +303,22 @@ func warmPoolUnusableSince(env *platformv1alpha1.Environment) (time.Time, bool) 
 }
 
 func (r *WarmPoolReconciler) templateCurrent(ctx context.Context, observed *platformv1alpha1.EnvironmentTemplate) (bool, error) {
-	reader := r.APIReader
-	if reader == nil {
-		// Unit tests construct reconcilers without a manager. Production always
-		// installs the uncached API reader in SetupWithManager.
-		reader = r.Client
-	}
 	var current platformv1alpha1.EnvironmentTemplate
-	if err := reader.Get(ctx, client.ObjectKeyFromObject(observed), &current); apierrors.IsNotFound(err) {
+	if err := r.reader().Get(ctx, client.ObjectKeyFromObject(observed), &current); apierrors.IsNotFound(err) {
 		return false, nil
 	} else if err != nil {
 		return false, fmt.Errorf("revalidate environment template: %w", err)
 	}
 	return current.UID == observed.UID && current.Generation == observed.Generation && current.DeletionTimestamp.IsZero(), nil
+}
+
+func (r *WarmPoolReconciler) reader() client.Reader {
+	if r.APIReader != nil {
+		return r.APIReader
+	}
+	// Unit tests construct reconcilers without a manager. Production always
+	// installs the uncached API reader in SetupWithManager.
+	return r.Client
 }
 
 func warmPoolTemplateRequests(object client.Object) []reconcile.Request {
@@ -315,6 +339,18 @@ func warmPoolTemplateRequests(object client.Object) []reconcile.Request {
 	return requests
 }
 
+func (r *WarmPoolReconciler) installationTemplateRequests(ctx context.Context, _ client.Object) []reconcile.Request {
+	var templates platformv1alpha1.EnvironmentTemplateList
+	if err := r.List(ctx, &templates); err != nil {
+		return nil
+	}
+	requests := make([]reconcile.Request, 0, len(templates.Items))
+	for i := range templates.Items {
+		requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&templates.Items[i])})
+	}
+	return requests
+}
+
 // SetupWithManager registers the warm-pool controller with the manager.
 func (r *WarmPoolReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.APIReader = mgr.GetAPIReader()
@@ -329,6 +365,7 @@ func (r *WarmPoolReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			new, ok2 := e.ObjectNew.(*platformv1alpha1.Environment)
 			return !ok1 || !ok2 || warmPoolRelevantEnvironmentUpdate(old, new)
 		}})).
+		Watches(&platformv1alpha1.Installation{}, handler.EnqueueRequestsFromMapFunc(r.installationTemplateRequests)).
 		Complete(r)
 }
 

--- a/internal/controllers/warmpool_controller_test.go
+++ b/internal/controllers/warmpool_controller_test.go
@@ -951,7 +951,7 @@ func TestWarmPoolTemplateReplacementAfterMemberCreateDeletesOldOwnerMember(t *te
 	}
 }
 
-func TestRestrictedInstallationStopsWarmReplenishmentAndCleanup(t *testing.T) {
+func TestRestrictedInstallationStopsWarmReplenishmentAndCleanupDuringProjectFencing(t *testing.T) {
 	scheme := isolationTestScheme(t)
 	installation := &platformv1alpha1.Installation{
 		ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "system", UID: "installation-uid"},
@@ -964,7 +964,8 @@ func TestRestrictedInstallationStopsWarmReplenishmentAndCleanup(t *testing.T) {
 		tenancy.InstallationUIDAnnotation:       string(installation.UID),
 		tenancy.ProjectNameAnnotation:           project.Name,
 		tenancy.ProjectUIDAnnotation:            string(project.UID),
-		tenancy.LifecycleAnnotation:             string(tenancy.LifecycleActive),
+		tenancy.LifecycleAnnotation:             string(tenancy.LifecycleFencing),
+		tenancy.LifecycleOperationAnnotation:    tenancy.OperationOffboarding,
 	}}}
 	template := &platformv1alpha1.EnvironmentTemplate{
 		ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: namespace.Name, UID: "template-uid", Generation: 1, Annotations: map[string]string{

--- a/internal/controllers/warmpool_controller_test.go
+++ b/internal/controllers/warmpool_controller_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -19,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	platformv1alpha1 "github.com/Chris-Cullins/swe-platform/api/v1alpha1"
+	"github.com/Chris-Cullins/swe-platform/internal/tenancy"
 )
 
 func TestWarmPoolReconcileCreatesMinimum(t *testing.T) {
@@ -946,6 +948,66 @@ func TestWarmPoolTemplateReplacementAfterMemberCreateDeletesOldOwnerMember(t *te
 	}
 	if len(members.Items) != 0 {
 		t.Fatalf("old-owner member survived post-Create replacement: %#v", members.Items)
+	}
+}
+
+func TestRestrictedInstallationStopsWarmReplenishmentAndCleanup(t *testing.T) {
+	scheme := isolationTestScheme(t)
+	installation := &platformv1alpha1.Installation{
+		ObjectMeta: metav1.ObjectMeta{Name: "main", Namespace: "system", UID: "installation-uid"},
+		Spec:       platformv1alpha1.InstallationSpec{Isolation: restrictedIsolationSelection()},
+	}
+	project := &platformv1alpha1.Project{ObjectMeta: metav1.ObjectMeta{Name: "project", Namespace: "default", UID: "project-uid"}}
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default", UID: "namespace-uid", Annotations: map[string]string{
+		tenancy.InstallationNamespaceAnnotation: installation.Namespace,
+		tenancy.InstallationNameAnnotation:      installation.Name,
+		tenancy.InstallationUIDAnnotation:       string(installation.UID),
+		tenancy.ProjectNameAnnotation:           project.Name,
+		tenancy.ProjectUIDAnnotation:            string(project.UID),
+		tenancy.LifecycleAnnotation:             string(tenancy.LifecycleActive),
+	}}}
+	template := &platformv1alpha1.EnvironmentTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "small", Namespace: namespace.Name, UID: "template-uid", Generation: 1, Annotations: map[string]string{
+			tenancy.InstallationNamespaceAnnotation: installation.Namespace,
+			tenancy.InstallationNameAnnotation:      installation.Name,
+			tenancy.InstallationUIDAnnotation:       string(installation.UID),
+			tenancy.ProjectNameAnnotation:           project.Name,
+			tenancy.ProjectUIDAnnotation:            string(project.UID),
+			tenancy.CatalogNameAnnotation:           "small",
+			tenancy.CatalogRevisionAnnotation:       "revision-1",
+			tenancy.CatalogSourceUIDAnnotation:      "source-uid",
+		}},
+		Spec:   platformv1alpha1.EnvironmentTemplateSpec{WarmPool: &platformv1alpha1.WarmPoolSpec{Min: 1}},
+		Status: platformv1alpha1.EnvironmentTemplateStatus{WarmPoolReady: 1},
+	}
+	member := &platformv1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "warm-small", Namespace: namespace.Name, UID: "environment-uid", Labels: map[string]string{warmPoolLabel: template.Name}},
+		Spec:       platformv1alpha1.EnvironmentSpec{TemplateRef: template.Name},
+		Status:     platformv1alpha1.EnvironmentStatus{ObservedGeneration: 1, Phase: platformv1alpha1.EnvironmentPhaseFailed},
+	}
+	setWarmPoolOwner(t, scheme, template, member)
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(template, member).WithObjects(installation, namespace, project, template, member).Build()
+	identity := tenancy.InstallationIdentity{Key: client.ObjectKeyFromObject(installation), UID: installation.UID}
+	verifier := &tenancy.Verifier{Reader: kubeClient, Installation: identity, Mode: tenancy.ModeScoped}
+	reconciler := &WarmPoolReconciler{Client: kubeClient, APIReader: kubeClient, Scheme: scheme, Scope: &tenancy.ReconcileScope{Verifier: verifier}}
+
+	if result, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(template)}); err != nil || !result.Requeue {
+		t.Fatalf("Reconcile() = (%#v, %v)", result, err)
+	}
+	var updatedTemplate platformv1alpha1.EnvironmentTemplate
+	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(template), &updatedTemplate); err != nil {
+		t.Fatal(err)
+	}
+	var retained platformv1alpha1.Environment
+	if err := kubeClient.Get(context.Background(), client.ObjectKeyFromObject(member), &retained); err != nil {
+		t.Fatal("restricted isolation deleted an existing warm Environment")
+	}
+	var members platformv1alpha1.EnvironmentList
+	if err := kubeClient.List(context.Background(), &members, client.InNamespace(namespace.Name), client.MatchingLabels{warmPoolLabel: template.Name}); err != nil {
+		t.Fatal(err)
+	}
+	if updatedTemplate.Status.WarmPoolReady != 0 || len(members.Items) != 1 || retained.Annotations[warmPoolCleanupAnnotation] != "" {
+		t.Fatalf("restricted warm pool status=%d members=%d retained=%#v", updatedTemplate.Status.WarmPoolReady, len(members.Items), retained)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add the controller-owned Installation isolation selection lifecycle with uncached exact dependency resolution and bounded non-secret status
- permit omitted legacy and explicit non-production development states while making restricted selection fence every Environment and warm pool before settling `Blocked`
- require durable `Fencing` before first restricted dependency reads, on observed dependency authority drift, and before a non-legacy transition can reopen development execution
- include exact Installation isolation authority in Run pre/post execution-currentness checks and repeat it at the adapter-acceptance process boundary
- include the same authority in the final uncached Environment backend fence immediately before and after Pod creation, covering clone/setup/resume hooks
- fence repository-declared service work both before reconciliation and immediately before every sandboxd managed-process reconcile boundary
- report zero warm-pool capacity under blocked isolation even when Project lifecycle is already fencing, without replenishing or cleaning members
- preserve PVCs, transcripts, and ingress policy while reusing readiness withdrawal, exact Pod deletion, then credential revocation
- scope system object caches/RBAC and trusted-admin fence proof to the exact Installation ownership boundary

This is a compatibility/fencing release, not restricted runtime activation. It does **not** enable currentness authorization, egress proxy transport/identity, forced network paths, Calico enforcement, scheduling gates, or a production-ready restricted claim.

Refs #10 and #68.

## Verification
- `make generate manifests` (worker)
- `go test ./internal/controllers ./internal/isolation ./internal/egresspolicy ./cmd/operator ./api/v1alpha1 -count=1`
- `go test -race ./internal/controllers -run 'TestBackendCreationSourcesRevalidateInstallationIsolation|TestDeclaredServiceReconcilerRevalidatesInstallationIsolationBeforeProcessReconcile|TestAdapterAcceptanceDialRevalidates(ActiveTenancyClaim|InstallationIsolation)|TestRestrictedInstallationStopsWarmReplenishmentAndCleanupDuringProjectFencing' -count=1`
- `make test`
- `make vet`
- `make check-chart-crds`
- `./hack/helm-rbac_test.sh`
- Helm lint: base plus kind, argocd, k3s, gke, and eks presets
- `bash -n hack/e2e.sh`
- `git diff --check origin/main...HEAD`

Full live kind acceptance is delegated to required CI.