### PR TITLE
fix(e2e): isolate fixture commit from inherited signing

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -1499,7 +1499,7 @@ const server = http.createServer((request, response) => {
 server.listen(Number(process.env.PORT), "127.0.0.1");
 EOF
 git -C "$PROJECT_WORKTREE" add .agents/setup .agents/resume .swe/services.yaml .swe/service.js
-git -C "$PROJECT_WORKTREE" commit -m "Add e2e lifecycle hooks and declared service" >/dev/null
+git -C "$PROJECT_WORKTREE" -c commit.gpgsign=false commit -m "Add e2e lifecycle hooks and declared service" >/dev/null
 git -C "$PROJECT_WORKTREE" bundle create "$PROJECT_REPO/repo.bundle" main
 kubectl create configmap e2e-git-repo --from-file="$PROJECT_REPO/repo.bundle"
 kubectl apply -f - <<EOF


### PR DESCRIPTION
## Summary
Disable signing only for the disposable acceptance fixture commit. Developer or orb Git configuration may require signing, but this temporary repository has no signing identity. Global/system Git configuration and normal repository commits remain unchanged.

## Reproduction and verification
- Full live acceptance on fresh origin/main reached fixture creation after installation/onboarding, legacy Environment migration, warm-pool, and two-release/offboarding checks, then failed with `No signing key is available for this commit` (exit 128).
- With inherited `commit.gpgsign=true`, `gpg.format=ssh`, `gpg.ssh.program=/bin/false`, and `user.signingkey=/dev/null`: original command exits 128; patched command exits 0.
- The exact patched fixture command creates an unsigned commit and a verified Git bundle.
- `bash -n hack/e2e.sh` and `git diff --check` pass.
- Baseline `make test`, `make vet`, build, PostgreSQL 17 integration contracts, focused Go race suites, and UI lint/typecheck/build pass. UI suite passes 100/100 on rerun; initial concurrent cold-build run exposed a pre-existing timing-sensitive assertion.
- Full kind/gVisor acceptance rerun with the deliberately failing inherited SSH signer is in progress; this PR does not yet claim complete live acceptance.

No restricted-egress live conformance runner, provider credentials, or shared clusters were used.