### PR TITLE
fix(e2e): relay sandboxd checks across runtime network stacks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,6 +206,9 @@ runs both via `make` targets:
   declared-service portal allocation/proxy authorization and lifecycle fencing, process-scoped fake Claude, Amp, and Codex API-key delivery without ambient
   setup/resume/sandboxd exposure, and Secret-only sandboxd process/service-observation/portal
   capability tokens without Environment pod projection.
+  Direct sandboxd acceptance RPCs always use the system-namespace policy-authorized relay
+  to the Environment Pod IP, including on kindnet: direct Environment port-forward cannot
+  reach gVisor's userspace listener. Relay cleanup is independent of runtime and CNI selection.
   Runs in CI as the `e2e` workflow on relevant PRs and via `workflow_dispatch`.
 - **CRD installation/upgrades:** `make install-crds` uses server-side apply with force-conflicts;
   plain Helm upgrades must apply the chart's `crds/` directory before `helm upgrade`.

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -200,28 +200,23 @@ check_sandboxd_process() {
 	local pod_name="$1"
 	local run_uid="$2"
 	local expected_key="$3"
-	local secret_name identity checked=false forward_namespace="$PROJECT_NAMESPACE" forward_pod="$pod_name"
+	local secret_name identity pod_ip checked=false
 	secret_name=$(kubectl -n "$PROJECT_NAMESPACE" get pod "$pod_name" -o jsonpath='{.metadata.annotations.swe\.dev/sandboxd-secret-name}')
 	identity=$(kubectl -n "$PROJECT_NAMESPACE" get pod "$pod_name" -o jsonpath='{.metadata.annotations.swe\.dev/sandboxd-identity}')
 	kubectl -n "$PROJECT_NAMESPACE" get secret "$secret_name" -o jsonpath='{.data.tls\.crt}' | base64 --decode > /tmp/swe-platform-sandboxd-cert-"$$"
 	kubectl -n "$PROJECT_NAMESPACE" get secret "$secret_name" -o jsonpath='{.data.process-token}' | base64 --decode > /tmp/swe-platform-sandboxd-token-"$$"
-	if [[ -n "${E2E_ENFORCING_CNI:-}" ]]; then
-		# Exercise the exact authenticated RPC through the policy-authorized path;
-		# a runner-to-Environment port-forward is correctly denied by Calico.
-		local pod_ip
-		pod_ip=$(kubectl -n "$PROJECT_NAMESPACE" get pod "$pod_name" -o jsonpath='{.status.podIP}')
-		kubectl -n "$SYSTEM_NAMESPACE" delete pod swe-sandboxd-relay --ignore-not-found --wait=true >/dev/null
-		kubectl -n "$SYSTEM_NAMESPACE" run swe-sandboxd-relay \
-			--image=busybox:1.36.1 --restart=Never \
-			--labels='app.kubernetes.io/name=swe-platform,app.kubernetes.io/instance=swe-platform,app.kubernetes.io/component=control-plane' \
-			-- sh -c "exec nc -ll -p 50051 -e nc '$pod_ip' 50051"
-		kubectl -n "$SYSTEM_NAMESPACE" wait --for=condition=Ready pod/swe-sandboxd-relay --timeout=30s
-		forward_namespace="$SYSTEM_NAMESPACE"
-		forward_pod="swe-sandboxd-relay"
-	fi
+	# Always use the policy-authorized Pod-IP path. Direct Environment port-forward
+	# can be denied by Calico or miss gVisor's userspace network stack, even on kindnet.
+	pod_ip=$(kubectl -n "$PROJECT_NAMESPACE" get pod "$pod_name" -o jsonpath='{.status.podIP}')
+	kubectl -n "$SYSTEM_NAMESPACE" delete pod swe-sandboxd-relay --ignore-not-found --wait=true >/dev/null
+	kubectl -n "$SYSTEM_NAMESPACE" run swe-sandboxd-relay \
+		--image=busybox:1.36.1 --restart=Never \
+		--labels='app.kubernetes.io/name=swe-platform,app.kubernetes.io/instance=swe-platform,app.kubernetes.io/component=control-plane' \
+		-- sh -c "exec nc -ll -p 50051 -e nc '$pod_ip' 50051"
+	kubectl -n "$SYSTEM_NAMESPACE" wait --for=condition=Ready pod/swe-sandboxd-relay --timeout=30s
 	for _ in $(seq 1 5); do
 		: > /tmp/swe-platform-sandboxd-port-forward.log
-		kubectl -n "$forward_namespace" port-forward pod/"$forward_pod" 15051:50051 >/tmp/swe-platform-sandboxd-port-forward.log 2>&1 &
+		kubectl -n "$SYSTEM_NAMESPACE" port-forward pod/swe-sandboxd-relay 15051:50051 >/tmp/swe-platform-sandboxd-port-forward.log 2>&1 &
 		SANDBOXD_PORT_FORWARD_PID=$!
 		for _ in $(seq 1 30); do
 			if kill -0 "$SANDBOXD_PORT_FORWARD_PID" >/dev/null 2>&1 && \
@@ -242,9 +237,7 @@ check_sandboxd_process() {
 		sleep 1
 	done
 	rm -f /tmp/swe-platform-sandboxd-cert-"$$" /tmp/swe-platform-sandboxd-token-"$$"
-	if [[ -n "${E2E_ENFORCING_CNI:-}" ]]; then
-		kubectl -n "$SYSTEM_NAMESPACE" delete pod swe-sandboxd-relay --ignore-not-found --wait=true >/dev/null
-	fi
+	kubectl -n "$SYSTEM_NAMESPACE" delete pod swe-sandboxd-relay --ignore-not-found --wait=true >/dev/null
 	[[ "$checked" == "true" ]]
 }
 
@@ -254,24 +247,20 @@ manage_observation_listener() {
 	local owner="$3"
 	local role="$4"
 	local port="${5:-}"
-	local secret_name identity forward_namespace="$PROJECT_NAMESPACE" forward_pod="$pod_name"
+	local secret_name identity pod_ip
 	secret_name=$(kubectl -n "$PROJECT_NAMESPACE" get pod "$pod_name" -o jsonpath='{.metadata.annotations.swe\.dev/sandboxd-secret-name}')
 	identity=$(kubectl -n "$PROJECT_NAMESPACE" get pod "$pod_name" -o jsonpath='{.metadata.annotations.swe\.dev/sandboxd-identity}')
 	kubectl -n "$PROJECT_NAMESPACE" get secret "$secret_name" -o jsonpath='{.data.tls\.crt}' | base64 --decode > /tmp/swe-platform-observation-cert-"$$"
 	kubectl -n "$PROJECT_NAMESPACE" get secret "$secret_name" -o jsonpath='{.data.process-token}' | base64 --decode > /tmp/swe-platform-observation-process-token-"$$"
-	if [[ -n "${E2E_ENFORCING_CNI:-}" ]]; then
-		local pod_ip
-		pod_ip=$(kubectl -n "$PROJECT_NAMESPACE" get pod "$pod_name" -o jsonpath='{.status.podIP}')
-		kubectl -n "$SYSTEM_NAMESPACE" delete pod swe-sandboxd-relay --ignore-not-found --wait=true >/dev/null
-		kubectl -n "$SYSTEM_NAMESPACE" run swe-sandboxd-relay \
-			--image=busybox:1.36.1 --restart=Never \
-			--labels='app.kubernetes.io/name=swe-platform,app.kubernetes.io/instance=swe-platform,app.kubernetes.io/component=control-plane' \
-			-- sh -c "exec nc -ll -p 50051 -e nc '$pod_ip' 50051"
-		kubectl -n "$SYSTEM_NAMESPACE" wait --for=condition=Ready pod/swe-sandboxd-relay --timeout=30s
-		forward_namespace="$SYSTEM_NAMESPACE"
-		forward_pod="swe-sandboxd-relay"
-	fi
-	kubectl -n "$forward_namespace" port-forward pod/"$forward_pod" 15052:50051 >/tmp/swe-platform-observation-port-forward.log 2>&1 &
+	# Match the process check's runtime-independent, policy-authorized relay path.
+	pod_ip=$(kubectl -n "$PROJECT_NAMESPACE" get pod "$pod_name" -o jsonpath='{.status.podIP}')
+	kubectl -n "$SYSTEM_NAMESPACE" delete pod swe-sandboxd-relay --ignore-not-found --wait=true >/dev/null
+	kubectl -n "$SYSTEM_NAMESPACE" run swe-sandboxd-relay \
+		--image=busybox:1.36.1 --restart=Never \
+		--labels='app.kubernetes.io/name=swe-platform,app.kubernetes.io/instance=swe-platform,app.kubernetes.io/component=control-plane' \
+		-- sh -c "exec nc -ll -p 50051 -e nc '$pod_ip' 50051"
+	kubectl -n "$SYSTEM_NAMESPACE" wait --for=condition=Ready pod/swe-sandboxd-relay --timeout=30s
+	kubectl -n "$SYSTEM_NAMESPACE" port-forward pod/swe-sandboxd-relay 15052:50051 >/tmp/swe-platform-observation-port-forward.log 2>&1 &
 	SANDBOXD_PORT_FORWARD_PID=$!
 	for _ in $(seq 1 30); do
 		if grep -q 'Forwarding from' /tmp/swe-platform-observation-port-forward.log; then
@@ -293,9 +282,7 @@ manage_observation_listener() {
 	wait "$SANDBOXD_PORT_FORWARD_PID" >/dev/null 2>&1 || true
 	SANDBOXD_PORT_FORWARD_PID=""
 	rm -f /tmp/swe-platform-observation-cert-"$$" /tmp/swe-platform-observation-process-token-"$$"
-	if [[ -n "${E2E_ENFORCING_CNI:-}" ]]; then
-		kubectl -n "$SYSTEM_NAMESPACE" delete pod swe-sandboxd-relay --ignore-not-found --wait=true >/dev/null
-	fi
+	kubectl -n "$SYSTEM_NAMESPACE" delete pod swe-sandboxd-relay --ignore-not-found --wait=true >/dev/null
 }
 
 wait_service_observation() {


### PR DESCRIPTION
## Summary
Use the existing system-namespace, policy-authorized Pod-IP relay for both direct sandboxd acceptance helpers on every runtime. Remove the CNI-only setup/cleanup predicates and unused forwarding-target variables. No RuntimeClass-name inference or new network permissions; existing labels, TLS identity, process capability and EXIT cleanup remain unchanged.

## Reproduction
The documented kind-up/gVisor acceptance path on kindnet reached a successful fake Claude Run, then failed the process check five times with TLS handshake EOF. Kubectl reported connection refused on network-namespace localhost:50051. The same exact Pod/process/certificate/capability check passed through the existing relay.

## Verification
- Live gVisor + kindnet with CNI/runtime selector variables unset: process credential check and service start/running/stop/stopped passed; relay absent after helper cleanup.
- Live default runtime (Pod has no RuntimeClass): fake warm Run Succeeded; identical process/service/cleanup checks passed.
- An initial default-runtime probe used a cold Owned Run, whose terminal lifecycle correctly fenced/deleted its Pod; it was replaced with a claimed warm Run for the preserved-process check.
- `bash -n hack/e2e.sh` and `git diff --check` pass.
- Full acceptance rerun with this patch plus the independent fixture-signing fix #183 follows. This PR does not yet claim full acceptance.

No provider credentials, shared cluster, or restricted-egress conformance runner used. Local kindnet results are not Calico enforcement evidence.